### PR TITLE
Remove the bws- prefix on charm/bundle tabs.

### DIFF
--- a/app/subapps/browser/browser.js
+++ b/app/subapps/browser/browser.js
@@ -383,7 +383,14 @@ YUI.add('subapp-browser', function(Y) {
       this._viewState.viewmode = params.viewmode;
 
       if (hash) {
+        // If the hash starts with bws- then reset it to provide backwards
+        // compatibility.
+        if (hash.indexOf('#bws-') === 0) {
+          hash = hash.replace('bws-', '');
+        }
+
         this._viewState.hash = hash.replace('/', '');
+        window.location.hash = this._viewState.hash;
       }
 
       // Check for a charm id in the request.

--- a/app/subapps/browser/templates/browser_charm.handlebars
+++ b/app/subapps/browser/templates/browser_charm.handlebars
@@ -56,17 +56,17 @@
         <div class="tabs">
             <nav>
                 <ul>
-                    <li><a href="#bws-summary" class="bws-summary">Summary</a></li>
+                    <li><a href="#summary" class="summary">Summary</a></li>
                     {{#unless isLocal}}
-                        <li><a href="#bws-readme" class="bws-readme">Readme</a></li>
+                        <li><a href="#readme" class="readme">Readme</a></li>
                     {{/unless}}
                     {{#unless forInspector}}
-                    <li><a href="#bws-related-charms" class="bws-related-charms">Related Charms</a></li>
+                    <li><a href="#related-charms" class="related-charms">Related Charms</a></li>
                     {{/unless}}
                     {{#unless isLocal}}
-                        <li><a href="#bws-configuration" class="bws-configuration">Configuration</a></li>
-                        <li><a href="#bws-code" class="bws-code">Code</a></li>
-                        <li><a href="#bws-features" class="bws-features">Features</a></li>
+                        <li><a href="#configuration" class="configuration">Configuration</a></li>
+                        <li><a href="#code" class="code">Code</a></li>
+                        <li><a href="#features" class="features">Features</a></li>
                     {{/unless}}
                 </ul>
                 <div class="selected"></div>
@@ -89,7 +89,7 @@
             {{/unless}}
             <div class="tab-panels">
                 <div class="tab-carousel">
-                    <div id="bws-summary" class="tab-panel">
+                    <div id="summary" class="tab-panel">
                         <div class="summary">
                             {{>providers}}
                             <h2>Summary</h2>
@@ -162,10 +162,10 @@
                         {{/if}}
                     </div>
                     {{#unless isLocal}}
-                        <div id="bws-readme" class="tab-panel"></div>
+                        <div id="readme" class="tab-panel"></div>
                     {{/unless}}
                     {{#unless forInspector}}
-                    <div id="bws-related-charms" class="tab-panel">
+                    <div id="related-charms" class="tab-panel">
                         <p class="intro">
                             Interfaces determine how this charm relates to other charms. A relationship between charms can only be made if they share a common interface.
                             {{#if interfaceIntro.noRequiresNoProvides}}
@@ -259,7 +259,7 @@
                     {{! Do not show the related charms tab when for inspector}}
                     {{/unless}}
                     {{#unless isLocal}}
-                        <div id="bws-configuration" class="tab-panel">
+                        <div id="configuration" class="tab-panel">
                             <p class="intro">
                                 These are the ways in which you can configure this
                                 charm to best suit your deployment. You can change the
@@ -283,7 +283,7 @@
                               <p>This charm does not expose any configuration options.</p>
                             {{/if}}
                         </div>
-                        <div id="bws-code" class="tab-panel">
+                        <div id="code" class="tab-panel">
                             <p class="intro">
                                 The source code of the charm includes scripts, metadata,
                                 and other supporting files to describe and install a
@@ -305,7 +305,7 @@
                             <div class="filecontent">
                             </div>
                         </div>
-                        <div id="bws-features" class="tab-panel"></div>
+                        <div id="features" class="tab-panel"></div>
                     {{/unless}}
                 </div>
             </div>

--- a/app/subapps/browser/views/bundle.js
+++ b/app/subapps/browser/views/bundle.js
@@ -49,7 +49,7 @@ YUI.add('subapp-browser-bundleview', function(Y) {
       '.changelog h3 .expandToggle': {
         click: '_toggleLog'
       },
-      '#bws-code select': {
+      '#code select': {
         change: '_loadHookContent'
       },
       '.bundle .back': {
@@ -208,7 +208,7 @@ YUI.add('subapp-browser-bundleview', function(Y) {
       this._parseData(bundle).then(function() {
         self.environment = new views.BundleTopology(Y.mix({
           db: self.fakebackend.db,
-          container: node.one('#bws-bundle'), // Id because of Y.TabView
+          container: node.one('#bundle'), // Id because of Y.TabView
           store: self.get('store')
         }, options));
         self.environment.render();

--- a/app/subapps/browser/views/charm.js
+++ b/app/subapps/browser/views/charm.js
@@ -59,7 +59,7 @@ YUI.add('subapp-browser-charmview', function(Y) {
       '.changelog h3 .expandToggle': {
         click: '_toggleLog'
       },
-      '#bws-code select': {
+      '#code select': {
         change: '_loadHookContent'
       },
       '.charm .back': {

--- a/app/subapps/browser/views/entity-base.js
+++ b/app/subapps/browser/views/entity-base.js
@@ -99,7 +99,7 @@ YUI.add('subapp-browser-entitybaseview', function(Y) {
       var index = ev.currentTarget.get('selectedIndex');
       var filename = ev.currentTarget.get('options').item(
           index).getAttribute('value'),
-          node = this.get('container').one('#bws-code .filecontent');
+          node = this.get('container').one('#code .filecontent');
 
       // Load the file, but make sure we prettify the code.
       if (filename) {
@@ -133,19 +133,19 @@ YUI.add('subapp-browser-entitybaseview', function(Y) {
       this.addEvent(
           tabview.after('selectionChange', function(e) {
             switch (e.newVal.get('hash')) {
-              case '#bws-features':
+              case '#features':
                 if (!this._qaContentLoaded) {
                   this._loadQAContent();
                 }
                 this._qaContentLoaded = true;
                 break;
-              case '#bws-related-charms':
+              case '#related-charms':
                 if (!this._interfacesContentLoaded) {
                   this._loadInterfacesTabCharms();
                 }
                 this._interfacesContentLoaded = true;
                 break;
-              case '#bws-readme':
+              case '#readme':
                 if (!this._readmeContentLoaded) {
                   this._loadReadmeTab();
                 }
@@ -268,7 +268,7 @@ YUI.add('subapp-browser-entitybaseview', function(Y) {
      *
      */
     _loadQAContent: function() {
-      var node = Y.one('#bws-features');
+      var node = Y.one('#features');
       this.showIndicator(node);
       // Only load the QA data once.
       this.get('store').qa(
@@ -296,9 +296,9 @@ YUI.add('subapp-browser-entitybaseview', function(Y) {
         var readme = this._locateReadme();
 
         if (readme) {
-          this._loadFile(tplNode.one('#bws-readme'), readme);
+          this._loadFile(tplNode.one('#readme'), readme);
         } else {
-          this._noReadme(tplNode.one('#bws-readme'));
+          this._noReadme(tplNode.one('#readme'));
         }
         this.loadedReadme = true;
       }

--- a/app/templates/bundle.handlebars
+++ b/app/templates/bundle.handlebars
@@ -51,20 +51,20 @@
         <div class="tabs">
             <nav>
                 <ul>
-                    <li><a href="#bws-bundle" class="bundle">Bundle</a></li>
-                    <li><a href="#bws-readme" class="readme">Readme</a></li>
-                    <li><a href="#bws-deploy" class="deploy">Deploy</a></li>
-                    <li><a href="#bws-summary" class="summary">Summary</a></li>
-                    <li><a href="#bws-services" class="services">Services</a></li>
-                    <li><a href="#bws-code" class="code">Code</a></li>
+                    <li><a href="#bundle" class="bundle">Bundle</a></li>
+                    <li><a href="#readme" class="readme">Readme</a></li>
+                    <li><a href="#deploy" class="deploy">Deploy</a></li>
+                    <li><a href="#summary" class="summary">Summary</a></li>
+                    <li><a href="#services" class="services">Services</a></li>
+                    <li><a href="#code" class="code">Code</a></li>
                 </ul>
                 <div class="selected"></div>
             </nav>
             <div class="tab-panels">
                 <div class="tab-carousel">
-                    <div id="bws-bundle" class="tab-panel"></div>
-                    <div id="bws-readme" class="tab-panel"></div>
-                    <div id="bws-deploy" class="tab-panel">
+                    <div id="bundle" class="tab-panel"></div>
+                    <div id="readme" class="tab-panel"></div>
+                    <div id="deploy" class="tab-panel">
                         <p>Deploying a bundle will ask your cloud provider to immediately provision all associated machines.</p>
                         <h3>Deploy via the GUI</h3>
                         <p>Click the 'Deploy this bundle' button above, or drag the bundle listing from the search results onto the canvas.</p>
@@ -89,7 +89,7 @@
                             <pre>juju deployer -e &lt;JUJU_ENV&gt; -c \</pre>
                             <pre>    {{deployer_file_url}}</pre></p>
                     </div>
-                    <div id="bws-summary" class="tab-panel">
+                    <div id="summary" class="tab-panel">
                         <div class="summary">
                             {{>providers}}
                             <h2>Description</h2>
@@ -152,7 +152,7 @@
                             {{/if}}
                         </div>
                     </div>
-                    <div id="bws-services" class="tab-panel">
+                    <div id="services" class="tab-panel">
                         <p>
                             These are the services that the bundle will deploy.
                             Non-default configuration values are listed.
@@ -193,7 +193,7 @@
                             {{/each}}
                         </ul>
                     </div>
-                    <div id="bws-code" class="tab-panel">
+                    <div id="code" class="tab-panel">
                         <p class="intro">
                             The source code of the bundle includes scripts, metadata,
                             and other supporting files to describe and install a

--- a/lib/views/browser/bundle-panel.less
+++ b/lib/views/browser/bundle-panel.less
@@ -1,6 +1,6 @@
 #subapp-browser .bundle {
 
-    #bws-bundle {
+    #bundle {
         position: relative;
         padding: 10px;
         .service {
@@ -60,7 +60,7 @@
     .topology-canvas {
         .crosshatch-background;
     }
-    #bws-services {
+    #services {
         padding-top: 50px;
     }
 }

--- a/lib/views/browser/charm-full.less
+++ b/lib/views/browser/charm-full.less
@@ -174,13 +174,13 @@
             }
         }
     }
-    #bws-readme {
+    #readme {
         ul {
             list-style-type: disc;
             padding-left: 2em;
         }
     }
-    #bws-configuration {
+    #configuration {
         dt {
             margin: 20px 0 15px 0;
 
@@ -205,7 +205,7 @@
             }
         }
     }
-    #bws-features {
+    #features {
         li {
             margin-bottom: 4px;
             padding-left: 25px;
@@ -217,7 +217,7 @@
             }
         }
     }
-    #bws-code {
+    #code {
         select {
             margin: 6px 0 23px 0;
         }

--- a/test/test_browser_charm_details.js
+++ b/test/test_browser_charm_details.js
@@ -91,7 +91,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       view.render();
       assert.isNull(view.get('container').one('.heading'));
       // There is no 'related charms' tab to display.
-      assert.equal(view.get('container').all('.bws-related-charms').size(), 0);
+      assert.equal(view.get('container').all('.related-charms').size(), 0);
     });
 
     // Return the charm heading node included in the charm detail view.
@@ -138,10 +138,10 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
       view.render();
       assert.isNull(view.get('container').one('.heading'));
-      assert.isNull(view.get('container').one('#bws-readme'));
-      assert.isNull(view.get('container').one('#bws-configuration'));
-      assert.isNull(view.get('container').one('#bws-code'));
-      assert.isNull(view.get('container').one('#bws-features'));
+      assert.isNull(view.get('container').one('#readme'));
+      assert.isNull(view.get('container').one('#configuration'));
+      assert.isNull(view.get('container').one('#code'));
+      assert.isNull(view.get('container').one('#features'));
     });
 
     it('has sharing links', function() {
@@ -230,7 +230,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
         container: utils.makeContainer(this)
       });
       view.render();
-      var options = Y.one('#bws-code').all('select option');
+      var options = Y.one('#code').all('select option');
       assert.equal(options.size(), 3);
       assert.deepEqual(
           options.get('text'),
@@ -297,7 +297,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       });
 
       view = new CharmView({
-        activeTab: '#bws-readme',
+        activeTab: '#readme',
         entity: new models.Charm({
           files: [
             'hooks/install',
@@ -312,13 +312,13 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
       view.render();
 
-      Y.one('#bws-readme').get('text').should.eql('README content.');
+      Y.one('#readme').get('text').should.eql('README content.');
     });
 
     // EVENTS
     it('should catch when the add control is clicked', function(done) {
       view = new CharmView({
-        activeTab: '#bws-readme',
+        activeTab: '#readme',
         entity: new models.Charm({
           files: [
             'hooks/install'
@@ -332,7 +332,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       // Hook up to the callback for the click event.
       view._addCharmEnvironment = function(ev) {
         ev.halt();
-        Y.one('#bws-readme h3').get('text').should.eql('Charm has no README');
+        Y.one('#readme h3').get('text').should.eql('Charm has no README');
         done();
       };
 
@@ -400,14 +400,14 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       });
 
       view.render();
-      Y.one('#bws-code').all('select option').size().should.equal(3);
+      Y.one('#code').all('select option').size().should.equal(3);
 
       // Select the hooks install and the content should update.
-      Y.one('#bws-code').all('select option').item(2).set(
+      Y.one('#code').all('select option').item(2).set(
           'selected', 'selected');
-      Y.one('#bws-code').one('select').simulate('change');
+      Y.one('#code').one('select').simulate('change');
 
-      var content = Y.one('#bws-code').one('div.filecontent');
+      var content = Y.one('#code').one('div.filecontent');
       // Content is escaped, so we read it out as text, not tags.
       content.get('text').should.eql('<install hook content>');
     });
@@ -431,7 +431,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       });
 
       view = new CharmView({
-        activeTab: '#bws-readme',
+        activeTab: '#readme',
         entity: new models.Charm({
           files: [
             'readme.md'
@@ -444,7 +444,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       });
 
       view.render();
-      Y.one('#bws-readme').get('innerHTML').should.eql(
+      Y.one('#readme').get('innerHTML').should.eql(
           '<h1>README Header</h1>');
     });
 
@@ -466,9 +466,9 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       });
       view.render();
 
-      Y.one('#bws-configuration dd div').get('text').should.eql(
+      Y.one('#configuration dd div').get('text').should.eql(
           'Default: 9160');
-      Y.one('#bws-configuration dd p').get('text').should.eql(
+      Y.one('#configuration dd p').get('text').should.eql(
           'Port for client communcation');
     });
 
@@ -851,7 +851,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       data.charm.files = [];
 
       view = new CharmView({
-        activeTab: '#bws-configuration',
+        activeTab: '#configuration',
         entity: new models.Charm(data.charm),
         container: utils.makeContainer(this)
       });
@@ -860,7 +860,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
       // We've selected the activeTab specified.
       var selected = view.get('container').one('nav .active');
-      assert.equal(selected.getAttribute('href'), '#bws-configuration');
+      assert.equal(selected.getAttribute('href'), '#configuration');
     });
 
     it('loads related charms when interface tab selected', function() {
@@ -884,7 +884,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       });
 
       view = new CharmView({
-        activeTab: '#bws-related-charms',
+        activeTab: '#related-charms',
         entity: new models.Charm(data),
         renderTo: testContainer,
         store: fakeStore
@@ -892,7 +892,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       view.render();
 
       assert.equal(
-          testContainer.all('#bws-related-charms .token').size(),
+          testContainer.all('#related-charms .token').size(),
           9);
       assert.isTrue(view.loadedRelatedInterfaceCharms);
     });
@@ -918,7 +918,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       });
 
       view = new CharmView({
-        activeTab: '#bws-related-charms',
+        activeTab: '#related-charms',
         entity: new models.Charm(data),
         renderTo: testContainer,
         store: fakeStore
@@ -972,7 +972,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
       assert.equal(
           testContainer.one('nav .active').getAttribute('href'),
-          '#bws-summary');
+          '#summary');
     });
 
   });

--- a/test/test_bundle_details_view.js
+++ b/test/test_bundle_details_view.js
@@ -140,7 +140,7 @@ describe('Browser bundle detail view', function() {
     view.set('entity', new models.Bundle(data));
     view.render();
     container.one('a.code').simulate('click');
-    var codeNode = container.one('#bws-code');
+    var codeNode = container.one('#code');
     codeNode.all('select option').item(2).set('selected', 'selected');
     codeNode.one('select').simulate('change');
   });
@@ -190,7 +190,7 @@ describe('Browser bundle detail view', function() {
        view.on('topologyRendered', function(e) {
          assert.isNotNull(container.one('.topology-canvas'));
          // Check that the bundle topology tab is the landing tab.
-         assert.equal(view.tabview.get('selection').get('hash'), '#bws-bundle');
+         assert.equal(view.tabview.get('selection').get('hash'), '#bundle');
          var vis = d3.select(container.one('svg').getDOMNode());
 
          // Check that an error is shown.
@@ -254,7 +254,7 @@ describe('Browser bundle detail view', function() {
     view.on('topologyRendered', function(e) {
       assert.isNotNull(container.one('.topology-canvas'));
       // Check that the bundle topology tab is the landing tab.
-      assert.equal(view.tabview.get('selection').get('hash'), '#bws-bundle');
+      assert.equal(view.tabview.get('selection').get('hash'), '#bundle');
       done();
     });
     view.set('entity', new models.Bundle(entity));
@@ -275,7 +275,7 @@ describe('Browser bundle detail view', function() {
       relLabel.simulate('click');
       assert.isNotNull(container.one('.topology-canvas'));
       // Check that the bundle topology tab is the landing tab.
-      assert.equal(view.tabview.get('selection').get('hash'), '#bws-bundle');
+      assert.equal(view.tabview.get('selection').get('hash'), '#bundle');
       done();
     });
 
@@ -337,7 +337,7 @@ describe('Browser bundle detail view', function() {
     };
     view.set('entity', new models.Bundle(entity));
     view.render();
-    var tab = container.one('#bws-services');
+    var tab = container.one('#services');
     assert.equal(tab.all('.token').size(), 2);
     var charmConfigNodes = tab.all('.charm-config');
     assert.equal(
@@ -347,14 +347,14 @@ describe('Browser bundle detail view', function() {
   });
 
   it('selects the proper tab when given one', function() {
-    view.set('activeTab', '#bws-services');
+    view.set('activeTab', '#services');
     view._parseData = function() {
       return new Y.Promise(function(resolve) { resolve(); });
     };
     view.set('entity', new models.Bundle(data));
     view.render();
     var selected = view.get('container').one('nav .active');
-    assert.equal(selected.getAttribute('href'), '#bws-services');
+    assert.equal(selected.getAttribute('href'), '#services');
   });
 
 

--- a/test/test_routing.js
+++ b/test/test_routing.js
@@ -227,18 +227,18 @@ describe('Namespaced Routing', function() {
   it('should properly parse the QS of a given url', function() {
     var router = juju.Router('charmbrowser');
     var qs = router.getQS(
-        '/minimized/search/precise/jenkins-5/?text=jenkins#bws-readme');
+        '/minimized/search/precise/jenkins-5/?text=jenkins#readme');
     assert.equal(qs, 'text=jenkins');
   });
 
   it('should split a url into components properly', function() {
     var router = juju.Router('charmbrowser');
     var components = router.split(
-        '/minimized/search/precise/jenkins-5/?text=jenkins#bws-readme');
+        '/minimized/search/precise/jenkins-5/?text=jenkins#readme');
     assert.equal(
         components.pathname,
         '/minimized/search/precise/jenkins-5/');
-    assert.equal(components.hash, 'bws-readme');
+    assert.equal(components.hash, 'readme');
     assert.equal(components.search, 'text=jenkins');
   });
 


### PR DESCRIPTION
- They are ids, so we have to watch out for collisions. I don't currently see
  any, but if we hit one we might have to migrate the names over. I did not do
  this here so that we can keep things backwards compatible with a simple rule
  of s/bws-// for the name of the tab.

QA:

Go to a charm and select a tab. The url should be updated to show the #<tab>
and it should not have any bws- in it.

Paste that url into a new window and it should route back correctly for you.

Add a bws- in fromt of the hash and it should auto remove it and still route
you to the correct tab on the correct charm.
