### PR TITLE
Fixes not closing ghost inspector

### DIFF
--- a/app/views/inspectors/ghost-service-inspector.js
+++ b/app/views/inspectors/ghost-service-inspector.js
@@ -77,10 +77,16 @@ YUI.add('ghost-service-inspector', function(Y) {
       var model = this.get('model');
       model.set('displayName', '(' + model.get('packageName') + ')');
       // The emptySectionA method will destroy this inspector.
-      this.fire('changeState', {
-        sectionA: {
-          component: 'charmbrowser',
-          metadata: { id: null }}});
+      if (window.flags && window.flags.il) {
+        this.fire('changeState', {
+          sectionA: {
+            component: 'charmbrowser',
+            metadata: { id: null }
+          }
+        });
+      } else {
+        this.destroy();
+      }
     },
 
     /**


### PR DESCRIPTION
Per the [bug](https://bugs.launchpad.net/juju-gui/+bug/1315043), without flags clicking "X" to close the ghost inspector
doesn't work. This is because the inspector only fires a `changeState` event when
the close button is clicked.

This is pretty simple to remedy: the inspector now checks for the il flag, and
either fires the `changeState` event or calls `destroy`, as appropriate.

A test has been added for the no-flags situation, and the current test was
updated to set the il flag.
