### PR TITLE
Animate cleanup

### DIFF
--- a/app/views/state.js
+++ b/app/views/state.js
@@ -288,7 +288,10 @@ YUI.add('juju-app-state', function(Y) {
         url += '?' + this.filter.genQueryString();
       }
       // Add the hash to the end of the url.
-      if (hash.length > 0) { url += '#' + hash; }
+      if (hash.length > 0) {
+        hash = (hash.indexOf('#') === 0) ? hash : '#' + hash;
+        url += hash;
+      }
       return url;
     },
 

--- a/app/views/viewlets/charm-details.js
+++ b/app/views/viewlets/charm-details.js
@@ -40,8 +40,9 @@ YUI.add('charm-details-view', function(Y) {
         viewlet manager.
     */
     render: function(charm, viewletManagerAttrs) {
-      var container;
-      var store = viewletManagerAttrs.store;
+      var container,
+          store = viewletManagerAttrs.store,
+          panel = Y.one('.charmbrowser');
       if (window.flags && window.flags.il) {
         // Target the charm details div for the inspector popout content.
         container = Y.one('.bws-view-data');
@@ -49,8 +50,12 @@ YUI.add('charm-details-view', function(Y) {
           ev.halt();
           this.viewletManager.hideSlot(ev);
           window.location.hash = '';
+          panel.removeClass('animate-in');
           container.hide();
+          this.destroy({remove: true});
+          container.empty();
         }, '.close-slot', this);
+        panel.removeClass('animate-in');
         container.hide();
       } else {
         container = this.get('container');
@@ -78,6 +83,7 @@ YUI.add('charm-details-view', function(Y) {
       }, this, viewletManagerAttrs.db.charms);
 
       container.setHTML(this.templateWrapper({ initial: 'Loading...'}));
+      panel.addClass('animate-in');
       container.show();
     },
 

--- a/lib/views/browser/main.less
+++ b/lib/views/browser/main.less
@@ -126,7 +126,7 @@
   .bws-view-data {
     left: @bws-sidebar-width;
   }
-  .content-visible .bws-view-data {
+  .animate-in .bws-view-data {
     -webkit-animation: sidebar-details-slide-in 0.5s;
     animation: sidebar-details-slide-in 0.5s;
   }

--- a/test/test_browser_app.js
+++ b/test/test_browser_app.js
@@ -26,6 +26,8 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       '</div>',
       '<div id="content">',
       '<div id="subapp-browser">',
+      '<div class="charmbrowser">',
+      '</div>',
       '</div>',
       '</div>'
     ].join('')).appendTo(container);
@@ -273,6 +275,8 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
           it('renders & editorial charm details with id provided', function() {
             stubRenderers(this);
+            var showStub = utils.makeStubMethod(app, '_shouldShowCharm', true);
+            this._cleanups.push(showStub.reset);
             app._charmbrowser({
               id: 'foo'
             });
@@ -281,6 +285,8 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
           it('renders search and charm details', function() {
             stubRenderers(this);
+            var showStub = utils.makeStubMethod(app, '_shouldShowCharm', true);
+            this._cleanups.push(showStub.reset);
             app._charmbrowser({
               search: 'foo',
               id: 'foo'
@@ -296,6 +302,10 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
             var activeStub = utils.makeStubMethod(app._editorial,
                 'updateActive');
             this._cleanups.push(activeStub.reset);
+            var cleanupStub = utils.makeStubMethod(app,
+                '_cleanupEntityDetails');
+            this._cleanups.push(cleanupStub.reset);
+
             app._charmbrowser();
             assertions(0, 0, 0, 1);
           });
@@ -308,6 +318,9 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
             var activeStub = utils.makeStubMethod(app._editorial,
                 'updateActive');
             this._cleanups.push(activeStub.reset);
+            var cleanupStub = utils.makeStubMethod(app,
+                '_cleanupEntityDetails');
+            this._cleanups.push(cleanupStub.reset);
             app._charmbrowser();
             assert.equal(activeStub.callCount(), 1);
           });

--- a/test/test_inspector_charm.js
+++ b/test/test_inspector_charm.js
@@ -61,7 +61,12 @@ describe('Inspector Charm', function() {
   it('renders the view with a charm', function() {
     var data = utils.loadFixture('data/browsercharm.json', false);
     testContainer = utils.makeContainer(this);
-    testContainer.setHTML('<div class="left-breakout"></div>');
+    testContainer.setHTML([
+      '<div class="charmbrowser">',
+      '<div class="left-breakout">',
+      '</div>',
+      '</div>'
+    ].join(''));
 
     fakeStore = new Y.juju.charmworld.APIv3({});
     fakeStore.set('datasource', {
@@ -106,7 +111,12 @@ describe('Inspector Charm', function() {
   it('renders the viewlet with a cached charm', function(done) {
     var data = utils.loadFixture('data/browsercharm.json', true);
     testContainer = utils.makeContainer(this);
-    testContainer.setHTML('<div class="left-breakout"></div>');
+    testContainer.setHTML([
+      '<div class="charmbrowser">',
+      '<div class="left-breakout">',
+      '</div>',
+      '</div>'
+    ].join(''));
 
     fakeStore = new Y.juju.charmworld.APIv3({});
     var cache = new Y.juju.models.CharmList();


### PR DESCRIPTION
## QA

Show and hide entity details (from search/browse) and charm details (from the inspector) in both `il` flagged and unflagged states. Make sure that switching between details, opening and closing details, closing and then opening other details, etc. all work properly.
