### PR TITLE
Fixing the fullscreen to sidebar redirection code to use the existing double dispatch mitigation code

### DIFF
--- a/test/test_browser_app.js
+++ b/test/test_browser_app.js
@@ -729,7 +729,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
         // Fullscreen urls get redirected to / which is sidebar
         browser.navigate = function(url) {
-          assert.equal(url, '/');
+          assert.equal(url, '');
           done();
         };
 
@@ -747,7 +747,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
         // Fullscreen urls get redirected to / which is sidebar
         browser.navigate = function(url) {
-          assert.equal(url, '/precise/apache2-2');
+          assert.equal(url, 'precise/apache2-2');
           done();
         };
 
@@ -765,7 +765,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
         // Fullscreen urls get redirected to / which is sidebar
         browser.navigate = function(url) {
-          assert.equal(url, '/search/precise/apache2-2');
+          assert.equal(url, 'sidebar/search/precise/apache2-2');
           done();
         };
 


### PR DESCRIPTION
To QA:
On sandbox visit the following urls and they should redirect to their sidebar equivalents:
<url>/fullscreen
<url>/fullscreen/precise/ceph-18/
<url>/sidebar/search/?text=wordpress
<url>/fullscreen/search/precise/ceph-18/?text=wordpress
