### PR TITLE
Removed always visible sidebar

### DIFF
--- a/lib/views/browser/main.less
+++ b/lib/views/browser/main.less
@@ -60,7 +60,7 @@
   }
   #bws-sidebar .bws-content {
     overflow-x: hidden;
-    overflow-y: scroll;
+    overflow-y: auto;
   }
   #bws-sidebar {
     z-index: 601;


### PR DESCRIPTION
After a discussion with UX the desired behaviour is that the scrollbar only appear when you can scroll.
