### PR TITLE
Add support for grouping promulgated bundles as recommended

### DIFF
--- a/app/models/bundle.js
+++ b/app/models/bundle.js
@@ -125,6 +125,25 @@ YUI.add('juju-bundle-models', function(Y) {
       id: {},
       name: {},
       description: {},
+      /**
+        For charms the api returns is_approved and we want to share that
+        across our templates. This maps to the promulgated api data from the
+        bundle results.
+
+        @attribute is_approved
+        @default false
+        @type {Boolean}
+       */
+      is_approved: {
+        /**
+          Reach into the promulgated attr
+
+          @method getter
+         */
+        getter: function() {
+          return this.get('promulgated');
+        }
+      },
       owner: {},
       permanent_url: {},
       promulgated: false,

--- a/app/subapps/browser/views/search.js
+++ b/app/subapps/browser/views/search.js
@@ -168,14 +168,25 @@ YUI.add('subapp-browser-searchview', function(Y) {
                 if (!series) {
                   series = DEFAULT_SEARCH_SERIES;
                 }
-                results.map(function(charm) {
-                  if (charm.get('is_approved') &&
-                      charm.get('series') === series) {
-                    recommended.push(charm);
+                results.map(function(entity) {
+                  // If this is a charm, make sure it's approved and is of the
+                  // correct series to be recommended.
+                  if (entity.entityType === 'bundle') {
+                    if (entity.get('is_approved')) {
+                      recommended.push(entity);
+                    } else {
+                      more.push(entity);
+                    }
                   } else {
-                    more.push(charm);
+                    if (entity.get('is_approved') &&
+                        entity.get('series') === series) {
+                      recommended.push(entity);
+                    } else {
+                      more.push(entity);
+                    }
                   }
                 }, this);
+
                 this._renderSearchResults({
                   recommended: recommended,
                   more: more

--- a/test/test_browser_search_view.js
+++ b/test/test_browser_search_view.js
@@ -179,8 +179,9 @@ describe('search view', function() {
 
   it('organizes results by approval status', function(done) {
     view._renderSearchResults = function(results) {
-      assert.equal(results.recommended.length, 1);
+      assert.equal(results.recommended.length, 2);
       assert.equal(results.recommended[0].get('id'), 'precise/bar-2');
+      assert.equal(results.recommended[1].get('id'), '~charmers/bar/2/bar');
       assert.equal(results.more.length, 1);
       done();
     };
@@ -200,6 +201,17 @@ describe('search view', function() {
           description: 'some charm named bar',
           files: [],
           is_approved: false
+        }
+      }, {
+        bundle: {
+          id: '~charmers/bar/2/bar',
+          name: 'bar bundle',
+          description: '',
+          files: [],
+          promulgated: true,
+          data: {
+            series: 'precise'
+          }
         }
       }]
     };

--- a/test/test_model_bundle.js
+++ b/test/test_model_bundle.js
@@ -98,6 +98,11 @@ describe('The bundle model', function() {
     assert.equal(expected, instance.get('promulgated'));
   });
 
+  it('must support is_approved as a proxy to promulgated', function() {
+    instance = new models.Bundle({promulgated: true});
+    assert.equal(instance.get('is_approved'), true);
+  });
+
   it('must store the title', function() {
     expected = 'My Bountiful Bundle';
     data.title = expected;


### PR DESCRIPTION
Search should show promulgated bundles as recommended. 

To QA:

Load the gui and search for "bundle" as the keyword. There should be one result that comes back as recommended and the charm token shows it as a recommended bundle. 
