### PR TITLE
Deployer bar fixes

### DIFF
--- a/app/templates/deployer-bar.handlebars
+++ b/app/templates/deployer-bar.handlebars
@@ -23,7 +23,7 @@
         </a>
     </li>
     <li class="change">
-        {{ latestChangeDescription }}
+        {{{ latestChangeDescription }}}
     </li>
 </ul>
 

--- a/app/widgets/deployer-bar.js
+++ b/app/widgets/deployer-bar.js
@@ -79,7 +79,7 @@ YUI.add('deployer-bar', function(Y) {
           ecs = this.get('ecs');
       var changes = this._getChangeCount(ecs);
       container.setHTML(this.template({
-        change_count: changes
+        changeCount: changes
       }));
       container.addClass('deployer-bar');
       ecs.on('changeSetModified', Y.bind(this.update, this));
@@ -140,11 +140,11 @@ YUI.add('deployer-bar', function(Y) {
       // wanted.
       if (container && container.get('parentNode')) {
         container.setHTML(this.template({
-          change_count: changes,
-          latest_change_description: latest
+          changeCount: changes,
+          latestChangeDescription: latest
         }));
         this.descriptionTimer = window.setTimeout(
-            Y.bind(this._hideChangeDesctiption, this),
+            Y.bind(this._hideChangeDescription, this),
             2000);
       }
     },
@@ -165,14 +165,8 @@ YUI.add('deployer-bar', function(Y) {
       @method _hideChangeDescription
       @param {Object} ect The environment change set.
     */
-    _hideChangeDesctiption: function() {
-      var container = this.get('container'),
-          ecs = this.get('ecs');
-      var changes = this._getChangeCount(ecs);
-      container.setHTML(this.template({
-        change_count: changes,
-        latest_change_description: ''
-      }));
+    _hideChangeDescription: function() {
+      this.get('container').one('.action-list .change').set('text', '');
       window.clearTimeout(this.descriptionTimer);
     },
     /**


### PR DESCRIPTION
1. Fixed deployer bar change notifications not appearing.
   It looks like this was because someone was renaming variables and missed a few.
2. Fixed summary being hidden.
   Instead of re-rendering the entire template it now just clears the contents of the element.

I also did a drive-by spelling fix of the `_hideChangeDescription` function name.

QA: Drag a service to the canvas. A notification of the action should appear in the deployer bar for two seconds and then disappear.
