### PR TITLE
Provide the idea of a demo mode to the gui.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,6 +56,22 @@ Some configurable parameters may be found in three files:
 If you are using `the charm <https://jujucharms.com/precise/juju-gui>`_, the
 end-user configuration is available from the charm configuration.
 
+Demonstration Mode
+===================
+
+When giving a demonstration with the Gui you often want to help the visual
+presentation by showing icons for charms that are not yet reviewed and
+recommended. Since you have reviewed the charms you intend to use in your
+presentation, you may override the safety features by manually setting
+"demo-mode" into your localStorage for the Gui website.  You can do this using
+the developer tools for the browser you're demonstrating with.
+
+Open a console and enter:
+
+::
+
+  localStorage.setItem('demo-mode', true);
+
 
 .. _HACKING: https://github.com/juju/juju-gui/blob/develop/HACKING.rst
 .. _on Github: https://github.com/juju/juju-gui

--- a/app/store/charmworld.js
+++ b/app/store/charmworld.js
@@ -401,6 +401,8 @@ YUI.add('juju-charm-store', function(Y) {
       @return {String} The URL of the charm's icon.
      */
     iconpath: function(charmID, isBundle) {
+      var demo_mode = '';
+
       // If this is a local charm, then we need use a hard coded path to the
       // default icon since we cannot fetch its category data or its own
       // icon.
@@ -417,6 +419,13 @@ YUI.add('juju-charm-store', function(Y) {
         // colon portion of the quote and leaves behind a charm ID.
         charmID = charmID.replace(/^[^:]+:/, '');
 
+        // If the user has selected to be in Demo mode then add a parameter to
+        // the url to enable indicating to charmworld to override permission
+        // checks for icons sent back.
+        if (localStorage.getItem('demo-mode')) {
+          demo_mode = '?demo=true';
+        }
+
         // Note that we make sure isBundle is Boolean. It's coming from a
         // handlebars template helper which will make the second argument the
         // context object when it's not supplied. We want it optional for
@@ -428,7 +437,8 @@ YUI.add('juju-charm-store', function(Y) {
           Y.Lang.isBoolean(isBundle) && isBundle === true ? 'bundle' : 'charm',
           charmID,
           'file',
-          'icon.svg'].join('/');
+          'icon.svg' + demo_mode
+        ].join('/');
       }
     },
 

--- a/test/test_charmworld.js
+++ b/test/test_charmworld.js
@@ -217,6 +217,16 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
           hostname + 'api/3/bundle/wiki/3/wiki/file/icon.svg');
     });
 
+    it('allows for a demo mode on icon urls', function() {
+      localStorage.setItem('demo-mode', true);
+      var iconPath = api.iconpath('wiki/3/wiki', true);
+      assert.equal(
+          iconPath,
+          hostname + 'api/3/bundle/wiki/3/wiki/file/icon.svg?demo=true');
+
+      localStorage.removeItem('demo-mode');
+    });
+
     it('can assemble proper urls to fetch files', function(done) {
       api.set('datasource', {
         sendRequest: function(options) {


### PR DESCRIPTION
- Enable passing a url param to the api calls for getting icons.
- This will enable manually overriding the icon safety checks for the purposes
  of a demo which has been sanity checked by the presenter.
