### PR TITLE
Sandbox mode local charms upload preparation.

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -394,7 +394,9 @@ YUI.add('juju-gui', function(Y) {
           conn: this.get('conn')
         };
         var apiBackend = this.get('apiBackend');
+        var webModule = Y.namespace('juju.environments.web');
         if (this.get('sandbox')) {
+          // The GUI is running in sandbox mode.
           var sandboxModule = Y.namespace('juju.environments.sandbox');
           var State = Y.namespace('juju.environments').FakeBackend;
           var state = new State({store: this.get('store')});
@@ -414,8 +416,17 @@ YUI.add('juju-gui', function(Y) {
             this.destroy();
             throw 'unrecognized backend type: ' + apiBackend;
           }
-
+          // Instantiate a fake Web handler, which simulates the
+          // request/response communication between the GUI and the juju-core
+          // HTTPS API.
+          envOptions.webHandler = new webModule.WebSandbox({state: state});
+        } else {
+          // The GUI is connected to a real Juju environment.
+          // Instantiate a Web handler allowing to perform asynchronous HTTPS
+          // requests to the juju-core API.
+          envOptions.webHandler = new webModule.WebHandler();
         }
+
         this.env = juju.newEnvironment(envOptions, apiBackend);
       }
 
@@ -1421,6 +1432,8 @@ YUI.add('juju-gui', function(Y) {
     'juju-env-fakebackend',
     'juju-fakebackend-simulator',
     'juju-env-sandbox',
+    'juju-env-web-handler',
+    'juju-env-web-sandbox',
     'juju-charm-models',
     'juju-views',
     'juju-view-environment',

--- a/app/modules-debug.js
+++ b/app/modules-debug.js
@@ -371,6 +371,14 @@ var GlobalConfig = {
           fullpath: '/juju-ui/store/env/sandbox.js'
         },
 
+        'juju-env-web-handler': {
+          fullpath: '/juju-ui/store/env/web-handler.js'
+        },
+
+        'juju-env-web-sandbox': {
+          fullpath: '/juju-ui/store/env/web-sandbox.js'
+        },
+
         'juju-notification-controller': {
           fullpath: '/juju-ui/store/notifications.js'
         },

--- a/app/store/env/base.js
+++ b/app/store/env/base.js
@@ -163,6 +163,17 @@ YUI.add('juju-env-base', function(Y) {
     'environmentName': {},
 
     /**
+      The object handling Web requests to external APIs.
+      This is usually an instance of app/store/web-handler.js:WebHandler when
+      the GUI is connected to a real Juju environment, or
+      app/store/web-sandbox.js:WebSandbox if the GUI is in sandbox mode.
+
+      @attribute webHandler
+      @type {Object}
+    */
+    'webHandler': {},
+
+    /**
       Operations that are prohibited in read-only mode, but which should fail
       silently because the failure message is not important to the user.
 
@@ -173,16 +184,8 @@ YUI.add('juju-env-base', function(Y) {
       value: [
         'update_annotations'
       ]
-    },
+    }
 
-    /**
-      The event handler attached to the charm upload xhr events. Stored so that
-      we can detach it after the file has been uploaded.
-
-      @attribute xhrEventHandler
-      @type {Function}
-    */
-    'xhrEventHandler': {}
   };
 
   Y.extend(BaseEnvironment, Y.Base, {

--- a/app/store/env/fakebackend.js
+++ b/app/store/env/fakebackend.js
@@ -1644,6 +1644,37 @@ YUI.add('juju-env-fakebackend', function(Y) {
     deployerNext: function(watcherId, callback) {
       // No op in the fakebackend. Just return and ignore the callback.
       return;
+    },
+
+    /**
+      Create and return an event including an error simulating an error
+      response as returned by the juju-core HTTPS API.
+
+      @method _createErrorEvent
+      @param {String} message The error message.
+    */
+    _createErrorEvent: function(message) {
+      return {
+        type: 'error',
+        target: {responseText: {Error: message}}
+      };
+    },
+
+    /**
+      Simulate uploading a local charm.
+      Read the given zip file, validate it, parse charm's metadata and populate
+      the database with the required info before invoking the given callback.
+
+      @method handleUploadLocalCharm
+      @param {Object} file The zip file object containing the charm.
+      @param {Function} completedCallback The load event callback.
+    */
+    handleUploadLocalCharm: function(file, completedCallback) {
+      var errorEvent = this._createErrorEvent(
+          'local charm upload in sandbox mode not yet implemented');
+      completedCallback(errorEvent);
+      // XXX frankban 2014-02-05: read the zip file, validate it, parse charm's
+      // metadata, populate the db, etc...
     }
 
   });

--- a/app/store/env/web-handler.js
+++ b/app/store/env/web-handler.js
@@ -1,0 +1,154 @@
+/*
+This file is part of the Juju GUI, which lets users view and manage Juju
+environments within a graphical interface (https://launchpad.net/juju-gui).
+Copyright (C) 2014 Canonical Ltd.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU Affero General Public License version 3, as published by
+the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero
+General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along
+with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+'use strict';
+
+/**
+ * The Web Handler used to communicate to the juju-core HTTPS API.
+ * Objects defined here can be used to make asynchronous HTTP(S) requests
+ * and handle responses.
+ *
+ * @module env
+ * @submodule env.web
+ */
+
+YUI.add('juju-env-web-handler', function(Y) {
+
+  var module = Y.namespace('juju.environments.web');
+
+  /**
+   * HTTP(S) requests handler.
+   *
+   * This object exposes the ability to perform asynchronous Web requests
+   * to the server.
+   *
+   * @class WebHandler
+   */
+  function WebHandler(config) {
+    // Invoke Base constructor, passing through arguments.
+    WebHandler.superclass.constructor.apply(this, arguments);
+  }
+
+  WebHandler.NAME = 'web-handler';
+  WebHandler.ATTRS = {
+    /**
+      The event handler attached to the charm upload xhr events. Stored so that
+      we can detach it after the request has been completed.
+
+      @attribute xhrEventHandler
+      @type {Function}
+    */
+    'xhrEventHandler': {}
+  };
+
+  Y.extend(WebHandler, Y.Base, {
+
+    /**
+      Send an asynchronous POST request to the given URL.
+
+      @method post
+      @param {String} url The target URL.
+      @param {Object} headers Additional request headers as key/value pairs.
+      @param {Object} data The data to send as a file object, a string or in
+        general as an ArrayBufferView/Blob object.
+      @param {String} username The user name for basic HTTP authentication
+        (or null if no authentication is required).
+      @param {String} password The password for basic HTTP authentication
+        (or null if no authentication is required).
+      @param {Function} progressCallback The progress event callback.
+      @param {Function} completedCallback The load event callback.
+    */
+    post: function(url, headers, data, username, password,
+                   progressCallback, completedCallback) {
+      var xhr = new XMLHttpRequest({});
+      // Set up the event handler.
+      var eventHandler = this._xhrEventHandler.bind(
+          this, xhr, progressCallback, completedCallback);
+      xhr.addEventListener('progress', eventHandler, false);
+      xhr.addEventListener('load', eventHandler, false);
+      // Store this handler so that we can detach the events later.
+      this.set('xhrEventHandler', eventHandler);
+      // Set up the request.
+      xhr.open('POST', url, true);
+      Y.each(headers, function(value, key) {
+        xhr.setRequestHeader(key, value);
+      });
+      // Handle basic HTTP authentication. Rather than passing the username
+      // and password to the xhr directly, we create the corresponding request
+      // header manually, so that a request/response round trip is avoided and
+      // the authentication works well in Firefox and IE.
+      if (username && password) {
+        var authHeader = this._createAuthorizationHeader(username, password);
+        xhr.setRequestHeader('Authorization', authHeader);
+      }
+      // Send the POST data.
+      xhr.send(data);
+    },
+
+    /**
+      The callback from the xhr progress and load events.
+
+      @method _xhrEventHandler
+      @param {Object} xhr Reference to the XHR instance.
+      @param {Function} progressCallback The progress event callback.
+      @param {Function} completedCallback The load event callback.
+      @param {Object} evt The event object from either of the events.
+    */
+    _xhrEventHandler: function(xhr, progressCallback, completedCallback, evt) {
+      if (evt.type === 'progress' && typeof progressCallback === 'function') {
+        progressCallback(evt);
+        // Return explicitly on progress.
+        return;
+      }
+      if (evt.type === 'load') {
+        // If it's not a progress event it's a load event which is fired when
+        // the transmission is completed for whatever reason.
+        var eventHandler = this.get('xhrEventHandler');
+        xhr.removeEventListener('progress', eventHandler);
+        xhr.removeEventListener('load', eventHandler);
+        if (typeof completedCallback === 'function') {
+          completedCallback(evt);
+        }
+      }
+    },
+
+    /**
+      Create and return a value for the HTTP "Authorization" header.
+      The resulting value includes the given credentials.
+
+      @method _createAuthorizationHeader
+      @param {String} username The user name.
+      @param {String} password The password associated to the user name.
+      @return {String} The resulting "Authorization" header value.
+    */
+    _createAuthorizationHeader: function(username, password) {
+      var hash = btoa(username + ':' + password);
+      return 'Basic ' + hash;
+    }
+
+  });
+
+  module.WebHandler = WebHandler;
+
+}, '0.1.0', {
+  requires: [
+    'base'
+  ]
+});
+
+

--- a/app/store/env/web-sandbox.js
+++ b/app/store/env/web-sandbox.js
@@ -1,0 +1,96 @@
+/*
+This file is part of the Juju GUI, which lets users view and manage Juju
+environments within a graphical interface (https://launchpad.net/juju-gui).
+Copyright (C) 2014 Canonical Ltd.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU Affero General Public License version 3, as published by
+the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero
+General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along
+with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+'use strict';
+
+/**
+ * The fake Web Handler used to simulate HTTP(S) communication with the
+ * fake backend when the GUI is run in sandbox mode.
+ *
+ * @module env
+ * @submodule env.web
+ */
+
+YUI.add('juju-env-web-sandbox', function(Y) {
+
+  var module = Y.namespace('juju.environments.web');
+
+  /**
+   * Sandbox Web requests handler.
+   *
+   * This object exposes the ability to simulate asynchronous Web requests to
+   * the server.
+   *
+   * @class WebSandbox
+   */
+  function WebSandbox(config) {
+    // Invoke Base constructor, passing through arguments.
+    WebSandbox.superclass.constructor.apply(this, arguments);
+  }
+
+  WebSandbox.NAME = 'sandbox-web-handler';
+  WebSandbox.ATTRS = {
+    /**
+      The fake backend instance, used to store state and to communicate with
+      the db.
+
+      @attribute state
+      @type {object}
+    */
+    'state': {}
+  };
+
+  Y.extend(WebSandbox, Y.Base, {
+
+    /**
+      Simulate an asynchronous POST request to the given URL.
+
+      @method post
+      @param {String} url The target URL.
+      @param {Object} headers Additional request headers as key/value pairs.
+      @param {Object} data The data to send as a file object, a string or in
+        general as an ArrayBufferView/Blob object.
+      @param {String} username The user name for basic HTTP authentication
+        (or null if no authentication is required).
+      @param {String} password The password for basic HTTP authentication
+        (or null if no authentication is required).
+      @param {Function} progressCallback The progress event callback.
+      @param {Function} completedCallback The load event callback.
+    */
+    post: function(url, headers, data, username, password,
+                   progressCallback, completedCallback) {
+      if (url.indexOf('/juju-core/charms?series=') === 0) {
+        // This is a request to upload a local charm to juju-core.
+        var state = this.get('state');
+        return state.handleUploadLocalCharm(data, completedCallback);
+      }
+      // This is in theory unreachable.
+      console.error('unexpected POST request to ' + url);
+    }
+
+  });
+
+  module.WebSandbox = WebSandbox;
+
+}, '0.1.0', {
+  requires: [
+    'base'
+  ]
+});
+
+

--- a/test/index.html
+++ b/test/index.html
@@ -166,6 +166,9 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
   <script src="test_viewlet_manager.js"></script>
   <script src="test_viewport_module.js"></script>
   <script src="test_websocket_logging.js"></script>
+
+  <script src="test_web_handler.js"></script>
+  <script src="test_web_sandbox.js"></script>
   <script>
   YUI_config = {
       async: false,

--- a/test/test_app.js
+++ b/test/test_app.js
@@ -885,6 +885,20 @@ function injectData(app, data) {
       // necessary parts are there.
       assert.isObject(app.env.get('conn').get('juju').get('state'));
     });
+
+    it('passes a fake web handler to the environment', function() {
+      app = new Y.juju.App({
+        container: container,
+        viewContainer: container,
+        sandbox: true,
+        apiBackend: 'go',
+        store: new Y.juju.charmworld.APIv3({})
+      });
+      app.showView(new Y.View());
+      var webHandler = app.env.get('webHandler');
+      assert.strictEqual(webHandler.name, 'sandbox-web-handler');
+    });
+
   });
 
 })();

--- a/test/test_fakebackend.js
+++ b/test/test_fakebackend.js
@@ -1874,4 +1874,37 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
   });
 
+  describe('FakeBackend.handleUploadLocalCharm', function() {
+    var environmentsModule, fakebackend, Y;
+    var requirements = ['node', 'juju-env-fakebackend'];
+
+    before(function(done) {
+      Y = YUI(GlobalConfig).use(requirements, function(Y) {
+        environmentsModule = Y.namespace('juju.environments');
+        done();
+      });
+    });
+
+    beforeEach(function() {
+      // Instantiate a fake backend.
+      fakebackend = new environmentsModule.FakeBackend();
+    });
+
+    afterEach(function() {
+      fakebackend.destroy();
+    });
+
+    it('has the ability to create an error event', function() {
+      var evt = fakebackend._createErrorEvent('bad wolf');
+      var expectedEvt = {
+        type: 'error',
+        target: {responseText: {Error: 'bad wolf'}}
+      };
+      assert.deepEqual(evt, expectedEvt);
+    });
+
+    // XXX frankban 2014-02-06: add the handleUploadLocalCharm tests here.
+
+  });
+
 })();

--- a/test/test_web_handler.js
+++ b/test/test_web_handler.js
@@ -1,0 +1,132 @@
+/*
+This file is part of the Juju GUI, which lets users view and manage Juju
+environments within a graphical interface (https://launchpad.net/juju-gui).
+Copyright (C) 2014 Canonical Ltd.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU Affero General Public License version 3, as published by
+the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero
+General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along
+with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+'use strict';
+
+(function() {
+
+  describe('Web handler', function() {
+    var mockXhr, utils, webHandler, webModule, Y;
+    var requirements = ['juju-env-web-handler', 'juju-tests-utils'];
+
+    before(function(done) {
+      // Set up the YUI instance, the test utils and the web namespace.
+      Y = YUI(GlobalConfig).use(requirements, function(Y) {
+        utils = Y.namespace('juju-tests.utils');
+        webModule = Y.namespace('juju.environments.web');
+        done();
+      });
+    });
+
+    beforeEach(function() {
+      // Instantiate a web handler and set up an XMLHttpRequest mock.
+      webHandler = new webModule.WebHandler();
+      var context = XMLHttpRequest.prototype;
+      mockXhr = {
+        addEventListener: utils.makeStubMethod(context, 'addEventListener'),
+        open: utils.makeStubMethod(context, 'open'),
+        setRequestHeader: utils.makeStubMethod(context, 'setRequestHeader'),
+        send: utils.makeStubMethod(context, 'send'),
+        removeEventListener: utils.makeStubMethod(
+            context, 'removeEventListener')
+      };
+    });
+
+    afterEach(function() {
+      webHandler.destroy();
+      // Reset all the method mocks.
+      Y.each(mockXhr, function(value) {
+        value.reset();
+      });
+    });
+
+    it('opens and sends an XHR request with the proper data', function() {
+      var url = '/juju-core/charms?series=trusty';
+      var headers = {'Content-Type': 'application/zip'};
+      var data = 'a zip file object';
+      // Make a POST request.
+      webHandler.post(
+          url, headers, data, 'user', 'passwd',
+          function() {return 'progress';}, function() {return 'completed';});
+      // Ensure the xhr instance has been used properly.
+      assert.strictEqual(mockXhr.addEventListener.callCount(), 2);
+      // Two events listeners are added, one for request's progress and one for
+      // request's completion. The same event handler is used for both, and
+      // then stored in the webHandler instance so that subscribers can be
+      // removed later, when the request/response process completes.
+      var args = mockXhr.addEventListener.allArguments();
+      var eventHandler = webHandler.get('xhrEventHandler');
+      assert.deepEqual(args[0], ['progress', eventHandler, false]);
+      assert.deepEqual(args[1], ['load', eventHandler, false]);
+      // The xhr is then asynchronously opened.
+      assert.strictEqual(mockXhr.open.callCount(), 1);
+      assert.deepEqual(mockXhr.open.lastArguments(), ['POST', url, true]);
+      // Headers are properly set up.
+      assert.strictEqual(mockXhr.setRequestHeader.callCount(), 2);
+      args = mockXhr.setRequestHeader.allArguments();
+      assert.deepEqual(args[0], ['Content-Type', 'application/zip']);
+      assert.deepEqual(args[1], ['Authorization', 'Basic dXNlcjpwYXNzd2Q=']);
+      // The zip file is then correctly sent.
+      assert.strictEqual(mockXhr.send.callCount(), 1);
+      assert.deepEqual(mockXhr.send.lastArguments(), ['a zip file object']);
+      // The event listeners are only removed when the completed callback is
+      // called.
+      assert.strictEqual(mockXhr.removeEventListener.called(), false);
+    });
+
+    it('handles request progress', function() {
+      var progressCallback = utils.makeStubFunction();
+      // Make a POST request.
+      webHandler.post('/url/', {}, 'data', 'user', 'passwd', progressCallback);
+      var eventHandler = webHandler.get('xhrEventHandler');
+      // Set up a progress event.
+      var evt = {type: 'progress'};
+      eventHandler(evt);
+      // The progress callback has been correctly called.
+      assert.strictEqual(progressCallback.callCount(), 1);
+      assert.deepEqual(progressCallback.lastArguments(), [evt]);
+    });
+
+    it('handles request completion', function() {
+      var completedCallback = utils.makeStubFunction();
+      // Make a POST request.
+      webHandler.post(
+          '/url/', {}, 'data', 'user', 'passwd',
+          function() {}, completedCallback);
+      var eventHandler = webHandler.get('xhrEventHandler');
+      // Set up a progress event.
+      var evt = {type: 'load'};
+      eventHandler(evt);
+      // The completion callback has been correctly called.
+      assert.strictEqual(completedCallback.callCount(), 1);
+      assert.deepEqual(completedCallback.lastArguments(), [evt]);
+      // The event listeners have been removed.
+      assert.strictEqual(mockXhr.removeEventListener.callCount(), 2);
+      var args = mockXhr.removeEventListener.allArguments();
+      assert.deepEqual(args[0], ['progress', eventHandler]);
+      assert.deepEqual(args[1], ['load', eventHandler]);
+    });
+
+    it('defines a function which helps creating auth headers', function() {
+      var header = webHandler._createAuthorizationHeader('myuser', 'mypasswd');
+      assert.strictEqual(header, 'Basic bXl1c2VyOm15cGFzc3dk');
+    });
+
+  });
+
+})();

--- a/test/test_web_sandbox.js
+++ b/test/test_web_sandbox.js
@@ -1,0 +1,82 @@
+/*
+This file is part of the Juju GUI, which lets users view and manage Juju
+environments within a graphical interface (https://launchpad.net/juju-gui).
+Copyright (C) 2014 Canonical Ltd.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU Affero General Public License version 3, as published by
+the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero
+General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along
+with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+'use strict';
+
+(function() {
+
+  describe('Web sandbox', function() {
+    var mockState, utils, webSandbox, webModule, Y;
+    var requirements = ['juju-env-web-sandbox', 'juju-tests-utils'];
+
+    before(function(done) {
+      // Set up the YUI instance, the test utils and the web namespace.
+      Y = YUI(GlobalConfig).use(requirements, function(Y) {
+        utils = Y.namespace('juju-tests.utils');
+        webModule = Y.namespace('juju.environments.web');
+        done();
+      });
+    });
+
+    beforeEach(function() {
+      // Instantiate a web sandbox passing a mock state object.
+      mockState = {handleUploadLocalCharm: utils.makeStubFunction()};
+      webSandbox = new webModule.WebSandbox({state: mockState});
+    });
+
+    afterEach(function() {
+      webSandbox.destroy();
+    });
+
+    it('uses the given state to handle local charm uploads', function() {
+      var url = '/juju-core/charms?series=trusty';
+      var headers = {'Content-Type': 'application/zip'};
+      var data = 'a zip file object';
+      // Make a POST request.
+      webSandbox.post(
+          url, headers, data, 'user', 'passwd', function() {},
+          function() {return 'completed';});
+      // Ensure the state has been called with the expected arguments.
+      assert.strictEqual(mockState.handleUploadLocalCharm.callCount(), 1);
+      var lastArguments = mockState.handleUploadLocalCharm.lastArguments();
+      assert.strictEqual(lastArguments.length, 2);
+      var zipFile = lastArguments[0];
+      var completedCallback = lastArguments[1];
+      assert.strictEqual(zipFile, data);
+      assert.strictEqual(completedCallback(), 'completed');
+    });
+
+    it('prints a console error if the request is not valid', function() {
+      // Patch the console.error method.
+      var mockError = utils.makeStubMethod(console, 'error');
+      // Make a POST request to an unexpected URL.
+      webSandbox.post('/no-such-resource/', {}, 'data', 'user', 'passwd');
+      mockError.reset();
+      // The state object has not been used.
+      assert.strictEqual(mockState.handleUploadLocalCharm.called(), false);
+      // An error has been printed to the console.
+      assert.strictEqual(mockError.callCount(), 1);
+      var lastArguments = mockError.lastArguments();
+      assert.strictEqual(lastArguments.length, 1);
+      assert.strictEqual(
+          'unexpected POST request to /no-such-resource/', lastArguments[0]);
+    });
+
+  });
+
+})();


### PR DESCRIPTION
Sandbox mode local charms upload preparation.

Code reorganization to introduce a fake web handler
which will simulate the local charm upload process in
sandbox mode.

QA:
1) Bootstrap juju core trunk and deploy the charm with
this branch. One way to do it is:
juju bootstrap --upload-tools
juju deploy juju-gui
juju expose juju-gui
juju set juju-gui juju-gui-source="https://github.com/frankban/juju-gui.git local-charm-prepare-fake"
Another way to do the same is:
create a release (with BRANCH_IS_GOOD=1),
manually include it in a local the gui charm,
remove the stable release already in the charm,
and then run "make deploy".

2) Open the GUI, login and deploy a local charm
(zip drag and drop to the topology).

3) Ensure everything works well and deploy the local charm.

4) Now let's do the same in sandbox mode
(juju set juju-gui sandbox=true) or just "make prod"
in the branch.

5) This time, after dropping the zip, you should see
a notification message like
"local charm upload in sandbox mode not yet implemented".

6) Done. Destroy the environment.
