### PR TITLE
ECS Ghost Inspector

### DIFF
--- a/app/views/inspectors/ghost-service-inspector.js
+++ b/app/views/inspectors/ghost-service-inspector.js
@@ -159,6 +159,7 @@ YUI.add('ghost-service-inspector', function(Y) {
           ghostService = this.get('model'),
           environmentView = this.get('environment'),
           topo = this.get('topo'),
+          inspector = environmentView.inspector,
           createServiceInspector = false;
 
       if (e.err) {
@@ -180,9 +181,13 @@ YUI.add('ghost-service-inspector', function(Y) {
           }));
 
       var ghostId = ghostService.get('id');
-      if (environmentView.inspector) {
-        createServiceInspector =
-            environmentView.inspector.get('model').get('id') === ghostId;
+      if (inspector) {
+        // If there is a ghost inspector currently open for this service, then
+        // we know we need to create a service inspector for it.  However,
+        // since the user may have closed/destroyed the original one, we need
+        // to check based on the ID of the model involved, rather than simple
+        // equality.
+        createServiceInspector = inspector.get('model').get('id') === ghostId;
       }
       ghostService.setAttrs({
         id: serviceName,
@@ -214,9 +219,10 @@ YUI.add('ghost-service-inspector', function(Y) {
         // routing in the browser.js can build a correct url.
       } else {
         if (createServiceInspector) {
-          // Clean up any new instances of the inspector.
-          if (environmentView.inspector) {
-            environmentView.inspector.destroy();
+          // Clean up any existing instances of the inspector so that
+          // databinding won't encounter race conditions.
+          if (inspector) {
+            inspector.destroy();
           }
           environmentView.createServiceInspector(ghostService);
         }

--- a/test/test_ghost_inspector.js
+++ b/test/test_ghost_inspector.js
@@ -240,6 +240,23 @@ describe('Ghost Inspector', function() {
     assert.isTrue(stubCreate.calledOnce());
   });
 
+  it('destroys existing ghost inspector on deploy', function() {
+    inspector = setUpInspector();
+    var secondInspector = setUpInspector();
+    var stubCreate = utils.makeStubMethod(view, 'createServiceInspector');
+    this._cleanups.push(stubCreate.reset);
+    var secondDestroy = utils.makeStubMethod(secondInspector, 'destroy');
+    this._cleanups.push(secondDestroy.reset);
+    secondInspector.get('environment').inspector = secondInspector;
+    inspector.set('environment', secondInspector.get('environment'));
+    inspector._deployCallbackHandler('mediawiki', {}, {}, {});
+    // Assert that the service inspector is only created once.
+    assert.isTrue(stubCreate.calledOnce(), 'Create called once.');
+    // Despite the callback being called from the first inspector, the second
+    // inspector is destroyed as well.
+    assert.isTrue(secondDestroy.called(), '2nd destroy called');
+  });
+
   it('does not display unit count for subordinate charms', function() {
     inspector = setUpInspector(subordinateCharmData);
     var vmContainer = inspector.get('container');


### PR DESCRIPTION
This ensures that inspectors for multiple ghost services (as will be possible under ECS conditions) will not flicker and randomize on commit.  To QA:
1. Run with the ecs flag
2. drag two or more services onto the canvas and click deploy once on each
3. On the last services, run `app.ecs.commit()` in the debugger
4. The inspector should simply change from ghost to service inspector without flickering between services and possibly ending up on a random service.

NB: this PR was co-opted from earlier work that hasn't passed design yet, revolving around the immediate option flag.  Such may come up later.
