### PR TITLE
Make sure minimized updates view state.

### DIFF
--- a/app/subapps/browser/browser.js
+++ b/app/subapps/browser/browser.js
@@ -532,7 +532,6 @@ YUI.add('subapp-browser', function(Y) {
         deployService: this.get('deployService')
       };
 
-
       // If the only thing that changed was the hash, then don't redraw. It's
       // just someone clicking a tab in the UI.
       if (this._details && this._hasStateChanged('hash') &&
@@ -681,6 +680,9 @@ YUI.add('subapp-browser', function(Y) {
       this._minimized.set(
           'oldViewMode',
           this._oldState.viewmode ? this._oldState.viewmode : 'sidebar');
+
+      this._saveState();
+      next();
     },
 
     /**
@@ -996,9 +998,6 @@ YUI.add('subapp-browser', function(Y) {
         } else {
           minview.hide();
           browser.show();
-          // @todo remove this when the browser is in the default view since
-          // we'll be using the hidden/minimized to move it back.
-          this.get('container').setStyle('display', 'block');
         }
       }
     }

--- a/test/test_browser_app.js
+++ b/test/test_browser_app.js
@@ -467,6 +467,34 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
         // The viewmode should be populated now to the default.
         assert.equal(req.params, undefined);
       });
+
+      it('minmized updates state and moves to next', function() {
+        app = new browser.Browser({
+          store: new CharmworldAPI({
+            'apiHost': 'http://localhost',
+            'noop': true
+          })
+        });
+
+        // Set _minimized to prevent it from actually rendering the View. We
+        // only care about the state management going no.
+        app._minimized = {
+          set: function() {},
+          destroy: function() {}
+        };
+
+        // And we hard set that the viewmode was in _sidebar.
+        app._viewState.viewmode = 'sidebar';
+
+        var req = {
+          'viewmode': 'minimized'
+        };
+
+        app.minimized(req, null, next);
+        assert.equal(app._viewState.viewmode, 'sidebar');
+        assert.equal(app._oldState.viewmode, 'sidebar');
+
+      });
     });
 
     describe('browser subapp display tree', function() {


### PR DESCRIPTION
Minimized did not update the _viewState and _oldState when called. This caused https://launchpad.net/bugs/1260831 because the browser app was not properly detecting changes in viewmode and cleaning up after itself along with loading valid previous state (in this case the search values)

This update the minimized function to update the state. It should also be calling next() like the sidebar() call.

QA:

Perform the steps in the bug. It should not be reproduceable.
