### PR TITLE
Remove killing xvfb since it can be shared.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -479,7 +479,11 @@ test-browser: build-prod
 	DISPLAY=:34 virtualenv/bin/python test/test_browser.py -v || \
 	    touch $(BROWSER_TEST_FAILED_FILE)
 	# Stop the background processes.
-	kill $(xvfb_pid)
+	# Note: We do not kill the vxfb process since it's shared and safe to leave
+	# shared. If, in the future, we wish to take advantage of tools like
+	# taking image snapshots we can make this configurable at that time.
+	# kill $(xvfb_pid)
+
 	echo $(TEST_SERVER_PID)
 	cat $(TEST_SERVER_PID)
 	kill `cat $(TEST_SERVER_PID)`
@@ -505,7 +509,11 @@ endif
 	DISPLAY=:34 virtualenv/bin/python test/test_mocha_selenium.py -v || \
 	    touch $(BROWSER_TEST_FAILED_FILE)
 	# Stop the background processes.
-	kill $(xvfb_pid)
+	# Note: We do not kill the vxfb process since it's shared and safe to leave
+	# shared. If, in the future, we wish to take advantage of tools like
+	# taking image snapshots we can make this configurable at that time.
+	# kill $(xvfb_pid)
+
 	echo $(TEST_SERVER_PID)
 	cat $(TEST_SERVER_PID)
 	kill `cat $(TEST_SERVER_PID)`


### PR DESCRIPTION
- Currently if a test and a merge (landing) job are running on Jenkins they interfere and will not pass due to no fault of the dev.
- This is due to one of them killing the xvfb process running while the other is sharing it.
- After a pre-imp with Benji it was decided there's no harm in leaving it running currently and it's the most expedient way to getting a safer CI process into place. 

Notes:

We may want to revisit this, as noted in the docs in line, if we want to do things like snapshot images in case of a failing test, etc. We can then make the xvfb port configurable as part of that work.
## QA

Note that below we have failed test and merge runs. I've updated the branch to remove the failing test and it's ready for review.
