### PR TITLE
Fix unit mapping to machines

### DIFF
--- a/app/models/models.js
+++ b/app/models/models.js
@@ -713,7 +713,15 @@ YUI.add('juju-models', function(Y) {
         if (includeChildren) {
           // Filter by machine and the containers hosted by the machine.
           predicate = function(unit) {
-            return unit.machine && unit.machine.indexOf(machine) === 0;
+            if (machine && machine.toString().indexOf('/') >= 0) {
+              // If this is a container then match the entire string.
+              return unit.machine && unit.machine.indexOf(machine) === 0;
+            }
+            else {
+              // If this is a machine then match against the first token
+              // in the id. This prevents against '1' matching '15/lxc/5'.
+              return unit.machine && unit.machine.split('/')[0] === machine;
+            }
           };
         } else {
           // Filter by exact machine.

--- a/test/test_model.js
+++ b/test/test_model.js
@@ -532,17 +532,18 @@ describe('test_model.js', function() {
         units.add([
           {id: 'django/0', machine: null},
           {id: 'django/42', machine: '42'},
-          {id: 'haproxy/4', machine: '0/lxc/1'},
+          {id: 'haproxy/4', machine: '1/lxc/1'},
           {id: 'django/47', machine: '47'},
           {id: 'rails/0', machine: '42'},
           {id: 'rails/1', machine: '42'},
-          {id: 'mysql/42', machine: '0/kvm/0/lxc/0'},
-          {id: 'rails/42', machine: '0'},
+          {id: 'mysql/42', machine: '1/kvm/0/lxc/0'},
+          {id: 'rails/42', machine: '1'},
           {id: 'postgres/1'},
-          {id: 'django/2', machine: '0/lxc/2'},
-          {id: 'rails/2', machine: '0/lxc/1'},
+          {id: 'django/2', machine: '1/lxc/2'},
+          {id: 'rails/2', machine: '1/lxc/1'},
           {id: 'postgres/2'},
-          {id: 'mysql/47', machine: '0/kvm/0/lxc/1'}
+          {id: 'mysql/47', machine: '1/kvm/0/lxc/1'},
+          {id: 'mysql/12', machine: '15/lxc/6'}
         ]);
       });
 
@@ -550,11 +551,16 @@ describe('test_model.js', function() {
         units.destroy();
       });
 
-      // Ensure the resulting units match the given identifier.
-      var assertUnits = function(resultingUnits, ids) {
-        var resultingIds = resultingUnits.map(function(unit) {
+      // Map a list of units to their ids.
+      var mapUnitIds = function(units) {
+        return units.map(function(unit) {
           return unit.id;
         });
+      };
+
+      // Ensure the resulting units match the given identifier.
+      var assertUnits = function(resultingUnits, ids) {
+        var resultingIds = mapUnitIds(resultingUnits);
         assert.deepEqual(resultingIds, ids);
       };
 
@@ -564,12 +570,12 @@ describe('test_model.js', function() {
       });
 
       it('returns all the units hosted by a specific container', function() {
-        var resultingUnits = units.filterByMachine('0/lxc/1');
+        var resultingUnits = units.filterByMachine('1/lxc/1');
         assertUnits(resultingUnits, ['haproxy/4', 'rails/2']);
       });
 
       it('returns the machine hosted units including children', function() {
-        var resultingUnits = units.filterByMachine('0', true);
+        var resultingUnits = units.filterByMachine('1', true);
         var expectedUnits = [
           'haproxy/4', 'mysql/42', 'rails/42', 'django/2', 'rails/2',
           'mysql/47'
@@ -577,8 +583,14 @@ describe('test_model.js', function() {
         assertUnits(resultingUnits, expectedUnits);
       });
 
+      it('should not return units with partially matching ids', function() {
+        var resultingUnits = mapUnitIds(units.filterByMachine('1', true));
+        assert.equal(resultingUnits.indexOf('mysql/12'), -1,
+            'This item should not be returned');
+      });
+
       it('returns the container hosted units including children', function() {
-        var resultingUnits = units.filterByMachine('0/kvm/0', true);
+        var resultingUnits = units.filterByMachine('1/kvm/0', true);
         assertUnits(resultingUnits, ['mysql/42', 'mysql/47']);
       });
 


### PR DESCRIPTION
Unit mapping to machines was broken because it was doing partial id matches on the position of the match e.g. if the machine id was "1" it would match "14/lxc/0" or if it was "2" it would match "26/lxc/0".

QA:

Deploy some services and let the simulator run. Once the number of machines is over 9 the additional units created by the simulator were being mapped to the machine with id "1". This should no longer happen.

After the simulator has been running for some time, in a console run `app.db.units.filterByMachine("1", true)` and all the units returned should have `.machine: "1..."`.
