### PR TITLE
Update machine model.

### DIFF
--- a/app/models/handlers.js
+++ b/app/models/handlers.js
@@ -284,13 +284,44 @@ YUI.add('juju-delta-handlers', function(Y) {
       @return {undefined} Nothing.
      */
     machineInfo: function(db, action, change) {
+      var addresses = change.Addresses || [];
       var data = {
         id: change.Id,
+        addresses: addresses.map(function(address) {
+          return {
+            name: address.NetworkName,
+            scope: address.NetworkScope,
+            type: address.Type,
+            value: address.Value
+          };
+        }),
         instance_id: change.InstanceId,
         agent_state: change.Status,
         agent_state_info: change.StatusInfo,
-        agent_state_data: change.StatusData
+        agent_state_data: change.StatusData,
+        hardware: {},
+        jobs: change.Jobs,
+        life: change.Life,
+        series: change.Series,
+        supportedContainers: null
       };
+      // The HardwareCharacteristics attribute is undefined if the machine
+      // is not yet provisioned.
+      var hardwareCharacteristics = change.HardwareCharacteristics;
+      if (hardwareCharacteristics) {
+        data.hardware = {
+          arch: hardwareCharacteristics.Arch,
+          cpuCores: hardwareCharacteristics.CpuCores,
+          cpuPower: hardwareCharacteristics.CpuPower,
+          mem: hardwareCharacteristics.Mem,
+          disk: hardwareCharacteristics.RootDisk
+        };
+      }
+      // The supported containers are only available when the machine is
+      // provisioned.
+      if (change.SupportedContainersKnown) {
+        data.supportedContainers = change.SupportedContainers;
+      }
       db.machines.process_delta(action, data);
     },
 

--- a/app/models/models.js
+++ b/app/models/models.js
@@ -691,20 +691,159 @@ YUI.add('juju-models', function(Y) {
   var Machine = Y.Base.create('machine', Y.Model, [], {
     idAttribute: 'machine_id'
   }, {
+    // Since MachineList is a lazy model list, the attributes below are rarely
+    // used, and real object properties are created instead. That said, the
+    // comments below are useful since they also provide a description of
+    // machine lazy instances' properties.
     ATTRS: {
-      // The following attributes are automatically generated when a machine is
-      // added to the model list.
+      /**
+        The machine display name (e.g. "1" or "2/lxc/0"), automatically
+        generated when a machine is added to the model list.
+
+        @attribute displayName
+        @type {String}
+      */
       displayName: {},
+      /**
+        The parent machine name (e.g. "1" or "2/lxc/0"), automatically
+        generated when a machine is added to the model list. For top level
+        machines, this value is null.
+
+        @attribute parentId
+        @type {String}
+      */
       parentId: {},
+      /**
+        The machine container type (e.g. "lxc" or "kvm"), or null if this is a
+        top level machine. This attribute is automatically generated when a
+        machine is added to the model list.
+
+        @attribute containerType
+        @type {String}
+      */
       containerType: {},
+      /**
+        The machine or container number, automatically generated when a machine
+        is added to the model list.
+
+        @attribute number
+        @type {Int}
+      */
       number: {},
-      // The following attributes are included in the mega-watcher info.
+      /**
+        The machine id, usually provided by the pyJuju stream.
+
+        @attribute machine_id
+        @type {String}
+      */
       machine_id: {},
+      /**
+        The machine public address. This is set by the pyJuju machine stream,
+        or by the juju-core mega-watcher for units, when the unit is hosted by
+        this machine. When using juju-core, this is only set if the machine
+        hosts a unit. Also see the addresses property below.
+
+        @attribute public_address
+        @type {String}
+      */
       public_address: {},
+      /**
+        The machine addresses. Each address is an object including the
+        following string fields:
+          - name: the network name to which the address is associated;
+          - scope: "public" for exposed addresses or "local-cloud" for local
+            ones;
+          - type: the address type (e.g. "hostname" or "ipv4");
+          - value: the actual address.
+        This info is included in the juju-core mega-watcher for machines.
+
+        @attribute addresses
+        @type {Array}
+      */
+      addresses: {},
+      /**
+        The machine instance id assigned by the cloud provider.
+        This info is included in the juju-core mega-watcher for machines.
+
+        @attribute instance_id
+        @type {String}
+      */
       instance_id: {},
+      /**
+        The machine status (e.g. "pending", "started" or "error").
+        This info is included in the juju-core mega-watcher for machines.
+
+        @attribute instance_id
+        @type {String}
+      */
       agent_state: {},
+      /**
+        Additional information for a machine status.
+        For a more detailed info use the agent_state_data property below.
+        This info is included in the juju-core mega-watcher for machines.
+
+        @attribute agent_state_info
+        @type {String}
+      */
       agent_state_info: {},
-      agent_state_data: {}
+      /**
+        Additional information for a machine status.
+        This info is included in the juju-core mega-watcher for machines.
+
+        @attribute agent_state_data
+        @type {Object}
+      */
+      agent_state_data: {},
+      /**
+        The machine hardware characteristics as an object including the
+        following fields:
+          - arch {String}: the hardware architecture (e.g. "amd64");
+          - cpuCores {Int}: the number of CPU cores (e.g. 1 or 4);
+          - cpuPower {Int}: the CPU power (e.g. 100);
+          - mem {Int}: the machine memory in MB (e.g. 2048);
+          - disk {Int}: the root disk storage in MB (e.g. 8192).
+        This info is included in the juju-core mega-watcher for machines.
+
+        @attribute hardware
+        @type {Object}
+      */
+      hardware: {},
+      /**
+        The jobs this machine can be used for (e.g. "JobHostUnits").
+        This info is included in the juju-core mega-watcher for machines.
+
+        @attribute jobs
+        @type {Array}
+      */
+      jobs: {},
+      /**
+        The machine life cycle status ("alive", "dying" or "dead").
+        This info is included in the juju-core mega-watcher for machines.
+
+        @attribute life
+        @type {String}
+      */
+      life: {},
+      /**
+        The machine OS version (e.g. "precise" or "trusty").
+        This info is included in the juju-core mega-watcher for machines.
+
+        @attribute series
+        @type {String}
+      */
+      series: {},
+      /**
+        The container types that can be created in this machine (e.g. "lxc").
+        This info is only available when a machine is fully provisioned. The
+        attribute is set to null until the information is known, i.e.:
+        when supportedContainers is null this machine CAN support containers;
+        when supportedContainers is [] this machine DO NOT support containers.
+        This info is included in the juju-core mega-watcher for machines.
+
+        @attribute supportedContainers
+        @type {Array}
+      */
+      supportedContainers: {}
     }
   });
   models.Machine = Machine;


### PR DESCRIPTION
Include new info from the mega-watcher for machines.

QA:
- Bootstrap an ec2 environment with juju-core trunk (at least revno 2463):
  `juju bootstrap -e ec2 --upload-tools`.
- Deploy and expose the GUI:
  `juju deploy -e ec2 juju-gui && juju expose -e ec2 juju-gui`.
- Switch to this branch:
  `juju set -e ec2 juju-gui juju-gui-source="https://github.com/frankban/juju-gui.git machine-model-changes"`.
- Wait for the unit to be ready, log in and open the JS console.
- Check that two machines are present in the db:
  `app.db.machines.size();` --> 2.
- Inspect the GUI machine:
  `app.db.machines.getById('1');`.
- Check the returned fields, i.e. check that the machines properly includes:
  - four addresses (name is empty for now);
  - hardware characteristics (arch, cpuCores etc. in the hardware property);
  - jobs ('JobHostUnits');
  - life ('alive');
  - series ('precise');
  - supportedContainers ('lxc').
- Check that the bootstrap node also manages environments:
  `app.db.machines.getById('0').jobs;`
- Now create a new machine:
  `juju add-machine -e ec2 --series saucy`.
- And we have three machines:
  `app.db.machines.size();`.
- Check the new machine attributes multiple times:
  `app.db.machines.getById('2');`.
- You should see that supportedContainers is initially null, and then it will
  switch to ['lxc']. Also, series is 'saucy'.
- Let's add a container to machine 2:
  `juju add-machine -e ec2 lxc:2`.
- Retrieve information on the new container:
  `app.db.machines.getById('2/lxc/0');`
- You should see that initially hardware is an empty object and also
  supportedContainers is null.
- Wait until the container is fully provisioned (this can take a while):
  supportedContainers is an empty list and hardware include the architecture.
- Note that containers' addresses are not present because they are not
  returned by the cloud provider. The juju db also stores addresses returned
  by the machine itself. A change to juju-core is required if we find out
  we need to know LXC addresses.
- Done, destroy the environment, thank you!
