### PR TITLE
Add a ghost unit right after deploying a service.

### DIFF
--- a/app/models/models.js
+++ b/app/models/models.js
@@ -636,7 +636,11 @@ YUI.add('juju-models', function(Y) {
       obj.number = parseInt(raw[1], 10);
       obj.urlName = obj.id.replace('/', '-');
       obj.name = 'serviceUnit'; // This lets us more easily mimic models.
-      obj.displayName = this.createDisplayName(obj.id);
+      if (!obj.displayName) {
+        // The display name can be provided by callers, e.g. in the case a
+        // ghost unit is being added to a ghost service.
+        obj.displayName = this.createDisplayName(obj.id);
+      }
     },
 
     /**

--- a/app/store/env/fakebackend.js
+++ b/app/store/env/fakebackend.js
@@ -496,7 +496,11 @@ YUI.add('juju-env-fakebackend', function(Y) {
         // This is the current behavior in both implementations.
         unitCount = 1;
       }
-      var response = this.addUnit(options.name, unitCount, options.toMachine);
+      var response = {};
+      // Add units if requested.
+      if (unitCount !== 0) {
+        response = this.addUnit(options.name, unitCount, options.toMachine);
+      }
       response.service = service;
       callback(response);
     },

--- a/test/test_fakebackend.js
+++ b/test/test_fakebackend.js
@@ -143,9 +143,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
           fakebackend.db.charms.getById('cs:precise/wordpress-15'),
           'Fakebackend returned null when a charm was expected.');
       var service = fakebackend.db.services.getById('wordpress');
-      assert.isObject(
-          service,
-          'Null returend when a service was expected.');
+      assert.isObject(service, 'Null returned when a service was expected.');
       assert.strictEqual(service, result.service);
       var attrs = service.getAttrs();
       // clientId varies.
@@ -305,13 +303,29 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
           });
     });
 
-
     it('deploys multiple units.', function() {
       fakebackend.deploy('cs:precise/wordpress-15', callback, {unitCount: 3});
       var units = result.service.get('units').toArray();
       assert.lengthOf(units, 3);
       assert.lengthOf(result.units, 3);
       assert.deepEqual(units, result.units);
+    });
+
+    it('returns an error when adding multiple units to a machine', function() {
+      fakebackend.deploy(
+          'cs:precise/wordpress-15', callback, {unitCount: 3, toMachine: '2'});
+      assert.strictEqual(
+          result.error,
+          'When deploying to a specific machine, ' +
+          'the number of units requested must be 1.');
+    });
+
+    it('allows deploying a service without units', function() {
+      fakebackend.deploy('cs:precise/wordpress-15', callback, {unitCount: 0});
+      // There is no error.
+      assert.isUndefined(result.error);
+      // No units have been added.
+      assert.strictEqual(result.service.get('units').size(), 0);
     });
 
     it('reports when the API is inaccessible.', function() {


### PR DESCRIPTION
This is a follow up of Rick's work on this feature.
See https://github.com/juju/juju-gui/pull/299

QA:
- make devel;
- use `:flags:/mv/il/`;
- deploy a service;
- switch to machine view: you should se an unplaced unit/0 for that service.
