### PR TITLE
Minor fix to example hook in docs

### DIFF
--- a/HACKING.rst
+++ b/HACKING.rst
@@ -328,7 +328,7 @@ push your code to Github, you can add any of those targets to either the
 
   #!/bin/sh
 
-  if ($NO_VERIFY) ; then
+  if test ! $NO_VERIFY ; then
       make lint
   fi
 


### PR DESCRIPTION
Fix typo in docs (left in bash syntax, ensuring sh syntax)
