### PR TITLE
Ability to deploy units to specific machines.

### DIFF
--- a/app/store/env/python.js
+++ b/app/store/env/python.js
@@ -160,11 +160,15 @@ YUI.add('juju-env-python', function(Y) {
      * @method add_unit
      * @param {String} service The service to be scaled up.
      * @param {Integer} num_units The number of units to be added.
+     * @param {String} toMachine The machine/container name where to deploy the
+         service unit. Since pyJuju does not support units' co-location, this
+         argument is ignored, and only present for signature compatibility
+         with the GoEnvironment implementation.
      * @param {Function} callback A callable that must be called once the
          operation is performed.
      * @return {undefined} Sends a message to the server only.
      */
-    add_unit: function(service, num_units, callback) {
+    add_unit: function(service, num_units, toMachine, callback) {
       this._send_rpc({
         'op': 'add_unit',
         'service_name': service,
@@ -252,12 +256,16 @@ YUI.add('juju-env-python', function(Y) {
          provided, though `config_raw` takes precedence if it is given.
      * @param {Integer} num_units The number of units to be deployed.
      * @param {Object} constraintMap The constraints object.
+     * @param {String} toMachine The machine/container name where to deploy the
+         service unit. Since pyJuju does not support units' co-location, this
+         argument is ignored, and only present for signature compatibility
+         with the GoEnvironment implementation.
      * @param {Function} callback A callable that must be called once the
          operation is performed.
      * @return {undefined} Sends a message to the server only.
      */
     deploy: function(charm_url, service_name, config, config_raw, num_units,
-                     constraintMap, callback) {
+                     constraintMap, toMachine, callback) {
 
       if (!constraintMap) { constraintMap = {}; }
       // Format the constraints properly for the pyjuju backend

--- a/app/views/ghost-inspector.js
+++ b/app/views/ghost-inspector.js
@@ -130,6 +130,7 @@ YUI.add('juju-ghost-inspector', function(Y) {
           this.viewletManager.configFileContent,
           numUnits,
           constraints,
+          null, // Always deploy units to new machines for now.
           Y.bind(this._deployCallbackHandler,
                  this,
                  serviceName,

--- a/app/views/inspector.js
+++ b/app/views/inspector.js
@@ -180,9 +180,11 @@ YUI.add('juju-view-inspector', function(Y) {
 
       var delta = requested_unit_count - unit_count;
       if (delta > 0) {
-        // Add units!
+        // Add units! The third argument (null) below represents the machine
+        // where to deploy new units. For now a new machine is created for each
+        // unit.
         env.add_unit(
-            service.get('id'), delta,
+            service.get('id'), delta, null,
             Y.bind(this._addUnitCallback, this));
       } else if (delta < 0) {
         delta = Math.abs(delta);

--- a/test/test_env_python.js
+++ b/test/test_env_python.js
@@ -430,12 +430,12 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       assert.include(warning[0], 'Permission denied');
       assert.equal(operationName, warning[1].op);
       // The callback received an error.
-      assert.isTrue(errorRaised);
+      assert.deepEqual(errorRaised, true);
       // A *permissionDenied* was fired by the environment, or it was silenced.
       var silent = Y.Array.some(env.get('_silentFailureOps'), function(v) {
         return v === warning[1].op;
       });
-      assert.isTrue(permissionDeniedFired || silent);
+      assert.deepEqual(permissionDeniedFired || silent, true);
       // Restore the original *console.warn*.
       console.warn = original;
     };
@@ -447,7 +447,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     });
 
     it('denies adding a unit if the GUI is read-only', function() {
-      assertOperationDenied('add_unit', ['haproxy', 3]);
+      assertOperationDenied('add_unit', ['haproxy', 3, null]);
     });
 
     it('denies destroying a service if the GUI is read-only', function() {
@@ -456,7 +456,9 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
     it('denies deploying a charm if the GUI is read-only', function() {
       assertOperationDenied(
-          'deploy', ['cs:precise/haproxy', 'haproxy', {}, null, 3, null]);
+          'deploy',
+          ['cs:precise/haproxy', 'haproxy', {}, null, 3, null, null]
+      );
     });
 
     it('denies exposing a service if the GUI is read-only', function() {

--- a/test/test_sandbox_go.js
+++ b/test/test_sandbox_go.js
@@ -388,6 +388,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
           null,
           1,
           {},
+          null,
           callback);
     });
 
@@ -413,6 +414,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
           null,
           1,
           constraints,
+          null,
           callback);
     });
 
@@ -425,7 +427,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
         done();
       };
       env.deploy('cs:precise/wordpress-15', undefined, undefined, undefined,
-                 1, null, callback);
+                 1, null, null, callback);
     });
 
     it('can destroy a service', function(done) {
@@ -817,7 +819,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     */
     function generateIntegrationServices(callback) {
       var localCb = function(result) {
-        env.add_unit('kumquat', 2, function(data) {
+        env.add_unit('kumquat', 2, null, function(data) {
           // After finished generating integrated services.
           callback(data);
         });
@@ -829,6 +831,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
           {llama: 'pajama'},
           null,
           1,
+          null,
           null,
           localCb);
     }
@@ -882,6 +885,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
           {llama: 'pajama'},
           null,
           1,
+          null,
           null,
           localCb);
     }
@@ -1128,9 +1132,11 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     it('can add a relation (integration)', function(done) {
       env.connect();
       env.deploy(
-          'cs:precise/wordpress-15', null, null, null, 1, null, function() {
+          'cs:precise/wordpress-15', null, null, null, 1, null, null,
+          function() {
             env.deploy(
-                'cs:precise/mysql-26', null, null, null, 1, null, function() {
+                'cs:precise/mysql-26', null, null, null, 1, null, null,
+                function() {
                   var endpointA = ['wordpress', {name: 'db', role: 'client'}],
                       endpointB = ['mysql', {name: 'db', role: 'server'}];
                   env.add_relation(endpointA, endpointB, function(recData) {
@@ -1250,9 +1256,11 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     it('can remove a relation(integration)', function(done) {
       env.connect();
       env.deploy(
-          'cs:precise/wordpress-15', null, null, null, 1, null, function() {
+          'cs:precise/wordpress-15', null, null, null, 1, null, null,
+          function() {
             env.deploy(
-                'cs:precise/mysql-26', null, null, null, 1, null, function() {
+                'cs:precise/mysql-26', null, null, null, 1, null, null,
+                function() {
                   var endpointA = ['wordpress', {name: 'db', role: 'client'}],
                       endpointB = ['mysql', {name: 'db', role: 'server'}];
                   env.add_relation(endpointA, endpointB, function() {

--- a/test/test_sandbox_python.js
+++ b/test/test_sandbox_python.js
@@ -145,7 +145,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     function generateIntegrationServices(callback) {
       env.after('defaultSeriesChange', function() {
         var localCb = function(result) {
-          env.add_unit('kumquat', 2, function(data) {
+          env.add_unit('kumquat', 2, null, function(data) {
             // After finished generating integrated services
             callback(data);
           });
@@ -156,6 +156,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
             {llama: 'pajama'},
             null,
             1,
+            null,
             null,
             localCb);
       });
@@ -212,6 +213,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
             {llama: 'pajama'},
             null,
             1,
+            null,
             null,
             localCb);
       });
@@ -398,6 +400,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
             null,
             1,
             null,
+            null,
             callback);
       });
       env.connect();
@@ -421,6 +424,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
             undefined,
             undefined,
             1,
+            null,
             null,
             callback);
       });
@@ -1089,6 +1093,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
             undefined,
             1,
             null,
+            null,
             addRelation);
       });
     });
@@ -1196,8 +1201,9 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
         }
         env.deploy(
             'cs:precise/wordpress-15', 'kumquat',
-            {llama: 'pajama'}, null, 1, null, function() {
-              env.deploy('cs:precise/mysql-26', null, null, null, 1, null,
+            {llama: 'pajama'}, null, 1, null, null, function() {
+              env.deploy('cs:precise/mysql-26',
+                  null, null, null, 1, null, null,
                   function() {
                     env.add_relation(endpoints[0], endpoints[1], function() {
                       env.remove_relation(endpoints[0], endpoints[1], localCb);


### PR DESCRIPTION
Ability to deploy units to specific machines.

Support ToMachineSpec in goenv backend 
ServiceDeploy and AddServiceUnits calls.

Also update the pyenv for compatibility.

Drive by fix to code indentation/style.

QA:

Ensure the sandbox mode works well:
- make prod;
- deploy a service, add units, check
  everything is fine.

Live test the functionality on an ec2
environment:
- juju bootstrap -e ec2 --upload-tools
- juju deploy -e ec2 juju-gui --to 0
- juju expose -e ec2 juju-gui
- juju set -e ec2 juju-gui juju-gui-console-enabled=true juju-gui-source="https://github.com/frankban/juju-gui.git add-to-machine-spec"
- when the GUI is ready, log in, open the JS console;
- deploy a new service (e.g. mysql) as usual dragging the badge from
  the browser. This is done to ensure the usual way to deploy services
  from the GUI still works well: a new machine should be created to host
  mysql;
- add another unit to mysql using the inspector: at this point you should have
  mysql deploying to machines "1" and "2"
- using the console add a new machine, another new machine including an LXC
  container, and a new LXC on machine "1":
  app.env.addMachines([{}, {containerType: 'lxc'}, {containerType: 'lxc', parentId: '1'}]);
- use `juju status -e ec2` to ensure the new machines/containers have been 
  created: machine "3" and "4", containers "4/lxc/0" and "1/lxc/0"
- deploy wordpress to "1/lxc/0" by running the following:
  app.env.deploy('cs:precise/wordpress-21', 'wordpress', null, null, 1, null, '1/lxc/0');
- add another unit to wordpress, placing it on machine "3":
  app.env.add_unit('wordpress', 1, '3');
- define the following callback that will help visualizing
  the data returned by the API calls:
  var callback = function(data) {console.log(data)};
- ensure an error is returned when trying to deploy multiple units on
  the same machine:
  app.env.deploy('cs:precise/haproxy-27', 'ha', null, null, 3, null, '4/lxc/0', callback);
- deploy haproxy to machine "4" and container "4/lxc/0":
  app.env.deploy('cs:precise/haproxy-27', 'ha', null, null, 1, null, '4', callback);
  app.env.add_unit('ha', 1, '4/lxc/0');

Done, destroy your environment, thank you!
