### PR TITLE
Fixed issue where search coudln't be completed twice in the charmbrowser

### DIFF
--- a/app/subapps/browser/browser.js
+++ b/app/subapps/browser/browser.js
@@ -228,8 +228,8 @@ YUI.add('subapp-browser', function(Y) {
     _searchChanged: function() {
       if (window.flags && window.flags.state) {
         var state = this.state;
-        if (state.getState('current', 'sectionA', 'search') &&
-            state.hasChanged('sectionA', 'search')) {
+        if (state.getState('current', 'sectionA', 'metadata').search &&
+            state.hasChanged('sectionA', 'metadata')) {
           return true;
         } else {
           return false;

--- a/test/test_browser_app.js
+++ b/test/test_browser_app.js
@@ -1233,6 +1233,21 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
         browser.state.save();
       });
 
+      it('knows when the search cache should be updated (state)', function() {
+        window.flags.state = true;
+        // This flag needs to be set before creating the charmbrowser instance
+        // to get the proper settings in the charmbrowser. This can be removed
+        // once the state flag is removed.
+        var charmbrowser = new ns.Browser();
+        charmbrowser.state.set('current', {
+          sectionA: {
+            component: 'charmbrowser',
+            metadata: { search: 'foo' }
+          }, sectionB: {}});
+        assert.equal(charmbrowser._searchChanged(), true);
+        window.flags = {};
+      });
+
       it('re-renders charm details with the sidebar', function() {
         // Set a charm identifier in the view state, and patch the old state
         // so that it is no different than the current one.


### PR DESCRIPTION
#### To QA

Use the `state` flag.
- Perform a search in the charmbrowser search, the results should appear in the list.
- Perform another search, the url should update and new results should appear in the list.
