### PR TITLE
Fix scroll height for code browser

### DIFF
--- a/lib/views/browser/overlay-indicator.less
+++ b/lib/views/browser/overlay-indicator.less
@@ -16,4 +16,5 @@
 
 .yui3-overlay-indicator-hidden {
     visibility: hidden;
+    display: none;
 }


### PR DESCRIPTION
In the code browser switching to a shorter code file would not reduce the scroll height. This was because the hidden loading indicator still existed but was no completely hidden.

To reproduce open the Liferay charm details, view the Code tab, select 'README.md' file and then select the 'revision' file. The scrollbar should disappear (the scrollbar would remain the same previously).

Bug here: https://bugs.launchpad.net/juju-gui/+bug/1260061
