### PR TITLE
Polish

### DIFF
--- a/app/templates/deployer-bar.handlebars
+++ b/app/templates/deployer-bar.handlebars
@@ -1,35 +1,36 @@
-<div class="right">
-    <div class="pre-summary">
-        <span class="import-export">
-            <a href="">Import</a>
-            <a href="">Export</a>
-        </span>
-        <a href="" class="button deploy-button">Deploy</a>
-    </div>
-    <div class="post-summary">
-        <p>Confirm will deploy all changes</p>
-        <a href="" class="button cancel-button">Cancel</a>
-        <a href="" class="button confirm-button">Confirm</a>
-    </div>
-</div>
-<ul class="action-list">
-    <li>
-        <a href="" class="link">
-            {{ changeCount }} changes
-            <span class="expand">
-                <i class="sprite expand_icon more"></i>
-                <i class="sprite contract_icon less"></i>
+<div class="bar">
+    <div class="right">
+        <div class="pre-summary">
+            <span class="import-export">
+                <a href="">Import</a>
+                <a href="">Export</a>
             </span>
-        </a>
-    </li>
-    <li class="change">
-        {{ latestChangeDescription }}
-    </li>
-</ul>
-
+            <a href="" class="button deploy-button">Deploy</a>
+        </div>
+        <div class="post-summary">
+            <p>Confirm will deploy all changes</p>
+            <a href="" class="button cancel-button">Cancel</a>
+            <a href="" class="button confirm-button">Confirm</a>
+        </div>
+    </div>
+    <ul class="action-list">
+        <li>
+            <a href="" class="link">
+                {{ changeCount }} changes
+                <span class="expand">
+                    <i class="sprite expand_icon more"></i>
+                    <i class="sprite contract_icon less"></i>
+                </span>
+            </a>
+        </li>
+        <li class="change">
+            {{ latestChangeDescription }}
+        </li>
+    </ul>
+</div>
 <aside class="summary">
     <header>
-        <h2 class="title">These change will be deployed to: {{ machineName }}</h2>
+        <h2 class="title">These changes will be deployed to: {{ machineName }}</h2>
         <div class="right">
             <ul class="action-list">
                 <li><a href="" class="min"><i class="sprite DB-expand-01"></i></a></li>
@@ -69,3 +70,4 @@
         </div>
     </section>
 </aside>
+<div class="cover"></div>

--- a/lib/views/browser/main.less
+++ b/lib/views/browser/main.less
@@ -151,7 +151,7 @@
 
 .flag-mv #subapp-browser {
   .bws-view-data {
-      top: @environment-header-height;
+      top: @environment-header-height - 1px;
   }
   #bws-sidebar,
   .bws-view-data {

--- a/lib/views/deployer-bar.less
+++ b/lib/views/deployer-bar.less
@@ -1,37 +1,79 @@
 .deployer-bar {
+    .bar {
+        box-sizing: border-box;
+        position: absolute;
+        z-index: 652;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        height: @deployer-bar-height;
+        background: #ebecee url(/juju-ui/assets/images/non-sprites/paper-bg-dark.jpg) repeat 0 0;
+        box-shadow: 0 0 3px rgba(0, 0, 0, 0.15);
 
-    box-sizing: border-box;
-    position: absolute;
-    z-index: 650;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    height: @deployer-bar-height;
-    background: #ebecee url(/juju-ui/assets/images/non-sprites/paper-bg-dark.jpg) repeat 0 0;
-    box-shadow: 0 0 3px rgba(0, 0, 0, 0.15);
-
-    time {
-        color: #bfbab5;
-        margin-left: 7px;
-    }
-    a.button {
-        // Using a variable here because LESS strips commas in mixin args.
-        @box-shadow: inset 0 2px 2px rgba(0, 0, 0, 0.3);
-        .create-box-shadow(@box-shadow);
-        .create-border-radius(@border-radius);
-        display: inline-block;
-        height: 30px;
-        padding: 0 20px;
-        background-color: @charm-panel-orange;
-        color: #fff;
-        line-height: 30px;
-    }
-    .expand {
-        margin-left: 10px;
-
-        .less {
-            display: none;
+        time {
+            color: #bfbab5;
+            margin-left: 7px;
         }
+        a.button {
+            // Using a variable here because LESS strips commas in mixin args.
+            @box-shadow: inset 0 2px 2px rgba(0, 0, 0, 0.3);
+            .create-box-shadow(@box-shadow);
+            .create-border-radius(@border-radius);
+            display: inline-block;
+            height: 30px;
+            padding: 0 20px;
+            background-color: @charm-panel-orange;
+            color: #fff;
+            line-height: 30px;
+        }
+        .expand {
+            margin-left: 10px;
+
+            .less {
+                display: none;
+            }
+        }
+        .right {
+            margin-right: 20px;
+
+            a.button {
+                margin-left: 20px;
+            }
+            .import-export {
+                a {
+                    &:first-child:after {
+                        content: '';
+                        display: inline-block;
+                        height: 16px;
+                        margin: 0 5px 0 8px;
+                        border-right: 1px solid #bfbab5;
+                        vertical-align: middle;
+                    }
+                }
+            }
+            .post-summary {
+                display: none;
+
+                p {
+                    display: inline;
+                }
+                .cancel-button {
+                    background: #D6D6D6;
+                    color: #333;
+                }
+                .confirm-button {
+                    margin-left: 5px;
+                }
+            }
+            .pre-summary {
+                display: block;
+            }
+        }
+    }
+    .right {
+            float: right;
+            height: 50px;
+            line-height: 50px;
     }
     ul.action-list {
         margin: 0;
@@ -61,50 +103,10 @@
             }
         }
     }
-    .right {
-        float: right;
-        height: 50px;
-        margin-right: 20px;
-        line-height: 50px;
-
-        a.button {
-            margin-left: 20px;
-        }
-        .import-export {
-            a {
-                &:first-child:after {
-                    content: '';
-                    display: inline-block;
-                    height: 16px;
-                    margin: 0 5px 0 8px;
-                    border-right: 1px solid #bfbab5;
-                    vertical-align: middle;
-                }
-            }
-        }
-        .post-summary {
-            display: none;
-
-            p {
-                display: inline;
-            }
-            .cancel-button {
-                background: #D6D6D6;
-                color: #333;
-            }
-            .confirm-button {
-                margin-left: 5px;
-            }
-        }
-        .pre-summary {
-            display: block;
-        }
-    }
-
-
     .summary {
         display: none;
         position: absolute;
+        z-index: 651;
         bottom: 50px;
         left: 0;
         height: 450px;
@@ -168,14 +170,26 @@
             }
         }
     }
+    .cover {
+        display: none;
+        position: absolute;
+        z-index: 650;
+        top: @navbar-height;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        background-color: rgba(0, 0, 0, 0.7);
+    }
     &.summary-open {
         .summary,
-        .post-summary {
+        .bar .post-summary {
             display: block;
         }
-        .pre-summary {
+        .bar .pre-summary {
             display: none;
         }
-
+        .cover {
+            display: block;
+        }
     }
 }


### PR DESCRIPTION
1. Added a background over the gui behind the deployer confirm as per designs here: https://drive.google.com/a/canonical.com/folderview?id=0B7XG_QBXNwY1WGlyVzN2LWtrcmM&usp=drive_web

Most of the changes are indentation due to adding a wrapping `bar` element.

QA: Click deploy in the deployer bar and the visible area of the gui behind the changes panel should be covered in a semi transparent black.
1. Fixed sidebar details panel height (it wasn't quite touching the top).

QA: Click on a charm or bundle in the sidebar. The details panel should sit nicely below the environment header.
