### PR TITLE
Sandbox mode: handle missing machine properties.

### DIFF
--- a/app/store/env/go.js
+++ b/app/store/env/go.js
@@ -805,9 +805,7 @@ YUI.add('juju-env-go', function(Y) {
         to be added. Each item in the list must be an object containing the
         following keys (all optional):
           - constraints {Object}: the machine constraints;
-          - jobs {Array}: to juju-core jobs to associate with the new machine
-            (defaults to env.machineJobs.HOST_UNITS, which enables unit hosting
-            capabilities to new machines);
+          - jobs {Array}: the juju-core jobs to associate with the new machine.
           - series {String}: the machine series (the juju-core default series
             is used if none is specified);
           - parentId {String}: when adding a new container, this parameter can

--- a/app/store/env/sandbox.js
+++ b/app/store/env/sandbox.js
@@ -882,10 +882,29 @@ YUI.add('juju-env-sandbox', function(Y) {
         Config: 'config'
       },
       machine: {
-        Id: 'machine_d',
+        Id: 'id',
+        Addresses: 'addresses',
         InstanceId: 'instance_id',
         Status: 'agent_state',
-        StateInfo: 'agent_status_info'
+        StateInfo: 'agent_status_info',
+        StatusData: 'agent_state_data',
+        'HardwareCharacteristics': function(attrs) {
+          var hardware = attrs.hardware || {};
+          return {
+            Arch: hardware.arch,
+            CpuCores: hardware.cpuCores,
+            CpuPower: hardware.cpuPower,
+            Mem: hardware.mem,
+            RootDisk: hardware.disk
+          };
+        },
+        Jobs: 'jobs',
+        Life: 'life',
+        Series: 'series',
+        SupportedContainers: 'supportedContainers',
+        'SupportedContainersKnown': function() {
+          return true;
+        }
       },
       unit: {
         Name: 'id',
@@ -1179,7 +1198,7 @@ YUI.add('juju-env-sandbox', function(Y) {
           series: machineParam.Series,
           parentId: machineParam.ParentId,
           containerType: machineParam.ContainerType,
-          constrains: machineParam.Constraints
+          constraints: machineParam.Constraints
         };
       });
       var response = state.addMachines(params);

--- a/test/test_sandbox_go.js
+++ b/test/test_sandbox_go.js
@@ -296,8 +296,12 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       client.onmessage = function(received) {
         var receivedData = Y.JSON.parse(received.data);
         var deltas = receivedData.Response.Deltas;
-        assert.deepEqual(deltas, [
-          ['service', 'change', {
+        assert.equal(deltas.length, 3);
+        var serviceChange = deltas[0];
+        var machineChange = deltas[1];
+        var unitChange = deltas[2];
+        assert.deepEqual(serviceChange, [
+          'service', 'change', {
             'Name': 'wordpress',
             'Exposed': false,
             'CharmURL': 'cs:precise/wordpress-15',
@@ -309,17 +313,38 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
               'wp-content': ''
             },
             'Constraints': {}
-          }],
-          ['machine', 'change', {'Status': 'running'}],
-          ['unit', 'change', {
+          }], 'serviceChange'
+        );
+        assert.deepEqual(machineChange, [
+          'machine', 'change', {
+            Id: '0',
+            Addresses: [],
+            InstanceId: 'fake-instance',
+            Status: 'started',
+            Jobs: ['JobHostUnits'],
+            Life: 'alive',
+            Series: 'precise',
+            HardwareCharacteristics: {
+              Arch: 'amd64',
+              CpuCores: 1,
+              CpuPower: 100,
+              Mem: 1740,
+              RootDisk: 8192
+            },
+            SupportedContainers: ['lxc', 'kvm'],
+            SupportedContainersKnown: true
+          }], 'machineChange'
+        );
+        assert.deepEqual(unitChange, [
+          'unit', 'change', {
             'Name': 'wordpress/0',
             'Service': 'wordpress',
             'Series': 'precise',
             'CharmURL': 'cs:precise/wordpress-15',
-            'MachineId': '1',
+            'MachineId': '0',
             'Status': 'started'
-          }]
-        ]);
+          }], 'unitChange'
+        );
         done();
       };
       client.open();


### PR DESCRIPTION
Also completed the addMachines/destroyMachines delta
stream implementation in the fake backend.

Removed the ambiguity of having a machine_id attribute
in juju-core sandbox.

QA:
- make devel/debug/prod;
- open the JS console;
- add new machines/containers with the following command:
  app.env.addMachines([
    // A new machine with default properties.
    {}, 
    // A new trusty LXC inside a new machine.
    {containerType: 'lxc', series: 'trusty'}, 
    // A new customized machine
    {constraints:{'arch': 'i386', 'cpu-cores': 4, mem: 2000},
     jobs: ['JobHostUnits', 'JobManageEnviron']}
  ]);
- ensure four machines were added, and they contain the expected attributes,
  by running the following: `app.db.machines._items`
- now force the removal of machine 1: also the contained LXC should be
  destroyed: `app.env.destroyMachines(['1'], true);` and then
  `app.db.machines._items` again.
  Done, thank you.
