### PR TITLE
Keep menu in sync with relation updates.

### DIFF
--- a/app/views/topology/relation.js
+++ b/app/views/topology/relation.js
@@ -244,6 +244,9 @@ YUI.add('juju-topology-relation', function(Y) {
 
       // Update (+ enter selection).
       link.each(this.drawRelation);
+      if (this.get('relationMenuActive')) {
+        this.showRelationMenu(this.get('relationMenuRelation'));
+      }
 
       // Exit
       g.exit().remove();
@@ -709,6 +712,8 @@ YUI.add('juju-topology-relation', function(Y) {
     clearState: function() {
       this.cancelRelationBuild();
       this.hideSubordinateRelations();
+      this.set('relationMenuActive', false);
+      this.set('relationMenuRelation', undefined);
     },
 
     cancelRelationBuild: function() {
@@ -1108,6 +1113,8 @@ YUI.add('juju-topology-relation', function(Y) {
         relations: relation.relations
       }));
       menu.addClass('active');
+      this.set('relationMenuActive', true);
+      this.set('relationMenuRelation', relation);
       var topo = this.get('component');
       var tr = topo.zoom.translate();
       var z = topo.zoom.scale();
@@ -1168,7 +1175,25 @@ YUI.add('juju-topology-relation', function(Y) {
         @default undefined
         @type {Boolean}
       */
-      disableRelationInteraction: {}
+      disableRelationInteraction: {},
+      /**
+        Whether or not the relation menu is visible.
+
+        @attribute relationMenuActive
+        @default false
+        @type {Boolean}
+      */
+      relationMenuActive: {
+        value: false
+      },
+      /**
+        The relation for which the menu is currently showing.
+
+        @attribute relationMenuRElation
+        @default undefined
+        @type {Object}
+      */
+      relationMenuRelation: {}
     }
 
   });

--- a/test/test_environment_view.js
+++ b/test/test_environment_view.js
@@ -1014,6 +1014,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
         env: env,
         store: fakeStore
       }).render();
+      var module = view.topo.modules.RelationModule;
 
       // Single relation
       var relation = container.one(
@@ -1025,6 +1026,11 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
       assert.equal(menu.all('.relation-action').size(), 1);
       assert.equal(menu.one('.relation-action').getData('relationid'),
+          'relation-0000000001');
+
+      // Assert that relation module is storing the menu state for rerendering.
+      assert.equal(module.get('relationMenuActive'), true);
+      assert.equal(module.get('relationMenuRelation').id,
           'relation-0000000001');
 
       // Multiple relations


### PR DESCRIPTION
Uses the update cycle of the topology to keep the menu in sync.

To QA: run with `/:flags:/relationCollections`, add two services, relate them, bump one service up to 100 units, click the relation indicator, and wait for the relation to go bad; menu should reflect this.
