### PR TITLE
Added notification if you try and use local charm upload when your Juju version does not support it

### DIFF
--- a/app/assets/javascripts/local-charm-import-helpers.js
+++ b/app/assets/javascripts/local-charm-import-helpers.js
@@ -105,13 +105,20 @@ YUI.add('local-charm-import-helpers', function(Y) {
     */
     _uploadLocalCharmLoad: function(file, env, db, e) {
       var helper = ns.localCharmHelpers,
-          notifications = db.notifications,
-          res = helper._parseUploadResponse(e.target.responseText);
+          notifications = db.notifications;
+
+      var res = helper._parseUploadResponse(e.target.responseText);
 
       if (e.type === 'error' || e.target.status >= 400) {
+        // If the server does not return a properly formatted error response
+        // then it's safe to assume that local charm upload is not supported.
+        var errorMessage = res.Error || 'Your version of ' +
+                'Juju does not support local charm uploads. Please use at ' +
+                'least version 1.18.0.';
+
         notifications.add({
           title: 'Import failed',
-          message: 'Import from "' + file.name + '" failed. ' + res.Error,
+          message: 'Import from "' + file.name + '" failed. ' + errorMessage,
           level: 'error'
         });
         console.log('error', e);
@@ -137,7 +144,12 @@ YUI.add('local-charm-import-helpers', function(Y) {
       @param {String} data The data returned from the charm upload.
     */
     _parseUploadResponse: function(data) {
-      return JSON.parse(data);
+      try {
+        return JSON.parse(data);
+      } catch (e) {
+        return data;
+      }
+
     }
 
   };

--- a/test/test_local_charm_import_helpers.js
+++ b/test/test_local_charm_import_helpers.js
@@ -174,6 +174,25 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
       });
 
+      it('shows a notification if local charm upload is not supported',
+          function() {
+            var fileObj = { name: 'foo' },
+                eventObj = { target: { status: 500 } },
+                envObj = {};
+
+            stubLoadCharmDetails(this);
+            stubParseUploadResponse(this);
+
+            helper._uploadLocalCharmLoad(fileObj, envObj, dbObj, eventObj);
+            assert.deepEqual(notificationParams, {
+              title: 'Import failed',
+              message: 'Import from "foo" failed. Your version of ' +
+                  'Juju does not support local charm uploads. Please use at ' +
+                  'least version 1.18.0.',
+              level: 'error'
+            });
+          });
+
       it('shows a notification on a successful upload', function() {
         var fileObj = { name: 'foo' },
             eventObj = { target: { responseText: '' }},
@@ -219,6 +238,11 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
         assert.deepEqual(helper._parseUploadResponse(data), {
           foo: 'bar'
         });
+      });
+
+      it('returns the raw data if JSON parsing fails', function() {
+        var data = '<div>Error</div>';
+        assert.strictEqual(helper._parseUploadResponse(data), data);
       });
     });
 


### PR DESCRIPTION
**To QA**
- Downgrade your version of Juju to 1.16.x version.
- Deploy the ~juju-gui latest charm.
- Set juju-gui-source to this branch.
- Try and deploy a zip archive of a charm and a notification should show.
