### PR TITLE
Fixed flags after rename.

### DIFF
--- a/app/views/viewlet-manager.js
+++ b/app/views/viewlet-manager.js
@@ -415,6 +415,10 @@ YUI.add('juju-viewlet-manager', function(Y) {
         var height = winHeight - headerHeight - footerHeight - (
             TB_SPACING * 3);
 
+        if (window.flags.mv) {
+          height -= 50;
+        }
+
         // The viewlet manager has a couple different wrapper elements which
         // impact which components are shown. In this case we are grabbing an
         // internal wrapper to resize without causing the elements to reflow.

--- a/lib/views/browser/main.less
+++ b/lib/views/browser/main.less
@@ -159,19 +159,20 @@
     .bws-content {
       top: 0;
       border-top: none;
+
       .sticky {
         top: 60px;
       }
     }
-  }
-  #bws-sidebar,
-  .bws-view-data {
-    bottom: @deployer-bar-height;
   }
 }
 
 .flag-mv #subapp-browser {
   .bws-view-data {
       top: @environment-header-height;
+  }
+  #bws-sidebar,
+  .bws-view-data {
+    bottom: @deployer-bar-height;
   }
 }

--- a/lib/views/juju-inspector.less
+++ b/lib/views/juju-inspector.less
@@ -35,11 +35,11 @@
 @keyframes pulse-green {.pulse-green-frames-mixin;}
 
 .yui3-juju-inspector {
+    .customize-scrollbar;
     top: 20px;
     right: 70px;
     position: absolute;
 
-    .customize-scrollbar;
 
     .left-breakout {
         .type9;
@@ -1069,7 +1069,7 @@
 .flag-mv .yui3-juju-inspector {
     top: @environment-header-height + 20px;
 }
-.flag-state .yui3-juju-inspector {
+.flag-state #subapp-browser .yui3-juju-inspector {
     .create-border-radius(0);
     top: auto;
     right: auto;
@@ -1078,6 +1078,14 @@
     .juju-inspector {
         position: static;
 
+        ::-webkit-scrollbar-track {
+            background-color: #1c1815;
+        }
+        ::-webkit-scrollbar-thumb {
+            background-color: #505050;
+            border-width: 0 1px;
+            border-color: #1c1815;
+        }
         .viewlet-manager-wrapper {
             .display-flex;
             .flex-direction(column);


### PR DESCRIPTION
This branch fixes a bunch of issues with the placement and positioning of the sidebar, inspector etc.

You will need to QA separately with the 'mv' and 'state' flags and make sure the sidebar, sidebar details panel, inspector, deployer bar and machine view panel and make sure everything is spaced and positioned correctly, nothing overlaps or is out of line.

(There is one fix that could have been done here that has already been done in https://github.com/juju/juju-gui/pull/243/files#diff-d3130848cd477c7fd200ab4516aab633R59)
