### PR TITLE
Popover now matches mock from design.

### DIFF
--- a/app/views/topology/relation.js
+++ b/app/views/topology/relation.js
@@ -1039,7 +1039,7 @@ YUI.add('juju-topology-relation', function(Y) {
       menu.setStyle('top', locateAt[1]);
       // Shift the arrow to the left by half the menu's width minus half the
       // width of the arrow itself (10px).
-      menu.one('.triangle').setStyle('left', menu.get('clientWidth') / 2 - 10);
+      menu.one('.triangle').setStyle('left', menu.get('clientWidth') / 2 - 5);
 
       // Firing resized will ensure the menu's positioned properly.
       topo.fire('resized');

--- a/lib/views/stylesheet.less
+++ b/lib/views/stylesheet.less
@@ -497,10 +497,11 @@ th {
 #relation-menu {
     .relation-container {
         cursor: inherit;
-        padding-left: 27px;
+        padding-left: 30px;
         padding-right: 0;
+        line-height: 30px;
         background-repeat: no-repeat;
-        background-position: 5px 12px;
+        background-position: 10px 11px;
         background-image: url("/juju-ui/assets/images/inspector-charm-running.png");
         &.error {
             background-image: url("/juju-ui/assets/images/inspector-charm-error.png");
@@ -512,15 +513,19 @@ th {
             background-color: inherit;
         }
     }
+    .triangle {
+        bottom: -3px;
+        border-width: 3px 5px 0 5px;
+    }
     .relation-remove {
         cursor: pointer;
         display: inline-block;
-        width: 32px;
-        height: 32px;
+        width: 30px;
+        height: 30px;
         background-repeat: no-repeat;
-        background-position: 11px 11px;
+        background-position: 10px 10px;
         background-image: url("/juju-ui/assets/images/trash.png");
-        margin-bottom: -11px;
+        margin-bottom: -10px;
     }
     .inspect-relation {
         cursor: pointer;


### PR DESCRIPTION
Specifically the spacing within the popover has been tighetened up. 30px
overall height, 10px horizontal spacing between the elements. The arrow
is now 3px height and 10px wide.

For reference:

https://launchpadlibrarian.net/168947326/Juju-Tooltip.png
