### PR TITLE
Fix support for displaying number of units in bundle view

### DIFF
--- a/app/templates/bundle.handlebars
+++ b/app/templates/bundle.handlebars
@@ -170,9 +170,10 @@
                                         <li>Service name: {{ origService.name }}</li>
                                         {{#unless charmModel.is_subordinate}}
                                             <li>
+
                                                 Number of units:
-                                                {{#if num_units }}
-                                                    {{ num_units }}
+                                                {{#if origService.data.num_units }}
+                                                    {{ origService.data.num_units }}
                                                 {{else}}
                                                     1
                                                 {{/if}}

--- a/test/test_bundle_details_view.js
+++ b/test/test_bundle_details_view.js
@@ -97,6 +97,11 @@ describe('Browser bundle detail view', function() {
 
     assert.notEqual(container.get('innerHTML').indexOf('Deployed 5'), -1,
         'Download count is not added to the page.');
+
+    // Verify that the num_units is represented correctly.
+    assert(
+        container.one('.charm-config').get('innerHTML').match(/units:\s+5/),
+        'Expected to find the number of units to be 5, but not found.');
   });
 
   it('fetches the readme when requested', function(done) {


### PR DESCRIPTION
Currently all unit counts in the bundle display are showing the default of 1. The num_units attribute is actually buried as you can see in the other attribute access above (origService.name).

This fixes the access and adds a quick assertion that it's getting picked up. 

To QA:

Load http://gui:8888/sidebar/search/bundle/~gary/demo/2/instantBigDataNoSQL/?text=gary#bws-services and make sure that the unit counts are correct. They should not all be 1.
