### PR TITLE
Service inspector closes without flags.

### DIFF
--- a/app/views/inspectors/service-inspector.js
+++ b/app/views/inspectors/service-inspector.js
@@ -112,11 +112,15 @@ YUI.add('service-inspector', function(Y) {
     */
     onCloseInspector: function(e) {
       e.preventDefault();
+      if (!window.flags || !window.flags.il) {
+        this.destroy();
+      } else {
+        this.fire('changeState', {
+          sectionA: {
+            component: null,
+            metadata: { id: null }}});
+      }
       // The emptySectionA method will destroy this inspector.
-      this.fire('changeState', {
-        sectionA: {
-          component: null,
-          metadata: { id: null }}});
     },
 
     /**

--- a/test/test_inspector_overview.js
+++ b/test/test_inspector_overview.js
@@ -1089,10 +1089,15 @@ describe('Inspector Overview', function() {
   });
 
   describe('Inspector level actions', function() {
+    afterEach(function(done) {
+      window.flags = {};
+    });
+
     it('should fire the changeState event when closed', function() {
       inspector = setUpInspector(null, true);
       var fireStub = utils.makeStubMethod(inspector, 'fire');
       this._cleanups.push(fireStub.reset);
+      window.flags.il = true;
       inspector.get('container').one('.close').simulate('click');
       assert.equal(fireStub.calledOnce(), true);
       var fireArgs = fireStub.lastArguments();


### PR DESCRIPTION
This resolves a simple bug wherein the service inspector (absent flags) would not close after deploying a service; this was simply because the original call to .destroy was no longer made, even without the state flag.

I've not bothered adding tests, as this code will only live for a short while (e.g. the end of this week). In the meantime, we would like comingsoon to still work.

QA
This branch must be QAed against the state flag and without flags. In both cases, after deploying a service, you should be able to close that service's inspector using the close button.
