### PR TITLE
Update to support multiple browsers in CI tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -412,7 +412,12 @@ ci-check: check
 	# Report any server already running and abort.
 	! netstat -tnap 2> /dev/null | grep ":8888 " | grep " LISTEN "
 	# Run the browser tests against a remote browser (uses Sauce Labs).
+	echo "Starting tests against Firefox"
+	JUJU_GUI_TEST_BROWSER="firefox" make test-browser
+	echo "Starting tests against Chrome"
 	JUJU_GUI_TEST_BROWSER="chrome" make test-browser
+	echo "Starting tests against IE"
+	JUJU_GUI_TEST_BROWSER="ie" make test-browser
 
 test/extracted_startup_code: app/index.html
 	# Pull the JS out of the index so we can run tests against it.
@@ -454,9 +459,9 @@ test-misc:
 	    test/test_deploy_charm_for_testing.py
 	PYTHONPATH=bin virtualenv/bin/python test/test_http_server.py
 
-test-browser: build-debug
+test-browser: build-prod
 	# Start the web server we will be testing against.
-	(cd build-debug && \
+	(cd build-prod && \
 	    python ../bin/http_server.py 8888 2> /dev/null & \
 	    echo $$!>$(TEST_SERVER_PID))
 	# Start Xvfb as a background process, capturing its PID.
@@ -464,7 +469,7 @@ test-browser: build-debug
 	# Run the tests inside the virtual frame buffer.  If any tests fail a
 	# marker file is created.
 	rm -rf $(BROWSER_TEST_FAILED_FILE)
-	DISPLAY=:34 virtualenv/bin/python test/test_browser.py || \
+	DISPLAY=:34 virtualenv/bin/python test/test_browser.py -v || \
 	    touch $(BROWSER_TEST_FAILED_FILE)
 	# Stop the background processes.
 	kill $(xvfb_pid)
@@ -623,11 +628,11 @@ else
 endif
 
 # targets are alphabetically sorted, they like it that way :-)
-.PHONY: beautify build build-files build-devel clean clean-all clean-deps \
-	clean-docs code-doc debug devel docs dist gjslint help \
+.PHONY: beautify build build-files build-devel ci-check clean clean-all \
+	clean-deps clean-docs code-doc debug devel docs dist gjslint help \
 	install-npm-packages jshint lint lint-yuidoc main-doc npm-cache \
-	npm-cache-file prep prod recess server spritegen test test-debug \
-	test-misc test-prep test-prod undocumented view-code-doc view-docs \
-	view-main-doc
+	npm-cache-file prep prod recess server spritegen test \
+	test-debug test-misc test-prep test-prod undocumented view-code-doc \
+	view-docs view-main-doc
 
 .DEFAULT_GOAL := all

--- a/app/config-prod.js
+++ b/app/config-prod.js
@@ -38,10 +38,10 @@ var juju_config = {
   // ignored (the port/protocol behavior overrides socket_url).
   socket_protocol: 'ws',
   socket_port: 8081,
-  user: undefined,
-  password: undefined,
+  user: 'admin',
+  password: 'admin',
   apiBackend: 'go', // Value can be 'python' or 'go'.
-  sandbox: false,
+  sandbox: true,
   // When in sandbox mode should we create events to simulate a live env.
   // You can also use the :flags:/simulateEvents feature flag.
   simulateEvents: false,

--- a/docs/process.rst
+++ b/docs/process.rst
@@ -216,9 +216,8 @@ Checklist for Making a Stable Release
   string that combines the value in the branch's ``CHANGES.yaml`` with the
   branch's revno.
 - While still in the directory where you extracted the tar file, change
-  build-prod/juju-ui/assets/config.js to specify sandbox: true,
-  user: 'admin', password: 'admin',
-  simulateEvents: false, and showGetJujuButton: true.
+  build-prod/juju-ui/assets/config.js to specify simulateEvents: false
+  and showGetJujuButton: true.
 - Serve the app with a python module.
 
   - cd build-prod && python -m SimpleHTTPServer

--- a/test/browser.py
+++ b/test/browser.py
@@ -25,7 +25,6 @@ import getpass
 import httplib
 import json
 import os
-import socket
 import subprocess
 import sys
 import unittest
@@ -44,11 +43,6 @@ import shelltoolbox
 
 # Utility function to print to stderr.
 printerr = partial(print, file=sys.stderr)
-
-# Set a socket timeout to help selenium wait for page load. Selenium loads in
-# debug mode and all the single JS files take a while to load. The
-# set_page_load_timeout fails to work.
-socket.setdefaulttimeout(120)
 
 # Add ../lib to sys.path to get the retry module.
 root_path = os.path.dirname(os.path.dirname(os.path.normpath(__file__)))
@@ -142,12 +136,12 @@ def get_capabilities(browser_name):
             # Juju GUI supports Firefox >= 16 (quantal base).  At the time of
             # this comment the default version used in Saucelabs, if none is
             # specified, is 11.
-            {'platform': 'Linux', 'version': '16'},
+            {'platform': 'Linux', 'version': '25'},
         ),
         'ie': (
             desired.INTERNETEXPLORER,
             # Internet Explorer version must be >= 10.
-            {'platform': 'Windows 2012', 'version': '10'},
+            {'platform': 'Windows 7', 'version': '10'},
         ),
     }
     if browser_name in choices:


### PR DESCRIPTION
- Add to ci-check sequential browser runs of Firefox and IE.
- Update the version of Firefox to 25, the latest supported by saucelabs
- Update the Windows running IE due to the compatibility info on Saucelabs:
- Update to use build-prod for testing against
- Update the prod config.js to use the sandbox by default. It's not used in
  the charm deploys and is safe for us to change the default behaviour of
  without issue.
- Update the process doc since we've tweaked the prod config.js settings.
- Make the test running verbose in sauce tests to aid in tracking and
  debugging.

https://saucelabs.com/platforms
