### PR TITLE
Create a new factory.js for test utils.

### DIFF
--- a/test/factory.js
+++ b/test/factory.js
@@ -1,0 +1,77 @@
+/*
+This file is part of the Juju GUI, which lets users view and manage Juju
+environments within a graphical interface (https://launchpad.net/juju-gui).
+Copyright (C) 2012-2013 Canonical Ltd.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU Affero General Public License version 3, as published by
+the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero
+General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along
+with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+'use strict';
+
+YUI(GlobalConfig).add('juju-tests-factory', function(Y) {
+  var tests = Y.namespace('juju-tests');
+
+  var _cached_charms = (function() {
+    var url,
+        charms = {},
+        names = [
+          'wordpress', 'mysql', 'puppet', 'haproxy', 'mediawiki', 'hadoop',
+          'memcached', 'puppetmaster'
+        ];
+    Y.Array.each(names, function(name) {
+      url = 'data/' + name + '-api-response.json';
+      charms[name] = tests.utils.loadFixture(url, true);
+    });
+    return charms;
+  })();
+
+  tests.factory = {
+
+    makeFakeStore: function() {
+      var fakeStore = new Y.juju.charmworld.APIv3({});
+      fakeStore.charm = function(store_id, callbacks, bindscope, cache) {
+        store_id = this.apiHelper.normalizeCharmId(store_id, 'precise');
+        var charmName = store_id.split('/')[1];
+        charmName = charmName.split('-', 1);
+        if (Y.Lang.isArray(charmName)) {
+          charmName = charmName[0];
+        }
+        if (charmName in _cached_charms) {
+          var response = _cached_charms[charmName];
+          if (cache) {
+            cache.add(response.charm);
+          }
+          callbacks.success(response);
+        } else {
+          callbacks.failure(new Error('Unable to load charm ' + charmName));
+        }
+      };
+      return fakeStore;
+    },
+
+    makeFakeBackend: function() {
+      var fakeStore = this.makeFakeStore();
+      var fakebackend = new Y.juju.environments.FakeBackend({
+        store: fakeStore
+      });
+      fakebackend.login('admin', 'password');
+      return fakebackend;
+    }
+
+  };
+
+}, '0.1.0', {
+  requires: [
+    'juju-tests-utils'
+  ]
+});

--- a/test/index.html
+++ b/test/index.html
@@ -48,6 +48,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
   <script src="/juju-ui/assets/node-event-simulate.js"></script>
   <script src="/juju-ui/assets/javascripts/spin.min.js"></script>
   <script src="utils.js"></script>
+  <script src="factory.js"></script>
 
   <!-- Tests (Alphabetical) -->
 

--- a/test/test_bundle_details_view.js
+++ b/test/test_bundle_details_view.js
@@ -19,7 +19,9 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 'use strict';
 
 describe('Browser bundle detail view', function() {
-  var Y, cleanUp, utils, data, container, view, fakestore, browser, models;
+
+  var browser, cleanUp, container, data, factory, fakestore, models, utils,
+      view, Y;
 
   before(function(done) {
     Y = YUI(GlobalConfig).use(
@@ -34,16 +36,18 @@ describe('Browser bundle detail view', function() {
         'subapp-browser-bundleview',
         'juju-view-utils',
         'juju-tests-utils',
+        'juju-tests-factory',
         'event-simulate',
         'node-event-simulate',
         function(Y) {
           models = Y.namespace('juju.models');
           utils = Y.namespace('juju-tests.utils');
+          factory = Y.namespace('juju-tests.factory');
           data = utils.loadFixture('data/browserbundle.json', true);
 
           // Required to register the handlebars helpers
           browser = new Y.juju.subapps.Browser({
-            store: utils.makeFakeStore()
+            store: factory.makeFakeStore()
           });
 
           done();
@@ -53,7 +57,7 @@ describe('Browser bundle detail view', function() {
   beforeEach(function() {
     view = generateBundleView();
     view._setupLocalFakebackend = function() {
-      this.fakebackend = utils.makeFakeBackend();
+      this.fakebackend = factory.makeFakeBackend();
     };
     cleanUp = utils.stubCharmIconPath();
   });
@@ -64,11 +68,15 @@ describe('Browser bundle detail view', function() {
     cleanUp();
   });
 
+  after(function() {
+    browser.destroy();
+  });
+
   function generateBundleView(options) {
     container = utils.makeContainer();
     container.append('<div class="bws-view-data"></div>');
     var defaults = {
-      store: utils.makeFakeStore(),
+      store: factory.makeFakeStore(),
       db: {},
       entityId: data.id,
       renderTo: container
@@ -92,7 +100,7 @@ describe('Browser bundle detail view', function() {
   });
 
   it('fetches the readme when requested', function(done) {
-    var fakeStore = utils.makeFakeStore();
+    var fakeStore = factory.makeFakeStore();
     fakeStore.file = function(id, filename, entityType, callbacks) {
       assert.equal(entityType, 'bundle');
       assert.equal(id, data.id);
@@ -110,7 +118,7 @@ describe('Browser bundle detail view', function() {
   });
 
   it('fetches a source file when requested', function(done) {
-    var fakeStore = utils.makeFakeStore();
+    var fakeStore = factory.makeFakeStore();
     fakeStore.file = function(id, filename, entityType, callbacks) {
       assert.equal(entityType, 'bundle');
       assert.equal(id, data.id);
@@ -356,7 +364,5 @@ describe('Browser bundle detail view', function() {
     var revnoLink = view._getRevnoLink(url, 1);
     assert.equal(expected + '/1', revnoLink);
   });
-
-
 
 });

--- a/test/test_bundle_module.js
+++ b/test/test_bundle_module.js
@@ -20,7 +20,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 describe('topology bundle module', function() {
   var utils, views, Y, bundleModule;
-  var bundle, container, fakebackend;
+  var bundle, container, factory, fakebackend;
 
   before(function(done) {
     Y = YUI(GlobalConfig).use([
@@ -29,10 +29,12 @@ describe('topology bundle module', function() {
       'juju-charm-store',
       'juju-models',
       'juju-tests-utils',
+      'juju-tests-factory',
       'node-event-simulate'
     ],
     function(Y) {
       utils = Y.namespace('juju-tests.utils');
+      factory = Y.namespace('juju-tests.factory');
       views = Y.namespace('juju.views');
       done();
     });
@@ -45,7 +47,7 @@ describe('topology bundle module', function() {
 
   function promiseBundle(options, visableContainer) {
     container = utils.makeContainer('canvas', true);
-    fakebackend = utils.makeFakeBackend();
+    fakebackend = factory.makeFakeBackend();
     fakebackend.db.environment.set('defaultSeries', 'precise');
 
     options = options || {};

--- a/test/test_charmworld.js
+++ b/test/test_charmworld.js
@@ -21,19 +21,19 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 (function() {
 
   describe('Charmworld API v3 interface', function() {
-    var Y, models, conn, data, juju, utils, charmworld, hostname, api;
-
+    var api, charmworld, conn, data, factory, hostname, juju, models, utils, Y;
 
     before(function(done) {
       Y = YUI(GlobalConfig).use(
           'datasource-local', 'json-stringify', 'juju-charm-store',
           'datasource-io', 'io', 'array-extras', 'juju-charm-models',
-          'juju-tests-utils', 'juju-bundle-models',
+          'juju-tests-factory', 'juju-tests-utils', 'juju-bundle-models',
           function(Y) {
             juju = Y.namespace('juju');
             charmworld = Y.namespace('juju.charmworld');
             models = Y.namespace('juju.models');
             utils = Y.namespace('juju-tests').utils;
+            factory = Y.namespace('juju-tests').factory;
             done();
           });
     });
@@ -248,7 +248,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     });
 
     it('finds upgrades for charms - upgrade available', function(done) {
-      var store = utils.makeFakeStore();
+      var store = factory.makeFakeStore();
       var charm = new models.Charm({url: 'cs:precise/wordpress-10'});
       store.promiseUpgradeAvailability(charm)
         .then(function(upgrade) {
@@ -261,7 +261,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     });
 
     it('finds upgrades for charms - no upgrade available', function(done) {
-      var store = utils.makeFakeStore();
+      var store = factory.makeFakeStore();
       var charm = new models.Charm({url: 'cs:precise/wordpress-15'});
       store.promiseUpgradeAvailability(charm)
         .then(function(upgrade) {
@@ -274,7 +274,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     });
 
     it('copies metadata while transforming results', function() {
-      var store = utils.makeFakeStore();
+      var store = factory.makeFakeStore();
       var fakebundle = {bundle: {id: 'bundle0'},
                          metadata: 'bundledata'};
       var fakecharm = {charm: {url: 'cs:precise/wordpress-15'},

--- a/test/test_endpoints.js
+++ b/test/test_endpoints.js
@@ -320,12 +320,13 @@ describe('Endpoints map', function() {
 });
 
 describe('Endpoints map handlers', function() {
-  var Y, juju, utils, models, app, conn, env, controller, destroyMe;
+  var app, conn, controller, destroyMe, env, factory, juju, models, utils, Y;
 
   before(function(done) {
     Y = YUI(GlobalConfig).use(['juju-gui',
                                'juju-models',
                                'juju-tests-utils',
+                               'juju-tests-factory',
                                'juju-endpoints-controller',
                                'juju-controllers',
                                'juju-charm-store',
@@ -333,6 +334,7 @@ describe('Endpoints map handlers', function() {
     function(Y) {
       juju = Y.namespace('juju');
       utils = Y.namespace('juju-tests.utils');
+      factory = Y.namespace('juju-tests.factory');
       models = Y.namespace('juju.models');
       done();
     });
@@ -347,7 +349,7 @@ describe('Endpoints map handlers', function() {
     app = new Y.juju.App({
       env: env,
       consoleEnabled: true,
-      store: utils.makeFakeStore()
+      store: factory.makeFakeStore()
     });
     app.showView(new Y.View());
     destroyMe.push(app);
@@ -383,7 +385,7 @@ describe('Endpoints map handlers', function() {
 
   it('should update endpoints map when non-pending services are added',
      function(done) {
-       var store = utils.makeFakeStore();
+       var store = factory.makeFakeStore();
        var service_name = 'wordpress';
        var charm_id = 'cs:precise/wordpress-2';
        app.db.charms.add({id: charm_id});

--- a/test/test_fakebackend.js
+++ b/test/test_fakebackend.js
@@ -93,18 +93,21 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
   describe('FakeBackend.deploy', function() {
     var requires = [
-      'node', 'juju-tests-utils', 'juju-models', 'juju-charm-models'];
-    var Y, fakebackend, utils, result, callback;
+      'node', 'juju-tests-utils', 'juju-tests-factory', 'juju-models',
+      'juju-charm-models'
+    ];
+    var Y, factory, fakebackend, utils, result, callback;
 
     before(function(done) {
       Y = YUI(GlobalConfig).use(requires, function(Y) {
         utils = Y.namespace('juju-tests.utils');
+        factory = Y.namespace('juju-tests.factory');
         done();
       });
     });
 
     beforeEach(function() {
-      fakebackend = utils.makeFakeBackend();
+      fakebackend = factory.makeFakeBackend();
       result = undefined;
       callback = function(response) {
         result = response;
@@ -388,18 +391,22 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
   describe('FakeBackend.setCharm', function() {
     var requires = [
-      'node', 'juju-tests-utils', 'juju-models', 'juju-charm-models'];
-    var Y, fakebackend, utils, result, callback, service;
+      'node', 'juju-tests-utils', 'juju-tests-factory', 'juju-models',
+      'juju-charm-models'
+    ];
+
+    var Y, factory, fakebackend, utils, result, callback, service;
 
     before(function(done) {
       Y = YUI(GlobalConfig).use(requires, function(Y) {
         utils = Y.namespace('juju-tests.utils');
+        factory = Y.namespace('juju-tests.factory');
         done();
       });
     });
 
     beforeEach(function() {
-      fakebackend = utils.makeFakeBackend();
+      fakebackend = factory.makeFakeBackend();
       result = undefined;
       callback = function(response) { result = response; };
       fakebackend.deploy('cs:precise/wordpress-15', callback);
@@ -450,18 +457,21 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
   describe('FakeBackend.expose', function() {
     var requires = [
-      'node', 'juju-tests-utils', 'juju-models', 'juju-charm-models'];
-    var Y, fakebackend, utils, result, callback, service;
+      'node', 'juju-tests-utils', 'juju-tests-factory', 'juju-models',
+      'juju-charm-models'
+    ];
+    var Y, factory, fakebackend, utils, result, callback, service;
 
     before(function(done) {
       Y = YUI(GlobalConfig).use(requires, function(Y) {
         utils = Y.namespace('juju-tests.utils');
+        factory = Y.namespace('juju-tests.factory');
         done();
       });
     });
 
     beforeEach(function() {
-      fakebackend = utils.makeFakeBackend();
+      fakebackend = factory.makeFakeBackend();
       result = undefined;
       callback = function(response) { result = response; };
       fakebackend.deploy('cs:precise/wordpress-15', callback);
@@ -508,18 +518,21 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
   describe('FakeBackend.unexpose', function() {
     var requires = [
-      'node', 'juju-tests-utils', 'juju-models', 'juju-charm-models'];
-    var Y, fakebackend, utils, result, callback, service;
+      'node', 'juju-tests-utils', 'juju-tests-factory', 'juju-models',
+      'juju-charm-models'
+    ];
+    var Y, factory, fakebackend, utils, result, callback, service;
 
     before(function(done) {
       Y = YUI(GlobalConfig).use(requires, function(Y) {
         utils = Y.namespace('juju-tests.utils');
+        factory = Y.namespace('juju-tests.factory');
         done();
       });
     });
 
     beforeEach(function() {
-      fakebackend = utils.makeFakeBackend();
+      fakebackend = factory.makeFakeBackend();
       result = undefined;
       callback = function(response) { result = response; };
       fakebackend.deploy('cs:precise/wordpress-15', callback);
@@ -566,19 +579,22 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
   });
 
   describe('FakeBackend deployer support', function() {
-    var requires = ['node',
-      'juju-tests-utils', 'juju-models', 'juju-charm-models'];
-    var Y, fakebackend, utils;
+    var requires = [
+      'node', 'juju-tests-utils', 'juju-tests-factory', 'juju-models',
+      'juju-charm-models'
+    ];
+    var Y, factory, fakebackend, utils;
 
     before(function(done) {
       Y = YUI(GlobalConfig).use(requires, function(Y) {
         utils = Y.namespace('juju-tests.utils');
+        factory = Y.namespace('juju-tests.factory');
         done();
       });
     });
 
     beforeEach(function() {
-      fakebackend = utils.makeFakeBackend();
+      fakebackend = factory.makeFakeBackend();
     });
 
     afterEach(function() {
@@ -588,47 +604,50 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     });
 
     it('should support YAML imports', function(done) {
-      utils.promiseImport('data/wp-deployer.yaml')
-        .then(function(resolve) {
-            var result = resolve.result;
-            fakebackend = resolve.backend;
-            assert.equal(result.Error, undefined);
-            assert.equal(result.DeploymentId, 1,
-                         'deployment id incorrect');
-            assert.isNotNull(fakebackend.db.services.getById('wordpress'),
-                             'failed to import wordpress');
-            assert.isNotNull(fakebackend.db.services.getById('mysql'),
-                             'failed to import mysql');
-            assert.equal(fakebackend.db.relations.size(), 1,
-                         'failed to import relations');
-            // Verify units created.
-            assert.equal(fakebackend.db.services.getById('wordpress')
-                         .get('units').size(), 2,
-                         'Unit count wrong');
+      utils.promiseImport(
+          'data/wp-deployer.yaml',
+          undefined,
+          factory.makeFakeBackend()
+      ).then(function(resolve) {
+        var result = resolve.result;
+        fakebackend = resolve.backend;
+        assert.equal(result.Error, undefined);
+        assert.equal(result.DeploymentId, 1,
+                     'deployment id incorrect');
+        assert.isNotNull(fakebackend.db.services.getById('wordpress'),
+                         'failed to import wordpress');
+        assert.isNotNull(fakebackend.db.services.getById('mysql'),
+                         'failed to import mysql');
+        assert.equal(fakebackend.db.relations.size(), 1,
+                     'failed to import relations');
+        // Verify units created.
+        assert.equal(fakebackend.db.services.getById('wordpress')
+                     .get('units').size(), 2,
+                     'Unit count wrong');
 
-            // Verify config.
-            var wordpress = fakebackend.db.services.getById('wordpress');
-            var wordpressCharm = fakebackend.db.charms.getById(
-                'cs:precise/wordpress-15');
-            var mysql = fakebackend.db.services.getById('mysql');
-            // This value is different from the default (nginx).
-            assert.equal(wordpressCharm.get('options.engine.default'), 'nginx');
-            assert.equal(wordpress.get('config.engine'), 'apache');
-            // This value is the default, as provided by the charm.
-            assert.equal(wordpress.get('config.tuning'), 'single');
-            assert.isTrue(wordpress.get('exposed'));
-            assert.isFalse(mysql.get('exposed'));
+        // Verify config.
+        var wordpress = fakebackend.db.services.getById('wordpress');
+        var wordpressCharm = fakebackend.db.charms.getById(
+            'cs:precise/wordpress-15');
+        var mysql = fakebackend.db.services.getById('mysql');
+        // This value is different from the default (nginx).
+        assert.equal(wordpressCharm.get('options.engine.default'), 'nginx');
+        assert.equal(wordpress.get('config.engine'), 'apache');
+        // This value is the default, as provided by the charm.
+        assert.equal(wordpress.get('config.tuning'), 'single');
+        assert.isTrue(wordpress.get('exposed'));
+        assert.isFalse(mysql.get('exposed'));
 
-            // Constraints
-            var constraints = mysql.get('constraints');
-            assert.equal(constraints['cpu-power'], '2', 'wrong cpu power');
-            assert.equal(constraints['cpu-cores'], '4', 'wrong cpu cores');
-            done();
-          }).then(undefined, done);
+        // Constraints
+        var constraints = mysql.get('constraints');
+        assert.equal(constraints['cpu-power'], '2', 'wrong cpu power');
+        assert.equal(constraints['cpu-cores'], '4', 'wrong cpu cores');
+        done();
+      }).then(undefined, done);
     });
 
     it('should stop importing if service names conflict', function(done) {
-      var fakebackend = utils.makeFakeBackend();
+      var fakebackend = factory.makeFakeBackend();
       // If there is a problem within the promises `done` will be called
       // at the end of each promise chain with the error.
       utils.promiseImport('data/wp-deployer.yaml', null, fakebackend)
@@ -646,29 +665,31 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     });
 
     it('should provide status of imports', function(done) {
-      utils.promiseImport('data/wp-deployer.yaml')
-        .then(function(resolve) {
-            fakebackend = resolve.backend;
-            fakebackend.statusDeployer(
-                function(status) {
-                  assert.lengthOf(status.LastChanges, 1);
-                  assert.equal(status.LastChanges[0].Status, 'completed');
-                  assert.equal(status.LastChanges[0].DeploymentId, 1);
-                  assert.isNumber(status.LastChanges[0].Timestamp);
-                  done();
-                });
-          });
+      utils.promiseImport(
+          'data/wp-deployer.yaml',
+          undefined,
+          factory.makeFakeBackend()
+      ).then(function(resolve) {
+        fakebackend = resolve.backend;
+        fakebackend.statusDeployer(function(status) {
+          assert.lengthOf(status.LastChanges, 1);
+          assert.equal(status.LastChanges[0].Status, 'completed');
+          assert.equal(status.LastChanges[0].DeploymentId, 1);
+          assert.isNumber(status.LastChanges[0].Timestamp);
+          done();
+        });
+      });
     });
 
     it('throws an error with more than one import target', function() {
-      fakebackend = utils.makeFakeBackend();
+      fakebackend = factory.makeFakeBackend();
       assert.throws(function() {
         fakebackend.importDeployer({a: {}, b: {}});
       }, 'Import target ambigious, aborting.');
     });
 
     it('detects service id collisions', function(done) {
-      fakebackend = utils.makeFakeBackend();
+      fakebackend = factory.makeFakeBackend();
       fakebackend.db.services.add({id: 'mysql', charm: 'cs:precise/mysql-26'});
       var data = {
         a: {services: {mysql: {
@@ -683,7 +704,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     });
 
     it('properly implements inheritence in target definitions', function(done) {
-      fakebackend = utils.makeFakeBackend();
+      fakebackend = factory.makeFakeBackend();
       var data = {
         a: {services: {mysql: {charm: 'cs:precise/mysql-26',
           num_units: 2, options: {debug: false}}}},
@@ -711,7 +732,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     });
 
     it('properly builds relations on import', function(done) {
-      fakebackend = utils.makeFakeBackend();
+      fakebackend = factory.makeFakeBackend();
       var data = {
         a: {
           services: {
@@ -725,7 +746,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
           relations: [['mysql', 'wordpress']]
         }};
 
-      fakebackend.promiseImport(data)
+      fakebackend.promiseImport(data, undefined, factory.makeFakeBackend())
           .then(function() {
             var mysql = fakebackend.db.services.getById('mysql');
             var wordpress = fakebackend.db.services.getById('wordpress');
@@ -748,22 +769,25 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       // Use import to import many charms and then resolve them with a few
       // different keys.
       var defaultSeries = 'precise';
-      utils.promiseImport('data/blog.yaml', 'wordpress-prod')
-        .then(function(resolve) {
-            var db = resolve.backend.db;
-            assert.isNotNull(db.charms.find('wordpress', defaultSeries));
-            assert.isNotNull(db.charms.find('precise/wordpress',
-                                            defaultSeries));
-            assert.isNotNull(db.charms.find('precise/wordpress'));
-            assert.isNotNull(db.charms.find('cs:precise/wordpress'));
-            assert.isNotNull(db.charms.find('cs:precise/wordpress-999'));
-            // Can't find this w/o a series
-            assert.isNull(db.charms.find('wordpress'));
-            // Find fails on missing items as well.
-            assert.isNull(db.charms.find('foo'));
-            assert.isNull(db.charms.find('foo', defaultSeries));
-            done();
-          }).then(undefined, done);
+      utils.promiseImport(
+          'data/blog.yaml',
+          'wordpress-prod',
+          factory.makeFakeBackend()
+      ).then(function(resolve) {
+        var db = resolve.backend.db;
+        assert.isNotNull(db.charms.find('wordpress', defaultSeries));
+        assert.isNotNull(db.charms.find('precise/wordpress',
+                                        defaultSeries));
+        assert.isNotNull(db.charms.find('precise/wordpress'));
+        assert.isNotNull(db.charms.find('cs:precise/wordpress'));
+        assert.isNotNull(db.charms.find('cs:precise/wordpress-999'));
+        // Can't find this w/o a series
+        assert.isNull(db.charms.find('wordpress'));
+        // Find fails on missing items as well.
+        assert.isNull(db.charms.find('foo'));
+        assert.isNull(db.charms.find('foo', defaultSeries));
+        done();
+      }).then(undefined, done);
     });
 
     it('should ignore calls to the deployer watcher', function(done) {
@@ -790,19 +814,22 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
   });
 
   describe('FakeBackend.uniformOperations', function() {
-    var requires = ['node',
-      'juju-tests-utils', 'juju-models', 'juju-charm-models'];
-    var Y, fakebackend, utils;
+    var requires = [
+      'node', 'juju-tests-utils', 'juju-tests-factory', 'juju-models',
+      'juju-charm-models'
+    ];
+    var Y, factory, fakebackend, utils;
 
     before(function(done) {
       Y = YUI(GlobalConfig).use(requires, function(Y) {
         utils = Y.namespace('juju-tests.utils');
+        factory = Y.namespace('juju-tests.factory');
         done();
       });
     });
 
     beforeEach(function() {
-      fakebackend = utils.makeFakeBackend();
+      fakebackend = factory.makeFakeBackend();
     });
 
     afterEach(function() {
@@ -1105,18 +1132,21 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
   describe('FakeBackend.addUnit', function() {
     var requires = [
-      'node', 'juju-tests-utils', 'juju-models', 'juju-charm-models'];
-    var Y, fakebackend, utils, deployResult, callback;
+      'node', 'juju-tests-utils', 'juju-tests-factory', 'juju-models',
+      'juju-charm-models'
+    ];
+    var Y, factory, fakebackend, utils, deployResult, callback;
 
     before(function(done) {
       Y = YUI(GlobalConfig).use(requires, function(Y) {
         utils = Y.namespace('juju-tests.utils');
+        factory = Y.namespace('juju-tests.factory');
         done();
       });
     });
 
     beforeEach(function() {
-      fakebackend = utils.makeFakeBackend();
+      fakebackend = factory.makeFakeBackend();
       deployResult = undefined;
       callback = function(response) { deployResult = response; };
     });
@@ -1221,19 +1251,23 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
   describe('FakeBackend.removeUnit', function() {
     var requires = [
-      'node', 'juju-tests-utils', 'juju-models', 'juju-charm-models'];
-    var Y, fakebackend, utils, unitsRemoveData = '',
+      'node', 'juju-tests-utils', 'juju-tests-factory', 'juju-models',
+      'juju-charm-models'
+    ];
+    var Y, factory, fakebackend, utils;
+    var unitsRemoveData = '',
         removeCalled = 0;
 
     before(function(done) {
       Y = YUI(GlobalConfig).use(requires, function(Y) {
         utils = Y.namespace('juju-tests.utils');
+        factory = Y.namespace('juju-tests.factory');
         done();
       });
     });
 
     beforeEach(function() {
-      fakebackend = utils.makeFakeBackend();
+      fakebackend = factory.makeFakeBackend();
     });
 
     afterEach(function() {
@@ -1329,18 +1363,21 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
   describe('FakeBackend.next*', function() {
     var requires = [
-      'node', 'juju-tests-utils', 'juju-models', 'juju-charm-models'];
-    var Y, fakebackend, utils, deployResult, callback;
+      'node', 'juju-tests-utils', 'juju-tests-factory', 'juju-models',
+      'juju-charm-models'
+    ];
+    var Y, factory, fakebackend, utils, deployResult, callback;
 
     before(function(done) {
       Y = YUI(GlobalConfig).use(requires, function(Y) {
         utils = Y.namespace('juju-tests.utils');
+        factory = Y.namespace('juju-tests.factory');
         done();
       });
     });
 
     beforeEach(function() {
-      fakebackend = utils.makeFakeBackend();
+      fakebackend = factory.makeFakeBackend();
       deployResult = undefined;
       callback = function(response) { deployResult = response; };
     });
@@ -1452,18 +1489,21 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
   describe('FakeBackend.addRelation', function() {
     var requires = [
-      'node', 'juju-tests-utils', 'juju-models', 'juju-charm-models'];
-    var Y, fakebackend, utils, deployResult, callback;
+      'node', 'juju-tests-utils', 'juju-tests-factory', 'juju-models',
+      'juju-charm-models'
+    ];
+    var Y, factory, fakebackend, utils, deployResult, callback;
 
     before(function(done) {
       Y = YUI(GlobalConfig).use(requires, function(Y) {
         utils = Y.namespace('juju-tests.utils');
+        factory = Y.namespace('juju-tests.factory');
         done();
       });
     });
 
     beforeEach(function() {
-      fakebackend = utils.makeFakeBackend();
+      fakebackend = factory.makeFakeBackend();
       deployResult = undefined;
       callback = function(response) { deployResult = response; };
     });
@@ -1726,18 +1766,21 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
   describe('FakeBackend.removeRelation', function() {
     var requires = [
-      'node', 'juju-tests-utils', 'juju-models', 'juju-charm-models'];
-    var Y, fakebackend, utils;
+      'node', 'juju-tests-utils', 'juju-tests-factory', 'juju-models',
+      'juju-charm-models'
+    ];
+    var Y, factory, fakebackend, utils;
 
     before(function(done) {
       Y = YUI(GlobalConfig).use(requires, function(Y) {
         utils = Y.namespace('juju-tests.utils');
+        factory = Y.namespace('juju-tests.factory');
         done();
       });
     });
 
     beforeEach(function() {
-      fakebackend = utils.makeFakeBackend();
+      fakebackend = factory.makeFakeBackend();
     });
 
     afterEach(function() {

--- a/test/test_model_controller.js
+++ b/test/test_model_controller.js
@@ -19,19 +19,21 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 'use strict';
 
 describe('Model Controller Promises', function() {
-  var modelController, yui, env, db, conn, environment, load, serviceError,
-      getService, cleanups, aEach, utils;
+  var aEach, cleanups, conn, db, env, environment, factory, getService,
+      load, modelController, serviceError, utils, yui, Y;
 
   before(function(done) {
     YUI(GlobalConfig).use(
-        'juju-models', 'model-controller', 'juju-charm-models',
-        'juju-view-environment', 'juju-tests-utils', function(Y) {
+        'juju-charm-models', 'juju-models', 'juju-tests-factory',
+        'juju-tests-utils', 'juju-view-environment', 'model-controller',
+        function(Y) {
           var environments = Y.juju.environments;
           yui = Y;
           load = Y.juju.models.Charm.prototype.load;
           getService = environments.PythonEnvironment.prototype.get_service;
           aEach = Y.Array.each;
           utils = Y.namespace('juju-tests.utils');
+          factory = Y.namespace('juju-tests.factory');
           done();
         });
   });
@@ -45,7 +47,7 @@ describe('Model Controller Promises', function() {
     modelController = new yui.juju.ModelController({
       db: db,
       env: env,
-      store: utils.makeFakeStore()
+      store: factory.makeFakeStore()
     });
     cleanups = [];
   });
@@ -258,7 +260,7 @@ describe('Model Controller Promises', function() {
       loaded: true,
       charm: charmId
     });
-    modelController.set('store', utils.makeFakeStore());
+    modelController.set('store', factory.makeFakeStore());
     var promise = modelController.getServiceWithCharm(serviceId);
     promise.then(
         function(result) {

--- a/test/test_sandbox_go.js
+++ b/test/test_sandbox_go.js
@@ -22,23 +22,24 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
   describe('sandbox.GoJujuAPI', function() {
     var requires = [
-      'jsyaml',
-      'juju-env-sandbox', 'juju-tests-utils', 'juju-env-go',
-      'juju-models', 'promise'];
-    var Y, sandboxModule, ClientConnection, environmentsModule, state, juju,
-        client, env, utils;
+      'jsyaml', 'juju-env-sandbox', 'juju-tests-utils',
+      'juju-tests-factory', 'juju-env-go', 'juju-models', 'promise'
+    ];
+    var client, env, environmentsModule, factory, juju,
+        sandboxModule, state, utils, Y;
 
     before(function(done) {
       Y = YUI(GlobalConfig).use(requires, function(Y) {
         sandboxModule = Y.namespace('juju.environments.sandbox');
         environmentsModule = Y.namespace('juju.environments');
         utils = Y.namespace('juju-tests.utils');
+        factory = Y.namespace('juju-tests.factory');
         done();
       });
     });
 
     beforeEach(function() {
-      state = utils.makeFakeBackend();
+      state = factory.makeFakeBackend();
       juju = new sandboxModule.GoJujuAPI({state: state});
       client = new sandboxModule.ClientConnection({juju: juju});
       env = new environmentsModule.GoEnvironment({conn: client});

--- a/test/test_sandbox_python.js
+++ b/test/test_sandbox_python.js
@@ -22,22 +22,24 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
   describe('sandbox.PyJujuAPI', function() {
     var requires = [
-      'juju-env-sandbox', 'juju-tests-utils', 'juju-env-python',
-      'juju-models', 'promise'];
-    var Y, sandboxModule, ClientConnection, environmentsModule, state, juju,
-        client, env, utils, cleanups;
+      'juju-env-sandbox', 'juju-tests-utils', 'juju-tests-factory',
+      'juju-env-python', 'juju-models', 'promise'
+    ];
+    var cleanups, client, env, environmentsModule, factory,
+        juju, sandboxModule, state, utils, Y;
 
     before(function(done) {
       Y = YUI(GlobalConfig).use(requires, function(Y) {
         sandboxModule = Y.namespace('juju.environments.sandbox');
         environmentsModule = Y.namespace('juju.environments');
         utils = Y.namespace('juju-tests.utils');
+        factory = Y.namespace('juju-tests.factory');
         done();
       });
     });
 
     beforeEach(function() {
-      state = utils.makeFakeBackend();
+      state = factory.makeFakeBackend();
       juju = new sandboxModule.PyJujuAPI({state: state});
       client = new sandboxModule.ClientConnection({juju: juju});
       env = new environmentsModule.PythonEnvironment({conn: client});
@@ -336,7 +338,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     });
 
     it('can deploy.', function(done) {
-      // We begin logged in.  See utils.makeFakeBackend.
+      // We begin logged in.  See factory.makeFakeBackend.
       var data = {
         op: 'deploy',
         charm_url: 'cs:precise/wordpress-15',
@@ -374,7 +376,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     });
 
     it('can deploy (environment integration).', function(done) {
-      // We begin logged in.  See utils.makeFakeBackend.
+      // We begin logged in.  See factory.makeFakeBackend.
       env.after('defaultSeriesChange', function() {
         var callback = function(result) {
           assert.isUndefined(result.err);

--- a/test/test_simulator.js
+++ b/test/test_simulator.js
@@ -43,9 +43,10 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
   describe('FakeBackend.simulator', function() {
     var requires = ['node',
-      'juju-tests-utils', 'juju-models', 'juju-charm-models',
-      'juju-fakebackend-simulator'];
-    var Y, state, Simulator, simulator, utils, Agent, DEFAULT_AGENTS;
+      'juju-tests-utils', 'juju-tests-factory', 'juju-models',
+      'juju-charm-models', 'juju-fakebackend-simulator'
+    ];
+    var Agent, DEFAULT_AGENTS, factory, simulator, Simulator, state, utils, Y;
 
     before(function(done) {
       Y = YUI(GlobalConfig).use(requires, function(Y) {
@@ -54,16 +55,20 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
         Agent = ns.Agent;
         DEFAULT_AGENTS = ns.DEFAULT_AGENTS;
         utils = Y.namespace('juju-tests.utils');
+        factory = Y.namespace('juju-tests.factory');
         done();
       });
     });
 
     beforeEach(function(done) {
-      utils.promiseImport('data/wp-deployer.yaml', 'wordpress-prod')
-      .then(function(resolve) {
-            state = resolve.backend;
-            done();
-          });
+      utils.promiseImport(
+          'data/wp-deployer.yaml',
+          'wordpress-prod',
+          factory.makeFakeBackend()
+      ).then(function(resolve) {
+        state = resolve.backend;
+        done();
+      });
     });
 
     afterEach(function() {

--- a/test/test_topology.js
+++ b/test/test_topology.js
@@ -19,15 +19,14 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 'use strict';
 
 describe('topology', function() {
-  var Y, NS, views,
-      TestModule, modA, state,
-      container, topo, utils,
-      models, db;
+  var NS, TestModule, container, db, factory, modA, models, state, topo,
+      utils, views, Y;
 
   before(function(done) {
     Y = YUI(GlobalConfig).use(['juju-topology',
                                'd3-components',
                                'juju-tests-utils',
+                               'juju-tests-factory',
                                'juju-view-bundle',
                                'node',
                                'node-event-simulate'],
@@ -36,6 +35,7 @@ describe('topology', function() {
       views = Y.namespace('juju.views');
       models = Y.namespace('juju.models');
       utils = Y.namespace('juju-tests.utils');
+      factory = Y.namespace('juju-tests.factory');
 
       TestModule = Y.Base.create('TestModule', NS.Module, [], {
         events: {
@@ -116,30 +116,33 @@ describe('topology', function() {
     container.destroy(true);
     container = utils.makeContainer();
 
-    utils.promiseImport('data/wp-deployer.yaml', 'wordpress-prod')
-    .then(function(resolve) {
-          // Init the topo with the db at this point and ...
-          var fakebackend = resolve.backend;
-          var bundle = new views.BundleTopology({
-            container: container,
-            size: [320, 240],
-            db: fakebackend.db,
-            store: fakebackend.get('store')}).render();
+    utils.promiseImport(
+        'data/wp-deployer.yaml',
+        'wordpress-prod',
+        factory.makeFakeBackend()
+    ).then(function(resolve) {
+      // Init the topo with the db at this point and ...
+      var fakebackend = resolve.backend;
+      var bundle = new views.BundleTopology({
+        container: container,
+        size: [320, 240],
+        db: fakebackend.db,
+        store: fakebackend.get('store')}).render();
 
-          // The size of the element should reflect the passed in params
-          var svg = d3.select(container.getDOMNode()).select('svg');
-          assert.equal(svg.attr('width'), 320);
-          assert.equal(svg.attr('height'), 240);
+      // The size of the element should reflect the passed in params
+      var svg = d3.select(container.getDOMNode()).select('svg');
+      assert.equal(svg.attr('width'), 320);
+      assert.equal(svg.attr('height'), 240);
 
-          // We should have the two rendered services
-          assert.equal(container.all('.service').size(), 2);
-          // and the one relation between them
-          assert.equal(container.all('.relation').size(), 1);
+      // We should have the two rendered services
+      assert.equal(container.all('.service').size(), 2);
+      // and the one relation between them
+      assert.equal(container.all('.relation').size(), 1);
 
-          container.remove(true);
-          bundle.destroy();
-          done();
-        }).then(undefined, done);
+      container.remove(true);
+      bundle.destroy();
+      done();
+    }).then(undefined, done);
   });
 
   describe('servicePointOutside', function() {


### PR DESCRIPTION
- Move the existing methods over to it and refactor all the things.
- Drive by to sort and cleanup.
- Remove the circular import between utils/factory and update calls to always
  pass the fake backend.
## QA

It's a very mechanical change. Tests should pass. No tests were added or removed in the making of this pull request. 
