### PR TITLE
Get local charm icons from the Juju API.

### DIFF
--- a/app/store/charmworld.js
+++ b/app/store/charmworld.js
@@ -409,6 +409,7 @@ YUI.add('juju-charm-store', function(Y) {
       // XXX: #1202703 - this is a short term fix for the bug. Need longer
       // term solution.
       if (charmID.indexOf('local:') === 0) {
+        // XXX frankban: this place should become unreachable soon.
         return this.get('apiHost') +
             'static/img/charm_160.svg';
 

--- a/app/store/env/go.js
+++ b/app/store/env/go.js
@@ -459,7 +459,7 @@ YUI.add('juju-env-go', function(Y) {
     },
 
     /**
-      Handles uploading a local charm to Juju
+      Handles uploading a local charm to Juju.
 
       @method uploadLocalCharm
       @param {Object} file The file object from the fileSources event object.
@@ -490,6 +490,24 @@ YUI.add('juju-env-go', function(Y) {
       webHandler.post(
           url, headers, file, credentials.user, credentials.password,
           progress, callback);
+    },
+
+    /**
+      Return the full URL to the Juju HTTPS API serving a local charm file.
+
+      @method getLocalCharmFileUrl
+      @param {String} charmUrl The local charm URL,
+        e.g. "local:strusty/django-42".
+      @param {String} filename The file name/path.
+        e.g. "icon.svg" or "hooks/install".
+      @return {String} The full URL to the file contents, including auth
+        credentials.
+    */
+    getLocalCharmFileUrl: function(charmUrl, filename) {
+      var credentials = this.getCredentials();
+      var path = '/juju-core/charms?url=' + charmUrl + '&file=' + filename;
+      var webHandler = this.get('webHandler');
+      return webHandler.getUrl(path, credentials.user, credentials.password);
     },
 
     /*

--- a/app/store/env/web-handler.js
+++ b/app/store/env/web-handler.js
@@ -101,6 +101,23 @@ YUI.add('juju-env-web-handler', function(Y) {
     },
 
     /**
+      Given a path and credentials, return a URL including the user:password
+      fragment. The current host is used.
+
+      @method getUrl
+      @param {String} path The target path.
+      @param {String} username The user name for basic HTTP authentication.
+      @param {String} password The password for basic HTTP authentication.
+      @return {String} The resulting URL.
+    */
+    getUrl: function(path, username, password) {
+      var location = window.location;
+      return location.protocol + '//' +
+          username + ':' + password + '@' +
+          location.host + path;
+    },
+
+    /**
       The callback from the xhr progress and load events.
 
       @method _xhrEventHandler

--- a/app/store/env/web-sandbox.js
+++ b/app/store/env/web-sandbox.js
@@ -28,6 +28,8 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 YUI.add('juju-env-web-sandbox', function(Y) {
 
+  var DEFAULT_CHARM_ICON_PATH = 'static/img/charm_160.svg';
+
   var module = Y.namespace('juju.environments.web');
   var localCharmExpression = /\/juju-core\/charms\?series=(\w+)/;
 
@@ -83,6 +85,28 @@ YUI.add('juju-env-web-sandbox', function(Y) {
       }
       // This is in theory unreachable.
       console.error('unexpected POST request to ' + url);
+    },
+
+    /**
+      Given a path and credentials, return a URL including the user:password
+      fragment.
+
+      @method getUrl
+      @param {String} path The target path.
+      @param {String} username The user name for basic HTTP authentication.
+      @param {String} password The password for basic HTTP authentication.
+      @return {String} The resulting URL.
+    */
+    getUrl: function(path, username, password) {
+      if (path.indexOf('/juju-core/charms') === 0 &&
+          path.indexOf('file=icon.svg') !== -1) {
+        // This is a request for a local charm's icon.
+        // Just return the charmworld's fallback icon.
+        var store = this.get('state').get('store');
+        return store.get('apiHost') + DEFAULT_CHARM_ICON_PATH;
+      }
+      // This is in theory unreachable.
+      console.error('unexpected getUrl request to ' + path);
     }
 
   });

--- a/app/views/topology/service.js
+++ b/app/views/topology/service.js
@@ -47,9 +47,11 @@ YUI.add('juju-topology-service', function(Y) {
     var vis = topo.vis;
     var db = topo.get('db');
     var store = topo.get('store');
+    var env = topo.get('env');
 
     var visibleServices = db.services.visible();
-    views.toBoundingBoxes(this, visibleServices, topo.service_boxes, store);
+    views.toBoundingBoxes(
+        this, visibleServices, topo.service_boxes, store, env);
     // Break a reference cycle that results in uncollectable objects leaking.
     visibleServices.reset();
 

--- a/app/views/utils.js
+++ b/app/views/utils.js
@@ -757,6 +757,25 @@ YUI.add('juju-view-utils', function(Y) {
   };
 
   /**
+    Return the URL to the charm icon, handling both charms present in the
+    store and local charms.
+
+    @method getCharmIconUrl
+    @param {String} charmUrl The charm URL.
+    @param {Object} store The charm store.
+    @param {Object} env The Juju environment.
+    @return {String} The URL to the icon.svg file.
+  */
+  utils.getCharmIconUrl = function(charmUrl, store, env) {
+    if (charmUrl.indexOf('local:') === 0) {
+      // Retrieve the icon from the Juju HTTP API.
+      return env.getLocalCharmFileUrl(charmUrl, 'icon.svg');
+    }
+    // Retrieve the icon from the charm store.
+    return store.iconpath(charmUrl);
+  };
+
+  /**
    Return a template-friendly array of settings.
 
    Used for service-configuration.partial adding isBool, isNumeric metadata.
@@ -1183,7 +1202,7 @@ YUI.add('juju-view-utils', function(Y) {
    * @param {Object} store The charm store.
    * @return {Object} id:box mapping.
    */
-  views.toBoundingBoxes = function(module, services, existing, store) {
+  views.toBoundingBoxes = function(module, services, existing, store, env) {
     var result = existing || {};
     Y.each(result, function(val, key, obj) {
       if (!Y.Lang.isValue(services.getById(key))) {
@@ -1201,13 +1220,14 @@ YUI.add('juju-view-utils', function(Y) {
           if (!service.get('icon') && service.get('charm')) {
             var icon;
             var charmID = service.get('charm');
-            icon = this.store.iconpath(charmID);
+            icon = utils.getCharmIconUrl(charmID, this.store, this.env);
             service.set('icon', icon);
           }
           result[id].icon = service.get('icon');
         },
-        // Pass 'store' into the closure through the context variable 'this'.
-        {store: store}
+        // Pass 'env' and 'store' into the closure through the context variable
+        // 'this'.
+        {env: env, store: store}
     );
     return result;
   };

--- a/app/views/viewlets/inspector-header.js
+++ b/app/views/viewlets/inspector-header.js
@@ -74,7 +74,9 @@ YUI.add('inspector-header-view', function(Y) {
       pojoModel.charmUrl = pojoModel.charm;
       // Manually add the icon url for the charm since we don't have access to
       // the browser handlebars helper at this location.
-      pojoModel.icon = viewContainerAttrs.store.iconpath(pojoModel.charmUrl);
+      pojoModel.icon = utils.getCharmIconUrl(
+          pojoModel.charmUrl, viewContainerAttrs.store,
+          viewContainerAttrs.env);
       if (pojoModel.pending) {
         // Check if there is already a service using the default name to
         // trigger the name ux.

--- a/test/test_env_go.js
+++ b/test/test_env_go.js
@@ -602,6 +602,29 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
     });
 
+    describe('getLocalCharmFileUrl', function() {
+
+      it('uses the stored webHandler to retrieve the file URL', function() {
+        var mockWebHandler = {getUrl: utils.makeStubFunction('myurl')};
+        env.set('webHandler', mockWebHandler);
+        var url = env.getLocalCharmFileUrl(
+            'local:trusty/django-42', 'icon.svg');
+        assert.strictEqual(url, 'myurl');
+        // Ensure the web handler's getUrl method has been called with the
+        // expected arguments.
+        assert.strictEqual(mockWebHandler.getUrl.callCount(), 1);
+        var lastArguments = mockWebHandler.getUrl.lastArguments();
+        assert.lengthOf(lastArguments, 3);
+        assert.strictEqual(
+            lastArguments[0],
+            '/juju-core/charms?url=local:trusty/django-42&file=icon.svg');
+        assert.strictEqual(lastArguments[1], 'user'); // User name.
+        assert.strictEqual(lastArguments[2], 'password'); // Password.
+      });
+
+    });
+
+
     it('sends the correct expose message', function() {
       env.expose('apache');
       var last_message = conn.last_message();

--- a/test/test_environment_view.js
+++ b/test/test_environment_view.js
@@ -1535,10 +1535,17 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       assert.equal(boxes.haproxy, undefined);
     });
 
-    it('sets the default icon for local charms without an icon', function() {
+    it('retrieves local charms icons from the Juju env', function() {
       var iconFakeStore = new Y.juju.charmworld.APIv3({
         apiHost: 'http://localhost'
       });
+      var fakeEnv = {
+        getLocalCharmFileUrl: function(charmUrl, filename) {
+          assert.strictEqual(charmUrl, 'local:ceph-1');
+          assert.strictEqual(filename, 'icon.svg');
+          return 'https://example.com/icon.svg';
+        }
+      };
       var services = new models.ServiceList();
       services.add([
         {
@@ -1562,12 +1569,12 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       };
 
       var boxes = views.toBoundingBoxes(
-          module, services, existing, iconFakeStore);
+          module, services, existing, iconFakeStore, fakeEnv);
 
       // the ceph charm should have the default icon path.
       assert.equal(
           boxes['local:ceph-1'].icon,
-          'http://localhost/static/img/charm_160.svg'
+          'https://example.com/icon.svg'
       );
 
       // The mysql charm has an icon from on the server.

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -811,6 +811,52 @@ describe('utilities', function() {
 })();
 
 (function() {
+  describe('utils.getCharmIconUrl', function() {
+    var env, store, testUtils, utils, Y;
+    var requirements = ['juju-tests-utils', 'juju-views'];
+
+    before(function(done) {
+      Y = YUI(GlobalConfig).use(requirements, function(Y) {
+        utils = Y.namespace('juju.views.utils');
+        testUtils = Y.namespace('juju-tests.utils');
+        done();
+      });
+    });
+
+    beforeEach(function() {
+      env = {getLocalCharmFileUrl: testUtils.makeStubFunction('env-icon')};
+      store = {iconpath: testUtils.makeStubFunction('store-icon')};
+    });
+
+    it('uses the env to retrieve local charm icons', function() {
+      var url = utils.getCharmIconUrl('local:trusty/django-42', store, env);
+      assert.strictEqual(url, 'env-icon');
+      // The icon has been retrieved by calling the env method.
+      assert.strictEqual(env.getLocalCharmFileUrl.callCount(), 1);
+      var lastArguments = env.getLocalCharmFileUrl.lastArguments();
+      assert.lengthOf(lastArguments, 2);
+      assert.strictEqual('local:trusty/django-42', lastArguments[0]);
+      assert.strictEqual('icon.svg', lastArguments[1]);
+      // The store has not been used.
+      assert.strictEqual(store.iconpath.called(), false);
+    });
+
+    it('uses the store to retrieve charm store charm icons', function() {
+      var url = utils.getCharmIconUrl('cs:trusty/django-42', store, env);
+      assert.strictEqual(url, 'store-icon');
+      // The icon has been retrieved by calling the store method.
+      assert.strictEqual(store.iconpath.callCount(), 1);
+      var lastArguments = store.iconpath.lastArguments();
+      assert.lengthOf(lastArguments, 1);
+      assert.strictEqual('cs:trusty/django-42', lastArguments[0]);
+      // The env has not been used.
+      assert.strictEqual(env.getLocalCharmFileUrl.called(), false);
+    });
+
+  });
+})();
+
+(function() {
   describe('utils.extractServiceSettings', function() {
     var utils, Y;
 

--- a/test/test_web_handler.js
+++ b/test/test_web_handler.js
@@ -127,6 +127,13 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       assert.strictEqual(header, 'Basic bXl1c2VyOm15cGFzc3dk');
     });
 
+    it('returns a complete URL based on the given credentials', function() {
+      var url = webHandler.getUrl('/my/path', 'myuser', 'mypassword');
+      var expectedUrl = 'http://myuser:mypassword@' +
+          window.location.host + '/my/path';
+      assert.strictEqual(url, expectedUrl);
+    });
+
   });
 
 })();


### PR DESCRIPTION
QA:

Check the local charm icons are correctly displayed
when using a real env.
- juju quickstart an environment;
- switch to this branch:
  `juju set juju-gui juju-gui-source="https://github.com/frankban/juju-gui.git local-icons"`
- wait for the GUI to be ready;
- deploy local charms including an icon:
  you should see the icons are correctly displayed in the
  service blocks and inspector header;
- deploy a local charm not including an icon:
  you should see a broken image: this will be fixed
  in a follow up branch;
- deploy a charm from the store: ensure the usual icon is
  still properly displayed both in the service block and
  inspector header;
- destroy the environment.

Ensure the fallback icon is used whe deploying local
charms in sandbox mode.
- `make devel`
- deploy local charms:
  you should see the fallback icons are correctly 
  displayed in the service blocks and inspector header;
- deploy a charm from the store: ensure the usual icon is
  still properly displayed both in the service block and
  inspector header.

Done, thank you!
