### PR TITLE
Sidebar scrollbar visible

### DIFF
--- a/lib/views/browser/main.less
+++ b/lib/views/browser/main.less
@@ -60,7 +60,7 @@
   }
   #bws-sidebar .bws-content {
     overflow-x: hidden;
-    overflow-y: auto;
+    overflow-y: scroll;
   }
   #bws-sidebar {
     z-index: 601;


### PR DESCRIPTION
Sidebar scrollbar should be always visible so the content doesn't jump around.
