### PR TITLE
Sandbox mode support: read the zip contents.

### DIFF
--- a/app/store/env/web-sandbox.js
+++ b/app/store/env/web-sandbox.js
@@ -29,6 +29,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 YUI.add('juju-env-web-sandbox', function(Y) {
 
   var module = Y.namespace('juju.environments.web');
+  var localCharmExpression = /\/juju-core\/charms\?series=(\w+)/;
 
   /**
    * Sandbox Web requests handler.
@@ -74,10 +75,11 @@ YUI.add('juju-env-web-sandbox', function(Y) {
     */
     post: function(url, headers, data, username, password,
                    progressCallback, completedCallback) {
-      if (url.indexOf('/juju-core/charms?series=') === 0) {
+      var match = localCharmExpression.exec(url);
+      if (match) {
         // This is a request to upload a local charm to juju-core.
         var state = this.get('state');
-        return state.handleUploadLocalCharm(data, completedCallback);
+        return state.handleUploadLocalCharm(data, match[1], completedCallback);
       }
       // This is in theory unreachable.
       console.error('unexpected POST request to ' + url);

--- a/app/widgets/browser-tabview.js
+++ b/app/widgets/browser-tabview.js
@@ -94,7 +94,9 @@ YUI.add('browser-tabview', function(Y) {
 
       // Once the animation is complete reduce the height of all tabs except
       // the visible tab so the container only scrolls for the visible tab.
-      var handler = this.tabCarousel.on(['transitionend', 'webkitTransitionEnd'], function() {
+
+      var transitions = ['transitionend', 'webkitTransitionEnd'];
+      var handler = this.tabCarousel.on(transitions, function() {
         // Because this event will fire shortly after this method completes we
         // can detach it here instead of setting up a destructor sequence.
         handler.detach();

--- a/test/test_web_sandbox.js
+++ b/test/test_web_sandbox.js
@@ -54,10 +54,12 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       // Ensure the state has been called with the expected arguments.
       assert.strictEqual(mockState.handleUploadLocalCharm.callCount(), 1);
       var lastArguments = mockState.handleUploadLocalCharm.lastArguments();
-      assert.strictEqual(lastArguments.length, 2);
+      assert.strictEqual(lastArguments.length, 3);
       var zipFile = lastArguments[0];
-      var completedCallback = lastArguments[1];
+      var series = lastArguments[1];
+      var completedCallback = lastArguments[2];
       assert.strictEqual(zipFile, data);
+      assert.strictEqual(series, 'trusty');
       assert.strictEqual(completedCallback(), 'completed');
     });
 


### PR DESCRIPTION
Sandbox mode support: read the zip contents.

This is another incremental step for
the local charm functionality in sandbox mode.

Read the contents of the files (included in the zip)
we are interested in.

Now the only missing bits are updating db.charms and 
returning the expected charm URL to the caller.

QA:

1) make debug;

2) Open the GUI and the js console.

3) Drag a zip containing a charm and click "upload":
    - you should see the 
      "charm upload in sandbox mode is not yet implemented" 
      notification;
    - in the js console, you should also see a list of 
      the three files we are interested in, included in the zip,
      and their contents;

4) Now drag a zip not including a charm: 
   you should see an error notification similar 
   to "unable to find the following required files: ...".
