### PR TITLE
Update to run unit tests via selenium.

### DIFF
--- a/docs/browser-testing.rst
+++ b/docs/browser-testing.rst
@@ -12,21 +12,77 @@ GUI charm and then running tests against it.
 Setting up
 ==========
 
-Environment
------------
-
-In order to run the tests you must have a Juju environment named
-"juju-gui-testing".  Consult the Juju documentation for how to set up
-an environment.
-
 Building
 --------
 
-The test script has a few system dependencies::
+The testing has the same system dependencies as development. Make sure to
+follow the HACKING doc for instructions on setting up your environment.
 
-    sudo apt-get install python-shelltoolbox python-selenium python-yaml juju
 
-It does not require that the Makefile be run.
+Manually running the browser tests
+===================================
+
+Note that there are four valid browser targets currently.
+
+  - chrome
+  - ie
+  - firefox
+  - local-firefox
+
+These are set in the below commands via an ENV variable
+`JUJU_GUI_TEST_BROWSER`. The `PORT` ENV variable is also important to help
+start the web server that serves out the test files.
+
+The commands below also mention a `[whatismyip]`. In order for SauceLabs to
+run the tests the server needs to be exposed externally via the port
+specified. In one use case, you can port forward from your router to your
+local computer and then update the `[whatismyip]` to be the actual external
+address of your home network.
+
+You can also setup things through external server with handy tactics such as
+ssh tunnels, but direct exposure is noted below as the simplest use case.
+
+
+Running Functional Tests
+------------------------
+
+There are a series of functional tests that use Selenium in the Gui. They are
+run via the Python API to Selenium and may be run against any local browser as
+well as remote browsers provided by SauceLabs.
+
+Below is a sample command to run the functional tests against the SauceLabs
+Firefox browser. If you wanted to run it against a local Firefox instance, you
+could change the `JUJU_GUI_TEST_BROWSER` to be `local-firefox`.
+
+::
+
+    APP_URL=http://[whatismyip]:8889 PORT=8889 JUJU_GUI_TEST_BROWSER="firefox" make test-browser
+
+
+Running the unit test suite a browser
+-------------------------------------
+
+You can run the prod tests in any browser locally by running the test server.
+
+::
+
+    PORT=8889 node ./test-server.js prod $(PORT)
+
+At this point you will get a url that you can point your browser to and it'll
+run against the `build-prod` version of the Gui source.
+
+
+You can also run these in SauceLabs manually by using the following:
+
+::
+
+    APP_URL=http://[whatismyip]:8889 PORT=8889 JUJU_GUI_TEST_BROWSER="chrome" make test-browser-mocha
+
+
+
+===================================================================
+BitRotted Instructions that require updating into the new CI world.
+===================================================================
 
 
 Running the tests

--- a/test-server.js
+++ b/test-server.js
@@ -46,5 +46,6 @@ app.get('/juju-ui/:file', function(req, res) {
 
 var server = http.createServer(app);
 // Bind 0 requests a random port which we read back.
-server.listen(0);
+var port = process.env.PORT || 0;
+server.listen(process.env.PORT);
 console.log('http://0.0.0.0:' + server.address().port + '/test/index.html');

--- a/test-server.sh
+++ b/test-server.sh
@@ -7,8 +7,12 @@ else
     MOCHA="mocha-phantomjs"
 fi
 
+if [ $TEST_PORT ] ; then
+    PORT=$(TEST_PORT)
+fi
+
 fn=`tempfile`
-(node ./test-server.js $1 | tee $fn )  &
+(node ./test-server.js $1 $(PORT) | tee $fn )  &
 sleep 2
 if [ -n "$2" ]; then
     xdg-open `cat $fn`
@@ -21,4 +25,3 @@ else
 fi
 
 rm $fn
-

--- a/test/index.html
+++ b/test/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 <!--
 This file is part of the Juju GUI, which lets users view and manage Juju
@@ -27,12 +28,15 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
   <script>
     // Default window.flags to an empty object.
     window.flags = {};
+    // This is only the Mocha timeout. There's a selenium timeout in
+    //  test_mocha_selenium as well that can effect CI test runs.
+    var TIMEOUT = 100000;
     var assert = chai.assert,
         expect = chai.expect,
         should = chai.should();
     mocha.reporter('html');
     mocha.ui('bdd');
-    mocha.setup({ignoreLeaks: false, timeout: 30000});
+    mocha.setup({ignoreLeaks: false, timeout: TIMEOUT});
   </script>
 
   <!-- Load up YUI base, app modules, and test utils -->
@@ -147,12 +151,12 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       // Do not attempt to dispatch a new route when an anchor tag appears in
       // the url. This is intended to keep charm details from reloading on tab
       // selection in the browser.
-      navigateOnHash: false,
+      navigateOnHash: false
   };
 
 
   // Set the url so we can full path loading fixture files.
-  GlobalConfig.test_url = window.location.origin + "/test/";
+  GlobalConfig.test_url = window.location.protocol + '//' + window.location.host + "/test/";
 
   // tabview needs to be here since it doesn't auto load it for some reason.
   YUI().use(['node', 'event', 'tabview'], function(Y) {

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -102,6 +102,7 @@ class TestAuthentication(browser.TestCase):
         # It is possible to login to and logout from the unit detail view.
         self.process_path('/:gui:/unit/haproxy-0/')
 
+
 if __name__ == '__main__':
     browser.browser_name = os.getenv('JUJU_GUI_TEST_BROWSER', 'local-firefox')
     unittest.main()

--- a/test/test_charm_running.py
+++ b/test/test_charm_running.py
@@ -22,56 +22,6 @@ from selenium.common import exceptions
 import browser
 
 
-class TestTests(browser.TestCase):
-
-    def test_gui_unit_tests(self):
-        # Ensure Juju GUI unit tests pass.
-        def tests_completed(driver):
-            stats = driver.execute_script('return testRunner.stats;')
-            # Return when tests completed or a failure occurred.
-            # The duration and end values are only specified after the tests
-            # complete. Sometimes only one or the other are available, for
-            # reasons yet to be determined.
-            if stats.get('duration') or stats.get('end') or stats['failures']:
-                return stats['tests'], stats['failures']
-
-        def run_tests():
-            # Ensure the window receives focus. In Firefox, blur/focus unit
-            # tests fail if the window in which they are running is not
-            # focused. See https://bugzilla.mozilla.org/show_bug.cgi?id=566671
-            self.driver.execute_script('window.focus();')
-            self.wait_for_css_selector('#mocha-stats')
-            try:
-                total, failures = self.wait_for(
-                    tests_completed, 'Unable to complete test run.',
-                    timeout=600)
-            except exceptions.TimeoutException:
-                msg = "Tests did not complete. Check video and timeout value"
-                browser.printerr(msg)
-                browser.printerr("Test Runner Stats:")
-                browser.printerr(
-                    self.driver.execute_script('return testRunner.stats;'))
-                browser.printerr("Re-raising TimeoutException")
-                raise
-            return total, failures
-        self.load('/test/')
-        for i in range(5):
-            total, failures = run_tests()
-            if failures and i < 4 and total < 100:
-                # XXX bug 1161937 gary 2013-03-29
-                # We sometimes see initial failures and we don't know why :-(.
-                # Reload and retry.
-                msg = '{} failure(s) running {} tests.  Retrying.'.format(
-                    failures, total)
-                browser.printerr(msg)
-                self.driver.refresh()
-            else:
-                break
-        if failures:
-            msg = '{} failure(s) running {} tests.'.format(failures, total)
-            self.fail(msg)
-
-
 class DeployTestMixin(object):
     """Mixin exposing a deploy method."""
 

--- a/test/test_mocha_selenium.py
+++ b/test/test_mocha_selenium.py
@@ -1,0 +1,83 @@
+# This file is part of the Juju GUI, which lets users view and manage Juju
+# environments within a graphical interface (https://launchpad.net/juju-gui).
+# Copyright (C) 2012-2013 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License version 3, as published by
+# the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+# SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import print_function
+
+import os
+from selenium.common import exceptions
+import unittest
+
+import browser
+
+# This timeout only effects how lone selenium waits. Test runs also are
+# effected by a Mocha timeout in the test/index.html setup.
+TIMEOUT = 10000
+
+
+class TestTests(browser.TestCase):
+
+    def test_gui_unit_tests(self):
+        # Ensure Juju GUI unit tests pass.
+        def tests_completed(driver):
+            stats = driver.execute_script('return testRunner.stats;')
+            # Return when tests completed or a failure occurred.
+            # The duration and end values are only specified after the tests
+            # complete. Sometimes only one or the other are available, for
+            # reasons yet to be determined.
+            if stats.get('duration') or stats.get('end') or stats['failures']:
+                return stats['tests'], stats['failures']
+
+        def run_tests():
+            # Ensure the window receives focus. In Firefox, blur/focus unit
+            # tests fail if the window in which they are running is not
+            # focused. See https://bugzilla.mozilla.org/show_bug.cgi?id=566671
+            self.driver.execute_script('window.focus();')
+            self.wait_for_css_selector('#mocha-stats')
+            try:
+                total, failures = self.wait_for(
+                    tests_completed, 'Unable to complete test run.',
+                    timeout=TIMEOUT)
+            except exceptions.TimeoutException:
+                msg = "Tests did not complete. Check video and timeout value"
+                browser.printerr(msg)
+                browser.printerr("Test Runner Stats:")
+                browser.printerr(
+                    self.driver.execute_script('return testRunner.stats;'))
+                browser.printerr("Re-raising TimeoutException")
+                raise
+            return total, failures
+
+        self.load('/test/index.html')
+        for i in range(5):
+            total, failures = run_tests()
+            if failures and i < 4 and total < 100:
+                # XXX bug 1161937 gary 2013-03-29
+                # We sometimes see initial failures and we don't know why :-(.
+                # Reload and retry.
+                msg = '{} failure(s) running {} tests.  Retrying.'.format(
+                    failures, total)
+                browser.printerr(msg)
+                self.driver.refresh()
+            else:
+                break
+        if failures:
+            msg = '{} failure(s) running {} tests.'.format(failures, total)
+            self.fail(msg)
+
+
+if __name__ == '__main__':
+    browser.browser_name = os.getenv('JUJU_GUI_TEST_BROWSER', 'local-firefox')
+    unittest.main()

--- a/test/test_model_bundle.js
+++ b/test/test_model_bundle.js
@@ -209,9 +209,11 @@ describe('The bundle model', function() {
 
   it('has the correct date in GMT', function() {
     instance = new models.Bundle(data);
+    // IE doesn't format 03 but as just 3. They also end in UTC vs GMT. So we
+    // regex the match to say this is close enough to work in each browser.
+    var expected = /^Thu, 0?3 Oct 2013 15:29:36/;
     var commits = instance.get('recentCommits');
-    assert.equal('Thu, 03 Oct 2013 15:29:36 GMT',
-        commits[0].date.toUTCString());
+    assert(commits[0].date.toUTCString().match(expected));
   });
 
   it('has the commit message', function() {


### PR DESCRIPTION
- Update to move the unit tests to their own function test file.
- Update to provide for allowing port specification so that tests can be run
  on specified ports to avoid collisions and make for predictable urls.
- Fix failing IE tests
- Fix the setting up of the json loading paths to work in IE since it didn't
  support location.origin.
- Provide a new makefile target for the unit tests to be started, run, and
  marked as failing/not.
- Update the ci-check to run the unit tests.
- Begin to update the browser-testing docs for the way we're currently looking
  to run them with example commands.
