### PR TITLE
Ignore in-flight ac suggestions on submit.

### DIFF
--- a/app/widgets/charm-search.js
+++ b/app/widgets/charm-search.js
@@ -103,6 +103,20 @@ YUI.add('browser-search-widget', function(Y) {
     },
 
     /**
+     * When the AC input has focus adjust css properties to note it's active.
+     *
+     * @method _handleInputFocus
+     * @param {Event} ev the focus event from YUI.
+     *
+     */
+    _handleInputFocus: function(ev) {
+      // Make sure we reset to respond to suggestions coming in.
+      this.ignoreInFlight = false;
+      // Update the styling to represent an active input.
+      this._setActive();
+    },
+
+    /**
      * Halt page reload from form submit and let the app know we have a new
      * search.
      *
@@ -463,13 +477,7 @@ YUI.add('browser-search-widget', function(Y) {
               'submit', this._handleSubmit, this)
       );
       this.addEvent(
-          container.one('input').on(
-              'focus', function() {
-                // Make sure we reset to respond to suggestions coming in.
-                this.ignoreInFlight = false;
-                // Update the styling to represent an active input.
-                this._setActive();
-          }, this)
+          container.one('input').on('focus', this._handleInputFocus, this)
       );
       this.addEvent(
           container.one('input').on(

--- a/test/test_browser_search_widget.js
+++ b/test/test_browser_search_widget.js
@@ -287,7 +287,11 @@ describe('search widget autocomplete', function() {
     search.get('boundingBox').one('form').simulate('submit');
     assert.equal(search.ignoreInFlight, true);
     search.get('boundingBox').one('input').simulate('focus');
-    search.get('boundingBox').one('input').trigger('focus');
+    // IE does not trigger a focus event through simulate so we call the
+    // function directly.
+    if (Y.UA.ie) {
+      search._handleInputFocus();
+    }
     assert.equal(search.ignoreInFlight, false);
   });
 


### PR DESCRIPTION
- See #1237457

If you hit submit while there's an ongoing ajax request for completion
suggestions the timing can be that you get suggestions overlaying your real
results

This adds a simple flag 'off' that is used to track if we should ignore those
in flight suggestions when they come back.

QA:

Compare the results of the test from the bug on comingsoon vs this branch.
When you hit enter quickly after the 'i' in wiki you should not get the
results popup while you do on comingsoon.
