### PR TITLE
Update page title to function

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -1261,7 +1261,7 @@ YUI.add('juju-gui', function(Y) {
       @method onEnvironmentNameChange
     */
     onEnvironmentNameChange: function(evt) {
-      var environmentName = evt.newValue;
+      var environmentName = evt.newVal;
       this.db.environment.set('name', environmentName);
       Y.all('.environment-name').set('text', environmentName);
     },

--- a/app/index.html
+++ b/app/index.html
@@ -149,7 +149,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
               </a>
             </li>
             <li id="environment-switcher">
-              <span id="environment-name" draggable="true"></span>
+              <span id="environment-name" class="environment-name" draggable="true"></span>
               <span id="provider-type" class="provider-type"></span>
             </li>
             <li class="import-export">

--- a/app/store/env/fakebackend.js
+++ b/app/store/env/fakebackend.js
@@ -49,7 +49,8 @@ YUI.add('juju-env-fakebackend', function(Y) {
     authenticated: {value: false},
     store: {required: true},
     defaultSeries: {value: 'precise'},
-    providerType: {value: 'demonstration'}
+    providerType: {value: 'demonstration'},
+    name: {value: 'Environment'}
   };
 
   Y.extend(FakeBackend, Y.Base, {

--- a/test/test_app.js
+++ b/test/test_app.js
@@ -71,7 +71,8 @@ function injectData(app, data) {
           .set('id', 'test-container')
           .addClass('container')
           .append(Y.Node.create('<span/>')
-            .set('id', 'environment-name'))
+            .set('id', 'environment-name')
+            .addClass('environment-name'))
           .append(Y.Node.create('<span/>')
             .addClass('provider-type'))
           .hide();
@@ -191,6 +192,23 @@ function injectData(app, data) {
          container.one('#environment-name').get('text'),
          'Environment');
        });
+
+    it('should show a the environment name if one is configured', function() {
+      constructAppInstance({
+        env: juju.newEnvironment({
+          conn: {
+            send: function() {},
+            close: function() {}
+          }
+        })
+      });
+      var name = 'Sandbox';
+      assert.equal(
+          'Environment',
+          container.one('.environment-name').get('text'));
+      app.env.set('environmentName', name);
+      assert.equal(container.one('.environment-name').get('text'), 'Sandbox');
+    });
 
     it('should show the provider type, when available', function() {
       constructAppInstance({

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -39,7 +39,7 @@ class TestBasics(browser.TestCase):
         # information)""
         self.wait_for_css_selector('svg')
         body = self.driver.find_element_by_xpath('//body')
-        self.assertTrue('Environment on ' in body.text)
+        self.assertTrue('Sandbox on ' in body.text)
 
     def test_environment_connection(self):
         # The GUI connects to the API backend.


### PR DESCRIPTION
- Name was grabbing the wrong value from the event.
- Added a test that setting a name does change the title fixing ^
- The fake backend wasn't setting a name so it was defaulting to Environment
- Changed the name to have a class to follow suit on the provider type for
  consistency.

QA
- make devel and note that the title is now "Sandbox on demonstration"
- Deploy the gui to a live environment and set the branch
  
  juju switch local
  juju-quickstart 
  juju set juju-gui juju-gui-source="https://github.com/mitechie/juju-gui.git custom-title"

Note that the title will be the environment name on the provider.
