### PR TITLE
Update the link to the charm quality docs

### DIFF
--- a/app/subapps/browser/templates/browser_qa.handlebars
+++ b/app/subapps/browser/templates/browser_qa.handlebars
@@ -4,10 +4,10 @@
     Charm reviewers verify that recommended charms conform to <a
     href="https://juju.ubuntu.com/docs/authors-charm-policy.html">the
     requirements listed by the Charm Store Policy</a>.  Additionally,
-    reviewers evaluate charms using <a href="https://juju.ubuntu.com/docs
-    /authors-charm-quality.html">a standardized feature list</a>. This list
-    includes data handling, security, reliability, flexibility, and other
-    capabilities.
+    reviewers evaluate charms using
+    <a href="https://juju.ubuntu.com/docs/authors-charm-quality.html">a standardized feature list</a>.
+    This list includes data handling, security, reliability, flexibility, and
+    other capabilities.
 </p>
 {{#if totalScore}}
     <p>


### PR DESCRIPTION
Per bug https://bugs.launchpad.net/juju-gui/+bug/1257878 the docs to the quality information moved and the Features tab for charms needed updating. That's all that's been changed. 
