### PR TITLE
Set metadata to null on gohome event.

### DIFF
--- a/app/subapps/browser/views/view.js
+++ b/app/subapps/browser/views/view.js
@@ -147,7 +147,12 @@ YUI.add('subapp-browser-mainview', function(Y) {
      */
     _goHome: function(ev) {
       if (window.flags && window.flags.il) {
-        this.fire('changeState', { sectionA: {} });
+        this.fire('changeState', {
+          sectionA: {
+            metadata: null,
+            component: null
+          }
+        });
       } else {
         var change = {
           charmID: undefined,

--- a/test/test_ui_state.js
+++ b/test/test_ui_state.js
@@ -959,5 +959,21 @@ describe('UI State object', function() {
           'The object ' + JSON.stringify(changeState) +
               ' did not generate the proper url');
     });
+
+    it('can reset metadata', function() {
+      var defaultState = {
+        sectionA: {
+          metadata: {
+            search: 'apache2' }
+        }, sectionB: {}};
+      var changeState = {
+        sectionA: { metadata: null }
+      };
+      state.set('current', Y.clone(defaultState));
+      assert.equal(
+          state.generateUrl(changeState), '/',
+          'The object ' + JSON.stringify(changeState) +
+              ' did not generate the proper url');
+    });
   });
 });


### PR DESCRIPTION
Fix the charm browser's Home button search
- Set's metadata for sectionA to null on `EVT_SEARCH_GOHOME`
- Adds test to test_ui_state ensuring `metadata: null` results in navigating back to '/' from a search

QA with and without the `il` flag
