### PR TITLE
Fix the width of the machine view panel

### DIFF
--- a/lib/views/environment-header.less
+++ b/lib/views/environment-header.less
@@ -3,7 +3,7 @@
     position: absolute;
     z-index: 600;
     top: @navbar-height;
-    left: 0;
+    left: @bws-sidebar-width;
     right: 0;
     height: @environment-header-height;
     background-color: #eee;
@@ -12,7 +12,7 @@
     ul {
         .display-flex;
         height: @environment-header-height - 1;
-        margin: 0 0 0 @left-panel-width + 1px;
+        margin: 0;
         list-style: none;
 
         li {

--- a/lib/views/machine-view/machine-view-panel.less
+++ b/lib/views/machine-view/machine-view-panel.less
@@ -7,7 +7,7 @@
     bottom: 0;
     left: @bws-sidebar-width;
     right: 0;
-    padding: 10px 0 0 @left-panel-width + 1px;
+    padding: 10px 0 0 0;
     background-color: #fff;
 
     .column {


### PR DESCRIPTION
The width of the machine view panel were not correct, the columns were mis-aligned and the header was sitting under the sidebar.

QA:
Use mv flag. Deploy a service and open the machine view.
Check that the columns do not have a space on the left.
Check that the header does not display under the sidebar (there is not a visual difference, you'll need to inspect the element to see the change).
