### PR TITLE
Add drop states to the machine view headers

### DIFF
--- a/app/templates/machine-view-panel-header.handlebars
+++ b/app/templates/machine-view-panel-header.handlebars
@@ -1,3 +1,6 @@
 <h3 class="title">{{ title }}</h3>
 <a href="" class="action">{{ action }}</a>
 <span class="label">{{ label }}</span>
+<div class="drop">
+  <span>{{ dropLabel }}</span>
+</div>

--- a/app/widgets/machine-view-panel-header.js
+++ b/app/widgets/machine-view-panel-header.js
@@ -70,6 +70,24 @@ YUI.add('machine-view-panel-header', function(Y) {
         },
 
         /**
+         * Change the header to the drop state.
+         *
+         * @method setDroppable
+         */
+        setDroppable: function(label) {
+          this.get('container').addClass('droppable');
+        },
+
+        /**
+         * Change the header back from drop state to the default state.
+         *
+         * @method setNotDroppable
+         */
+        setNotDroppable: function(label) {
+          this.get('container').removeClass('droppable');
+        },
+
+        /**
          * Sets up the DOM nodes and renders them to the DOM.
          *
          * @method render
@@ -103,7 +121,14 @@ YUI.add('machine-view-panel-header', function(Y) {
     @default undefined
     @type {String}
     */
-    action: {}
+    action: {},
+
+    /**
+    @attribute dropLabel
+    @default undefined
+    @type {String}
+    */
+    dropLabel: {}
   };
 
   views.MachineViewPanelHeaderView = MachineViewPanelHeaderView;

--- a/app/widgets/machine-view-panel.js
+++ b/app/widgets/machine-view-panel.js
@@ -94,11 +94,13 @@ YUI.add('machine-view-panel', function(Y) {
           this._machinesHeader = this._renderHeader(
               '.column.machines .head', {
                 title: 'Environment',
-                action: 'New machine'
+                action: 'New machine',
+                dropLabel: 'Create new machine'
               });
           this._containersHeader = this._renderHeader(
               '.column.containers .head', {
-                action: 'New container'
+                action: 'New container',
+                dropLabel: 'Create new container'
               });
           this._unplacedHeader = this._renderHeader(
               '.column.unplaced .head', {

--- a/lib/views/machine-view/machine-view-panel.less
+++ b/lib/views/machine-view/machine-view-panel.less
@@ -19,9 +19,13 @@
 
         .head {
             .flex-basis(auto);
+            position: relative;
             padding: 20px;
             border-bottom: 1px solid @machine-view-border-colour;
 
+            &.droppable .drop {
+                display: block;
+            }
             h3 {
                 .type3;
                 display: block;
@@ -30,9 +34,31 @@
             a {
                 float: right;
             }
-            span {
+            .label {
                 display: block;
                 height: 20px;
+            }
+            .drop {
+                .type4;
+                display: none;
+                position: absolute;
+                top: 0;
+                bottom: 0;
+                left: 0;
+                right: 0;
+                background-color: #fff;
+
+                span {
+                    position: absolute;
+                    top: 0;
+                    bottom: 10px;
+                    left: 10px;
+                    right: 10px;
+                    display: block;
+                    border: 2px dashed #d6d3cf;
+                    text-align: center;
+                    line-height: 72px;
+                }
             }
         }
         .content {

--- a/test/test_machine_view_panel_header.js
+++ b/test/test_machine_view_panel_header.js
@@ -75,4 +75,16 @@ describe('machine view panel header view', function() {
     });
     container.one('.action').simulate('click');
   });
+
+  it('can be set to the droppable state', function() {
+    view.setDroppable();
+    assert.equal(container.hasClass('droppable'), true);
+  });
+
+  it('can be set from the droppable state back to the default', function() {
+    view.setDroppable();
+    assert.equal(container.hasClass('droppable'), true);
+    view.setNotDroppable();
+    assert.equal(container.hasClass('droppable'), false);
+  });
 });


### PR DESCRIPTION
Adding in the drop states in the machine view headers. These states are not currently hooked up to anything, but are ready for when drag and drop is implemented.
