### PR TITLE
Allow configuring mocha color escape codes

### DIFF
--- a/HACKING.rst
+++ b/HACKING.rst
@@ -45,7 +45,7 @@ importantly, to support testing from the command line, ``phantomjs`` and
 
 ::
 
-  sudo npm install -g jshint@2.1.3 mocha-phantomjs@2.0.0 phantomjs@1.9.1-0
+  sudo npm install -g jshint@2.1.3 mocha-phantomjs@3.2.0 phantomjs@1.9.1-0
 
 Note: Make sure to get the latest phantomjs from npm and not rely on an older
 .deb packaged version. mocha-phantomjs will fail silently when running.

--- a/Makefile
+++ b/Makefile
@@ -398,6 +398,7 @@ prep: beautify lint
 
 # XXX bac: the order of test-debug and test-prod seems to affect the execution
 # of this target when called by lbox.  Please do not change.
+# You can disable the colored mocha output by setting ENV var MOCHA_NO_COLOR=1
 check: lint test-debug test-prod test-misc docs
 
 test/extracted_startup_code: app/index.html

--- a/test-server.sh
+++ b/test-server.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 
 set -m
+if [ $MOCHA_NO_COLOR ] ; then
+    MOCHA="mocha-phantomjs --no-color"
+else
+    MOCHA="mocha-phantomjs"
+fi
 
 fn=`tempfile`
 (node ./test-server.js $1 | tee $fn )  &
@@ -9,7 +14,7 @@ if [ -n "$2" ]; then
     xdg-open `cat $fn`
     fg %1
 else
-    mocha-phantomjs -t 40000 `cat $fn`
+    $MOCHA -t 40000 `cat $fn`
     status=$?
     kill %1
     exit $status


### PR DESCRIPTION
- Upgrade mocha-phantomjs to get access to the --no-color feature. It's only listed in the hacking docs.
- Add a in the Makefile so it's evident the option exists in the test-server.sh script.
- Update test-server.sh script to check for the ENV var and set the mocha command appropriately. 

QA:

This is done so that test results are easier to read in the jenkins CI output. The change should be present and qa'able now by looking at the test run of this pull request vs an older pull request. You have to look at the console data to see the test output. 

http://ci.jujugui.org:8080/job/juju-gui/88/

vs. 

http://ci.jujugui.org:8080/job/juju-gui/87/

NOTE: 

It appears that the GET requests still escape. There's nothing in phantomjs I can see to set for this and it appears this is a limitation in the implementation of the --no-color flag to mocha-phantomjs. Perhaps a patch upstream would be worthwhile at some point, but this at least helps reading/finding the actual test lines. 
