### PR TITLE
Fix rerender of sidebar when the details panel is opened

### DIFF
--- a/app/subapps/browser/browser.js
+++ b/app/subapps/browser/browser.js
@@ -420,7 +420,12 @@ YUI.add('subapp-browser', function(Y) {
       // If there is no provided metadata show the defaults.
       if (!metadata || !metadata.search) {
         this._sidebar.showSearch();
-        this.renderEditorial();
+        if (!this._editorial) {
+          this.renderEditorial();
+        } else if (!metadata || !metadata.id) {
+          // Deselect the active charm.
+          this._editorial.updateActive();
+        }
       }
       if (metadata && metadata.search) {
         this._sidebar.showSearch();
@@ -479,7 +484,10 @@ YUI.add('subapp-browser', function(Y) {
       @method emptySectionA
     */
     emptySectionA: function() {
-      if (this._editorial) { this._editorial.destroy(); }
+      if (this._editorial) {
+        this._editorial.destroy();
+        this._editorial = null;
+      }
       if (this._search) { this._search.destroy(); }
       if (this._sidebar.search) { this._sidebar.hideSearch(); }
       if (this._details) {

--- a/app/subapps/browser/views/charmresults.js
+++ b/app/subapps/browser/views/charmresults.js
@@ -73,7 +73,7 @@ YUI.add('subapp-browser-charmresults', function(Y) {
               id = this.get('container').one(
                   '.token[data-charmid="' + id + '"]');
             }
-            this._updateActive(id);
+            this.updateActive(id);
           })
       );
     },
@@ -92,7 +92,7 @@ YUI.add('subapp-browser-charmresults', function(Y) {
       var charmID = charm.getData('charmid');
 
       // Update the UI for the active one.
-      this._updateActive(ev.currentTarget);
+      this.updateActive(ev.currentTarget);
 
       var change = {
         charmID: charmID,
@@ -113,11 +113,11 @@ YUI.add('subapp-browser-charmresults', function(Y) {
     /**
       Update the node in the editorial list marked as 'active'.
 
-      @method _updateActive
+      @method updateActive
       @param {Node} clickTarget the token clicked on to activate.
 
     */
-    _updateActive: function(clickTarget) {
+    updateActive: function(clickTarget) {
       // Remove the active class from any nodes that have it.
       Y.all('.yui3-token.active').removeClass('active');
 

--- a/app/subapps/browser/views/editorial.js
+++ b/app/subapps/browser/views/editorial.js
@@ -145,7 +145,7 @@ YUI.add('subapp-browser-editorial', function(Y) {
           // Set the active charm if available.
           var active = this.get('activeID');
           if (active) {
-            this._updateActive(
+            this.updateActive(
                 container.one('.token[data-charmid="' + active + '"]')
             );
           }

--- a/app/subapps/browser/views/search.js
+++ b/app/subapps/browser/views/search.js
@@ -100,7 +100,7 @@ YUI.add('subapp-browser-searchview', function(Y) {
           // Set the active charm if available.
           var active = this.get('activeID');
           if (active) {
-            this._updateActive(
+            this.updateActive(
                 this.get('container').one(
                     '.token[data-charmid="' + active + '"]')
             );

--- a/test/test_browser_app.js
+++ b/test/test_browser_app.js
@@ -241,10 +241,12 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
           function assertions(
               editorialCount, searchCount, entityCount, showSearchCount) {
-            assert.equal(editorialStub.callCount(), editorialCount);
-            assert.equal(searchStub.callCount(), searchCount);
-            assert.equal(entityStub.callCount(), entityCount);
-            assert.equal(showSearchStub.callCount(), showSearchCount);
+            assert.equal(editorialStub.callCount(), editorialCount,
+                'editorialStub');
+            assert.equal(searchStub.callCount(), searchCount, 'searchStub');
+            assert.equal(entityStub.callCount(), entityCount, 'entityStub');
+            assert.equal(showSearchStub.callCount(), showSearchCount,
+                'showSearchStub');
           }
 
           it('renders the editorial when no metadata is provided', function() {
@@ -282,6 +284,30 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
               id: 'foo'
             });
             assertions(0, 1, 1, 2);
+          });
+
+          it('does not rerender the editorial if it exists', function() {
+            stubRenderers(this);
+            // Start with an exisiting editorial so that the test skips
+            // the creation.
+            app._editorial = {};
+            var activeStub = utils.makeStubMethod(app._editorial,
+                'updateActive');
+            this._cleanups.push(activeStub.reset);
+            app._charmbrowser();
+            assertions(0, 0, 0, 1);
+          });
+
+          it('deselects the last active charm', function() {
+            stubRenderers(this);
+            // Start with an exisiting editorial so that the test skips
+            // the creation.
+            app._editorial = {};
+            var activeStub = utils.makeStubMethod(app._editorial,
+                'updateActive');
+            this._cleanups.push(activeStub.reset);
+            app._charmbrowser();
+            assert.equal(activeStub.callCount(), 1);
           });
         });
 
@@ -350,10 +376,19 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
           it('emptySectionA', function() {
             stubMethods(app);
-            var bwsdata = utils.makeContainer(this);
+            var bwsdata = utils.makeContainer(this),
+                destroyMethod = app._editorial.destroy,
+                destroyCalled = false;
             bwsdata.addClass('bws-view-data');
+            // The original destroy method is set to null after the
+            // destroy is called so we need to stub out the method here
+            // so that we can track the destroy.
+            app._editorial.destroy = function() {
+              destroyCalled = true;
+              app._editorial.destroy = destroyMethod;
+            };
             app.emptySectionA();
-            assert.equal(app._editorial.destroy.callCount(), 1);
+            assert.equal(destroyCalled, true);
             assert.equal(app._search.destroy.callCount(), 1);
             assert.equal(app._sidebar.hideSearch.callCount(), 1);
             assert.equal(app._details.destroy.callCount(), 1);


### PR DESCRIPTION
The editorial was being rerendered when the details panel was opened or closed. Fixing that also required deselecting the charm when the panel is closed.
