### PR TITLE
Sandbox mode addMachines API.

### DIFF
--- a/app/store/env/go.js
+++ b/app/store/env/go.js
@@ -876,7 +876,7 @@ YUI.add('juju-env-go', function(Y) {
           Error: 'only defined if a global error occurred',
           Response: {
             Machines: [
-              {Machine: '2', Error: 'a machine error occurred'},
+              {Machine: '2', Error: {Code: "code", Message: "error message"}},
               {Machine: '2/lxc/1', Error: null}
             ]
           }
@@ -887,8 +887,16 @@ YUI.add('juju-env-go', function(Y) {
       var transformedData = {
         err: data.Error,
         machines: machines.map(function(machine) {
+          var error = null;
+          var machineError = machine.Error;
+          if (machineError) {
+            error = machineError.Message;
+            if (machineError.Code) {
+              error += ' (code ' + machineError.Code + ')';
+            }
+          }
           return {
-            err: machine.Error,
+            err: error,
             name: machine.Machine
           };
         })

--- a/app/store/env/sandbox.js
+++ b/app/store/env/sandbox.js
@@ -1164,6 +1164,42 @@ YUI.add('juju-env-sandbox', function(Y) {
     },
 
     /**
+      Handle AddMachines messages.
+
+      @method handleClientAddMachines
+      @param {Object} data The contents of the API arguments.
+      @param {Object} client The active ClientConnection.
+      @param {Object} state An instance of FakeBackend.
+    */
+    handleClientAddMachines: function(data, client, state) {
+      var params = data.Params.MachineParams.map(function(machineParam) {
+        return {
+          jobs: machineParam.Jobs,
+          series: machineParam.Series,
+          parentId: machineParam.ParentId,
+          containerType: machineParam.ContainerType,
+          constrains: machineParam.Constraints
+        };
+      });
+      var response = state.addMachines(params);
+      var machines = response.machines.map(function(data) {
+        var error = null;
+        if (data.error) {
+          // There is no need for the sandbox to simulate the juju-core error
+          // code machinery. Most of the times this is an empty string in real
+          // environments. The message can always be found in Error.Message.
+          error = {Code: '', Message: data.error};
+        }
+        return {Machine: data.name || '', Error: error};
+      });
+      client.receive({
+        RequestId: data.RequestId,
+        Error: response.error,
+        Response: {Machines: machines}
+      });
+    },
+
+    /**
       Handle DestroyMachines messages.
 
       @method handleClientDestroyMachines

--- a/test/test_model.js
+++ b/test/test_model.js
@@ -513,20 +513,41 @@ describe('test_model.js', function() {
             machines.createDisplayName('1/kvm/0/lxc/42'), '1/kvm/0/lxc/42');
       });
 
-      it('returns the parent id for a machine', function() {
-        assert.isNull(machines.createParentId('0'));
-        assert.isNull(machines.createParentId('42'));
+      it('retrieves machine info parsing the bootstrap node name', function() {
+        var info = machines.parseMachineName('0');
+        assert.isNull(info.parentId);
+        assert.isNull(info.containerType);
+        assert.strictEqual(info.number, 0);
       });
 
-      it('returns the parent id for a container', function() {
-        assert.deepEqual(machines.createParentId('0/lxc/0'), '0');
-        assert.deepEqual(machines.createParentId('1/kvm/0/lxc/42'), '1/kvm/0');
+      it('retrieves machine info parsing a machine name', function() {
+        var info = machines.parseMachineName('42');
+        assert.isNull(info.parentId);
+        assert.isNull(info.containerType);
+        assert.strictEqual(info.number, 42);
       });
 
-      it('stores the machines parent id', function() {
+      it('retrieves machine info parsing a container name', function() {
+        var info = machines.parseMachineName('0/lxc/0');
+        assert.strictEqual(info.parentId, '0');
+        assert.strictEqual(info.containerType, 'lxc');
+        assert.strictEqual(info.number, 0);
+      });
+
+      it('retrieves machine info parsing a sub-container name', function() {
+        var info = machines.parseMachineName('1/lxc/0/kvm/42');
+        assert.strictEqual(info.parentId, '1/lxc/0');
+        assert.strictEqual(info.containerType, 'kvm');
+        assert.strictEqual(info.number, 42);
+      });
+
+      it('stores machines data parsing machine names', function() {
         ['42', '0/lxc/0', '1/kvm/0/lxc/42'].forEach(function(id) {
           var machine = machines.add({id: id});
-          assert.deepEqual(machine.parentId, machines.createParentId(id), id);
+          var info = machines.parseMachineName(id);
+          assert.strictEqual(machine.parentId, info.parentId, id);
+          assert.strictEqual(machine.containerType, info.containerType, id);
+          assert.strictEqual(machine.number, info.number, id);
         });
       });
 


### PR DESCRIPTION
Sandbox mode addMachines API.

Implement the fake addMachines call, using
the error messages as returned by juju-core.

Include in the machine model some basic
container/machine number info which can
be parsed from the machine name.

Clean up the destroyMachines sandbox call.

Fix the go environment addMachines API call:
errors for specific machines are now
correctly handled (including error codes).

No QA needed.
