### PR TITLE
Open select series inspector when local charm archive is dropped on the canvas

### DIFF
--- a/app/modules-debug.js
+++ b/app/modules-debug.js
@@ -317,6 +317,10 @@ var GlobalConfig = {
           fullpath: '/juju-ui/views/viewlets/service-relations.js'
         },
 
+        'viewlet-request-series': {
+          fullpath: '/juju-ui/views/viewlets/request-series.js'
+        },
+
         // Models
         'juju-endpoints': {
           fullpath: '/juju-ui/models/endpoints.js'

--- a/app/templates/request-series.handlebars
+++ b/app/templates/request-series.handlebars
@@ -1,0 +1,5 @@
+<span>Please enter the Ubuntu series you would like this charm deployed to.</span>
+<span>File: {{name}}</span>
+<span>Size: {{size}}b</span>
+<input type="text" defaultSeries value="{{defaultSeries}}" />
+<button upload>Upload</button><button cancel>Cancel</button>

--- a/app/views/viewlet-manager.js
+++ b/app/views/viewlet-manager.js
@@ -146,7 +146,15 @@ YUI.add('juju-viewlet-manager', function(Y) {
       if (typeof this.template === 'string') {
         this.template = Y.Handlebars.compile(this.template);
       }
-      this.container.setHTML(this.template(model.getAttrs()));
+
+      var modelAttrs;
+      if (model && model.getAttrs) {
+        modelAttrs = model.getAttrs();
+      } else {
+        modelAttrs = model;
+      }
+
+      this.container.setHTML(this.template(modelAttrs));
     },
 
     /**

--- a/app/views/viewlets/request-series.js
+++ b/app/views/viewlets/request-series.js
@@ -1,0 +1,36 @@
+/*
+This file is part of the Juju GUI, which lets users view and manage Juju
+environments within a graphical interface (https://launchpad.net/juju-gui).
+Copyright (C) 2012-2013 Canonical Ltd.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU Affero General Public License version 3, as published by
+the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero
+General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along
+with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+'use strict';
+
+
+YUI.add('viewlet-request-series', function(Y) {
+  var ns = Y.namespace('juju.viewlets'),
+      templates = Y.namespace('juju.views').Templates;
+
+  ns.requestSeries = {
+    name: 'requestSeries',
+    template: templates['request-series']
+  };
+
+}, '0.0.1', {
+  requires: [
+    'juju-templates',
+    'juju-view'
+  ]
+});


### PR DESCRIPTION
**To QA**
- Drag a charm archive to the canvas
- It should pop up a basic inspector asking you for the series name you would like to deploy to

**Notes**
The inspector is very ugly and is intended to have new markup and styling done in a follow-up
