### PR TITLE
Adds informative console error as requested in earlier review.

### DIFF
--- a/app/widgets/machine-view-panel.js
+++ b/app/widgets/machine-view-panel.js
@@ -322,13 +322,15 @@ YUI.add('machine-view-panel', function(Y) {
          * @param {Array} units The units to decorate
          */
         _addIconsToUnits: function(units) {
-          var db = this.get('db');
+          var db = this.get('db'),
+              service;
           Y.Object.each(units, function(unit) {
-            var service = db.services.getById(unit.service);
+            service = db.services.getById(unit.service);
             if (service) {
               unit.icon = service.get('icon');
+            } else {
+              console.error('Unit ' + unit.id + ' has no service.');
             }
-            // XXX What to do if there is no icon?
           });
           return units;
         },

--- a/test/test_machine_view_panel.js
+++ b/test/test_machine_view_panel.js
@@ -201,6 +201,25 @@ describe('machine view panel view', function() {
     });
   });
 
+  describe('_addIconsToUnits', function() {
+    it('should annotate units with icons for its tokens', function() {
+      var db = view.get('db'),
+          unit = {id: 'foo/0', service: 'foo' };
+      db.services.add({ id: 'foo', icon: 'http://example.com/foo.png' });
+      unit = view._addIconsToUnits([unit])[0];
+      assert.equal(unit.icon, 'http://example.com/foo.png');
+    });
+
+    it('should log an error when it cannot find the service', function() {
+      var unit = {id: 'foo/0', service: 'foo' },
+          errorStub = utils.makeStubMethod(console, 'error');
+      this._cleanups.push(errorStub.reset);
+      unit = view._addIconsToUnits([unit])[0];
+      assert.equal(errorStub.calledOnce(), true);
+      assert.equal(errorStub.lastArguments(), 'Unit foo/0 has no service.');
+    });
+  });
+
   describe('machine list', function() {
     it('should render a list of machines', function() {
       view.render();


### PR DESCRIPTION
- This addresses a request from hatch that the _addIconsToUnits method log an
  error under certain failure modes that would otherwise be silent.
