### PR TITLE
Added a flag to enable the databinding functionality in the Viewlet Manager so that it can be used without databinding

### DIFF
--- a/app/views/inspector.js
+++ b/app/views/inspector.js
@@ -1384,6 +1384,9 @@ YUI.add('juju-view-inspector', function(Y) {
             });
           });
 
+      // Enable databinding.
+      options.enableDatabinding = true;
+
       options.events = Y.mix(options.events, options.viewletEvents);
 
       this.viewletManager = new viewletNS.ViewletManager(options);

--- a/test/test_unit_detail_viewlet.js
+++ b/test/test_unit_detail_viewlet.js
@@ -163,6 +163,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       });
       manager = new ViewletManager(
           { interval: 0,
+            enableDatabinding: true,
             template: '<div class="viewlet"></div>',
             container: Y.Node.create(
                 '<div><div class="leftSlot"></div>' +

--- a/test/test_viewlet_manager.js
+++ b/test/test_viewlet_manager.js
@@ -24,7 +24,8 @@ describe('Viewlet Manager', function() {
   var fakeController = function() {};
   fakeController.prototype.bind = function() { /* noop */};
 
-  var generateViewletManager = function(context, options, viewletList) {
+  var generateViewletManager = function(
+      context, options, viewletList, managerOptions) {
     container = utils.makeContainer(context);
     container.setHTML([
       '<div class="yui3-juju-inspector">',
@@ -37,10 +38,11 @@ describe('Viewlet Manager', function() {
       template: '<div class="viewlet" data-bind="name">{{name}}</div>'
     }, options || {}, false, undefined, 0, true);
 
-    viewletManager = new Y.juju.viewlets.ViewletManager({
+    managerOptions = Y.mix({
       databinding: {
         interval: 0
       },
+      enableDatabinding: true,
       viewlets: {
         serviceConfig: Y.merge(viewletConfig),
         constraints: Y.merge(viewletConfig)
@@ -55,7 +57,9 @@ describe('Viewlet Manager', function() {
       },
       viewletContainer: '.viewlet-container',
       model: new Y.Model({id: 'test', name: 'foo'})
-    });
+    }, managerOptions || {}, true, undefined, 0, true);
+
+    viewletManager = new Y.juju.viewlets.ViewletManager(managerOptions);
   };
 
   before(function(done) {
@@ -307,6 +311,14 @@ describe('Viewlet Manager', function() {
        assert.equal(
            container.one('.left-breakout .viewlet').get('text'), 'ice cream');
      });
+
+  it('can be instantiated without databinding', function() {
+    generateViewletManager(this, null, null, {
+      enableDatabinding: false
+    });
+
+    assert.strictEqual(viewletManager.bindingEngine, undefined);
+  });
 
   it('can remove a slot from the dom', function() {
     generateViewletManager(this);

--- a/test/utils.js
+++ b/test/utils.js
@@ -277,6 +277,7 @@ YUI(GlobalConfig).add('juju-tests-utils', function(Y) {
     renderViewlet: function(viewlet, model, container) {
       container.append('<div class="juju-inspector"></div>');
       var viewletManager = new Y.juju.viewlets.ViewletManager({
+        enableDatabinding: true,
         viewlets: [viewlet],
         container: container,
         viewletContainer: '.viewlet-manager',


### PR DESCRIPTION
**To QA**
We just need to make sure that the databinding still works:
- deploy wordpress
- open the inspector to the configuration tab
- run `var srv = app.db.services.item(0); var cfg = srv.getAttrs().config; cfg.debug = 'yes'; srv.set('config', cfg);`
- the "debug" option should now read yes
