### PR TITLE
Adds recent change list to summary

### DIFF
--- a/app/templates/deployer-bar.handlebars
+++ b/app/templates/deployer-bar.handlebars
@@ -7,18 +7,27 @@
             </span>
             <a href="" class="button deploy-button">Deploy</a>
         </div>
+        {{#if confirmDeploy}}
         <div class="post-summary">
             <p>Confirm will deploy all changes</p>
             <a href="" class="button cancel-button">Cancel</a>
             <a href="" class="button confirm-button">Confirm</a>
         </div>
+        {{/if}}
     </div>
     <ul class="action-list">
-        <li>
+        <li class="show">
             <a href="" class="link">
                 {{ changeCount }} changes
                 <span class="expand">
                     <i class="sprite expand_icon more"></i>
+                </span>
+            </a>
+        </li>
+        <li class="hide">
+            <a href="" class="link">
+                {{ changeCount }} changes
+                <span class="contract">
                     <i class="sprite contract_icon less"></i>
                 </span>
             </a>
@@ -30,6 +39,7 @@
 </div>
 <aside class="summary">
     <header>
+        {{#if confirmDeploy}}
         <h2 class="title">The following changes will be deployed</h2>
         <div class="right">
             <ul class="action-list">
@@ -39,7 +49,9 @@
                 <li><a href="" class="close"><i class="sprite DB-close"></i></a></li>
             </ul>
         </div>
+        {{/if}}
     </header>
+    {{#if confirmDeploy}}
     <section>
         <h2 class="title">Deployment summary</h2>
         <div class="summary-panel">
@@ -135,5 +147,23 @@
             {{/if}}
         </div>
     </section>
+    {{else}}
+    <section>
+        <h2 class="title">Recent changes</h2>
+        <div class="summary-panel">
+          <div class="change-list">
+          {{#if changeList}}
+            <ul>
+            {{#each changeList}}
+            <li>{{{.}}}</li>
+            {{/each}}
+            </ul>
+          {{else}}
+            <p>No recent changes</p>
+          {{/if}}
+          </div>
+        </div>
+    </section>
+    {{/if}}
 </aside>
 <div class="cover"></div>

--- a/lib/views/deployer-bar.less
+++ b/lib/views/deployer-bar.less
@@ -78,6 +78,12 @@
     ul.action-list {
         margin: 0;
         list-style: none;
+        .hide {
+            display: none;
+        }
+        .show {
+            display: block;
+        }
 
         li {
             float: left;
@@ -190,6 +196,14 @@
         }
         .cover {
             display: block;
+        }
+        .action-list {
+            .hide {
+                display: block;
+            }
+            .show {
+                display: none
+            }
         }
     }
 }

--- a/test/test_deployer_bar.js
+++ b/test/test_deployer_bar.js
@@ -20,7 +20,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
 describe('deployer bar view', function() {
-  var Y, container, ECS, ecs, dbObj, envObj, mockEvent, testUtils, utils, views,
+  var Y, container, ECS, ecs, mockEvent, testUtils, utils, views,
       view, View;
 
   before(function(done) {
@@ -42,9 +42,7 @@ describe('deployer bar view', function() {
   });
 
   beforeEach(function() {
-    ecs = new ECS({
-      db: dbObj
-    });
+    ecs = new ECS({});
     container = utils.makeContainer(this, 'deployer-bar');
     view = new View({container: container, ecs: ecs}).render();
   });
@@ -69,18 +67,74 @@ describe('deployer bar view', function() {
     assert.equal(view._getChangeCount(ecs), 1);
   });
 
-  it('show a summary of uncommitted changes', function() {
+
+  it('can be told to show deploy confirmation or recent changes', function() {
+    var summaryStub = utils.makeStubMethod(view, '_showSummary');
+    this._cleanups.push(summaryStub.reset);
+
+    view.showDeployConfirmation(mockEvent);
+    assert.equal(
+        summaryStub.lastArguments()[0], true,
+        '_showSummary did not receive true from showDeployConfirmation.'
+    );
+
+    view.showRecentChanges(mockEvent);
+    assert.equal(
+        summaryStub.lastArguments()[0], false,
+        '_showSummary did not receive false from showRecentChanges.'
+    );
+  });
+
+  it('can show a summary of uncommitted changes for deployment', function() {
     var changesStub = utils.makeStubMethod(view, '_getChangeCount', 0),
         deployStub = utils.makeStubMethod(view, '_getDeployedServices', []),
         relationsStub = utils.makeStubMethod(view, '_getAddRelations', []);
     this._cleanups.push(changesStub.reset);
     this._cleanups.push(deployStub.reset);
     this._cleanups.push(relationsStub.reset);
-    view.showSummary(mockEvent);
-    assert.equal(container.hasClass('summary-open'), true,
-                 'summary is not open');
-    assert.notEqual(container.one('.summary-panel'), null,
-                    'summary panel HTML is not present');
+    view._showSummary(true);
+    assert.equal(
+        container.hasClass('summary-open'), true,
+        'Summary is not open.'
+    );
+    assert.notEqual(
+        container.one('.summary-panel'), null,
+        'Summary panel HTML is not present.'
+    );
+    assert.notEqual(
+        container.one('.post-summary'), null,
+        'Deployment confirmation not present.'
+    );
+    assert.equal(
+        container.one('.change-list'), null,
+        'Recent changes present when they should not be.'
+    );
+  });
+
+  it('can show a list of recent changes', function() {
+    var changesStub = utils.makeStubMethod(view, '_getChangeCount', 0),
+        deployStub = utils.makeStubMethod(view, '_getDeployedServices', []),
+        relationsStub = utils.makeStubMethod(view, '_getAddRelations', []);
+    this._cleanups.push(changesStub.reset);
+    this._cleanups.push(deployStub.reset);
+    this._cleanups.push(relationsStub.reset);
+    view._showSummary(false);
+    assert.equal(
+        container.hasClass('summary-open'), true,
+        'Summary is not open.'
+    );
+    assert.notEqual(
+        container.one('.summary-panel'), null,
+        'Summary panel HTML is not present.'
+    );
+    assert.equal(
+        container.one('.post-summary'), null,
+        'Deployment confirmation present when it should not be.'
+    );
+    assert.notEqual(
+        container.one('.change-list'), null,
+        'Recent changes not present.'
+    );
   });
 
   it('should commit on confirmation', function() {
@@ -96,6 +150,109 @@ describe('deployer bar view', function() {
   it('closes the summary', function() {
     view.hideSummary(mockEvent);
     assert.equal(container.hasClass('summary-open'), false);
+  });
+
+  it('can generate descriptions for any change type', function() {
+    var tests = [{
+      icon: '<i class="sprite service-added"></i>',
+      msg: ' bar has been added.',
+      change: {
+        command: {
+          method: '_deploy',
+          args: ['foo', 'bar']
+        }
+      }
+    }, {
+      icon: '<i class="sprite service-added"></i>',
+      msg: ' 1 foo unit has been added.',
+      change: {
+        command: {
+          method: '_add_unit',
+          args: ['foo', 1]
+        }
+      }
+    }, {
+      icon: '<i class="sprite service-added"></i>',
+      msg: ' 2 foo units have been added.',
+      change: {
+        command: {
+          method: '_add_unit',
+          args: ['foo', 2]
+        }
+      }
+    }, {
+      icon: '<i class="sprite relation-added"></i>',
+      msg: 'bar relation added between foo and baz.',
+      change: {
+        command: {
+          method: '_add_relation',
+          args: [
+            ['foo', { name: 'bar' }],
+            ['baz']
+          ]
+        }
+      }
+    }, {
+      icon: '<i class="sprite container-created01"></i>',
+      msg: '1 container has been added.',
+      change: {
+        command: {
+          method: '_addMachines',
+          args: [[{ parentId: 1 }]]
+        }
+      }
+    }, {
+      icon: '<i class="sprite container-created01"></i>',
+      msg: '2 containers have been added.',
+      change: {
+        command: {
+          method: '_addMachines',
+          args: [[{ parentId: 1 }, { parentId: 1 }]]
+        }
+      }
+    }, {
+      icon: '<i class="sprite machine-created01"></i>',
+      msg: '1 machine has been added.',
+      change: {
+        command: {
+          method: '_addMachines',
+          args: [[{}]]
+        }
+      }
+    }, {
+      icon: '<i class="sprite machine-created01"></i>',
+      msg: '2 machines have been added.',
+      change: {
+        command: {
+          method: '_addMachines',
+          args: [[{}, {}]]
+        }
+      }
+    }, {
+      icon: '<i class="sprite service-exposed"></i>',
+      msg: 'An unknown change has been made to this enviroment via the CLI.',
+      change: {
+        command: {
+          method: '_anUnknownMethod'
+        }
+      }
+    }];
+
+    var msg;
+    tests.forEach(function(test) {
+      msg = test.icon + test.msg + '<time>00:00</time>';
+      assert.equal(view._generateChangeDescription(test.change, true), msg);
+    });
+  });
+
+  it('can generate descriptions for all the changes in the ecs', function() {
+    var stubDescription = utils.makeStubMethod(
+        view,
+        '_generateChangeDescription');
+    this._cleanups.push(stubDescription.reset);
+    ecs.changeSet = { foo: {}, bar: {} };
+    view._generateAllChangeDescriptions(ecs);
+    assert.equal(stubDescription.callCount(), 2);
   });
 
   it('provides a way to retrieve the service icon', function() {
@@ -142,5 +299,4 @@ describe('deployer bar view', function() {
     assert.deepEqual(results[1], machine);
     assert.deepEqual(results[2], container);
   });
-
 });


### PR DESCRIPTION
The changes button on the left of the deployer bar can now be used to show
recent changes in the summary panel. This largely reuses the logic of the
deploy confirmation functionality, with some refactoring to allow both actions
to coexist.

There are still changes necessary to for this work to be done:
- The recent changes should be rendered in the confirm deploy version, in a
  collapsed summary panel that can be expanded.
- There is still a lot of visual polish necessary to match the mockups.

QA:

with :flags:/il/mv/

1) Deploy a service
2) Click "changes" on the left of the deployer bar.

You should see a list showing that the service has been added and a unit for
that service has been added. You should not have deploy buttons or other
controls.

3) Click "changes" again.

The the summary panel should close.

4) Click deploy

You should see the usual deploy confirmation; it should all work normally.
