### PR TITLE
Clean up State API.

### DIFF
--- a/app/views/state.js
+++ b/app/views/state.js
@@ -31,61 +31,108 @@ YUI.add('juju-app-state', function(Y) {
 
   ns.State = Y.Base.create('state', Y.Base, [], {
     /**
-       Create an initial state for later url generation.
+     * Set the value for the current state. Protected because clients should
+     * provide new values for the state via the
+     * {{#crossLink "loadRequest:method"}} method.
+     *
+     * @method _setCurrent
+     * @protected
+     * @param {String} field the part of the state to set.
+     * @param {String} value the new value.
+     */
+    _setCurrent: function(field, value) {
+      this._current[field] = value;
+    },
 
-       @method initializer
+    /**
+     * Set the value for the previous state. Protected because clients should
+     * provide new values for the state via the
+     * {{#crossLink "loadRequest:method"}} method.
+     *
+     * @method _setPrevious
+     * @protected
+     * @param {String} field the part of the state to set.
+     * @param {String} value the new value.
+     */
+    _setPrevious: function(field, value) {
+      this._previous[field] = value;
+    },
+
+    /**
+     * Create an initial state for later url generation.
+     *
+     * @method initializer
      */
     initializer: function() {
-      this.old = {
+      this._previous = {
         charmID: null,
         querystring: null,
         hash: null,
         search: null,
         viewmode: null
       };
-      this.view = Y.merge(this.old, {});
+      this._current = Y.merge(this._previous, {});
       this.filter = new ns.Filter();
     },
 
     /**
-       Cleanup after ourselves on destroy.
-
-       @method destructor
+     * Cleanup after ourselves on destroy.
+     *
+     * @method destructor
      */
     destructor: function() {
-      delete this.view;
+      delete this._current;
       this.filter.destroy();
     },
 
     /**
-       Verify that a particular part of the state has changed.
-
-       @method hasChanged
-       @param {String} field the part of the state to check.
+     * Verify that a particular part of the state has changed.
+     *
+     * @method hasChanged
+     * @param {String} field the part of the state to check.
      */
     hasChanged: function(field) {
-      return this.old[field] !== this.view[field];
+      return this.getPrevious(field) !== this.getCurrent(field);
     },
 
     /**
-       Update the old state with the view state now that we're done processing
-       the request.
+     * Get the value for the current state.
+     *
+     * @method getCurrent
+     * @param {String} field the part of the state to get.
+     */
+    getCurrent: function(field) {
+      return this._current[field];
+    },
 
-       @method save
+    /**
+     * Get the value for the previous state.
+     *
+     * @method getPrevious
+     * @param {String} field the part of the state to get.
+     */
+    getPrevious: function(field) {
+      return this._previous[field];
+    },
+
+    /**
+     * Update the previous state with the view state now that we're done
+     * processing the request.
+     *
+     * @method save
      */
     save: function() {
-      this.old = Y.merge(
-          this.old,
-          this.view);
+      this._previous = Y.merge(
+          this._previous,
+          this._current);
     },
 
     /**
-      Given the current subapp state, generate a url to pass up to the
-      routing code to route to.
-
-      @method getUrl
-      @param {Object} change the values to change in the current state.
-
+     * Given the current subapp state, generate a url to pass up to the
+     * routing code to route to.
+     *
+     * @method getUrl
+     * @param {Object} change the values to change in the current state.
      */
     getUrl: function(change) {
       var urlParts = [];
@@ -108,55 +155,55 @@ YUI.add('juju-app-state', function(Y) {
         change.querystring = this.filter.genQueryString();
       }
 
-      this.view = Y.merge(this.view, change);
+      this._current = Y.merge(this._current, change);
 
-      if (this.view.viewmode !== 'sidebar' ||
-          this.view.search) {
+      if (this.getCurrent('viewmode') !== 'sidebar' ||
+          this.getCurrent('search')) {
         // There's no need to add the default view if we
         // don't need it. However it's currently required for search views to
         // match our current routes.
-        urlParts.push(this.view.viewmode);
+        urlParts.push(this.getCurrent('viewmode'));
       }
 
-      if (this.view.search) {
+      if (this.getCurrent('search')) {
         urlParts.push('search');
-      } else if (this.old.search) {
-        // We had a search, but are moving away; clear the old search.
+      } else if (this.getPrevious('search')) {
+        // We had a search, but are moving away; clear the previous search.
         this.filter.clear();
       }
 
-      if (this.view.charmID) {
-        urlParts.push(this.view.charmID);
+      if (this.getCurrent('charmID')) {
+        urlParts.push(this.getCurrent('charmID'));
       }
 
       var url = urlParts.join('/');
-      if (this.view.querystring) {
+      if (this.getCurrent('querystring')) {
         url = Y.Lang.sub('{ url }?{ qs }', {
           url: url,
-          qs: this.view.querystring
+          qs: this.getCurrent('querystring')
         });
       }
-      if (this.view.hash) {
-        url = url + this.view.hash;
+      if (this.getCurrent('hash')) {
+        url = url + this.getCurrent('hash');
       }
       return url;
     },
 
     /**
-       Given the params in the route determine what the new state is going to
-       be.
-
-       @method update
-       @param {Object} req the request payload.
+     * Given the params in the route determine what the new state is going to
+     * be.
+     *
+     * @method update
+     * @param {Object} req the request payload.
      */
-    update: function(req) {
+    loadRequest: function(req) {
       // Update the viewmode. Every request has a viewmode.
       var path = req.path,
           params = req.params,
           query = req.query,
           hash = window.location.hash;
 
-      this.view.viewmode = params.viewmode;
+      this._setCurrent('viewmode', params.viewmode);
 
       if (hash) {
         // If the hash starts with bws- then reset it to provide backwards
@@ -165,30 +212,30 @@ YUI.add('juju-app-state', function(Y) {
           hash = hash.replace('bws-', '');
         }
 
-        this.view.hash = hash.replace('/', '');
-        window.location.hash = this.view.hash;
+        this._setCurrent('hash', hash.replace('/', ''));
+        window.location.hash = this.getCurrent('hash');
       }
 
       // Check for a charm id in the request.
       if (params.id && params.id !== 'search') {
-        this.view.charmID = params.id;
+        this._setCurrent('charmID', params.id);
       } else {
-        this.view.charmID = null;
+        this._setCurrent('charmID', null);
       }
 
       // Check for search in the request.
       if (path.indexOf('search') !== -1) {
-        this.view.search = true;
+        this._setCurrent('search', true);
       } else {
-        this.view.search = false;
+        this._setCurrent('search', false);
       }
 
       // Check if there's a query string to set.
       if (query) {
         // Store it as a straight string.
-        this.view.querystring = Y.QueryString.stringify(query);
+        this._setCurrent('querystring', Y.QueryString.stringify(query));
       } else {
-        this.view.querystring = null;
+        this._setCurrent('querystring', null);
       }
 
       this.filter.update(query);
@@ -206,7 +253,6 @@ YUI.add('juju-app-state', function(Y) {
    *
    * @class Filter
    * @extends {Y.Model}
-   *
    */
   ns.Filter = Y.Base.create('filter', Y.Model, [], {
     /**
@@ -272,7 +318,6 @@ YUI.add('juju-app-state', function(Y) {
      * @method initializer
      * @param {Object} cfg object attrs override.
      * @return {undefined} nadda.
-     *
      */
     initializer: function(cfg) {
       if (cfg) {
@@ -285,19 +330,18 @@ YUI.add('juju-app-state', function(Y) {
     },
 
     /**
-       Update the current filters given an update object that's keyed on the
-       property and the new values to use for it.
-
-       This is used to help pre-populate the filters from the url on an
-       initial url load (a shared searc link) as well as updates from the
-       widgets that turn into change events that make sure we update the
-       current set of filters based on the changes detected in widgets lower
-       in the stack.
-
-       @method update
-       @param {Object} data the properties to update.
-       @return {undefined} nadda.
-
+     * Update the current filters given an update object that's keyed on the
+     * property and the new values to use for it.
+     *
+     * This is used to help pre-populate the filters from the url on an
+     * initial url load (a shared searc link) as well as updates from the
+     * widgets that turn into change events that make sure we update the
+     * current set of filters based on the changes detected in widgets lower
+     * in the stack.
+     *
+     * @method update
+     * @param {Object} data the properties to update.
+     * @return {undefined} nadda.
      */
     update: function(data) {
       // If you don't give a real object then pass.
@@ -329,51 +373,51 @@ YUI.add('juju-app-state', function(Y) {
   }, {
     ATTRS: {
       /**
-        The categories of charm to search filter the search to.
-
-        @attribute categories
-        @default []
-        @type {Array}
+       * The categories of charm to search filter the search to.
+       *
+       * @attribute categories
+       * @default []
+       * @type {Array}
        */
       categories: {
         value: []
       },
       /**
-        The providers for charms to filter to.
-
-        @attribute provider
-        @default []
-        @type {Array}
+       * The providers for charms to filter to.
+       *
+       * @attribute provider
+       * @default []
+       * @type {Array}
        */
       provider: {
         value: []
       },
       /**
-        The series to filter to for the search.
-
-        @attribute series
-        @default []
-        @type {Array}
+       * The series to filter to for the search.
+       *
+       * @attribute series
+       * @default []
+       * @type {Array}
        */
       series: {
         value: []
       },
       /**
-        The text to search for.
-
-        @attribute text
-        @default ''
-        @type {String}
+       * The text to search for.
+       *
+       * @attribute text
+       * @default ''
+       * @type {String}
        */
       text: {
         value: ''
       },
       /**
-        The type of charms to filter to.
-
-        @attribute type
-        @default []
-        @type {Array}
+       * The type of charms to filter to.
+       *
+       * @attribute type
+       * @default []
+       * @type {Array}
        */
       type: {
         value: []
@@ -382,6 +426,7 @@ YUI.add('juju-app-state', function(Y) {
   });
 }, '0.1.0', {
   requires: [
-    'model'
+    'model',
+    'querystring'
   ]
 });

--- a/test/index.html
+++ b/test/index.html
@@ -84,6 +84,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
   <script src="test_browser_models.js"></script>
   <script src="test_browser_search_view.js"></script>
   <script src="test_browser_search_widget.js"></script>
+  <script src="test_state.js"></script>
   <script src="test_bundle_details_view.js"></script>
   <script src="test_bundle_module.js"></script>
   <script src="test_bundle_import_helpers.js"></script>

--- a/test/test_state.js
+++ b/test/test_state.js
@@ -1,0 +1,191 @@
+
+/**
+This file is part of the Juju GUI, which lets users view and manage Juju
+environments within a graphical interface (https://launchpad.net/juju-gui).
+Copyright (C) 2012-2013 Canonical Ltd.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU Affero General Public License version 3, as published by
+the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero
+General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along
+with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+'use strict';
+
+describe('State object', function() {
+  var Y, ns, state, request;
+
+  before(function(done) {
+    Y = YUI(GlobalConfig).use(
+        'juju-app-state',
+        function(Y) {
+          ns = Y.namespace('juju.models');
+          done();
+        });
+  });
+
+  beforeEach(function() {
+    state = new ns.State();
+    // Setup an empty request mock
+    request = {
+      path: '',
+      params: {},
+      query: ''
+    };
+  });
+
+  afterEach(function(done) {
+    state.after('destroy', function() { done(); });
+    state.destroy();
+  });
+
+  it('detects changed fields appropriately', function() {
+    state._setPrevious('charmID', 'bar');
+    state._setCurrent('charmID', 'foo');
+    assert.equal(state.hasChanged('charmID'), true,
+                 'Did not detect changed field');
+    state._setPrevious('querystring', 'foo');
+    state._setCurrent('querystring', 'foo');
+    assert.equal(state.hasChanged('querystring'), false,
+                 'False positive on an unchanged field');
+  });
+
+  it('saves the current state back to the old state', function() {
+    var expected = {
+      charmID: 'scooby',
+      querystring: 'shaggy',
+      hash: 'velma',
+      search: 'daphne',
+      viewmode: 'fred'
+    };
+    state._current = expected;
+    state.save();
+    assert.deepEqual(state._previous, expected);
+  });
+
+  it('parses viewmode out of the request properly', function() {
+    var viewmode = 'foo';
+    request.params.viewmode = viewmode;
+    state.loadRequest(request);
+    assert.equal(state.getCurrent('viewmode'), viewmode);
+  });
+
+  it('parses hash out of the request properly', function() {
+    var hash = 'foo';
+    window.location.hash = hash;
+    state.loadRequest(request);
+    assert.equal(state.getCurrent('hash'), '#' + hash);
+  });
+
+  it('does not add sidebar to urls that do not require it', function() {
+    // sidebar is the default viewmode and is not required on urls that have
+    // a charm id in them or the root url. Leave out the viewmode in these
+    // cases.
+    var url = state.getUrl({
+      viewmode: 'sidebar',
+      charmID: 'precise/mysql-10',
+      search: undefined,
+      filter: undefined
+    });
+    assert.equal(url, 'precise/mysql-10');
+
+    url = state.getUrl({
+      viewmode: 'sidebar',
+      charmID: undefined,
+      search: undefined,
+      filter: undefined
+    });
+    assert.equal(url, '');
+
+    // The viewmode is required for search related routes though.
+    url = state.getUrl({
+      viewmode: 'sidebar',
+      charmID: undefined,
+      search: true,
+      filter: undefined
+    });
+    assert.equal(url, 'sidebar/search');
+  });
+
+  describe('Filter for State object', function() {
+    var Y, ns, state;
+
+    before(function(done) {
+      Y = YUI(GlobalConfig).use(
+          'juju-app-state',
+          function(Y) {
+            ns = Y.namespace('juju.models');
+            done();
+          });
+    });
+
+    beforeEach(function() {
+      state = new ns.State();
+    });
+
+    afterEach(function(done) {
+      state.after('destroy', function() { done(); });
+      state.destroy();
+    });
+
+    it('resets filters when navigating away from search', function() {
+      state._setCurrent('search', true);
+      state.filter.set('text', 'foo');
+      // Set the state before changing up.
+      state.save();
+      state.getUrl({search: false});
+      assert.equal('', state.filter.get('text'));
+    });
+
+    it('permits a filter clear command', function() {
+      var url = state.getUrl({
+        'search': true,
+        'filter': {
+          text: 'apache'
+        }
+      });
+
+      // We have a good valid search.
+      assert.equal(url, '/search?text=apache');
+
+      // Now let's clear it and make sure it's emptied.
+      url = state.getUrl({
+        'filter': {
+          clear: true
+        }
+      });
+      assert.equal(url, '/search');
+    });
+
+    it('permits a filter replace command', function() {
+      var url = state.getUrl({
+        'search': true,
+        'filter': {
+          text: 'apache',
+          categories: ['app-servers']
+        }
+      });
+      // We have a good valid search.
+      assert.equal(
+          url,
+          '/search?categories=app-servers&text=apache');
+
+      // Now let's update it and force all the rest to go away.
+      url = state.getUrl({
+        'filter': {
+          replace: true,
+          text: 'mysql'
+        }
+      });
+      assert.equal(url, '/search?text=mysql');
+    });
+
+  });
+});


### PR DESCRIPTION
Plunk around with the service inspector, hit refresh, ensure that everything re-renders properly (i.e., the inspector is still displaying the proper service). Repeat for view charm details. Give the public API for State extra scrutiny; methods are:
- `getCurrent(field)` - get the specified field for the current state
- `getPrevious(field)` - get the specified field for the previous state
- `hasChanged(field)` - check to see if the field differs between previous and current states
- `getUrl(field)` - generate the proper URL based on the current state (not called directly; subscribes to `viewNavigate` event)
- `loadRequest(request)` - set the current state based on the request passed in
- `save()` - save the current state back to the previous state

Note that the API may be further simplified as we move forward with locating State someplace else other than as a field off Browser. Personally, I'd like to see the last two methods dropped so that clients don't need to actively manage State; it should be more intelligent about when it needs to pull in a new request or save off the current state.
