### PR TITLE
Add machine view panel

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -53,6 +53,7 @@ YUI.add('juju-gui', function(Y) {
                                                   Y.juju.Cookies,
                                                   Y.juju.GhostDeployer,
                                                   Y.juju.EnvironmentHeader,
+                                                  Y.juju.MachineViewPanel,
                                                   Y.Event.EventTracker], {
 
     /*
@@ -554,6 +555,7 @@ YUI.add('juju-gui', function(Y) {
         }
         if (window.flags.mv) {
           this._renderEnvironmentHeaderView();
+          this._renderMachineViewPanelView();
         }
       }, this);
 
@@ -923,6 +925,9 @@ YUI.add('juju-gui', function(Y) {
       }
       if (this.environmentHeader) {
         this.destroyEnvironmentHeader();
+      }
+      if (this.machineViewPanel) {
+        this.destroyMachineViewPanel();
       }
       if (this._keybindings) {
         this._keybindings.detach();
@@ -1336,9 +1341,11 @@ YUI.add('juju-gui', function(Y) {
         if (window.flags.mv) {
           if (url.match('/minimized/')) {
             this.environmentHeader.setWidthFull();
+            this.machineViewPanel.setWidthFull();
           }
           else {
             this.environmentHeader.removeWidthFull();
+            this.machineViewPanel.removeWidthFull();
           }
         }
       }
@@ -1664,6 +1671,7 @@ YUI.add('juju-gui', function(Y) {
     'help-dropdown',
     'deployer-bar',
     'environment-header-extension',
+    'machine-view-panel-extension',
     'local-charm-import-helpers',
     'environment-change-set'
   ]

--- a/app/assets/javascripts/machine-view-panel-extension.js
+++ b/app/assets/javascripts/machine-view-panel-extension.js
@@ -1,0 +1,64 @@
+/*
+This file is part of the Juju GUI, which lets users view and manage Juju
+environments within a graphical interface (https://launchpad.net/juju-gui).
+Copyright (C) 2012-2013 Canonical Ltd.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU Affero General Public License version 3, as published by
+the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero
+General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along
+with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+'use strict';
+
+
+YUI.add('machine-view-panel-extension', function(Y) {
+
+  /**
+   * Adds the machine view panel functionality to the app. You need to call
+   * the _renderMachineViewPanelView from the render method of the view to
+   * trigger because Y.View's do not offer any render event.
+   *
+   * @namespace juju
+   * @class MachineViewPanel
+   */
+  function MachineViewPanel() {}
+
+  MachineViewPanel.prototype = {
+    /**
+     * Destroy the view.
+     *
+     * @method destroyMachineViewPanel
+     */
+    destroyMachineViewPanel: function() {
+      this.machineViewPanel.destroy();
+    },
+
+    /**
+     * Sets up the View and renders it to the DOM.
+     *
+     * @method _renderMachineViewPanelView
+     */
+    _renderMachineViewPanelView: function() {
+      var views = Y.namespace('juju.views');
+      this.machineViewPanel = new views.MachineViewPanelView({
+        container: Y.one('#machine-view-panel')
+      }).render();
+    }
+  };
+
+  Y.namespace('juju').MachineViewPanel = MachineViewPanel;
+
+}, '0.1.0', {
+  requires: [
+    'view',
+    'machine-view-panel'
+  ]
+});

--- a/app/index.html
+++ b/app/index.html
@@ -128,6 +128,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       <div id="onboarding"></div>
       <div id="deployer-bar"></div>
       <div id="environment-header"></div>
+      <div id="machine-view-panel"></div>
 
       <div class="cookie-policy" style="display:none;">
         <div class="wrapper">

--- a/app/modules-debug.js
+++ b/app/modules-debug.js
@@ -202,6 +202,11 @@ var GlobalConfig = {
               '/juju-ui/assets/javascripts/environment-header-extension.js'
         },
 
+        'machine-view-panel-extension': {
+          fullpath:
+              '/juju-ui/assets/javascripts/machine-view-panel-extension.js'
+        },
+
         'sub-app': {
           fullpath: '/juju-ui/assets/javascripts/sub-app.js'
         },
@@ -266,6 +271,14 @@ var GlobalConfig = {
           fullpath: '/juju-ui/widgets/environment-header.js'
         },
 
+        'juju-machine-view-panel': {
+          fullpath: '/juju-ui/widgets/machine-view-panel.js'
+        },
+
+        'juju-machine-view-panel-header': {
+          fullpath: '/juju-ui/widgets/machine-view-panel-header.js'
+        },
+
         'juju-view-environment': {
           fullpath: '/juju-ui/views/environment.js'
         },
@@ -299,6 +312,8 @@ var GlobalConfig = {
             'juju-help-dropdown',
             'juju-deployer-bar',
             'juju-environment-header',
+            'juju-machine-view-panel',
+            'juju-machine-view-panel-header',
             'juju-view-utils',
             'juju-topology',
             'juju-view-environment',

--- a/app/templates/machine-view-panel-header.handlebars
+++ b/app/templates/machine-view-panel-header.handlebars
@@ -1,0 +1,3 @@
+<h3 class="title">{{ title }}</h3>
+<a href="" class="action">{{ action }}</a>
+<span class="label">{{ label }}</span>

--- a/app/templates/machine-view-panel.handlebars
+++ b/app/templates/machine-view-panel.handlebars
@@ -1,0 +1,9 @@
+<div class="column unplaced">
+  <div class="head"></div>
+</div>
+<div class="column machines">
+  <div class="head"></div>
+</div>
+<div class="column containers">
+  <div class="head"></div>
+</div>

--- a/app/widgets/machine-view-panel-header.js
+++ b/app/widgets/machine-view-panel-header.js
@@ -1,0 +1,120 @@
+/*
+This file is part of the Juju GUI, which lets users view and manage Juju
+environments within a graphical interface (https://launchpad.net/juju-gui).
+Copyright (C) 2012-2013 Canonical Ltd.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU Affero General Public License version 3, as published by
+the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero
+General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along
+with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+'use strict';
+
+/**
+ * Provide the machine view panel header view.
+ *
+ * @module views
+ */
+
+YUI.add('machine-view-panel-header', function(Y) {
+
+  var views = Y.namespace('juju.views'),
+      widgets = Y.namespace('juju.widgets'),
+      Templates = views.Templates;
+
+  /**
+   * The view associated with the machine view panel header.
+   *
+   * @class MachineViewPanelHeaderView
+   */
+  var MachineViewPanelHeaderView = Y.Base.create(
+      'MachineViewPanelHeaderView',
+      Y.View,
+      [
+        Y.Event.EventTracker
+      ], {
+        template: Templates['machine-view-panel-header'],
+
+        events: {
+          'a': {
+            click: 'clickAction'
+          }
+        },
+
+        /**
+         * Fire the action event.
+         *
+         * @method clickAction
+         * @param {Event} ev the click event created.
+         */
+        clickAction: function(e) {
+          e.preventDefault();
+          this.fire('actionFired');
+        },
+
+        /**
+         * Set the header label.
+         *
+         * @method setLabel
+         */
+        setLabel: function(label) {
+          this.get('container').one('.label').set('text', label);
+        },
+
+        /**
+         * Sets up the DOM nodes and renders them to the DOM.
+         *
+         * @method render
+         */
+        render: function() {
+          var container = this.get('container'),
+              attrs = this.getAttrs();
+          container.setHTML(this.template(attrs));
+          container.addClass('machine-view-panel-header');
+          return this;
+        }
+      });
+
+  MachineViewPanelHeaderView.ATTRS = {
+    /**
+    @attribute title
+    @default undefined
+    @type {String}
+    */
+    title: {},
+
+    /**
+    @attribute label
+    @default undefined
+    @type {String}
+    */
+    label: {},
+
+    /**
+    @attribute action
+    @default undefined
+    @type {String}
+    */
+    action: {}
+  };
+
+  views.MachineViewPanelHeaderView = MachineViewPanelHeaderView;
+
+}, '0.1.0', {
+  requires: [
+    'view',
+    'juju-view-utils',
+    'event-tracker',
+    'node',
+    'handlebars',
+    'juju-templates'
+  ]
+});

--- a/app/widgets/machine-view-panel.js
+++ b/app/widgets/machine-view-panel.js
@@ -1,0 +1,118 @@
+/*
+This file is part of the Juju GUI, which lets users view and manage Juju
+environments within a graphical interface (https://launchpad.net/juju-gui).
+Copyright (C) 2012-2013 Canonical Ltd.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU Affero General Public License version 3, as published by
+the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero
+General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along
+with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+'use strict';
+
+/**
+ * Provide the machine view panel view.
+ *
+ * @module views
+ */
+
+YUI.add('machine-view-panel', function(Y) {
+
+  var views = Y.namespace('juju.views'),
+      widgets = Y.namespace('juju.widgets'),
+      Templates = views.Templates;
+
+  /**
+   * The view associated with the machine view panel.
+   *
+   * @class MachineViewPanelView
+   */
+  var MachineViewPanelView = Y.Base.create('MachineViewPanelView', Y.View,
+      [
+        Y.Event.EventTracker
+      ], {
+        template: Templates['machine-view-panel'],
+
+        events: {
+        },
+
+        /**
+         * Set the panel to be the full width of the screen.
+         *
+         * @method setWidthFull
+         */
+        setWidthFull: function() {
+          this.get('container').addClass('full');
+        },
+
+        /**
+         * Set the panel to leave space for the sidebar.
+         *
+         * @method removeWidthFull
+         */
+        removeWidthFull: function() {
+          this.get('container').removeClass('full');
+        },
+
+        /**
+         * Render the header widgets.
+         *
+         * @method _renderHeaders
+         */
+        _renderHeaders: function(label) {
+          var columns = this.get('container').all('.column');
+
+          columns.each(function(column) {
+            var attrs = {container: column.one('.head')};
+
+            if (column.hasClass('unplaced')) {
+              attrs.title = 'Unplaced units';
+            }
+            else if (column.hasClass('machines')) {
+              attrs.title = 'Environment';
+              attrs.label = '1 machine';
+              attrs.action = 'New machine';
+            }
+            else if (column.hasClass('containers')) {
+              attrs.label = '0 containers, 1 unit';
+              attrs.action = 'New container';
+            }
+            new views.MachineViewPanelHeaderView(attrs).render();
+          });
+        },
+
+        /**
+         * Sets up the DOM nodes and renders them to the DOM.
+         *
+         * @method render
+         */
+        render: function() {
+          var container = this.get('container');
+          container.setHTML(this.template());
+          container.addClass('machine-view-panel');
+          this._renderHeaders();
+          return this;
+        }
+      });
+
+  views.MachineViewPanelView = MachineViewPanelView;
+
+}, '0.1.0', {
+  requires: [
+    'view',
+    'juju-view-utils',
+    'event-tracker',
+    'node',
+    'handlebars',
+    'juju-templates',
+    'machine-view-panel-header'
+  ]
+});

--- a/bin/merge-files
+++ b/bin/merge-files
@@ -91,6 +91,7 @@ require('yui').YUI().use(['yui'], function(Y) {
     'app/assets/javascripts/local-charm-import-helpers.js',
     'app/assets/javascripts/view-dropdown-extension.js',
     'app/assets/javascripts/environment-header-extension.js',
+    'app/assets/javascripts/machine-view-panel-extension.js',
     'app/assets/javascripts/d3-components.js',
     'app/assets/javascripts/d3.min.js',
     'app/assets/javascripts/d3.status.js',

--- a/lib/views/environment-header.less
+++ b/lib/views/environment-header.less
@@ -14,10 +14,8 @@
         margin-left: 0;
     }
     ul {
+        .display-flex;
         .transition(margin-left 0.5s ease-out);
-        display: -webkit-box;
-        display: -ms-flexbox;
-        display: flex;
         height: @environment-header-height - 1;
         margin: 0 0 0 @left-panel-width + 1px;
         list-style: none;
@@ -40,10 +38,7 @@
 .environment-header-li(@spacer) {
     // The following styles are in a mixin so the styles can be munipulated
     // by parent classes.
-
-    -webkit-flex-basis: auto;
-    -ms-flex-basis: auto;
-    flex-basis: auto;
+    .flex-basis(auto);
     padding: 0 @spacer;
     border-right: 1px solid #d9d9d9;
     line-height: @environment-header-height;
@@ -58,9 +53,7 @@
         }
     }
     &.search {
-      -webkit-box-flex: 1;
-      -ms-flex: 1;
-      flex: 1;
+      .flex(1);
       position: relative;
       padding: 0;
 

--- a/lib/views/machine-view/machine-view-panel.less
+++ b/lib/views/machine-view/machine-view-panel.less
@@ -1,0 +1,44 @@
+.machine-view-panel {
+    @border-colour: #d9d9d9;
+    .display-flex;
+    .transition(padding-left 0.5s ease-out);
+    box-sizing: border-box;
+    position: absolute;
+    z-index: 600;
+    top: @navbar-height + @environment-header-height;
+    bottom: 0;
+    left:0;
+    right: 0;
+    padding: 10px 0 0 @left-panel-width + 1px;
+    background-color: #fff;
+
+    &.full {
+        .transition(padding-left 0s ease-out);
+        padding-left: 0;
+    }
+    .column {
+        .flex(1);
+        border-right: 1px solid @border-colour;
+
+        .machine-view-panel-header {
+            padding: 20px;
+            border-bottom: 1px solid @border-colour;
+
+            h3 {
+                .type3;
+                display: block;
+                height: 27px;
+            }
+            a {
+                float: right;
+            }
+            span {
+                display: block;
+                height: 20px;
+            }
+        }
+    }
+}
+.flag-il .machine-view-panel {
+    bottom: @deployer-bar-height;
+}

--- a/lib/views/mixins.less
+++ b/lib/views/mixins.less
@@ -108,3 +108,18 @@
         display: none;
     }
 }
+.display-flex {
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+}
+.flex-basis(@width) {
+    -webkit-flex-basis: @width;
+    -ms-flex-basis: @width;
+    flex-basis: @width;
+}
+.flex (@grow) {
+    -webkit-box-flex: @grow;
+    -ms-flex: @grow;
+    flex: @grow;
+}

--- a/lib/views/stylesheet.less
+++ b/lib/views/stylesheet.less
@@ -921,6 +921,7 @@ g.unit {
 @import "browser/overlay-indicator.less";
 @import "browser/section-title.less";
 @import "browser/tabview.less";
+@import "machine-view/machine-view-panel.less";
 @import "content-panel.less";
 @import "deployer-bar.less";
 @import "dropdown.less";

--- a/test/index.html
+++ b/test/index.html
@@ -126,6 +126,9 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
   <script src="test_local_new_upgrade_inspector.js"></script>
   <script src="test_local_new_upgrade_view.js"></script>
   <script src="test_login.js"></script>
+  <script src="test_machine_view_panel.js"></script>
+  <script src="test_machine_view_panel_extension.js"></script>
+  <script src="test_machine_view_panel_header.js"></script>
 
   <!-- FIXME: latter three modules depend on side effects from model tests. -->
   <script src="test_model.js"></script>

--- a/test/test_machine_view_panel.js
+++ b/test/test_machine_view_panel.js
@@ -1,0 +1,64 @@
+/*
+This file is part of the Juju GUI, which lets users view and manage Juju
+environments within a graphical interface (https://launchpad.net/juju-gui).
+Copyright (C) 2012-2013 Canonical Ltd.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU Affero General Public License version 3, as published by
+the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero
+General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along
+with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+'use strict';
+
+
+describe('machine view panel view', function() {
+  var Y, container, utils, views, view, View;
+
+  before(function(done) {
+    Y = YUI(GlobalConfig).use(['machine-view-panel',
+                               'juju-views',
+                               'juju-tests-utils',
+                               'event-simulate',
+                               'node-event-simulate',
+                               'node'], function(Y) {
+
+      utils = Y.namespace('juju-tests.utils');
+      views = Y.namespace('juju.views');
+      View = views.MachineViewPanelView;
+      done();
+    });
+  });
+
+  beforeEach(function() {
+    container = utils.makeContainer(this, 'machine-view-panel');
+    view = new View({container: container}).render();
+  });
+
+  afterEach(function() {
+    container.remove(true);
+    view.destroy();
+  });
+
+  it('should apply the wrapping class to the container', function() {
+    assert.equal(container.hasClass('machine-view-panel'), true);
+  });
+
+  it('can set whether to be full width', function() {
+    assert.equal(container.hasClass('full'), false);
+    view.setWidthFull();
+    assert.equal(container.hasClass('full'), true);
+  });
+
+  it('should render the header widgets', function() {
+    assert.equal(container.one('.column .head .title').get('text'),
+        'Unplaced units');
+  });
+});

--- a/test/test_machine_view_panel_extension.js
+++ b/test/test_machine_view_panel_extension.js
@@ -1,0 +1,62 @@
+/*
+This file is part of the Juju GUI, which lets users view and manage Juju
+environments within a graphical interface (https://launchpad.net/juju-gui).
+Copyright (C) 2012-2013 Canonical Ltd.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU Affero General Public License version 3, as published by
+the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero
+General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along
+with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+'use strict';
+
+
+describe('machine view panel extension', function() {
+  var Y, container, utils, view, View;
+
+  before(function(done) {
+    Y = YUI(GlobalConfig).use(['machine-view-panel-extension',
+                               'juju-tests-utils',
+                               'event-simulate',
+                               'node-event-simulate',
+                               'juju-views',
+                               'node'], function(Y) {
+
+      utils = Y.namespace('juju-tests.utils');
+      View = Y.Base.create('machine-view-panel', Y.View, [
+        Y.juju.MachineViewPanel
+      ], {
+        template: '<div id="machine-view-panel"></div>',
+        render: function() {
+          this.get('container').setHTML(this.template);
+          this._renderMachineViewPanelView();
+          return this;
+        }
+      });
+      done();
+    });
+  });
+
+  beforeEach(function() {
+    container = utils.makeContainer(this);
+    view = new View({container: container}).render();
+  });
+
+  afterEach(function() {
+    view.destroy();
+  });
+
+  it('can be destroyed', function() {
+    assert.equal(view.machineViewPanel.get('destroyed'), false);
+    view.destroyMachineViewPanel();
+    assert.equal(view.machineViewPanel.get('destroyed'), true);
+  });
+});

--- a/test/test_machine_view_panel_header.js
+++ b/test/test_machine_view_panel_header.js
@@ -1,0 +1,78 @@
+/*
+This file is part of the Juju GUI, which lets users view and manage Juju
+environments within a graphical interface (https://launchpad.net/juju-gui).
+Copyright (C) 2012-2013 Canonical Ltd.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU Affero General Public License version 3, as published by
+the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero
+General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along
+with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+'use strict';
+
+
+describe('machine view panel header view', function() {
+  var Y, container, utils, views, view, View;
+
+  before(function(done) {
+    Y = YUI(GlobalConfig).use(['machine-view-panel-header',
+                               'juju-views',
+                               'juju-tests-utils',
+                               'event-simulate',
+                               'node-event-simulate',
+                               'node'], function(Y) {
+
+      utils = Y.namespace('juju-tests.utils');
+      views = Y.namespace('juju.views');
+      View = views.MachineViewPanelHeaderView;
+      done();
+    });
+  });
+
+  beforeEach(function() {
+    container = utils.makeContainer(this, 'machine-view-panel-header');
+    view = new View({
+      container: container,
+      title: 'test title',
+      label: 'test label',
+      action: 'test action'
+    }).render();
+  });
+
+  afterEach(function() {
+    container.remove(true);
+    view.destroy();
+  });
+
+  it('should apply the wrapping class to the container', function() {
+    assert.equal(container.hasClass('machine-view-panel-header'), true);
+  });
+
+  it('should have the correct attributes set', function() {
+    assert.equal(container.one('.title').get('text'), 'test title');
+    assert.equal(container.one('.label').get('text'), 'test label');
+    assert.equal(container.one('.action').get('text'), 'test action');
+  });
+
+  it('can set the label', function() {
+    assert.equal(container.one('.label').get('text'), 'test label');
+    view.setLabel('new label');
+    assert.equal(container.one('.label').get('text'), 'new label');
+  });
+
+  it('fires an event on tab change', function(done) {
+    view.on('actionFired', function(e) {
+      assert.isObject(e);
+      done();
+    });
+    container.one('.action').simulate('click');
+  });
+});


### PR DESCRIPTION
Added a base for the machine view including a reusable header widget.

Test using the 'mv' flag.

We haven't made a decision about how to render the view yet so including it as a view extension in app.js. Also, it is always visible, it has not yet been hooked up to the environment header tabs.
