### PR TITLE
Export constraints as a space-separated list.

### DIFF
--- a/app/models/models.js
+++ b/app/models/models.js
@@ -285,7 +285,7 @@ YUI.add('juju-models', function(Y) {
         'setter': function(value) {
           if (typeof value === 'string') {
             var output = {};
-            value.split(',').map(function(pair) {
+            value.split(' ').map(function(pair) {
               var kv = pair.split('=');
               output[kv[0]] = kv[1];
             });
@@ -303,7 +303,7 @@ YUI.add('juju-models', function(Y) {
             }
           });
           if (result.length) {
-            return result.join(',');
+            return result.join(' ');
           }
           return undefined;
         }

--- a/app/store/env/fakebackend.js
+++ b/app/store/env/fakebackend.js
@@ -438,12 +438,21 @@ YUI.add('juju-env-fakebackend', function(Y) {
       // here so that the GUI displays it properly.
       var constraintsMap = {}, vals;
       if (typeof constraints === 'string') {
-        constraints = constraints.split(',');
+        // Determine the number of key-value pairs and try the old-style comma
+        // separator if not the same as the constraints length.
+        var numPairs = constraints.match(/=/g).length;
+        // Although comma-separation is deprecated, check it first as it
+        // allows easier parsing if a mix of commas and spaces is used.
+        var pairs = constraints.split(',');
+        if (numPairs !== pairs.length) {
+          pairs = constraints.split(' ');
+        }
+        constraints = pairs;
       }
       if (Y.Lang.isArray(constraints)) {
         constraints.forEach(function(cons) {
           vals = cons.split('=');
-          constraintsMap[vals[0]] = vals[1];
+          constraintsMap[vals[0].trim()] = vals[1].trim();
         });
       } else {
         constraintsMap = constraints;

--- a/test/data/mysql-deployer-mixed.yaml
+++ b/test/data/mysql-deployer-mixed.yaml
@@ -1,0 +1,7 @@
+envExport:
+  series: precise
+  services:
+    mysql:
+      charm: "cs:precise/mysql-27"
+      num_units: 1
+      constraints: 'cpu-power=2, cpu-cores=4,mem=10'

--- a/test/data/wp-deployer-commas.yaml
+++ b/test/data/wp-deployer-commas.yaml
@@ -1,0 +1,7 @@
+envExport:
+  series: precise
+  services:
+    mysql:
+      charm: "cs:precise/mysql-27"
+      num_units: 1
+      constraints: 'cpu-power=2,cpu-cores=4'

--- a/test/data/wp-deployer.yaml
+++ b/test/data/wp-deployer.yaml
@@ -1,10 +1,10 @@
-envExport: 
+envExport:
   series: precise
-  services: 
-    mysql: 
+  services:
+    mysql:
       charm: "cs:precise/mysql-27"
       num_units: 1
-      options: 
+      options:
         "binlog-format": MIXED
         "block-size": "5"
         "dataset-size": "80%"
@@ -20,21 +20,21 @@ envExport:
         vip: ""
         vip_cidr: "24"
         vip_iface: eth0
-      annotations: 
+      annotations:
         "gui-x": 115
         "gui-y": 89
-      constraints: 'cpu-power=2,cpu-cores=4'
-    wordpress: 
+      constraints: 'cpu-power=2 cpu-cores=4'
+    wordpress:
       charm: "cs:precise/wordpress-19"
       num_units: 2
-      options: 
+      options:
         debug: "no"
         engine: apache
         "wp-content": ""
-      annotations: 
+      annotations:
         "gui-x": 510
         "gui-y": 184
       expose: true
-  relations: 
+  relations:
     - - "wordpress:db"
       - "mysql:db"

--- a/test/test_model.js
+++ b/test/test_model.js
@@ -816,7 +816,7 @@ describe('test_model.js', function() {
         id: 'wordpress',
         charm: 'precise/wordpress-1',
         config: {debug: 'no', username: 'admin'},
-        constraints: 'cpu-power=2,cpu-cores=4',
+        constraints: 'cpu-power=2 cpu-cores=4',
         annotations: {'gui-x': 100, 'gui-y': 200}
       });
       db.relations.add({
@@ -862,7 +862,7 @@ describe('test_model.js', function() {
 
       // Constraints
       var constraints = result.services.wordpress.constraints;
-      assert.equal(constraints, 'cpu-power=2,cpu-cores=4');
+      assert.equal(constraints, 'cpu-power=2 cpu-cores=4');
 
       // Export position annotations.
       assert.equal(result.services.wordpress.annotations['gui-x'], 100);


### PR DESCRIPTION
Make exported bundles write constraints as space-separated.

The fakebackend is changed to accept either the older comma-separated constraints or space-separated.
