### PR TITLE
Observe pending/in progress bundle deployments.

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -1205,6 +1205,8 @@ YUI.add('juju-gui', function(Y) {
         if (redirectPath.indexOf('#') > -1) {
           this.dispatch();
         }
+        // Start observing bundle deployments.
+        importHelpers.watchAll(this.env, this.db);
       } else {
         this.showLogin();
       }

--- a/app/store/env/fakebackend.js
+++ b/app/store/env/fakebackend.js
@@ -1874,7 +1874,7 @@ YUI.add('juju-env-fakebackend', function(Y) {
       var deployStatus = {
         DeploymentId: self._deploymentId,
         Status: 'started',
-        Timestamp: Date.now()
+        Timestamp: Math.round(Date.now() / 1000)
       };
       self._importChanges.push(deployStatus);
       // Keep the list limited to the last 5

--- a/app/store/env/sandbox.js
+++ b/app/store/env/sandbox.js
@@ -1421,7 +1421,7 @@ YUI.add('juju-env-sandbox', function(Y) {
     },
 
     /**
-    Handle DeployerStatus messages
+    Handle DeployerStatus messages.
 
     @method handleDeployerStatus
     @param {Object} data The contents of the API arguments.
@@ -1434,13 +1434,11 @@ YUI.add('juju-env-sandbox', function(Y) {
       var callback = function(reply) {
         var response = {
           RequestId: request.RequestId,
+          Error: reply.Error,
           Response: {
             LastChanges: reply.LastChanges
           }
         };
-        if (reply.Error) {
-          response.Error = reply.Error;
-        }
         client.receive(response);
       };
       state.statusDeployer(Y.bind(callback, this));

--- a/test/test_app.js
+++ b/test/test_app.js
@@ -820,7 +820,7 @@ describe('File drag over notification system', function() {
         Y.juju.App.prototype.popLoginRedirectPath = oldPopRedirectMethod;
         return '/foo/bar';
       };
-      var app = makeApp(false);
+      var app = makeApp(true);
       stubit(app, 'hideMask');
       stubit(app, 'navigate');
       stubit(app, 'dispatch');
@@ -848,7 +848,7 @@ describe('File drag over notification system', function() {
         Y.juju.App.prototype.popLoginRedirectPath = oldPopRedirectMethod;
         return '/foo/bar#baz';
       };
-      var app = makeApp(false);
+      var app = makeApp(true);
       stubit(app, 'hideMask');
       stubit(app, 'navigate');
       stubit(app, 'dispatch');
@@ -858,6 +858,18 @@ describe('File drag over notification system', function() {
         '/foo/bar#baz',
         { overrideAllNamespaces: true }]);
       assert.equal(app.dispatch.calledOnce(), true);
+    });
+
+    it('retrieves the bundle deployments status on login', function() {
+      var app = makeApp(true);
+      app.onLogin({data: {result: true}});
+      var expectedMessage = {
+        RequestId: 2, // The first request is the login one.
+        Type: 'Deployer',
+        Request: 'Status',
+        Params: {}
+      };
+      assert.deepEqual(conn.last_message(), expectedMessage);
     });
 
     it('creates a notification if logged in with a token', function(done) {


### PR DESCRIPTION
Start observing scheduled/started deployments
right after a successful login.
Also notify recently occurred errors.

This way the GUI is able to provide bundle
progress information to the user even if
the user refreshes after deploying a bundle,
or if the bundle deployment itself wasn't
started from the GUI (e.g. from quickstart).

Also did some clean up on the Deployer:Status
related code.

QA:
- juju-quickstart an environment:
  `juju quickstart`;
- switch the GUI to this branch:
  `juju set juju-gui juju-gui-source="https://github.com/frankban/juju-gui.git deployer-status-api"`;
- wait for the GUI to be ready 
  (`tailf ~/.juju/local/log/unit-juju-gui-0.log`) can help;
- deploy a bundle from quickstart:
  `juju quickstart bundle:mediawiki/single`;
- when the GUI opens in the browser, 
  you should see a "bundle in progress" notification;
- now deploy a bundle from the GUI, e.g.: search for "rails"
  and drag the "example-single" bundle;
- you should see a notification;
- refresh to check both pending and in progress bundle are notified;
- wait for the first bundle to be deployed;
- refresh and you should see an "in progress" notification for
  the second one;
- destroy the mediawiki service, and wait for it to be gone;
- wait for the remaining deployment to be completed;
- deploy the failing bundle in http://dpaste.com/1767335/plain/:
  `juju quickstart http://dpaste.com/1767335/plain/`;
- when the GUI opens, you should see an "invalid relation" error for
  the last bundle;
- this error will be visible on each refresh for one hour, 
  and then it will go away: wait if you want, or just 
  trust me and destroy the environment.

Done, thank you!
