### PR TITLE
Fixed lingering pending class on new services.

### DIFF
--- a/app/views/topology/service.js
+++ b/app/views/topology/service.js
@@ -120,6 +120,7 @@ YUI.add('juju-topology-service', function(Y) {
       return d.subordinate;
     })
         .classed('subordinate', true);
+    node.classed('pending', function(d) { return d.pending; });
 
     // Size the node for drawing.
     node.attr({

--- a/test/test_service_module.js
+++ b/test/test_service_module.js
@@ -266,6 +266,19 @@ describe('service module events', function() {
     assert.deepPropertyVal(boxes, 'wordpress.model', wordpress);
   });
 
+  it('should fade pending services but not deployed services', function() {
+    db.services.add([
+      {id: 'rails', pending: true}
+    ]);
+    serviceModule.update();
+    assert.isTrue(topo.service_boxes.rails.pending);
+    assert.isFalse(topo.service_boxes.haproxy.pending);
+    // Assert that there are two services on the canvas, but only one is
+    // classed pending.
+    assert.equal(topo.vis.selectAll('.service')[0].length, 2);
+    assert.equal(topo.vis.selectAll('.service.pending')[0].length, 1);
+  });
+
   it('should deploy a service on charm token drop events', function(done) {
     var src = '/juju-ui/assets/svgs/service_health_mask.svg',
         preventCount = 0,


### PR DESCRIPTION
Newly created services (ghosts) still had the pending class because it was not removed on update, only on create.
