### PR TITLE
Clarify keyboard shortcut help.

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -114,6 +114,8 @@ YUI.add('juju-gui', function(Y) {
      *            keybindings.
      * callback: {Function} Taking (event, target).
      * help: {String} Help text to display in popup.
+     * label: {String} The label to display in the help text. Defaults to the
+     *        specified keybinding.
      *
      * All are optional.
      */
@@ -142,14 +144,15 @@ YUI.add('juju-gui', function(Y) {
                 // human <Alt> m
                 // <Control> <Shift> N (note caps)
                 // also 'g then i' style
-                bindings.push({key: k, help: v.help});
+                bindings.push({key: k, label: v.label || k, help: v.help});
               }
             }, this);
             target.setHTML(
                 views.Templates.shortcuts({bindings: bindings}));
           }
         },
-        help: 'Display this help'
+        help: 'Display this help',
+        label: 'S-?'
       },
       'A-e': {
         callback: function(evt) {
@@ -167,7 +170,8 @@ YUI.add('juju-gui', function(Y) {
       },
       'S-0': {
         fire: 'panToCenter',
-        help: 'Center the Environment overview'
+        help: 'Center the Environment overview',
+        label: 'S-)'
       },
       'esc': {
         fire: 'clearState',

--- a/app/templates/shortcuts.handlebars
+++ b/app/templates/shortcuts.handlebars
@@ -11,7 +11,7 @@
   <tbody>
   {{#bindings}}
   <tr>
-    <td class="binding">{{key}}</td>
+    <td class="binding">{{label}}</td>
     <td>{{help}}</td>
     </tr>
   {{/bindings}}

--- a/test/test_app_hotkeys.js
+++ b/test/test_app_hotkeys.js
@@ -64,7 +64,18 @@ describe('application hotkeys', function() {
       shiftKey: true
     });
     var help = Y.one('#shortcut-help');
-    assert.equal(help.getStyle('display'), 'block');
+    assert.equal(help.getStyle('display'), 'block',
+                 'Shortcut help not displayed');
+    // Is the "S-?" label displayed in the help?
+    var bindings = help.all('td.binding'),
+        found = false;
+    bindings.each(function(node) {
+      var text = node.getDOMNode().textContent;
+      if (text === 'S-?') {
+        found = true;
+      }
+    });
+    assert.equal(found, true, 'Shortcut label not found');
     help.hide();
   });
 


### PR DESCRIPTION
The shortcut labels had to match the lowercase version of the key. In
some cases that didn't make as much sense as the uppercase version. For
example, Shift+/ brings up the help, but Shift+? (the uppercase version)
is more intuitive. Add a way to separate the label displayed from the
actual keybinding (which had to be the lowercase version).
