### PR TITLE
Notify in the inspector when a service is dying.

### DIFF
--- a/app/templates/inspector-header.handlebars
+++ b/app/templates/inspector-header.handlebars
@@ -22,8 +22,12 @@
   </div>
 </header>
 {{#unless ghost}}
-  <div data-bind="charmChanged" class="charm-changed hidden inspector-buttons">
+  <div data-bind="charmChanged"
+       class="inspector-header-message hidden inspector-buttons">
       <p>{{displayName}} has been upgraded to <span data-bind="charm"></span>. Please reload the inspector.</p>
       <a class="rerender-config">Reload</a>
+  </div>
+  <div data-bind="life" class="inspector-header-message hidden">
+    <p>This service is being destroyed</p>
   </div>
 {{/unless}}

--- a/app/views/viewlets/inspector-header.js
+++ b/app/views/viewlets/inspector-header.js
@@ -43,6 +43,17 @@ YUI.add('viewlet-inspector-header', function(Y) {
             }
           }
         }
+      },
+      life: {
+        'update': function(node, value) {
+          // Show/hide the "service being destroyed" message in the inspector
+          // header based on the current life-cycle status of the service.
+          if (value === 'dying') {
+            node.removeClass('hidden');
+          } else {
+            node.addClass('hidden');
+          }
+        }
       }
     },
     'render': function(model, viewContainerAttrs) {

--- a/lib/views/juju-inspector.less
+++ b/lib/views/juju-inspector.less
@@ -596,7 +596,7 @@
                 }
 
             }
-            .charm-changed {
+            .inspector-header-message {
                 background-color: @charm-panel-background-color;
                 border-bottom: 1px solid @inspector-divider-bottom;
                 border-top: 1px solid @inspector-divider-top;

--- a/test/test_inspector_overview.js
+++ b/test/test_inspector_overview.js
@@ -857,20 +857,37 @@ describe('Inspector Overview', function() {
 
     var service = db.services.getById('mediawiki');
     assert.isFalse(service.get('charmChanged'));
-    assert.isTrue(newContainer.one('.charm-changed').hasClass('hidden'));
+    assert.isTrue(
+        newContainer.one('[data-bind=charmChanged]').hasClass('hidden'));
 
     db.onDelta({data: {result: [
       ['unit', 'change', {id: unitId, charmUrl: 'cs:precise/mediawiki-15'}]
     ]}});
 
     assert.isTrue(service.get('charmChanged'));
-    assert.isFalse(newContainer.one('.charm-changed').hasClass('hidden'));
+    assert.isFalse(
+        newContainer.one('[data-bind=charmChanged]').hasClass('hidden'));
     inspector.viewletManager.get('environment')
       .createServiceInspector = function(model, attrs) {
           assert.isFalse(model.get('charmChanged'));
           done();
         };
     newContainer.one('.rerender-config').simulate('click');
+  });
+
+  it('reflects that a service is dying', function() {
+    var inspector = setUpInspector();
+    var viewlets = inspector.viewletManager.viewlets;
+    var newContainer = viewlets.inspectorHeader.container;
+    var service = db.services.getById('mediawiki');
+    // The service is considered to be alive by default.
+    assert.strictEqual(service.get('life'), 'alive');
+    assert.strictEqual(
+        newContainer.one('[data-bind=life]').hasClass('hidden'), true);
+    // The inspector message is shown when the service's life is set to dying.
+    service.set('life', 'dying');
+    assert.strictEqual(
+        newContainer.one('[data-bind=life]').hasClass('hidden'), false);
   });
 
   it('toggles exposure', function() {


### PR DESCRIPTION
QA:
Test the functionality in a sandbox GUI instance:
- `make devel`;
- deploy a service;
- open the inspector for that service;
- open the JavaScript console and run:
  `app.db.services.item(0).set('life', 'dying');`
- you should see the "service is being destroyed" message
  in the inspector.

Test the functionality in a real Juju environment.
- bootstrap an environment and deploy the gui (e.g. with juju-quickstart);
- run `juju set juju-gui juju-gui-source="https://github.com/frankban/juju-gui.git dying-service"` 
  and wait some minutes for the new release to be built: 
  you can observe the progress with `juju debug-log` or running
  `tailf ~/.juju/local/log/unit-juju-gui-0.log` if you are using a local env;
- deploy a service;
- open the inspector for that service;
- destroy the service, either by using the inspector "destroy" button or
  the cli command;
- you should see the "service is being destroyed" message
  in the inspector.
