### PR TITLE
Fix clearing url hash on details close.

### DIFF
--- a/app/subapps/browser/views/entity-base.js
+++ b/app/subapps/browser/views/entity-base.js
@@ -237,7 +237,7 @@ YUI.add('subapp-browser-entitybaseview', function(Y) {
         this.fire('changeState', {
           sectionA: {
             component: 'charmbrowser',
-            metadata: { id: null }
+            metadata: { id: null, hash: null }
           }});
       } else {
         this.fire('viewNavigate', { change: { charmID: null, hash: null }});

--- a/test/test_browser_charm_details.js
+++ b/test/test_browser_charm_details.js
@@ -866,6 +866,30 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       assert.equal(selected.getAttribute('href'), '#configuration');
     });
 
+    it('sets the proper change request when closed', function(done) {
+      window.flags.il = true;
+      var data = utils.loadFixture('data/browsercharm.json', true);
+      // We don't want any files so we don't have to mock/load them.
+      data.charm.files = [];
+
+      view = new CharmView({
+        activeTab: '#configuration',
+        entity: new models.Charm(data.charm),
+        container: utils.makeContainer(this)
+      });
+
+      view.on('changeState', function(ev) {
+        assert.equal(ev.details[0].sectionA.metadata.id, null,
+                     'The charm id is not set to null.');
+        assert.equal(ev.details[0].sectionA.metadata.hash, null,
+                     'The charm details hash is not set to null.');
+        done();
+      });
+
+      view.render();
+      view.get('container').one('.charm .back').simulate('click');
+    });
+
     it('loads related charms when interface tab selected', function() {
       var data = utils.loadFixture('data/browsercharm.json', true).charm;
       testContainer = utils.makeContainer(this);

--- a/test/test_bundle_details_view.js
+++ b/test/test_bundle_details_view.js
@@ -376,6 +376,23 @@ describe('Browser bundle detail view', function() {
     assert.equal(selected.getAttribute('href'), '#services');
   });
 
+  it('sets the proper change request when closed', function(done) {
+    window.flags.il = true;
+    view.set('activeTab', '#services');
+    view._parseData = function() {
+      return new Y.Promise(function(resolve) { resolve(); });
+    };
+    view.set('entity', new models.Bundle(data));
+    view.on('changeState', function(ev) {
+      assert.equal(ev.details[0].sectionA.metadata.id, null,
+                   'The charm id is not set to null.');
+      assert.equal(ev.details[0].sectionA.metadata.hash, null,
+                   'The charm details hash is not set to null.');
+      done();
+    });
+    view.render();
+    view.get('container').one('.bundle .back').simulate('click');
+  });
 
   it('can generate source and revno links from its charm', function() {
     view.set('entity', new models.Bundle(data));


### PR DESCRIPTION
- Update the entity-base to pass a null hash in the metadata during the change
  event.
- Add tests to both the bundle and charm details that the hash is cleared.
## QA

Make sure to use the :flags:/il for all QA steps.
- open a charm details view, go to the readme tab. Verify the url has
  #readme. Close the details and the url should not have any hash any longer.
- Repeat the process, make sure that you can copy and paste that url with the
  hash into a new browser tab. Then close the details, and the hash goes away.
- Do the same for bundles.
