### PR TITLE
Support bundle exports in Safari 7

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -842,8 +842,10 @@ YUI.add('juju-gui', function(Y) {
     exportYAML: function() {
       var result = this.db.exportDeployer();
       var exportData = jsyaml.dump(result);
+      // In order to support Safari 7 the type of this blob needs
+      // to be text/plain instead of it's actual type of application/yaml.
       var exportBlob = new Blob([exportData],
-          {type: 'application/yaml;charset=utf-8'});
+          {type: 'text/plain;charset=utf-8'});
       saveAs(exportBlob, 'export.yaml');
     },
 

--- a/app/assets/javascripts/FileSaver.js
+++ b/app/assets/javascripts/FileSaver.js
@@ -1,22 +1,29 @@
-/* FileSaver.js
- * A saveAs() FileSaver implementation.
- * 2013-01-23
+/*! FileSaver.js
+ *  A saveAs() FileSaver implementation.
+ *  2014-01-24
  *
- * By Eli Grey, http://eligrey.com
- * License: X11/MIT
- *   See LICENSE.md
+ *  By Eli Grey, http://eligrey.com
+ *  License: X11/MIT
+ *    See LICENSE.md
  */
 
 /*global self */
-/*jslint bitwise: true, regexp: true, confusion: true, es5: true, vars: true, white: true,
-  plusplus: true */
+/*jslint bitwise: true, indent: 4, laxbreak: true, laxcomma: true, smarttabs: true, plusplus: true */
 
 /*! @source http://purl.eligrey.com/github/FileSaver.js/blob/master/FileSaver.js */
 
 var saveAs = saveAs
-  || (navigator.msSaveBlob && navigator.msSaveBlob.bind(navigator))
+  // IE 10+ (native saveAs)
+  || (typeof navigator !== "undefined" &&
+      navigator.msSaveOrOpenBlob && navigator.msSaveOrOpenBlob.bind(navigator))
+  // Everyone else
   || (function(view) {
 	"use strict";
+	// IE <10 is explicitly unsupported
+	if (typeof navigator !== "undefined" &&
+	    /MSIE [1-9]\./.test(navigator.userAgent)) {
+		return;
+	}
 	var
 		  doc = view.document
 		  // only get URL when necessary in case BlobBuilder.js hasn't overridden it yet
@@ -25,7 +32,7 @@ var saveAs = saveAs
 		}
 		, URL = view.URL || view.webkitURL || view
 		, save_link = doc.createElementNS("http://www.w3.org/1999/xhtml", "a")
-		, can_use_save_link = "download" in save_link
+		, can_use_save_link = !view.externalHost && "download" in save_link
 		, click = function(node) {
 			var event = doc.createEvent("MouseEvents");
 			event.initMouseEvent(
@@ -36,7 +43,7 @@ var saveAs = saveAs
 		}
 		, webkit_req_fs = view.webkitRequestFileSystem
 		, req_fs = view.requestFileSystem || webkit_req_fs || view.mozRequestFileSystem
-		, throw_outside = function (ex) {
+		, throw_outside = function(ex) {
 			(view.setImmediate || view.setTimeout)(function() {
 				throw ex;
 			}, 0);
@@ -94,6 +101,8 @@ var saveAs = saveAs
 					}
 					if (target_view) {
 						target_view.location.href = object_url;
+					} else {
+						window.open(object_url, "_blank");
 					}
 					filesaver.readyState = filesaver.DONE;
 					dispatch_all();
@@ -114,9 +123,20 @@ var saveAs = saveAs
 			}
 			if (can_use_save_link) {
 				object_url = get_object_url(blob);
+				// FF for Android has a nasty garbage collection mechanism
+				// that turns all objects that are not pure javascript into 'deadObject'
+				// this means `doc` and `save_link` are unusable and need to be recreated
+				// `view` is usable though:
+				doc = view.document;
+				save_link = doc.createElementNS("http://www.w3.org/1999/xhtml", "a");
 				save_link.href = object_url;
 				save_link.download = name;
-				click(save_link);
+				var event = doc.createEvent("MouseEvents");
+				event.initMouseEvent(
+					"click", true, false, view, 0, 0, 0, 0, 0
+					, false, false, false, false, 0, null
+				);
+				save_link.dispatchEvent(event);
 				filesaver.readyState = filesaver.DONE;
 				dispatch_all();
 				return;
@@ -137,8 +157,6 @@ var saveAs = saveAs
 			}
 			if (type === force_saveable_type || webkit_req_fs) {
 				target_view = view;
-			} else {
-				target_view = view.open();
 			}
 			if (!req_fs) {
 				fs_error();
@@ -212,5 +230,18 @@ var saveAs = saveAs
 		null;
 
 	view.addEventListener("unload", process_deletion_queue, false);
+	saveAs.unload = function() {
+		process_deletion_queue();
+		view.removeEventListener("unload", process_deletion_queue, false);
+	};
 	return saveAs;
-}(self));
+}(
+	   typeof self !== "undefined" && self
+	|| typeof window !== "undefined" && window
+	|| this.content
+));
+// `self` is undefined in Firefox for Android content script context
+// while `this` is nsIContentFrameMessageManager
+// with an attribute `content` that corresponds to the window
+
+if (typeof module !== "undefined") module.exports = saveAs;


### PR DESCRIPTION
## To QA
- Make sure that bundle export/import still works as expected in Chrome/FF/IE
- Bundle export from Safari. It should open the yaml in another tab. You will then need to cmd+s to save the bundle as a yaml file. 
- Import that bundle into Safari to make sure that it exports properly.
## Notes

The fix is in app.js.
The changes to Filesaver.js are simply an update to the latest version
