### PR TITLE
Hide the drag notifications when the inspector is destroyed via the global event

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -650,6 +650,10 @@ YUI.add('juju-gui', function(Y) {
       ['dragenter', 'dragover', 'dragleave'].forEach(function(eventName) {
         Y.config.doc.addEventListener(eventName, this._boundAppDragOverHandler);
       }, this);
+
+      // XXX (Jeff 19-02-2014) When the inspector mask code is moved into
+      // the inspector shortly this can be removed.
+      this.on('*:destroyServiceInspector', this.hideDragNotifications, this);
     },
 
     /**


### PR DESCRIPTION
Fixes issue https://bugs.launchpad.net/juju-gui/+bug/1282125

**To QA**
Follow the steps in the bug to reproduce issue, if the issue isn't there then it's resolved. 

**Note**
This code will be removed shortly when the inspector mask code gets moved inside the new inspector class. 
