### PR TITLE
Menu with icons, aggregated relation status, and per-endpoint styling

### DIFF
--- a/app/templates/relationList.handlebars
+++ b/app/templates/relationList.handlebars
@@ -1,7 +1,10 @@
 <div class="menu">
     <ul>
         {{#each relations}}
-        <li class="relation-action" data-relationid="{{id}}">{{id}}</li>
+        <li class="relation-action {{#if hasRelationError}}error{{else}}running{{/if}}" data-relationid="{{id}}">
+        <span class="endpoint{{#if sourceHasError}} error{{/if}}">{{sourceId}}</span>
+        <span class="endpoint{{#if targetHasError}} error{{/if}}">{{targetId}}</span>
+        </li>
         {{/each}}
     </ul>
 </div>

--- a/lib/views/stylesheet.less
+++ b/lib/views/stylesheet.less
@@ -486,6 +486,21 @@ th {
         display: inline;
     }
 }
+#relation-menu {
+    .relation-action {
+        padding-left: 27px;
+        background-repeat: no-repeat;
+        background-position: 5px 12px;
+        background-image: url("/juju-ui/assets/images/inspector-charm-running.png");
+        &.error {
+            background-image: url("/juju-ui/assets/images/inspector-charm-error.png");
+        }
+        .endpoint.error {
+            color: red;
+        }
+    }
+}
+
 .relation {
     stroke: rgb(167, 167, 167);
     stroke-width: 3px;

--- a/test/test_environment_view.js
+++ b/test/test_environment_view.js
@@ -1040,6 +1040,18 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
           additionalRelations.result[0][2].id);
       assert.equal(menu.all('.relation-action').item(1).getData('relationid'),
           additionalRelations.result[1][2].id);
+
+      // Errors are shown.
+      var unit = db.services.getById('mysql').get('units').item(0);
+      unit.agent_state = 'error';
+      unit.agent_state_data = {
+        hook: 'db-relation'
+      };
+      relation.simulate('click');
+      menu = container.one('#relation-menu');
+      assert.equal(menu.all('.endpoint.error').size(), 1);
+      assert.equal(menu.all('.relation-action.error').size(), 1);
+      assert.equal(menu.all('.relation-action.running').size(), 1);
     });
 
     it('allows deletion of relations within collections', function() {
@@ -1185,7 +1197,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       }).render();
       var module = view.topo.modules.RelationModule;
       // RelationCollections have an aggregatedStatus.
-      assert.equal(module.relations[0].aggregatedStatus, 'healthy');
+      assert.equal(module.relations[0].aggregatedStatus, 'subordinate');
       // RelationCollections can store more than one relation.
       assert.equal(module.relations[2].relations.length, 2);
       // Only one line is drawn (that is, there are four container relations,


### PR DESCRIPTION
Relation menu now shows icons based on aggregated relation status.  Additionally, endpoints as listed in the menu are styled per each endpoint's status (endpoints in error are shown in red).  Action remains delete, for now, but all other actions remain available through inspector.

QA with `/:flags:/relationCollections`, deploy Mysql and Wordpress, bump Wordpress to 100 units, and wait for a relation error.  Check that the menu displays proper icons and colors endpoints based on error/running status.
