### PR TITLE
API for retrieving/listing local charm files.

### DIFF
--- a/app/store/env/go.js
+++ b/app/store/env/go.js
@@ -464,7 +464,7 @@ YUI.add('juju-env-go', function(Y) {
       @method uploadLocalCharm
       @param {Object} file The file object from the fileSources event object.
       @param {String} series The series to deploy this local charm into.
-      @param {Function} progress The callback to handle xhr progress events.
+      @param {Function} progress The callback to handle progress events.
       @param {Function} callback The callback to call after the upload returns
         success or failure.
     */
@@ -476,7 +476,7 @@ YUI.add('juju-env-go', function(Y) {
         return;
       }
       var credentials = this.getCredentials();
-      var url = '/juju-core/charms?series=' + series;
+      var path = '/juju-core/charms?series=' + series;
       var headers = {'Content-Type': 'application/zip'};
       // Use a web handler to communicate to the Juju HTTPS API. The web
       // handler takes care of setting up asynchronous requests with basic
@@ -487,8 +487,8 @@ YUI.add('juju-env-go', function(Y) {
       // sandbox mode, a fake handler is used, in which no HTTP requests are
       // involved: see app/store/web-sandbox.js:WebSandbox.
       var webHandler = this.get('webHandler');
-      webHandler.post(
-          url, headers, file, credentials.user, credentials.password,
+      webHandler.sendPostRequest(
+          path, headers, file, credentials.user, credentials.password,
           progress, callback);
     },
 
@@ -508,6 +508,57 @@ YUI.add('juju-env-go', function(Y) {
       var path = '/juju-core/charms?url=' + charmUrl + '&file=' + filename;
       var webHandler = this.get('webHandler');
       return webHandler.getUrl(path, credentials.user, credentials.password);
+    },
+
+    /**
+      Make a GET request to the Juju HTTPS API.
+
+      @method _jujuHttpGet
+      @param {String} path The remote path.
+      @param {Function} progress The callback to handle progress events.
+      @param {Function} callback The callback to call after the Juju API
+        response is returned.
+    */
+    _jujuHttpGet: function(path, progress, callback) {
+      var credentials = this.getCredentials();
+      var webHandler = this.get('webHandler');
+      var headers = Object.create(null);
+      webHandler.sendGetRequest(
+          path, headers, credentials.user, credentials.password,
+          progress, callback);
+    },
+
+    /**
+      Handle retrieving the list of local charm files.
+
+      @method listLocalCharmFiles
+      @param {String} charmUrl The local charm URL,
+        e.g. "local:strusty/django-42".
+      @param {Function} progress The callback to handle progress events.
+      @param {Function} callback The callback to call after the list has been
+        retrieved.
+    */
+    listLocalCharmFiles: function(charmUrl, progress, callback) {
+      var path = '/juju-core/charms?url=' + charmUrl;
+      this._jujuHttpGet(path, progress, callback);
+    },
+
+    /**
+      Handle retrieving the contents of a local charm file.
+
+      @method getLocalCharmFileContents
+      @param {String} charmUrl The local charm URL,
+        e.g. "local:strusty/django-42".
+      @param {String} filename The file name/path.
+        e.g. "readme.md" or "hooks/install".
+      @param {Function} progress The callback to handle progress events.
+      @param {Function} callback The callback to call after the file contents
+        have been retrieved.
+    */
+    getLocalCharmFileContents: function(charmUrl, filename,
+                                        progress, callback) {
+      var path = '/juju-core/charms?url=' + charmUrl + '&file=' + filename;
+      this._jujuHttpGet(path, progress, callback);
     },
 
     /*

--- a/test/test_env_go.js
+++ b/test/test_env_go.js
@@ -576,19 +576,19 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
       it('uses the stored webHandler to perform requests', function() {
         env.userIsAuthenticated = true;
-        var mockWebHandler = {post: utils.makeStubFunction()};
+        var mockWebHandler = {sendPostRequest: utils.makeStubFunction()};
         env.set('webHandler', mockWebHandler);
         env.uploadLocalCharm(
             'a zip file', 'trusty',
             function() {return 'progress';},
             function() {return 'completed';});
-        // Ensure the web handler's post method has been called with the
-        // expected arguments.
-        assert.strictEqual(mockWebHandler.post.callCount(), 1);
-        var lastArguments = mockWebHandler.post.lastArguments();
+        // Ensure the web handler's sendPostRequest method has been called with
+        // the expected arguments.
+        assert.strictEqual(mockWebHandler.sendPostRequest.callCount(), 1);
+        var lastArguments = mockWebHandler.sendPostRequest.lastArguments();
         assert.strictEqual(lastArguments.length, 7);
         assert.strictEqual(
-            lastArguments[0], '/juju-core/charms?series=trusty'); // URL.
+            lastArguments[0], '/juju-core/charms?series=trusty'); // Path.
         assert.deepEqual(
             lastArguments[1], {'Content-Type': 'application/zip'}); // Headers.
         assert.strictEqual(lastArguments[2], 'a zip file'); // Zip file object.
@@ -624,6 +624,60 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
     });
 
+    describe('listLocalCharmFiles', function() {
+
+      it('uses the stored webHandler to retrieve the file list', function() {
+        var mockWebHandler = {sendGetRequest: utils.makeStubFunction()};
+        env.set('webHandler', mockWebHandler);
+        env.listLocalCharmFiles(
+            'local:trusty/django-42',
+            function() {return 'progress';},
+            function() {return 'completed';});
+        // Ensure the web handler's sendGetRequest method has been called with
+        // the expected arguments.
+        assert.strictEqual(mockWebHandler.sendGetRequest.callCount(), 1);
+        var lastArguments = mockWebHandler.sendGetRequest.lastArguments();
+        assert.lengthOf(lastArguments, 6);
+        assert.strictEqual(
+            lastArguments[0], '/juju-core/charms?url=local:trusty/django-42');
+        assert.deepEqual(lastArguments[1], {}); // Headers.
+        assert.strictEqual(lastArguments[2], 'user'); // User name.
+        assert.strictEqual(lastArguments[3], 'password'); // Password.
+        assert.strictEqual(
+            lastArguments[4](), 'progress'); // Progress callback.
+        assert.strictEqual(
+            lastArguments[5](), 'completed'); // Completed callback.
+      });
+
+    });
+
+    describe('getLocalCharmFileContents', function() {
+
+      it('uses the stored webHandler to retrieve the contents', function() {
+        var mockWebHandler = {sendGetRequest: utils.makeStubFunction()};
+        env.set('webHandler', mockWebHandler);
+        env.getLocalCharmFileContents(
+            'local:trusty/django-42', 'hooks/install',
+            function() {return 'progress';},
+            function() {return 'completed';});
+        // Ensure the web handler's sendGetRequest method has been called with
+        // the expected arguments.
+        assert.strictEqual(mockWebHandler.sendGetRequest.callCount(), 1);
+        var lastArguments = mockWebHandler.sendGetRequest.lastArguments();
+        assert.lengthOf(lastArguments, 6);
+        assert.strictEqual(
+            lastArguments[0],
+            '/juju-core/charms?url=local:trusty/django-42&file=hooks/install');
+        assert.deepEqual(lastArguments[1], {}); // Headers.
+        assert.strictEqual(lastArguments[2], 'user'); // User name.
+        assert.strictEqual(lastArguments[3], 'password'); // Password.
+        assert.strictEqual(
+            lastArguments[4](), 'progress'); // Progress callback.
+        assert.strictEqual(
+            lastArguments[5](), 'completed'); // Completed callback.
+      });
+
+    });
 
     it('sends the correct expose message', function() {
       env.expose('apache');

--- a/test/test_web_sandbox.js
+++ b/test/test_web_sandbox.js
@@ -21,7 +21,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 (function() {
 
   describe('Web sandbox', function() {
-    var mockState, mockStore, utils, webSandbox, webModule, Y;
+    var mockState, utils, webSandbox, webModule, Y;
     var requirements = ['juju-env-web-sandbox', 'juju-tests-utils'];
 
     before(function(done) {
@@ -29,14 +29,6 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       Y = YUI(GlobalConfig).use(requirements, function(Y) {
         utils = Y.namespace('juju-tests.utils');
         webModule = Y.namespace('juju.environments.web');
-        // Create a mock store object.
-        mockStore = {
-          get: function(attr) {
-            if (attr === 'apiHost') {
-              return 'https://charmworld.example.com';
-            }
-          }
-        };
         done();
       });
     });
@@ -44,13 +36,9 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     beforeEach(function() {
       // Instantiate a web sandbox passing a mock state object.
       mockState = {
-        handleUploadLocalCharm: utils.makeStubFunction(),
-        get: function(attr) {
-          if (attr === 'store') {
-            // Return the mock store object.
-            return mockStore;
-          }
-        }
+        getLocalCharmFileUrl: utils.makeStubFunction('file-url'),
+        handleLocalCharmFileRequest: utils.makeStubFunction(),
+        handleUploadLocalCharm: utils.makeStubFunction()
       };
       webSandbox = new webModule.WebSandbox({state: mockState});
     });
@@ -59,63 +47,139 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       webSandbox.destroy();
     });
 
-    it('uses the given state to handle local charm uploads', function() {
-      var url = '/juju-core/charms?series=trusty';
-      var headers = {'Content-Type': 'application/zip'};
-      var data = 'a zip file object';
-      // Make a POST request.
-      webSandbox.post(
-          url, headers, data, 'user', 'passwd', function() {},
-          function() {return 'completed';});
-      // Ensure the state has been called with the expected arguments.
-      assert.strictEqual(mockState.handleUploadLocalCharm.callCount(), 1);
-      var lastArguments = mockState.handleUploadLocalCharm.lastArguments();
-      assert.strictEqual(lastArguments.length, 3);
-      var zipFile = lastArguments[0];
-      var series = lastArguments[1];
-      var completedCallback = lastArguments[2];
-      assert.strictEqual(zipFile, data);
-      assert.strictEqual(series, 'trusty');
-      assert.strictEqual(completedCallback(), 'completed');
+    describe('sendPostRequest', function() {
+
+      it('uses the given state to handle local charm uploads', function() {
+        var path = '/juju-core/charms?series=trusty';
+        var headers = {'Content-Type': 'application/zip'};
+        var data = 'a zip file object';
+        // Make a POST request.
+        webSandbox.sendPostRequest(
+            path, headers, data, 'user', 'passwd', function() {},
+            function() {return 'completed';});
+        // Ensure the state has been called with the expected arguments.
+        assert.strictEqual(mockState.handleUploadLocalCharm.callCount(), 1);
+        var lastArguments = mockState.handleUploadLocalCharm.lastArguments();
+        assert.strictEqual(lastArguments.length, 3);
+        var zipFile = lastArguments[0];
+        var series = lastArguments[1];
+        var completedCallback = lastArguments[2];
+        assert.strictEqual(zipFile, data);
+        assert.strictEqual(series, 'trusty');
+        assert.strictEqual(completedCallback(), 'completed');
+      });
+
+      it('prints a console error if the request is not valid', function() {
+        // Patch the console.error method.
+        var mockError = utils.makeStubMethod(console, 'error');
+        // Make a POST request to an unexpected URL.
+        webSandbox.sendPostRequest(
+            '/no-such-resource/', {}, 'data', 'user', 'passwd');
+        mockError.reset();
+        // The state object has not been used.
+        assert.strictEqual(mockState.handleUploadLocalCharm.called(), false);
+        // An error has been printed to the console.
+        assert.strictEqual(mockError.callCount(), 1);
+        var lastArguments = mockError.lastArguments();
+        assert.strictEqual(lastArguments.length, 1);
+        assert.strictEqual(
+            'unexpected POST request to /no-such-resource/', lastArguments[0]);
+      });
+
     });
 
-    it('prints a console error if the post request is not valid', function() {
-      // Patch the console.error method.
-      var mockError = utils.makeStubMethod(console, 'error');
-      // Make a POST request to an unexpected URL.
-      webSandbox.post('/no-such-resource/', {}, 'data', 'user', 'passwd');
-      mockError.reset();
-      // The state object has not been used.
-      assert.strictEqual(mockState.handleUploadLocalCharm.called(), false);
-      // An error has been printed to the console.
-      assert.strictEqual(mockError.callCount(), 1);
-      var lastArguments = mockError.lastArguments();
-      assert.strictEqual(lastArguments.length, 1);
-      assert.strictEqual(
-          'unexpected POST request to /no-such-resource/', lastArguments[0]);
+    describe('sendGetRequest', function() {
+
+      it('handles local charm file contents retrieval', function() {
+        var path = '/juju-core/charms' +
+            '?url=local:trusty/juju-gui-42&file=hooks/install';
+        // Make a GET request.
+        webSandbox.sendGetRequest(
+            path, {}, 'user', 'passwd', function() {},
+            function() {return 'completed';});
+        // Ensure the state has been called with the expected arguments.
+        var method = mockState.handleLocalCharmFileRequest;
+        assert.strictEqual(method.callCount(), 1);
+        var lastArguments = method.lastArguments();
+        assert.strictEqual(lastArguments.length, 3);
+        var charmUrl = lastArguments[0];
+        var filename = lastArguments[1];
+        var completedCallback = lastArguments[2];
+        assert.strictEqual(charmUrl, 'local:trusty/juju-gui-42');
+        assert.strictEqual(filename, 'hooks/install');
+        assert.strictEqual(completedCallback(), 'completed');
+      });
+
+      it('handles local charm files listing', function() {
+        var path = '/juju-core/charms?url=local:saucy/django-42';
+        // Make a GET request.
+        webSandbox.sendGetRequest(
+            path, {}, 'user', 'passwd', function() {},
+            function() {return 'completed';});
+        // Ensure the state has been called with the expected arguments.
+        var method = mockState.handleLocalCharmFileRequest;
+        assert.strictEqual(method.callCount(), 1);
+        var lastArguments = method.lastArguments();
+        assert.strictEqual(lastArguments.length, 3);
+        var charmUrl = lastArguments[0];
+        var filename = lastArguments[1];
+        var completedCallback = lastArguments[2];
+        assert.strictEqual(charmUrl, 'local:saucy/django-42');
+        assert.isUndefined(filename);
+        assert.strictEqual(completedCallback(), 'completed');
+      });
+
+      it('prints a console error if the request is not valid', function() {
+        // Patch the console.error method.
+        var mockError = utils.makeStubMethod(console, 'error');
+        // Make a GET request to an unexpected URL.
+        webSandbox.sendGetRequest('/no-such-resource/', {}, 'user', 'passwd');
+        mockError.reset();
+        // The state object has not been used.
+        assert.strictEqual(
+            mockState.handleLocalCharmFileRequest.called(), false);
+        // An error has been printed to the console.
+        assert.strictEqual(mockError.callCount(), 1);
+        var lastArguments = mockError.lastArguments();
+        assert.strictEqual(lastArguments.length, 1);
+        assert.strictEqual(
+            'unexpected GET request to /no-such-resource/', lastArguments[0]);
+      });
+
     });
 
-    it('uses the state to handle returning charm file paths', function() {
-      var url = webSandbox.getUrl(
-          '/juju-core/charms?url=local:trusty/django-42&file=icon.svg',
-          'myuser', 'mypassword');
-      assert.strictEqual(
-          url, 'https://charmworld.example.comstatic/img/charm_160.svg');
-    });
+    describe('getUrl', function() {
 
-    it('prints a console error if a getUrl request is not valid', function() {
-      // Patch the console.error method.
-      var mockError = utils.makeStubMethod(console, 'error');
-      // Make a POST request to an unexpected URL.
-      webSandbox.getUrl('/no-such-resource/', 'myuser', 'mypassword');
-      mockError.reset();
-      // An error has been printed to the console.
-      assert.strictEqual(mockError.callCount(), 1);
-      var lastArguments = mockError.lastArguments();
-      assert.lengthOf(lastArguments, 1);
-      assert.strictEqual(
-          'unexpected getUrl request to /no-such-resource/',
-          lastArguments[0]);
+      it('uses the state to handle returning charm file paths', function() {
+        var url = webSandbox.getUrl(
+            '/juju-core/charms?url=local:trusty/django-42&file=icon.svg',
+            'myuser', 'mypassword');
+        assert.strictEqual(url, 'file-url');
+        // Ensure the state has been called with the expected arguments.
+        assert.strictEqual(mockState.getLocalCharmFileUrl.callCount(), 1);
+        var lastArguments = mockState.getLocalCharmFileUrl.lastArguments();
+        assert.lengthOf(lastArguments, 2);
+        var charmUrl = lastArguments[0];
+        var filename = lastArguments[1];
+        assert.strictEqual(charmUrl, 'local:trusty/django-42');
+        assert.strictEqual(filename, 'icon.svg');
+      });
+
+      it('prints a console error if the request is not valid', function() {
+        // Patch the console.error method.
+        var mockError = utils.makeStubMethod(console, 'error');
+        // Make a POST request to an unexpected URL.
+        webSandbox.getUrl('/no-such-resource/', 'myuser', 'mypassword');
+        mockError.reset();
+        // An error has been printed to the console.
+        assert.strictEqual(mockError.callCount(), 1);
+        var lastArguments = mockError.lastArguments();
+        assert.lengthOf(lastArguments, 1);
+        assert.strictEqual(
+            'unexpected getUrl request to /no-such-resource/',
+            lastArguments[0]);
+      });
+
     });
 
   });


### PR DESCRIPTION
This branch implements the basic API for retrieving/listing
local charm file contents from the Juju HTTPS endpoint.

Also changed the web handler so that xhr event subscribers
are no longer stored as an attribute.

This branch also includes some fixes clean up in the code
interactions between the environment object, the web handlers
and the fake backend.

Some tests have been reorganized.

Renamed web-handler and web-sandbox post methods:
`post` is now called `sendPostRequest`, so that consistency
is preserved between `sendPostRequest` and `sendGetRequest`,
given that `get` is already a base class method.

For all the reasons above the diff is long, sorry about that,
but they are mostly tests and I hope that word-based diff in 
Github will help reviewing some indentation changes.

QA:

For QAing, some code snippets must be executed in the
JavaScript console. I'll show them here, and they will be
referenced later:

Snippet 1:

```
app.env.listLocalCharmFiles(
    'local:precise/ghost-4', null,
    function(data) {
      console.log('status:', data.target.status);
      console.log('response:', data.target.responseText);
    }
);
```

Snippet 2:

```
app.env.listLocalCharmFiles(
    'local:precise/no-such', null,
    function(data) {
      console.log('status:', data.target.status);
      console.log('response:', data.target.responseText);
    }
);
```

Snippet 3:

```
app.env.getLocalCharmFileContents(
    'local:precise/ghost-4', 'hooks/install', null,
    function(data) {
      console.log('status:', data.target.status);
      console.log('response:', data.target.responseText);
    }
);
```

Snippet 4:

```
app.env.getLocalCharmFileContents(
    'local:precise/ghost-4', 'no-such-file', null,
    function(data) {
      console.log('status:', data.target.status);
    }
);
```

Sandbox QA:
- make devel
- open the JS console and define the following callback function:
  `var callback = function(data) {console.log(data)};`;
- ensure deploying local charms still work in sandbox mode, and 
  the default fallback icon is displayed in the service block and
  inspector header;
- deploy the local ghost charm;
- run Snippet 1: you should see a 200 status and a response
  with a JSON including an empty list of files;
- run Snippet 2: you should see a 400 status and a charm not found
  response;
- run snippet 4: it should return a 404.

Real env QA:
- juju quickstart an environment;
- switch to this branch and enable the JS console:
  `juju set juju-gui juju-gui-console-enabled=true juju-gui-source="https://github.com/frankban/juju-gui.git local-charm-files-api"`;
- wait for the GUI service to be ready, and then log in;
- ensure deploying local charms still works, and the charm own icons are
  properly displayed in the service block and inspector header;
- deploy the local ghost charm;
- run Snippet 1: you should see a 200 status and a response
  with a JSON including all the files in the ghost charm;
- run Snippet 2: you should see a 400 status and a charm not found
  response;
- run Snippet 3: you should see a 200 status and the hook's file
  contents;
- run snippet 4: it should return a 404.

Done. Sorry again for the long diff and QA, and thanks a lot!
