### PR TITLE
Fix ghost relations.

### DIFF
--- a/app/assets/svgs/relation-icon-pending.svg
+++ b/app/assets/svgs/relation-icon-pending.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+     width="20px" height="20px" viewBox="0 0 20 20" enable-background="new 0 0 20 20" xml:space="preserve">
+<g>
+    <path fill="#e2e2e2" d="M10,3c3.859,0,7,3.14,7,7c0,3.859-3.141,7-7,7c-3.86,0-7-3.141-7-7C3,6.14,6.14,3,10,3 M10,0
+        C4.477,0,0,4.477,0,10c0,5.522,4.477,10,10,10c5.522,0,10-4.478,10-10C20,4.477,15.522,0,10,0L10,0z"/>
+</g>
+</svg>

--- a/app/utils/environment-change-set.js
+++ b/app/utils/environment-change-set.js
@@ -52,7 +52,9 @@ YUI.add('environment-change-set', function(Y) {
           Y.Lang.isFunction(args[args.length - 2])) {
         cut = -1;
       }
-      return Array.prototype.slice.call(args, 0, cut);
+      // Deep copy the resulting array of arguments, in order to prevent
+      // changeset functions to mutate the given data structures.
+      return Y.clone(Array.prototype.slice.call(args, 0, cut));
     },
 
     /**

--- a/app/views/utils.js
+++ b/app/views/utils.js
@@ -1355,6 +1355,15 @@ YUI.add('juju-view-utils', function(Y) {
   Object.defineProperties(_relationCollection, {
     aggregatedStatus: {
       get: function() {
+        // Return pending if any of the relations are pending.
+        // Note that by "pending" in this context we mean the relation is added
+        // between two ghost/uncommitted services.
+        var pending = Y.Array.some(this.relations, function(relation) {
+          return relation.pending;
+        });
+        if (pending) {
+          return 'pending';
+        }
         // Return unhealthy regardless of subordinate status if any of the
         // relations are in error.
         var unhealthy = Y.Array.some(this.relations, function(relation) {

--- a/lib/views/stylesheet.less
+++ b/lib/views/stylesheet.less
@@ -546,6 +546,9 @@ th {
     &.healthy {
         stroke: #33cc33;
     }
+    &.pending {
+        stroke: #e2e2e2;
+    }
     &.pending-relation {
         stroke: #faaf40;
 

--- a/test/test_env_change_set.js
+++ b/test/test_env_change_set.js
@@ -79,6 +79,21 @@ describe('Environment Change Set', function() {
         test.apply(null, args);
       });
 
+      it('deep copies the original arguments', function(done) {
+        var args = [{key: 'value'}, [42], function() {}];
+        var backup = Y.clone(args);
+        function test() {
+          var result = ecs._getArgs(arguments);
+          // Mutate the resulting arguments.
+          result[0].key = 'another value';
+          result[1].push(47);
+          // Ensure the original ones have not been changed.
+          assert.deepEqual(args, backup);
+          done();
+        }
+        test.apply(null, args);
+      });
+
       it('strips the ecs options argument off the end', function(done) {
         var stub = testUtils.makeStubFunction();
         var args = [1, 2, 'foo', 'bar', stub, { options: 'foo'}];

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -1182,6 +1182,9 @@ describe('utilities', function() {
       // Any subordinate relations with any errors - error.
       collections[1].relations[0].isSubordinate = true;
       assert.equal(collections[1].aggregatedStatus, 'error');
+      // Any pending relation - pending.
+      collections[1].relations[0].pending = true;
+      assert.equal(collections[1].aggregatedStatus, 'pending');
     });
 
   });


### PR DESCRIPTION
This branch fixes the following issues:
- the ghost relation line disappears right after creating
  the relation: that was due to ecs functions mutating the
  relation data;
- the ghost relation is now a grey line with hollow circle;
- the relation line now follows the service blocks when they
  are moved.

In my external monitor some more contrast between the
relation color and the background could help. Luca and
Spencer are working on that.

QA:
- make devel;
- go to `http://<GUIURL>/:flags:/mv/il/`;
- drag mysql, click deploy and close the inspector;
- do the same with wordpress;
- connect the two services;
- the grey relation should be displayed;
- move the two uncommited services, the relation line
  should be updated correctly;
- click deploy on the status bar,
  the services are now deployed.

Please also ensure relations still works without the flags.
