### PR TITLE
Fixing initial inspectors on deploy.

### DIFF
--- a/app/subapps/browser/browser.js
+++ b/app/subapps/browser/browser.js
@@ -387,6 +387,7 @@ YUI.add('subapp-browser', function(Y) {
       });
 
       this.on('*:changeState', function(e) {
+        this.state.set('allowInspector', true);
         var state = e.details[0];
         var url = this.state.generateUrl(state);
         this.navigate(url);

--- a/test/test_browser_app.js
+++ b/test/test_browser_app.js
@@ -501,6 +501,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
       it('listens to changeState events', function() {
         app = new browser.Browser();
+        app.state.set('allowInspector', false);
         var generateUrlStub = utils.makeStubMethod(
             app.state, 'generateUrl', 'genUrl');
         var navigateStub = utils.makeStubMethod(app, 'navigate');
@@ -509,6 +510,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
         assert.deepEqual(generateUrlStub.lastArguments()[0], {foo: 'bar'});
         assert.equal(navigateStub.calledOnce(), true);
         assert.equal(navigateStub.lastArguments()[0], 'genUrl');
+        assert.isTrue(app.state.get('allowInspector'));
       });
 
       it('verify that route callables exist', function() {


### PR DESCRIPTION
To QA:

With the il flag, drag and drop a service onto the canvas; the inspector should open.
