### PR TITLE
Realign inspector breakout panel to come from left

### DIFF
--- a/app/templates/left-breakout-panel.handlebars
+++ b/app/templates/left-breakout-panel.handlebars
@@ -1,4 +1,4 @@
-<div>
+<div class="left-breakout">
   <a href="" class="close-slot" data-slot="left-hand-panel">
      <i class="sprite panel_close"></i>
   </a>

--- a/app/views/viewlets/charm-details.js
+++ b/app/views/viewlets/charm-details.js
@@ -40,8 +40,22 @@ YUI.add('charm-details-view', function(Y) {
         viewlet manager.
     */
     render: function(charm, viewletManagerAttrs) {
+      var container;
       var store = viewletManagerAttrs.store;
-      var container = this.get('container');
+      if (window.flags && window.flags.il) {
+        // Target the charm details div for the inspector popout content.
+        container = Y.one('.bws-view-data');
+        container.delegate('click', function(ev) {
+          ev.halt();
+          this.viewletManager.hideSlot(ev);
+          window.location.hash = '';
+          container.hide();
+        }, '.close-slot', this);
+        container.hide();
+      } else {
+        container = this.get('container');
+      }
+
       store.charm(charm.get('storeId'), {
         'success': function(data, storeCharm) {
           this.charmView = new browserViews.BrowserCharmView({
@@ -64,6 +78,7 @@ YUI.add('charm-details-view', function(Y) {
       }, this, viewletManagerAttrs.db.charms);
 
       container.setHTML(this.templateWrapper({ initial: 'Loading...'}));
+      container.show();
     },
 
     /**

--- a/app/views/viewlets/unit-details.js
+++ b/app/views/viewlets/unit-details.js
@@ -171,7 +171,19 @@ YUI.add('unit-details-view', function(Y) {
       var context = this.getContext(db, service, unit);
       var template = Y.Node.create(this.templateWrapper({}));
       template.one('.content').setHTML(this.template(context));
-      this.get('container').setHTML(template);
+      if (window.flags && window.flags.il) {
+        // Target the charm details div for the inspector popout content.
+        var container = Y.one('.bws-view-data');
+        container.setHTML(template);
+        container.show();
+        container.delegate('click', function(ev) {
+          ev.halt();
+          this.viewletManager.hideSlot(ev);
+          container.hide();
+        }, '.close-slot', this);
+      } else {
+        this.get('container').setHTML(template);
+      }
     }
   });
 

--- a/lib/views/juju-inspector.less
+++ b/lib/views/juju-inspector.less
@@ -34,11 +34,11 @@
 @-o-keyframes pulse-green {.pulse-green-frames-mixin;}
 @keyframes pulse-green {.pulse-green-frames-mixin;}
 
-.yui3-juju-inspector {
+.yui3-juju-inspector, .bws-view-data {
     .customize-scrollbar;
-    top: 20px;
     right: 70px;
     position: absolute;
+    top: 20px;
 
 
     .left-breakout {
@@ -1069,6 +1069,11 @@
 .flag-mv .yui3-juju-inspector {
     top: @environment-header-height + 20px;
 }
+
+.bws-view-data {
+    top: 0;
+}
+
 .flag-il #subapp-browser .yui3-juju-inspector {
     .create-border-radius(0);
     top: auto;


### PR DESCRIPTION
This is a first step. The changes here break some of the ideas of the
viewlet-manager and viewlets. There are work arounds in place here so that we
can move forward and discuss how to adjust to the requirements here.
- Updates the unit and service details to come into the same space as charm
  details.
- Works around the issue of the close event not being in the same dom tree as
  the viewlet-manager and not caught to close the breakout panels.
- Updates the css for the new location.
## QA
- make devel
- view the site with :flags:/il
- deploy a service and once it's deployed, click on the "Charm details" link and
  a functional details popout should appear.
- Close and verify it closes properly and reopens as well.
- Go to a running unit and select the unit to open its details.
- Verify you can go straight from a unit to a service details and back/forth
  without issue.
- Verify that with a panel open, if you close the inspector the panel also
  closes.
- Verify that the inspector and panels work without the feature flag as
  expected.
