### PR TITLE
Create and show a mask covering the inspector when the user drags a zip file over the browser

### DIFF
--- a/test/test_overlay_indicator.js
+++ b/test/test_overlay_indicator.js
@@ -127,8 +127,16 @@ describe('overlay indicator', function() {
     assert.notEqual(expected_xy[1], actual_xy[1]);
     indicator.setBusy();
     var final_xy = indicator.get('boundingBox').getXY();
-    assert.equal(expected_xy[0], final_xy[0]);
-    assert.equal(expected_xy[1], final_xy[1]);
+
+    // (IE 10 on Win 8) The position of this indicator is positioned slightly
+    // different each time this test is run so as long as it falls within
+    // this range it is fine.
+    assert.equal(
+        (final_xy[0] > expected_xy[0] - 5) &&
+        (final_xy[0] < expected_xy[0] + 5), true);
+    assert.equal(
+        (final_xy[1] > expected_xy[1] - 5) &&
+        (final_xy[1] < expected_xy[1] + 5), true);
   });
 
   it('hides on success', function() {


### PR DESCRIPTION
**To QA**
- open app.js and place a breakpoint on line 686 & 730
- deploy a service and open its inspector
- drag a .zip from your desktop over the browser, it should hit your first breakpoint
- remove the first breakpoint and click continue
- drag a .zip from your desktop and drop on the open inspector, it should trigger the second breakpoint
- done!

**Note**
Until we get designs from UX about this mask it's transparent so it isn't discoverable.
