### PR TITLE
Show add relation menu even if we're on the il flag

### DIFF
--- a/app/views/environment.js
+++ b/app/views/environment.js
@@ -299,10 +299,12 @@ YUI.add('juju-view-environment', function(Y) {
     _attachTopoEvents: function() {
       this.topo.on(
           '*:destroyServiceInspector', this.destroyInspector, this);
-      this.topo.on(
-          '*:addRelationStart', this.shrinkInspector, this);
-      this.topo.on(
-          '*:addRelationEnd', this.expandInspector, this);
+      if (!window.flags.il) {
+        this.topo.on(
+            '*:addRelationStart', this.shrinkInspector, this);
+        this.topo.on(
+            '*:addRelationEnd', this.expandInspector, this);
+      }
       this.topo.on(
           '*:inspectRelation', this.onInspectRelation, this);
     }

--- a/app/views/topology/service.js
+++ b/app/views/topology/service.js
@@ -1459,8 +1459,8 @@ YUI.add('juju-topology-service', function(Y) {
           }});
       } else {
         this.show_service(box.model);
-        this.showServiceMenu(box);
       }
+      this.showServiceMenu(box);
     },
 
     /**


### PR DESCRIPTION
The build relation menu is still required when we're using the il flag, but we don't want to shrink or expand the inspector.

QA:
Deploy mysql and wordpress.
Click on the canvas so that the Build Relation menu disappears.
Now click on a service and the menu should appear again.
Click on the Build Relation menu and you should be able to create a relation between the two services.
