### PR TITLE
Remove non-working UI for release

### DIFF
--- a/app/templates/environment-header.handlebars
+++ b/app/templates/environment-header.handlebars
@@ -5,21 +5,6 @@
     <li class="tab machines">
         <a href="" data-view="machineView">Machines</a>
     </li>
-    <li class="search">
-        <form>
-            <input type="search" />
-            <input type="submit" value="" />
-        </form>
-    </li>
-    <li class="small">
-        <a href="">
-            <i class="sprite environment_share"></i>
-        </a>
-    </li>
-    <li class="tiny">
-        <a href="">
-            <i class="sprite environment_bubble"></i>
-            10
-        </a>
+    <li class="spacer">
     </li>
 </ul>

--- a/lib/views/environment-header.less
+++ b/lib/views/environment-header.less
@@ -16,13 +16,6 @@
         li {
             .environment-header-li(20px);
             background-color: #eee;
-
-            &.small {
-                .environment-header-li(15px);
-            }
-            &.tiny {
-                .environment-header-li(10px);
-            }
         }
     }
 }
@@ -57,30 +50,8 @@
             }
         }
     }
-    &.search {
+    &.spacer {
       .flex(1);
-      position: relative;
-      padding: 0;
-
-      input[type=search] {
-          box-sizing: border-box;
-          width: 100%;
-          height: @environment-header-height - 1;
-          padding-left: 40px;
-          background-color: transparent;
-          border: none;
-      }
-      input[type=submit] {
-          position: absolute;
-          top: 0;
-          left: 0;
-          width: @environment-header-height;
-          height: @environment-header-height - 1;
-          background: transparent
-              url(/juju-ui/assets/images/non-sprites/environment_search.png)
-              no-repeat center center;
-          border: none;
-      }
     }
     a {
         display: block;


### PR DESCRIPTION
**ONLY LAND IF APPROVED BY RICK**

We probably don't want to release with these non-working UI elements. Check with Rick/Luca before landing.

These elements are in the environment header and include the search box, share and comment buttons. I suspect some of these have changed in current designs anyway.
