### PR TITLE
Adding drag and drop support for local charm zip uploads

### DIFF
--- a/app/assets/javascripts/bundle-import-helpers.js
+++ b/app/assets/javascripts/bundle-import-helpers.js
@@ -82,7 +82,8 @@ YUI.add('bundle-import-helpers', function(Y) {
       utility.
 
       @method deployBundleFiles
-      @param {Array} fileSources The list of files from the import control.
+      @param {Array | Object} fileSources A list of files or file from the
+        bundle import control.
       @param {Environment} env Environment with access to the bundle back end.
       calls.
       @param {Database} db The app Database with access to the NotificationList.
@@ -101,7 +102,11 @@ YUI.add('bundle-import-helpers', function(Y) {
         return;
       }
 
-      // Handle dropping Deployer files on the canvas.
+      // Handle dropping Deployer files on the canvas. The current
+      // implementation of the canvasDropHandler loops through the files
+      // and sends individual requests but this method can support being
+      // send the fileSources object for multiple bundle files so we test
+      // for that here.
       if (!Y.Lang.isArray(fileSources)) {
         fileSources = [fileSources];
       }

--- a/app/assets/javascripts/local-charm-import-helpers.js
+++ b/app/assets/javascripts/local-charm-import-helpers.js
@@ -24,7 +24,33 @@ YUI.add('local-charm-import-helpers', function(Y) {
   ns.localCharmHelpers = {
 
     deployLocalCharm: function(file, env, db) {
+      // We will eventually be adding a dialogue of some
+      // sort to allow the user to confiure this value.
+      var series = env.get('defaultSeries'),
+          notifications = db.notifications;
 
+      env.uploadLocalCharm(
+          file,
+          series,
+          function(e) {
+            // progress callback
+          },
+          function(e) {
+            if (e.type === 'error') {
+              notifications.add({
+                title: 'Import failed',
+                message: 'Import from "' + file.name + '" failed.',
+                level: 'error'
+              });
+              console.log('error', e);
+            } else {
+              notifications.add({
+                title: 'Imported local charm file',
+                message: 'Import from "' + file.name + '" successful.',
+                level: 'important'
+              });
+            }
+          });
     }
 
   };

--- a/app/store/env/base.js
+++ b/app/store/env/base.js
@@ -173,7 +173,16 @@ YUI.add('juju-env-base', function(Y) {
       value: [
         'update_annotations'
       ]
-    }
+    },
+
+    /**
+      The event handler attached to the charm upload xhr events. Stored so that
+      we can detach it after the file has been uploaded.
+
+      @attribute xhrEventHandler
+      @type {Function}
+    */
+    'xhrEventHandler': {}
   };
 
   Y.extend(BaseEnvironment, Y.Base, {

--- a/app/views/topology/service.js
+++ b/app/views/topology/service.js
@@ -1326,6 +1326,7 @@ YUI.add('juju-topology-service', function(Y) {
     'juju-models',
     'juju-env',
     'unscaled-pack-layout',
-    'bundle-import-helpers'
+    'bundle-import-helpers',
+    'local-charm-import-helpers'
   ]
 });

--- a/bin/merge-files
+++ b/bin/merge-files
@@ -88,6 +88,7 @@ require('yui').YUI().use(['yui'], function(Y) {
     'app/assets/javascripts/app-subapp-extension.js',
     'app/assets/javascripts/app-cookies-extension.js',
     'app/assets/javascripts/bundle-import-helpers.js',
+    'app/assets/javascripts/local-charm-import-helpers.js',
     'app/assets/javascripts/view-dropdown-extension.js',
     'app/assets/javascripts/d3-components.js',
     'app/assets/javascripts/d3.min.js',

--- a/test/index.html
+++ b/test/index.html
@@ -94,6 +94,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
   <script src="test_inspector_settings.js"></script>
   <script src="test_inspector_widget.js"></script>
   <script src="test_landscape.js"></script>
+  <script src="test_local_charm_import_helpers.js"></script>
   <script src="test_login.js"></script>
 
   <!-- FIXME: latter three modules depend on side effects from model tests. -->

--- a/test/test_env_go.js
+++ b/test/test_env_go.js
@@ -494,6 +494,112 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
     });
 
+    describe('Local charm upload support', function() {
+
+      it('prevents non authorized users from sneding files', function(done) {
+        env.userIsAuthenticated = false;
+        var warn = console.warn,
+            called = false;
+
+        console.warn = function(msg) {
+          assert.equal(
+              msg, 'Attempted upload files without providing credentials.');
+          called = true;
+        };
+        var handler = env.on('login', function(e) {
+          assert.deepEqual(e.data, {result: false});
+          assert.equal(called, true, 'Console warning not called');
+          handler.detach();
+          console.warn = warn;
+          done();
+        });
+        env.uploadLocalCharm();
+      });
+
+      it('generates an XMLHTTPRequest instance', function() {
+        var xhr = env._generateXHRRequest();
+        assert.equal(xhr instanceof XMLHttpRequest, true);
+      });
+
+      it('opens and sends an XHR request with the proper data', function() {
+        var _generateXHRRequestCalled = false,
+            openCalled = false,
+            setRequestHeaderCalled = false,
+            sendCalled = false,
+            addEventListenerCallCount = 0,
+            addEventListenerEvents = [],
+            SERIES = 'precise',
+            FILEOBJ = { name: 'foo' };
+
+        env.userIsAuthenticated = true;
+        env._generateXHRRequest = function() {
+          _generateXHRRequestCalled = true;
+          return {
+            addEventListener: function(eventName, handler, dir) {
+              addEventListenerEvents.push(eventName);
+              assert.isFunction(handler);
+              assert.equal(dir, false);
+              addEventListenerCallCount += 1;
+            },
+            open: function(type, url, async, username, password) {
+              assert.equal(type, 'POST');
+              assert.equal(url, '/juju-core/charms?series=' + SERIES);
+              assert.equal(async, true);
+              assert.equal(username, 'user');
+              assert.equal(password, 'password');
+              openCalled = true;
+            },
+            setRequestHeader: function(key, val) {
+              assert.strictEqual(key, 'Content-Type');
+              assert.strictEqual(val, 'application/zip');
+              setRequestHeaderCalled = true;
+            },
+            send: function(file) {
+              assert.deepEqual(file, FILEOBJ);
+              sendCalled = true;
+            }
+          };
+        };
+
+        env.uploadLocalCharm(FILEOBJ, SERIES);
+
+        assert.equal(_generateXHRRequestCalled, true);
+        assert.equal(openCalled, true);
+        assert.equal(setRequestHeaderCalled, true);
+        assert.equal(sendCalled, true);
+        assert.equal(addEventListenerCallCount, 2);
+        assert.deepEqual(addEventListenerEvents, ['progress', 'load']);
+        // Test the storing of the event handler so we can detach it later.
+        assert.isFunction(env.get('xhrEventHandler'));
+      });
+
+      it('calls the progress callback on the progress event', function(done) {
+        var e = { type: 'progress'};
+        env._xhrEventHandler(null, function(event) {
+          assert.deepEqual(event, e);
+          done();
+        }, null, e);
+      });
+
+      it('calls the default callback on the load event', function(done) {
+        var e = { type: 'load'},
+            removeEventListenerCount = 0,
+            removeEventListenerEvents = [];
+        env._xhrEventHandler(function(event) {
+          assert.deepEqual(event, e);
+          assert.equal(removeEventListenerCount, 2);
+          assert.deepEqual(removeEventListenerEvents, ['progress', 'load']);
+          done();
+        }, null, {
+          removeEventListener: function(eventName) {
+            removeEventListenerEvents.push(eventName);
+            removeEventListenerCount += 1;
+          }
+        }, e);
+      });
+
+    });
+
     it('sends the correct expose message', function() {
       env.expose('apache');
       var last_message = conn.last_message();

--- a/test/test_local_charm_import_helpers.js
+++ b/test/test_local_charm_import_helpers.js
@@ -1,0 +1,120 @@
+/*
+This file is part of the Juju GUI, which lets users view and manage Juju
+environments within a graphical interface (https://launchpad.net/juju-gui).
+Copyright (C) 2012-2013 Canonical Ltd.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU Affero General Public License version 3, as published by
+the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero
+General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along
+with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+'use strict';
+
+(function() {
+
+  describe('local-charm-import-helpers', function() {
+    var db, env, Y, lch, notificationParams;
+
+    before(function(done) {
+      Y = YUI(GlobalConfig).use('local-charm-import-helpers', function(Y) {
+        lch = Y.juju.localCharmHelpers;
+        done();
+      });
+    });
+
+    beforeEach(function() {
+      db = {
+        notifications: {
+          add: function(info) {
+            notificationParams = info;
+          }
+        }
+      };
+    });
+
+    afterEach(function() {
+      db = undefined;
+    });
+
+    describe('destroyLocalCharm', function() {
+
+      it('requests an upload from the environment', function(done) {
+        var fileObj = { name: 'foo' },
+            defSeries = 'precise',
+            reqAttr = 'defaultSeries';
+
+        lch.deployLocalCharm(fileObj, {
+          uploadLocalCharm: function(file, series, progress, callback) {
+            assert.deepEqual(file, fileObj);
+            assert.equal(series, defSeries);
+            assert.isFunction(progress);
+            assert.isFunction(callback);
+            // called the proper env method
+            done();
+          },
+          get: function(attr) {
+            assert.equal(attr, reqAttr);
+            return defSeries;
+          }
+        }, db);
+      });
+
+      it('throws a notification on a successful upload', function(done) {
+        var fileObj = { name: 'foo' },
+            defSeries = 'precise',
+            reqAttr = 'defaultSeries';
+
+        lch.deployLocalCharm(fileObj, {
+          uploadLocalCharm: function(file, series, progress, callback) {
+            assert.isFunction(callback);
+            callback({type: 'load'});
+            assert.deepEqual(notificationParams, {
+              title: 'Imported local charm file',
+              message: 'Import from "foo" successful.',
+              level: 'important'
+            });
+
+            done();
+          },
+          get: function(attr) {
+            return defSeries;
+          }
+        }, db);
+      });
+
+      it('throws a notification on a failed upload', function(done) {
+        var fileObj = { name: 'foo' },
+            defSeries = 'precise',
+            reqAttr = 'defaultSeries';
+
+        lch.deployLocalCharm(fileObj, {
+          uploadLocalCharm: function(file, series, progress, callback) {
+            assert.isFunction(callback);
+            callback({type: 'error'});
+            assert.deepEqual(notificationParams, {
+              title: 'Import failed',
+              message: 'Import from "foo" failed.',
+              level: 'error'
+            });
+
+            done();
+          },
+          get: function(attr) {
+            return defSeries;
+          }
+        }, db);
+      });
+
+    });
+
+
+  });
+})();

--- a/test/test_service_module.js
+++ b/test/test_service_module.js
@@ -381,4 +381,35 @@ describe('service module events', function() {
     serviceModule.canvasDropHandler(fakeEventObject);
   });
 
+  it('should deploy a local charm on .zip file drop events', function(done) {
+    var file = {
+      // Using a complex name to make sure the extension filtering works
+      name: 'foo-bar.baz.zip',
+      type: 'application/zip'
+    };
+    var fakeEventObject = {
+      halt: function() {},
+      _event: {
+        dataTransfer: {
+          // All we need to fake things out is to have a file.
+          files: [file]
+        }
+      }
+    };
+
+    // mock out the Y.BundleHelpers call.
+    var deployLocalCharm = juju.localCharmHelpers.deployLocalCharm;
+    juju.localCharmHelpers.deployLocalCharm = function(files, env, db) {
+      assert.deepEqual(files, file);
+      assert.isObject(env);
+      assert.isObject(db);
+      // Restore the deployBundleFiles call for future tests.
+      juju.localCharmHelpers.deployLocalCharm = deployLocalCharm;
+      done();
+    };
+
+    serviceModule.set('component', view.topo);
+    serviceModule.canvasDropHandler(fakeEventObject);
+  });
+
 });


### PR DESCRIPTION
This branch cannot be properly QA'd until support in the charm lands. Dragging and dropping a zip right now will 'succeed' with a 405 error returned from the charm.
