### PR TITLE
Add containers creation to the simulator.

### DIFF
--- a/app/store/env/fakebackend.js
+++ b/app/store/env/fakebackend.js
@@ -920,6 +920,8 @@ YUI.add('juju-env-fakebackend', function(Y) {
     @param {String} serviceName The name of the service to be scaled up.
     @param {Integer} numUnits The number of units to be added, defaulting
       to 1.
+    @param {String} toMachine The machine/container where the unit will be
+      placed, or null/undefined to create a top level machine.
     @return {Object} Returns an object either with an "error" attribute
       containing a string describing the problem, or with a "units"
       attribute containing a list of the added units.


### PR DESCRIPTION
QA:
- make devel;
- deploy a large bundle (e.g. openstack) 
  so that more units are likely to be added
  by the simulator;
- wait a minute or two;
- in the JS console, run the following:
  `app.db.machines.map(function(machine) {return machine.id});`
- ensure containers have been correctly added.
