### PR TITLE
Support charm upgrades by dropping a .zip on the inspector

### DIFF
--- a/app/assets/javascripts/local-charm-import-helpers.js
+++ b/app/assets/javascripts/local-charm-import-helpers.js
@@ -181,7 +181,8 @@ YUI.add('local-charm-import-helpers', function(Y) {
     */
     loadCharmDetails: function(charmUrl, env, callback) {
       var charm = new Y.juju.models.Charm({ id: charmUrl });
-      charm.after('load', function(e) {
+      var handler = charm.after('load', function(e) {
+        handler.detach();
         callback(charm, env);
       });
       charm.load(env);
@@ -202,6 +203,16 @@ YUI.add('local-charm-import-helpers', function(Y) {
       Y.fire('initiateDeploy', charm, {});
     },
 
+    /**
+      Shows notifications for the status of the local charm upgrade. Callback
+      after a successful upload of the charm to upgrade.
+
+      @method _localCharmUpgradeCallback
+      @param {Object} db A reference to the db.
+      @param {Object} options The options from the file drop.
+      @param {Object} charm The charm model to upgrade to.
+      @param {Object} env A reference to the environment.
+    */
     _localCharmUpgradeCallback: function(db, options, charm, env) {
       env.setCharm(options.serviceId, charm.get('id'), false, function(e) {
         if (e.err) {

--- a/test/test_local_charm_import_helpers.js
+++ b/test/test_local_charm_import_helpers.js
@@ -24,7 +24,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     // Each method in local-charm-import-helpers.js has a describe() covering
     // every method and every path within that method. Because everything in
     // these tests is mocked out it's difficult to be sure that they will
-    // interact together properly. TO be sure that the two entry points reach
+    // interact together properly. To be sure that the two entry points reach
     // their proper exit points integration tests have been created and they are
     // at the very bottom of this file.
     var dbObj, env, helper, notificationParams, testUtils, Y;
@@ -330,6 +330,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     describe('loadCharmDetails', function() {
       it('calls supplied callback after the charm is loaded', function(done) {
         var envObj = {};
+
         var oldMethod = Y.juju.models.Charm.prototype.load;
         Y.juju.models.Charm.prototype.load = function(env) {
           assert.deepEqual(env, envObj);
@@ -339,12 +340,14 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
         this._cleanups.push(function() {
           Y.juju.models.Charm.prototype.load = oldMethod;
         });
-        helper.loadCharmDetails('local:precise/ghost-4', envObj,
-            function(charm, env) {
-              assert.isObject(charm);
-              assert.deepEqual(env, envObj);
-              done();
-            });
+
+        var charmUrl = 'local:precise/ghost-4';
+
+        helper.loadCharmDetails(charmUrl, envObj, function(charm, env) {
+          assert.isObject(charm);
+          assert.deepEqual(env, envObj);
+          done();
+        });
       });
     });
 
@@ -582,11 +585,13 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       });
     });
 
-    describe('integration tests', function() {
+    describe('import helpers integration tests', function() {
       var destroyStub, envStub, envUploadLocalStub, fileObj, viewletManager,
           stubOn;
 
       function stubitout(context) {
+        // the below mocks are externally called methods which will allow
+        // the script to execute to _attachViewletEvents.
         fileObj = { name: 'foo', size: '111' };
         envStub = testUtils.makeStubFunction();
 
@@ -619,6 +624,8 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
             viewletManager.prototype, 'destroy');
         // the above mocks are externally called methods which will allow
         // the script to execute to _attachViewletEvents.
+
+        // The below methods get us through the _attachViewletEvents method.
         var stubOnFn = testUtils.makeStubFunction();
         stubOn = testUtils.makeStubMethod(stubOnFn, 'on');
         var stubOneFn = testUtils.makeStubFunction();


### PR DESCRIPTION
## To QA
- Deploy a real environment.
- Drag and drop a local charm .zip from your desktop to the canvas and deploy.
- After it turns green open it's inspector.
- Drag and drop the same charm on the inspector
- You should get a notification that it completed successfully.
- If you wait a few seconds you will then get a notification in the inspector that the service has been upgraded.

**Notes**
You will need at least Juju 1.17.2
A small and quick to deploy charm: https://github.com/hatched/ghost-charm
If you are using Juju 1.17.2 and download the zip form Github you will need to repack it so that the files sit at the root of the zip. Juju 1.17.3 does not have this restriction. 
