### PR TITLE
Fire destroy-inspector event when a zip is dropped on the canvas fixes #1278559

### DIFF
--- a/app/views/topology/service.js
+++ b/app/views/topology/service.js
@@ -651,6 +651,7 @@ YUI.add('juju-topology-service', function(Y) {
           if ((file.type === 'application/zip' ||
                file.type === 'application/x-zip-compressed') &&
               ext === 'zip') {
+            topo.fire('destroyServiceInspector');
             localCharmHelpers.deployLocalCharm(file, env, db);
           } else {
             // We are going to assume it's a bundle if it's not a zip

--- a/test/test_service_module.js
+++ b/test/test_service_module.js
@@ -381,7 +381,7 @@ describe('service module events', function() {
     serviceModule.canvasDropHandler(fakeEventObject);
   });
 
-  it('deploys a local charm on .zip file drop events', function(done) {
+  it('deploys a local charm on .zip file drop events', function() {
     var file = {
       // Using a complex name to make sure the extension filtering works
       name: 'foo-bar.baz.zip',
@@ -400,21 +400,29 @@ describe('service module events', function() {
     };
 
     // mock out the Y.BundleHelpers call.
-    var deployLocalCharm = juju.localCharmHelpers.deployLocalCharm;
-    juju.localCharmHelpers.deployLocalCharm = function(files, env, db) {
-      assert.deepEqual(files, file);
-      assert.isObject(env);
-      assert.isObject(db);
-      // Restore the deployBundleFiles call for future tests.
-      juju.localCharmHelpers.deployLocalCharm = deployLocalCharm;
-      done();
-    };
+    var deployLocalCharmStub, topoFireStub;
+    deployLocalCharmStub = utils.makeStubMethod(
+        juju.localCharmHelpers, 'deployLocalCharm');
+    topoFireStub = utils.makeStubMethod(view.topo, 'fire');
 
     serviceModule.set('component', view.topo);
     serviceModule.canvasDropHandler(fakeEventObject);
+
+    var args = deployLocalCharmStub.lastArguments();
+    assert.deepEqual(args[0], file);
+    assert.isObject(args[1]);
+    assert.isObject(args[2]);
+
+    // Check to make sure the event to destroy any previously
+    // open inspector is fired
+    assert.equal(topoFireStub.calledOnce(), true);
+    assert.equal(topoFireStub.lastArguments()[0], 'destroyServiceInspector');
+
+    deployLocalCharmStub.reset();
+    topoFireStub.reset();
   });
 
-  it('deploys a local charm on .zip file drop events (IE)', function(done) {
+  it('deploys a local charm on .zip file drop events (IE)', function() {
     var file = {
       // Using a complex name to make sure the extension filtering works
       name: 'foo-bar.baz.zip',
@@ -433,18 +441,26 @@ describe('service module events', function() {
     };
 
     // mock out the Y.BundleHelpers call.
-    var deployLocalCharm = juju.localCharmHelpers.deployLocalCharm;
-    juju.localCharmHelpers.deployLocalCharm = function(files, env, db) {
-      assert.deepEqual(files, file);
-      assert.isObject(env);
-      assert.isObject(db);
-      // Restore the deployBundleFiles call for future tests.
-      juju.localCharmHelpers.deployLocalCharm = deployLocalCharm;
-      done();
-    };
+    var deployLocalCharmStub, topoFireStub;
+    deployLocalCharmStub = utils.makeStubMethod(
+        juju.localCharmHelpers, 'deployLocalCharm');
+    topoFireStub = utils.makeStubMethod(view.topo, 'fire');
 
     serviceModule.set('component', view.topo);
     serviceModule.canvasDropHandler(fakeEventObject);
+
+    var args = deployLocalCharmStub.lastArguments();
+    assert.deepEqual(args[0], file);
+    assert.isObject(args[1]);
+    assert.isObject(args[2]);
+
+    // Check to make sure the event to destroy any previously
+    // open inspector is fired
+    assert.equal(topoFireStub.calledOnce(), true);
+    assert.equal(topoFireStub.lastArguments()[0], 'destroyServiceInspector');
+
+    deployLocalCharmStub.reset();
+    topoFireStub.reset();
   });
 
 });


### PR DESCRIPTION
**To QA**
Deploy a charm and open the service inspector.
Drop a .zip onto the canvas and the old inspector should close and the series-select inspector should open.
