### PR TITLE
Add ability to skip nav on tabview clicks.

### DIFF
--- a/app/widgets/browser-tabview.js
+++ b/app/widgets/browser-tabview.js
@@ -53,6 +53,9 @@ YUI.add('browser-tabview', function(Y) {
      */
     clickTab: function(e) {
       this.setTab(e.currentTarget);
+      if (this.get('skipAnchorNavigation')) {
+        e.halt();
+      }
     },
 
     /**
@@ -141,6 +144,26 @@ YUI.add('browser-tabview', function(Y) {
       */
       selection: {
         value: ''
+      },
+
+      /**
+       * The links for the tabview are #anchor tags. These will navigate by
+       * default. Setting this to true will kill the click event and prevent
+       * it from navigating while still processing the change and selection
+       * events.
+       *
+       * This is primarily used in testing but could be used to create tabview
+       * widget that did not effect the current url. If you had 3 tabviews on
+       * the screen you might only want one of them to set a hash setting and
+       * be sharable state information.
+       *
+       * @attribute skipAnchorNavigation
+       * @default false
+       * @type {Boolean}
+       *
+       */
+      skipAnchorNavigation: {
+        value: false
       }
     }
   });

--- a/test/test_bundle_details_view.js
+++ b/test/test_bundle_details_view.js
@@ -118,6 +118,9 @@ describe('Browser bundle detail view', function() {
     view.set('store', fakeStore);
     view.set('entity', new models.Bundle(data));
     view.render();
+    // Bypass any routing that might take place for testing sanity.
+    view.tabview.set('skipAnchorNavigation', true);
+
     container.one('a.readme').simulate('click');
   });
 
@@ -139,6 +142,8 @@ describe('Browser bundle detail view', function() {
     view.set('store', fakeStore);
     view.set('entity', new models.Bundle(data));
     view.render();
+    // Bypass any routing that might take place for testing sanity.
+    view.tabview.set('skipAnchorNavigation', true);
     container.one('a.code').simulate('click');
     var codeNode = container.one('#bws-code');
     codeNode.all('select option').item(2).set('selected', 'selected');

--- a/test/test_tabview.js
+++ b/test/test_tabview.js
@@ -51,7 +51,8 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       ].join();
       Y.Node.create(testcontent).appendTo(container);
       tabview = new Y.juju.widgets.browser.TabView({
-        container: container.one('.tabs')
+        container: container.one('.tabs'),
+        skipAnchorNavigation: true
       });
     });
 


### PR DESCRIPTION
The tabview headers are anchor tags. By default, clicking an anchor tag will
cause the url to update. In tests, this causes issue. This adds a flag to the
tabview widget that enables halting the click event so that we can verify all
effects except the url hash change.

This might also prove useful if we need to reuse the tabview widget, yet not
allow for an instance to effect url state.

QA:

Run the tests and yay no hash left once they're complete.
