### PR TITLE
Add a service unit when dragging the service.

### DIFF
--- a/app/templates/deployer-bar.handlebars
+++ b/app/templates/deployer-bar.handlebars
@@ -30,7 +30,7 @@
 </div>
 <aside class="summary">
     <header>
-        <h2 class="title">These changes will be deployed to: {{ machineName }}</h2>
+        <h2 class="title">The following changes will be deployed</h2>
         <div class="right">
             <ul class="action-list">
                 <li><a href="" class="min"><i class="sprite DB-expand-01"></i></a></li>
@@ -46,7 +46,8 @@
             {{#if changeCount}}
                 {{#if deployServices.length}}
                     <h3>
-                        {{deployServices.length}} services added
+                        {{deployServices.length}}
+                        {{pluralize 'service' deployServices.length}} added
                     </h3>
                     <ul>
                     {{#each deployServices}}
@@ -56,7 +57,8 @@
                 {{/if}}
                 {{#if addedRelations.length}}
                     <h3>
-                        {{addedRelations.length}} relations added
+                        {{addedRelations.length}}
+                        {{pluralize 'relation' addedRelations.length}} added
                     </h3>
                     <ul>
                     {{#each addedRelations}}
@@ -64,8 +66,23 @@
                     {{/each}}
                     </ul>
                 {{/if}}
+                {{#if addedUnits.length}}
+                    <h3>
+                        {{addedUnits.length}}
+                        {{pluralize 'unit' addedUnits.length}} added
+                    </h3>
+                    <ul>
+                        {{#each addedUnits}}
+                            <li>
+                                <img src="{{icon}}" alt="" class="icon" />
+                                {{numUnits}} {{serviceName}}
+                                {{pluralize 'unit' numUnits}}
+                            </li>
+                        {{/each}}
+                    </ul>
+                {{/if}}
             {{else}}
-                <p>No uncommited changes</p>
+                <p>No uncommitted changes</p>
             {{/if}}
         </div>
     </section>

--- a/app/utils/environment-change-set.js
+++ b/app/utils/environment-change-set.js
@@ -532,11 +532,6 @@ YUI.add('environment-change-set', function(Y) {
   }, {
     ATTRS: {
       /**
-        Reference to the environment
-        @attribute env
-      */
-      env: {},
-      /**
         Reference to the db
         @attribute db
       */

--- a/test/test_deployer_bar.js
+++ b/test/test_deployer_bar.js
@@ -50,6 +50,7 @@ describe('deployer bar view', function() {
   });
 
   afterEach(function() {
+    ecs.destroy();
     container.remove(true);
     view.destroy();
   });
@@ -96,4 +97,35 @@ describe('deployer bar view', function() {
     view.summaryClose(mockEvent);
     assert.equal(container.hasClass('summary-open'), false);
   });
+
+  it('provides a way to retrieve the service icon', function() {
+    var url = view._getServiceIconUrl('django');
+    assert.strictEqual(
+        url,
+        'https://manage.jujucharms.com' +
+        '/api/3/charm/precise/django/file/icon.svg'
+    );
+  });
+
+  // XXX frankban 2014-05-12: it seems all this suite is not well isolated,
+  // or the view does not clean up correctly.
+  it.skip('retrieves all the unit changes', function() {
+    ecs.lazyAddUnits(['django', 1]);
+    ecs.lazyAddUnits(['rails', 2]);
+    var results = view._getAddUnits(ecs);
+    assert.lengthOf(results, 2);
+    assert.deepEqual(results[0], {
+      icon: 'https://manage.jujucharms.com' +
+          '/api/3/charm/precise/django/file/icon.svg',
+      numUnits: 1,
+      serviceName: 'django'
+    });
+    assert.deepEqual(results[1], {
+      icon: 'https://manage.jujucharms.com' +
+          '/api/3/charm/precise/rails/file/icon.svg',
+      numUnits: 2,
+      serviceName: 'rails'
+    });
+  });
+
 });


### PR DESCRIPTION
Also improved the changeset summary page + clean up.

QA:
- make devel;
- visit `/:flags:/mv/il/`;
- disable the simulator;
- drag a service;
- hit deploy in the status bar;
- you should see the deployment summary: if the description
  hides, click cancel and then deploy again (there is a XXX comment
  about this issue);
- click confirm, the service should be deployed with its unit;
- in the JS console `app.db.units.size()` should return 1 and
  `app.db.units.item(0)` should show the unit with the expected
  properties;
- the machine view should correctly show the unit (on machine 0).

TODO:
- do not deploy unplaced units;
- env.placeUnit to place a unit.
