### PR TITLE
Global units model list.

### DIFF
--- a/app/views/viewlets/service-overview.js
+++ b/app/views/viewlets/service-overview.js
@@ -807,7 +807,7 @@ YUI.add('inspector-overview-view', function(Y) {
             })
         );
       } else {
-        service.get('units').add(
+        db.addUnits(
             Y.Array.map(unit_names, function(unit_id) {
               return {id: unit_id,
                 agent_state: 'pending'};
@@ -853,9 +853,7 @@ YUI.add('inspector-overview-view', function(Y) {
         );
       } else {
         Y.Array.each(unit_names, function(unit_name) {
-          var service = db.services.getById(unit_name.split('/')[0]);
-          var units = service.get('units');
-          units.remove(units.getById(unit_name));
+          db.removeUnits(db.units.getById(unit_name));
         });
         service.set(
             'unit_count', service.get('unit_count') - unit_names.length);

--- a/test/test_landscape.js
+++ b/test/test_landscape.js
@@ -49,7 +49,7 @@ describe('Landscape integration', function() {
       db.services.add({id: 'mysql',
         annotations: {'landscape-computers': '+service:mysql'}
       });
-      db.services.getById('mysql').get('units').add([{
+      db.addUnits([{
         id: 'mysql/0',
         annotations: {'landscape-computer': '+unit:mysql-0'}
       }, {
@@ -132,7 +132,7 @@ describe('Landscape integration', function() {
     // Add a second service with a unit in a flagged state
     // and make sure the environment reflects this.
     var wordpress = db.services.add({id: 'wordpress'});
-    wordpress.get('units').add({
+    db.addUnits({
       id: 'wordpress/0',
       annotations: {'landscape-security-upgrades': true}
     });

--- a/test/test_sandbox_python.js
+++ b/test/test_sandbox_python.js
@@ -1315,8 +1315,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
             request_id: 99
           };
           client.onmessage = function(received) {
-            var unit = state.db.services.getById('wordpress')
-                .get('units').getById('wordpress/0');
+            var unit = state.db.units.getById('wordpress/0');
             var annotations = unit.annotations;
             assert.equal(annotations.foo, 'bar');
             // Error should be undefined.

--- a/test/test_unit_detail_viewlet.js
+++ b/test/test_unit_detail_viewlet.js
@@ -34,9 +34,9 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
         ViewletManager = viewlets.ViewletManager;
         db = new models.Database();
         service = db.services.add({id: 'haproxy'});
-        var units = service.get('units');
-        unit = units.add({
+        unit = db.addUnits({
           id: 'haproxy/42',
+          service: 'haproxy',
           annotations: {'landscape-computer': '+unit:haproxy-42'},
           agent_state: 'peachy',
           agent_state_info: 'keen',

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -1419,7 +1419,7 @@ describe('utilities', function() {
           id: 'django',
           annotations: {'landscape-computers': '+service:django'}
         });
-        unit = service.get('units').add({
+        unit = db.addUnits({
           id: 'django/42',
           annotations: {'landscape-computer': '+unit:django-42'}
         });


### PR DESCRIPTION
The db.units lazy model list includes all known units.
Also implement helper methods to add/remove units, and filter them by machine/container.

I was not able to properly live test this, but I am still proposing the code in order to unblock other branches.
For this reason please be very meticulous when QAing the branch: all the units-related GUI parts (showing units in the inspector, adding/removing them) should be tested for regressions, in both sandbox and real environments.

This does not include changes in the machine panel (wire service unit tokens etc.): the diff is already too long (my apologies). I changed my card description and created another one in "Ready to code" to reflect this.
