### PR TITLE
added a changeState event to interact with the state object instead of using viewNavigate

### DIFF
--- a/app/subapps/browser/browser.js
+++ b/app/subapps/browser/browser.js
@@ -389,6 +389,12 @@ YUI.add('subapp-browser', function(Y) {
         }
         this.navigate(url);
       });
+
+      this.on('*:changeState', function(e) {
+        var state = e.details[0];
+        var url = this.state.generateUrl(state);
+        this.navigate(url);
+      });
     },
 
     /**

--- a/app/subapps/browser/views/bundle.js
+++ b/app/subapps/browser/views/bundle.js
@@ -87,7 +87,15 @@ YUI.add('subapp-browser-bundleview', function(Y) {
     _deployBundle: function(e) {
       e.halt();
       var bundle = this.get('entity');
-      this.fire('viewNavigate', {change: {charmID: null}});
+      if (window.flags && window.flags.state) {
+        this.fire('changeState', {
+          sectionA: {
+            component: 'charmbrowser',
+            metadata: { id: null }
+          }});
+      } else {
+        this.fire('viewNavigate', {change: {charmID: null}});
+      }
       this.get('deployBundle')(bundle.get('data'), bundle.get('id'));
     },
 

--- a/app/subapps/browser/views/charm.js
+++ b/app/subapps/browser/views/charm.js
@@ -110,7 +110,15 @@ YUI.add('subapp-browser-charmview', function(Y) {
     _addCharmEnvironment: function(ev) {
       ev.halt();
       var charm = this.get('entity');
-      this.fire('viewNavigate', {change: {charmID: null}});
+      if (window.flags && window.flags.state) {
+        this.fire('changeState', {
+          sectionA: {
+            component: 'charmbrowser',
+            metadata: { id: null }
+          }});
+      } else {
+        this.fire('viewNavigate', {change: {charmID: null}});
+      }
       var ghostAttributes;
       ghostAttributes = {
         icon: this.get('store').iconpath(charm.get('storeId'))
@@ -134,7 +142,16 @@ YUI.add('subapp-browser-charmview', function(Y) {
         hash: undefined
       };
 
-      this.fire('viewNavigate', {change: change});
+      if (window.flags && window.flags.state) {
+        this.fire('changeState', {
+          sectionA: {
+            component: 'charmbrowser',
+            metadata: { id: charmID }
+          }});
+      } else {
+        this.fire('viewNavigate', {change: change});
+      }
+
     },
 
     /**

--- a/app/subapps/browser/views/charmresults.js
+++ b/app/subapps/browser/views/charmresults.js
@@ -99,7 +99,15 @@ YUI.add('subapp-browser-charmresults', function(Y) {
         hash: undefined
       };
 
-      this.fire('viewNavigate', {change: change});
+      if (window.flags && window.flags.state) {
+        this.fire('changeState', {
+          sectionA: {
+            component: 'charmbrowser',
+            metadata: { id: charmID }
+          }});
+      } else {
+        this.fire('viewNavigate', {change: change});
+      }
     },
 
     /**

--- a/app/subapps/browser/views/entity-base.js
+++ b/app/subapps/browser/views/entity-base.js
@@ -233,12 +233,15 @@ YUI.add('subapp-browser-entitybaseview', function(Y) {
      */
     _handleBack: function(ev) {
       ev.halt();
-      this.fire('viewNavigate', {
-        change: {
-          charmID: null,
-          hash: null
-        }
-      });
+      if (window.flags && window.flags.state) {
+        this.fire('changeState', {
+          sectionA: {
+            component: 'charmbrowser',
+            metadata: { id: null }
+          }});
+      } else {
+        this.fire('viewNavigate', { change: { charmID: null, hash: null }});
+      }
     },
 
     /**

--- a/app/subapps/browser/views/view.js
+++ b/app/subapps/browser/views/view.js
@@ -146,15 +146,19 @@ YUI.add('subapp-browser-mainview', function(Y) {
      *
      */
     _goHome: function(ev) {
-      var change = {
-        charmID: undefined,
-        hash: undefined,
-        search: false,
-        filter: {
-          clear: true
-        }
-      };
-      this.fire('viewNavigate', {change: change});
+      if (window.flags && window.flags.state) {
+        this.fire('changeState', { sectionA: {} });
+      } else {
+        var change = {
+          charmID: undefined,
+          hash: undefined,
+          search: false,
+          filter: {
+            clear: true
+          }
+        };
+        this.fire('viewNavigate', {change: change});
+      }
     },
 
     /**
@@ -207,8 +211,16 @@ YUI.add('subapp-browser-mainview', function(Y) {
       if (ev.change) {
         change = Y.merge(change, ev.change);
       }
+      if (window.flags && window.flags.state) {
+        this.fire('changeState', {
+          sectionA: {
+            component: 'charmbrowser',
+            metadata: { search: ev.newVal }
+          }});
+      } else {
+        this.fire('viewNavigate', {change: change});
+      }
 
-      this.fire('viewNavigate', {change: change});
     },
 
     /**

--- a/app/views/ghost-deployer-extension.js
+++ b/app/views/ghost-deployer-extension.js
@@ -61,11 +61,20 @@ YUI.add('ghost-deployer-extension', function(Y) {
         ghostService.set('icon', ghostAttributes.icon);
       }
       if (window.flags.il) {
-        this.get('subApps').charmbrowser.fire('viewNavigate', {
-          change: {
-            inspector: ghostService.get('clientId')
-          }
-        });
+        if (window.flags && window.flags.state) {
+          this.get('subApps').charmbrowser.fire('changeState', {
+            sectionA: {
+              component: 'inspector',
+              metadata: {
+                id: ghostService.get('clientId')}}});
+        } else {
+          this.get('subApps').charmbrowser.fire('viewNavigate', {
+            change: {
+              inspector: ghostService.get('clientId')
+            }
+          });
+        }
+
       } else {
         var environment = this.views.environment.instance;
         environment.createServiceInspector(ghostService);

--- a/app/views/state.js
+++ b/app/views/state.js
@@ -187,7 +187,8 @@ YUI.add('juju-app-state', function(Y) {
     */
     generateUrl: function(change) {
       // Generate the new state temporarily.
-      var newState = Y.mix(this.get('current'), change, true);
+      var newState = Y.mix(
+          Y.clone(this.get('current')), change, true, null, 0, true);
       var component, metadata, sectionState, searchQuery, id,
           genUrl = '',
           query = {},

--- a/test/test_browser_app.js
+++ b/test/test_browser_app.js
@@ -337,6 +337,18 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
         });
       });
 
+      it('listens to changeState events', function() {
+        app = new browser.Browser();
+        var generateUrlStub = utils.makeStubMethod(
+            app.state, 'generateUrl', 'genUrl');
+        var navigateStub = utils.makeStubMethod(app, 'navigate');
+        app.fire('changeState', {foo: 'bar'});
+        assert.equal(generateUrlStub.calledOnce(), true);
+        assert.deepEqual(generateUrlStub.lastArguments()[0], {foo: 'bar'});
+        assert.equal(navigateStub.calledOnce(), true);
+        assert.equal(navigateStub.lastArguments()[0], 'genUrl');
+      });
+
       it('verify that route callables exist', function() {
         app = new browser.Browser();
         Y.each(app.get('routes'), function(route) {

--- a/test/test_browser_charm_details.js
+++ b/test/test_browser_charm_details.js
@@ -47,6 +47,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     });
 
     beforeEach(function() {
+      window.flags = {};
       container = utils.makeContainer(this, 'container');
       var testcontent = [
         '<div id=testcontent><div class="bws-view-data">',
@@ -63,6 +64,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     });
 
     afterEach(function() {
+      window.flags = {};
       if (view) {
         view.destroy();
       }
@@ -342,6 +344,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
     it('_addCharmEnvironment displays the config panel', function(done) {
+      window.flags.state = true;
       var fakeStore = new Y.juju.charmworld.APIv3({});
       fakeStore.iconpath = function() {
         return 'charm icon url';
@@ -361,9 +364,20 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
         container: utils.makeContainer(this),
         store: fakeStore
       });
+      var changeStateFired = false;
+      var handler = view.on('changeState', function(state) {
+        changeStateFired = true;
+        assert.deepEqual(state.details[0], {
+          sectionA: {
+            component: 'charmbrowser',
+            metadata: { id: null }
+          }});
+      });
+      this._cleanups.push(function() { handler.detach(); });
       view.set('deployService', function(charm, serviceAttrs) {
         var serviceCharm = view.get('entity');
         assert.deepEqual(charm, serviceCharm);
+        assert.equal(changeStateFired, true);
         assert.equal(charm.get('id'), 'cs:precise/ceph-9');
         assert.equal(serviceAttrs.icon, 'charm icon url');
         done();

--- a/test/test_browser_editorial.js
+++ b/test/test_browser_editorial.js
@@ -28,6 +28,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       Y = YUI(GlobalConfig).use(
           'node-event-simulate',
           'juju-tests-utils',
+          'subapp-browser-charmresults',
           'subapp-browser-editorial',
           function(Y) {
             utils = Y.namespace('juju-tests.utils');

--- a/test/test_bundle_details_view.js
+++ b/test/test_bundle_details_view.js
@@ -59,10 +59,12 @@ describe('Browser bundle detail view', function() {
     view._setupLocalFakebackend = function() {
       this.fakebackend = factory.makeFakeBackend();
     };
+    window.flags = {};
     cleanUp = utils.stubCharmIconPath();
   });
 
   afterEach(function() {
+    window.flags = {};
     view.destroy();
     cleanUp();
   });
@@ -174,10 +176,22 @@ describe('Browser bundle detail view', function() {
 
   it('deploys a bundle when \'add\' and confirmation button is clicked',
       function(done) {
+        window.flags.state = true;
+        var changeStateFired = false;
+        var handler = view.on('changeState', function(state) {
+          changeStateFired = true;
+          assert.deepEqual(state.details[0], {
+            sectionA: {
+              component: 'charmbrowser',
+              metadata: { id: null }
+            }});
+        });
+        this._cleanups.push(function() { handler.detach(); });
         // app.js sets this to its deploy bundle method so
         // as long as it's called it's successful.
         view.set('deployBundle', function(data) {
           assert.isObject(data);
+          assert.equal(changeStateFired, true);
           done();
         });
         view.set('entity', new models.Bundle(data));

--- a/test/test_ui_state.js
+++ b/test/test_ui_state.js
@@ -929,5 +929,25 @@ describe('UI State object', function() {
         });
       });
     });
+
+    it('can generate proper urls from non default state objects', function() {
+      var defaultState = {
+        sectionA: {
+          component: 'charmbrowser',
+          metadata: {
+            id: 'precise/apache2',
+            search: 'apache2' }
+        }, sectionB: {}};
+      var changeState = {
+        sectionA: {
+          metadata: {
+            id: 'foo' }}};
+      state.set('current', Y.clone(defaultState));
+      assert.equal(
+          state.generateUrl(changeState),
+          '/foo?text=apache2',
+          'The object ' + JSON.stringify(changeState) +
+              ' did not generate the proper url');
+    });
   });
 });


### PR DESCRIPTION
#### To QA

Load the gui using the `state` flag.
The charmbrowser should load.
Click a charm, its details should open.
Close the details,
Click a bundle, its details should open.
Close the details.
Perform a search
Click one of the results, its details should open.
