### PR TITLE
Use simplified URLs for promulgated bundles.

### DIFF
--- a/app/models/bundle.js
+++ b/app/models/bundle.js
@@ -183,6 +183,23 @@ YUI.add('juju-bundle-models', function(Y) {
         value: 0
       },
 
+      bundleURL: {
+        /**
+          Return the bundle URL.
+          Use the simplified form if the bundle is promulgated.
+
+          @method getter
+        */
+        getter: function() {
+          if (this.get('promulgated')) {
+            var basket = this.get('basket_name');
+            var revision = this.get('basket_revision');
+            var name = this.get('name');
+            return 'bundle:' + basket + '/' + revision + '/' + name;
+          }
+          return this.get('permanent_url');
+        }
+      },
       relations: {
         /**
          Return the relations data as a list of objects.

--- a/app/templates/bundle.handlebars
+++ b/app/templates/bundle.handlebars
@@ -24,19 +24,21 @@
                         <a href="" class="add deploy">Deploy this bundle</a>
                     </div>
                     <ul>
-                        <li>Deployed {{downloads}} {{pluralize 'time' downloads}}</li>
-                        <li>
-                            {{serviceCount}}
-                            {{pluralize 'service' serviceCount}} |
-                            {{unitCount}} {{pluralize 'unit' unitCount}}
-                        </li>
                         <li>
                             {{#if is_approved}}
                                 Recommended
                             {{else}}
                                 {{owner}}
                             {{/if}}
-                            <span class="push-left">Location: {{permanent_url}}</span>
+                            <span class="push-left">
+                                Location: {{bundleURL}}
+                            </span>
+                        </li>
+                        <li>Deployed {{downloads}} {{pluralize 'time' downloads}}</li>
+                        <li>
+                            {{serviceCount}}
+                            {{pluralize 'service' serviceCount}} |
+                            {{unitCount}} {{pluralize 'unit' unitCount}}
                         </li>
                     </ul>
                     <div class="charms">
@@ -76,7 +78,7 @@
                             <pre>sudo apt-get install juju-quickstart</pre>
                         </p>
                         <p>Step 2 - Deploy bundle
-                            <pre>juju-quickstart {{permanent_url}} [-e &lt;JUJU_ENV&gt;]</pre>
+                            <pre>juju-quickstart {{bundleURL}} [-e &lt;JUJU_ENV&gt;]</pre>
                         </p>
                         <h3>Deploy via the deployer</h3>
                         <p>The Juju deployer is a tool that the quickstart plugin (above) uses.  It can also be used standalone to give you more control.</p>

--- a/test/test_model_bundle.js
+++ b/test/test_model_bundle.js
@@ -98,6 +98,18 @@ describe('The bundle model', function() {
     assert.equal(expected, instance.get('promulgated'));
   });
 
+  it('returns the proper bundle URL for non-promulgated bundles', function() {
+    data.promulgated = false;
+    instance = new models.Bundle(data);
+    assert.strictEqual(instance.get('bundleURL'), 'bundle:~benji/wiki/5/wiki');
+  });
+
+  it('returns the proper bundle URL for promulgated bundles', function() {
+    data.promulgated = true;
+    instance = new models.Bundle(data);
+    assert.strictEqual(instance.get('bundleURL'), 'bundle:wiki/5/wiki');
+  });
+
   it('must support is_approved as a proxy to promulgated', function() {
     instance = new models.Bundle({promulgated: true});
     assert.equal(instance.get('is_approved'), true);


### PR DESCRIPTION
Avoid showing the user part in the bundle URLs
displayed in the bundle browser view header and
in quickstart instructions.

Also moved the bundle location above the deployment
stats in the header, so that the URL is not hidden
by the "Deploy this bundle" button.

QA:
- make devel/debug/prod;
- search for bundles and pick a promulgated one;
- check the simplified bundle URL is showed in the header
  and in the quickstart howto (Deploy tab);
- now pick a non-promulgated bundle: this time the user
  is properly included in the URL.
