### PR TITLE
Fix default constraint values when scaling units.

### DIFF
--- a/app/templates/service-overview-constraints.handlebars
+++ b/app/templates/service-overview-constraints.handlebars
@@ -1,22 +1,28 @@
 <span>Scale up with these constraints?</span>
 <span class="constraint-details hide-on-edit">
   {{#srvConstraints}}
-    {{#if cpu}}
-      {{cpu}}Ghz
+    {{#if cpu-power}}
+      {{cpu-power}}Ghz
     {{else}}
-      Default CPU
+      default CPU power
+    {{/if}}
+    ,&nbsp;
+    {{#if cpu-cores}}
+      {{cpu-cores}} {{pluralize 'core' cpu-cores}}
+    {{else}}
+      default CPU cores
     {{/if}}
     ,&nbsp;
     {{#if mem}}
-      {{mem}}GB
+      {{mem}}MB
     {{else}}
-      default Mem
+      default memory
     {{/if}}
     ,&nbsp;
     {{#if arch}}
       {{arch}}
     {{else}}
-      default Arch
+      default arch
     {{/if}}
   {{/srvConstraints}}
   &nbsp;


### PR DESCRIPTION
Also fix the memory unit used (s/GB/MB).

QA:
- make devel;
- deploy a service, do not change constraints;
- scale up the service: you should see the constraints
  message indicating the default constraints will be used;
- refresh and deploy another service customizing constraints;
- scale up the service: you should see the message indicating
  constraints are set for this service, including CPU power and
  number of cores.
