### PR TITLE
Make machine view columns scrollable.

### DIFF
--- a/lib/views/machine-view/machine-view-panel.less
+++ b/lib/views/machine-view/machine-view-panel.less
@@ -16,10 +16,14 @@
         padding-left: 0;
     }
     .column {
+        .customize-scrollbar;
+        .display-flex;
         .flex(1);
+        .flex-direction(column);
         border-right: 1px solid @machine-view-border-colour;
 
-        .machine-view-panel-header {
+        .head {
+            .flex-basis(auto);
             padding: 20px;
             border-bottom: 1px solid @machine-view-border-colour;
 
@@ -36,16 +40,22 @@
                 height: 20px;
             }
         }
-        .content ul {
-          margin: 0;
-          list-style: none;
-        }
-        .content li {
-          padding: 10px;
-          border-bottom: 1px solid @machine-view-border-colour;
+        .content {
+            .flex(1);
+            overflow-x: hidden;
+            overflow-y: auto;
+
+            ul {
+                margin: 0;
+                list-style: none;
+            }
+            li {
+                padding: 10px;
+                border-bottom: 1px solid @machine-view-border-colour;
+            }
         }
     }
 }
-.flag-state .machine-view-panel {
+.flag-mv .machine-view-panel {
     bottom: @deployer-bar-height;
 }

--- a/lib/views/mixins.less
+++ b/lib/views/mixins.less
@@ -124,7 +124,7 @@
     -ms-flex-direction: @direction;
     flex-direction: @direction;
 }
-.flex (@grow) {
+.flex(@grow) {
     -webkit-box-flex: @grow;
     -ms-flex: @grow;
     flex: @grow;


### PR DESCRIPTION
This branch makes each column in the machine view panel scrollable. I could not actually find any designs for how scrolling should work, but this seems to make sense with the navigation/interactions we have.

To test use the 'mv' flag, add a service to the environment, open the machine view panel, wait for machines to fill the column or resize your browser until there is not enough vertical room to fit the machine tokens.
