### PR TITLE
fixed login routing issue causing onboarding to not be shown

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -892,6 +892,7 @@ YUI.add('juju-gui', function(Y) {
       // form was never shown - this handles that edge case.
       var noCredentials = !(credentials && credentials.areAvailable);
       if (noCredentials) {
+        this.set('loggedIn', false);
         // If there are no stored credentials redirect to the login page
         if (!req || req.path !== '/login/') {
           // Set the original requested path in the event the user has


### PR DESCRIPTION
To QA:
Sandbox:
Make sure you are able to log in/out. (u: admin p: admin)
Make sure the onboarding can be displayed at the root url. To clear your localstorage, open up the app and type `localStorage.clear()` in the console, then refresh, it should show the onboarding.

Real Env:
Make sure you are able to log in/out (password is in your environments.yaml file)
http://jujugui.wordpress.com/2013/10/15/if-you-want-to-run-a-custom-gui/
