### PR TITLE
Add a new test file at the end that verifies cleanup

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -169,6 +169,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
   <script src="test_web_handler.js"></script>
   <script src="test_web_sandbox.js"></script>
+  <script src="test_cleanup.js"></script>
   <script>
   YUI_config = {
       async: false,

--- a/test/test_cleanup.js
+++ b/test/test_cleanup.js
@@ -1,0 +1,40 @@
+/*
+This file is part of the Juju GUI, which lets users view and manage Juju
+environments within a graphical interface (https://launchpad.net/juju-gui).
+Copyright (C) 2012-2013 Canonical Ltd.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU Affero General Public License version 3, as published by
+the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero
+General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along
+with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+'use strict';
+
+(function() {
+
+  describe('test cleanup', function() {
+
+    it('does not have any hash pollution in the url', function() {
+      assert.equal('', window.location.hash);
+
+    });
+
+    it('does not have any querystring pollution in the url', function() {
+      assert.equal('', window.location.search);
+    });
+
+    it('has reset feature flags', function() {
+      assert.deepEqual({}, window.flags);
+    });
+
+
+  });
+})();


### PR DESCRIPTION
Verify that there are no url hashes left when the suite ends. This should help catch cases where a test clicks on an anchor tag and causes a navigate vs running a halt() on the click event.
