### PR TITLE
Support tags and root-disk constraints.

### DIFF
--- a/app/models/handlers.js
+++ b/app/models/handlers.js
@@ -92,6 +92,24 @@ YUI.add('juju-delta-handlers', function(Y) {
             data = {role: relation.Role, name: relation.Name};
         return [endpoint.ServiceName, data];
       });
+    },
+
+    /**
+      Return the constraints converting the tags to a comma separated string.
+
+      @method convertConstraints
+      @param {Object} constraints The constraints included in the mega-watcher
+        for services, or null/undefined if no constraints are set.
+      @return {Object} The converted constraints.
+    */
+    convertConstraints: function(constraints) {
+      var result = constraints || {};
+      var tags = result.tags || [];
+      delete result.tags;
+      if (tags.length) {
+        result.tags = tags.join(',');
+      }
+      return result;
     }
 
   };
@@ -205,8 +223,9 @@ YUI.add('juju-delta-handlers', function(Y) {
         charm: change.CharmURL,
         exposed: change.Exposed,
         life: change.Life,
-        constraints: change.Constraints || {}
+        constraints: utils.convertConstraints(change.Constraints)
       };
+      // Process the stream.
       db.services.process_delta(action, data);
       if (action !== 'remove') {
         var service = db.services.getById(change.Name);

--- a/app/store/env/fakebackend.js
+++ b/app/store/env/fakebackend.js
@@ -1567,20 +1567,16 @@ YUI.add('juju-env-fakebackend', function(Y) {
     */
     setConstraints: function(serviceName, data) {
       var constraints = {};
-
+      // Do not allow calls for unauthenticated users.
       if (!this.get('authenticated')) {
         return UNAUTHENTICATED_ERROR;
       }
+      // Retrieve the service.
       var service = this.db.services.getById(serviceName);
       if (!service) {
         return {error: 'Service "' + serviceName + '" does not exist.'};
       }
-
-      var existing = service.get('constraints');
-      if (!existing) {
-        existing = {};
-      }
-
+      // Retrieve the service constraints.
       if (Y.Lang.isArray(data)) {
         Y.Array.each(data, function(i) {
           var kv = i.split('=');
@@ -1589,11 +1585,16 @@ YUI.add('juju-env-fakebackend', function(Y) {
       } else if (data) {
         constraints = data;
       }
-      // Merge new constraints in.
-      existing = Y.mix(existing, constraints, true, undefined, 0, true);
-      // TODO: Validate the constraints.
-      // Reassign the attr.
-      service.set('constraints', existing);
+      // Convert the tags constraints into a comma separated string.
+      var tags = constraints.tags;
+      if (tags) {
+        constraints.tags = tags.join(',');
+      }
+      // For the fakebackend purposes, there is no need to validate the
+      // constraints. Moreover, since we are always setting all the constraints
+      // from the service inspector, merging existing and new constraints is
+      // not necessary.
+      service.set('constraints', constraints);
       this.changes.services[service.get('id')] = [service, true];
       return {result: true};
     },

--- a/app/store/env/sandbox.js
+++ b/app/store/env/sandbox.js
@@ -878,7 +878,16 @@ YUI.add('juju-env-sandbox', function(Y) {
         Exposed: 'exposed',
         CharmURL: 'charm',
         Life: 'life',
-        Constraints: 'constraints',
+        'Constraints': function(attrs) {
+          var constraints = attrs.constraints || {};
+          // Since juju-core sends the tags constraint as a list of strings,
+          // we need to convert the value to an array.
+          var tags = constraints.tags;
+          if (tags) {
+            constraints.tags = tags.split(',');
+          }
+          return constraints;
+        },
         Config: 'config'
       },
       machine: {

--- a/app/views/utils.js
+++ b/app/views/utils.js
@@ -625,7 +625,9 @@ YUI.add('juju-view-utils', function(Y) {
     'cpu': {title: 'CPU', unit: 'GHz'},
     'cpu-cores': {title: 'CPU cores'},
     'cpu-power': {title: 'CPU power', unit: 'GHz'},
-    'mem': {title: 'Memory', unit: 'MB'}
+    'mem': {title: 'Memory', unit: 'MB'},
+    'root-disk': {title: 'Root Disk Size', unit: 'MB'},
+    'tags': {title: 'Tags'}
   };
 
   /**

--- a/test/test_fakebackend.js
+++ b/test/test_fakebackend.js
@@ -1595,6 +1595,25 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
           done();
         });
       });
+
+      it('converts the tags constraint to a string', function(done) {
+        fakebackend.deploy('cs:precise/wordpress-15', function() {
+          fakebackend.setConstraints('wordpress', {'tags': ['tag1', 'tag2']});
+          var service = fakebackend.getService('wordpress').result;
+          assert.strictEqual(service.constraints.tags, 'tag1,tag2');
+          done();
+        });
+      });
+
+      it('lets new constraints override existing ones', function(done) {
+        fakebackend.deploy('cs:precise/wordpress-15', function() {
+          fakebackend.setConstraints(
+              'wordpress', {'tags': ['tag1', 'tag2'], mem: 400});
+          var service = fakebackend.getService('wordpress').result;
+          assert.deepEqual(service.constraints, {tags: 'tag1,tag2', mem: 400});
+          done();
+        }, {constraints: {mem: 200, 'cpu-cores': 4}});
+      });
     });
 
     describe('FakeBackend.destroyService', function() {

--- a/test/test_ghost_inspector.js
+++ b/test/test_ghost_inspector.js
@@ -273,7 +273,7 @@ describe('Ghost Inspector', function() {
     assert.equal(constraintsNode.size(), 1);
 
     var inputNodes = content.all('.service-constraints input');
-    assert.equal(inputNodes.size(), 4);
+    assert.equal(inputNodes.size(), env.genericConstraints.length);
   });
 
   it('does not display constraints for subordinate charms', function() {
@@ -315,8 +315,14 @@ describe('Ghost Inspector', function() {
       assert.deepEqual(deployArgs[2], {});
       assert.isUndefined(deployArgs[3]);
       assert.equal(deployArgs[4], 1);
-      assert.deepEqual(deployArgs[5],
-          { 'cpu-power': '', 'cpu-cores': '', 'mem': '', 'arch': '' });
+      assert.deepEqual(deployArgs[5], {
+        'cpu-power': '',
+        'cpu-cores': '',
+        'mem': '',
+        'arch': '',
+        'root-disk': '',
+        'tags': ''
+      });
       assert.strictEqual(deployArgs[6], null);
       assert.isFunction(deployArgs[7]);
     });

--- a/test/test_sandbox_go.js
+++ b/test/test_sandbox_go.js
@@ -421,15 +421,20 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       var constraints = {
         'cpu-cores': 1,
         'cpu-power': 0,
-        'mem': '512M',
-        'arch': 'i386'
+        mem: '512M',
+        arch: 'i386'
       };
 
       env.connect();
       // We begin logged in.  See utils.makeFakeBackend.
       var callback = function(result) {
         var service = state.db.services.getById('kumquat');
-        assert.deepEqual(service.get('constraints'), constraints);
+        assert.deepEqual(service.get('constraints'), {
+          'cpu-cores': 1,
+          'cpu-power': 0,
+          mem: 512,
+          arch: 'i386'
+        });
         done();
       };
       env.deploy(


### PR DESCRIPTION
Add support for setting/retrieving the missing
constraints: "tags" and "root-disk".

Fix a bug preventing constraints to be removed
in sandbox mode.
Also improve the constraints validation
performed before sending the API requests.

Note that currently bug 1309449 [1] prevents
tags to be removed when using a real juju-core
environment.

QA:
QA must be done in sandbox mode and real env [2].
It involves deploying charms, setting constraints
(including the new ones), changing and removing
them, to see if the backend reacts correctly.
When setting tags, ensure they are normalized (
e.g.: "foo bar, spam," is turned into "foo-bar,spam").
Also, please make sure that constraints are
preserved when exporting/importing bundles, whether
they are set or missing/removed.

[1] https://bugs.launchpad.net/juju-core/+bug/1309449
[2] E.g. by using juju-quickstart to deploy the GUI,
    then running `juju set juju-gui juju-gui-source="https://github.com/frankban/juju-gui.git tags-constraint"` and then waiting for the GUI
    to be ready.
