### PR TITLE
Ghost inspector opens via a viewNavigate event using a state change (WIP)

### DIFF
--- a/app/views/ghost-deployer-extension.js
+++ b/app/views/ghost-deployer-extension.js
@@ -61,7 +61,11 @@ YUI.add('ghost-deployer-extension', function(Y) {
         ghostService.set('icon', ghostAttributes.icon);
       }
       if (window.flags.il) {
-        this.get('subApps').charmbrowser.createGhostInspector(ghostService);
+        this.get('subApps').charmbrowser.fire('viewNavigate', {
+          change: {
+            inspector: ghostService.get('clientId')
+          }
+        });
       } else {
         var environment = this.views.environment.instance;
         environment.createServiceInspector(ghostService);

--- a/app/views/state.js
+++ b/app/views/state.js
@@ -157,6 +157,10 @@ YUI.add('juju-app-state', function(Y) {
 
       this._current = Y.merge(this._current, change);
 
+      if (change.inspector) {
+        urlParts.push('/inspector/' + change.inspector + '/');
+      }
+
       if (this.getCurrent('viewmode') !== 'sidebar' ||
           this.getCurrent('search')) {
         // There's no need to add the default view if we
@@ -217,10 +221,12 @@ YUI.add('juju-app-state', function(Y) {
       }
 
       // Check for a charm id in the request.
-      if (params.id && params.id !== 'search') {
-        this._setCurrent('charmID', params.id);
-      } else {
-        this._setCurrent('charmID', null);
+      if (params.viewmode !== 'inspector') {
+        if (params.id && params.id !== 'search') {
+          this._setCurrent('charmID', params.id);
+        } else {
+          this._setCurrent('charmID', null);
+        }
       }
 
       // Check for search in the request.


### PR DESCRIPTION
When going from browser to inspector the sidebar is re-rendered because the 'viewmode' is changing. I'm considering this OK because I think viewmode should be removed anyways. See the comments inline.
