### PR TITLE
Update process docs and Makefile for git releases.

### DIFF
--- a/HACKING.rst
+++ b/HACKING.rst
@@ -422,19 +422,19 @@ The following is a list of pertinent Makefile variables.
   Set this to any non-empty value to force the Makefile to believe it is
   working with a trunk checkout. Example usage::
 
-    IS_TRUNK_BRANCH=1 make dist
+    IS_TRUNK_BRANCH=0 make dist
 
 ``BRANCH_IS_CLEAN``
   Set this to any non-empty value to force the Makefile to believe that the
   current code tree has no changes. Example usage::
 
-    BRANCH_IS_CLEAN=1 make dist
+    BRANCH_IS_CLEAN=0 make dist
 
 ``BRANCH_IS_GOOD``
   Set this to any non-empty value to force the Makefile to bypass checks of
   ``IS_TRUNK_BRANCH`` and ``BRANCH_IS_CLEAN``. Example usage::
 
-    BRANCH_IS_GOOD=1 make dist
+    BRANCH_IS_GOOD=0 make dist
 
 Updating the ``nodejs`` dependencies
 ====================================


### PR DESCRIPTION
- Update the makefile to convert bzr-ism to git-ism
- I have qa'd a developer release up through uploading, but killed it when I needed to auth launchpad with an oauth credential.
- I have followed most of the release steps, but not all. There might still be a snag/two to work out on our first real release which we'll do next week and I'll volunteer to help with that in case I've missed a step, I just don't want to go through with a real release right now.
