### PR TITLE
Add support for running CI against Safari as well

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -423,12 +423,16 @@ ci-check: check
 	JUJU_GUI_TEST_BROWSER="chrome" make test-browser
 	echo "Starting tests against IE"
 	JUJU_GUI_TEST_BROWSER="ie" make test-browser
+	echo "Starting tests against Safari"
+	JUJU_GUI_TEST_BROWSER="safari" make test-browser
 	echo "Starting unit tests against Firefox"
 	JUJU_GUI_TEST_BROWSER="firefox" make test-browser-mocha
 	echo "Starting unit tests against Chrome"
 	JUJU_GUI_TEST_BROWSER="chrome" make test-browser-mocha
 	echo "Starting unit tests against IE"
 	JUJU_GUI_TEST_BROWSER="ie" make test-browser-mocha
+	echo "Starting unit tests against Safari"
+	JUJU_GUI_TEST_BROWSER="safari" make test-browser-mocha
 
 
 test/extracted_startup_code: app/index.html

--- a/test/browser.py
+++ b/test/browser.py
@@ -143,6 +143,10 @@ def get_capabilities(browser_name):
             # Internet Explorer version must be >= 10.
             {'platform': 'Windows 7', 'version': '10'},
         ),
+        'safari': (
+            desired.SAFARI,
+            {'platform': 'OS X 10.9', 'version': '7'},
+        ),
     }
     if browser_name in choices:
         base, updates = choices[browser_name]

--- a/test/test_environment_view.js
+++ b/test/test_environment_view.js
@@ -1433,10 +1433,10 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
                     {id: 'memcache'},
                     {id: 'wordpress'}]);
       var existing = {
-        'mysql': 1,
-        'haproxy': 2, // This entry is stale and will be removed.
-        'memcache': 3,
-        'wordpress': 4};
+        'mysql': {},
+        'haproxy': {}, // This entry is stale and will be removed.
+        'memcache': {},
+        'wordpress': {}};
 
       var boxes = views.toBoundingBoxes(module, services, existing);
       // The haproxy is removed from the results since it is no longer in


### PR DESCRIPTION
- Update to have existing be objects and not integers
- Integers cannot have .models assigned to them, they're read-only items.
