### PR TITLE
Update to use juju-quickstart

### DIFF
--- a/app/templates/bundle.handlebars
+++ b/app/templates/bundle.handlebars
@@ -76,7 +76,7 @@
                             <pre>sudo apt-get install juju-quickstart</pre>
                         </p>
                         <p>Step 2 - Deploy bundle
-                            <pre>juju quickstart {{permanent_url}} [-e &lt;JUJU_ENV&gt;]</pre>
+                            <pre>juju-quickstart {{permanent_url}} [-e &lt;JUJU_ENV&gt;]</pre>
                         </p>
                         <h3>Deploy via the deployer</h3>
                         <p>The Juju deployer is a tool that the quickstart plugin (above) uses.  It can also be used standalone to give you more control.</p>


### PR DESCRIPTION
Use the juju-quickstart so we can try to get the command-not-found to help aid in finding the plugin to install.
