### PR TITLE
Cleanup the toggling of the unplaced units message

### DIFF
--- a/app/widgets/machine-view-panel.js
+++ b/app/widgets/machine-view-panel.js
@@ -495,9 +495,9 @@ YUI.add('machine-view-panel', function(Y) {
               unitList = container.one('.unplaced .content .items');
 
           if (!units || !units.length) {
-            this._showAllPlacedMessage();
+            this._toggleAllPlacedMessage(true);
           } else {
-            this._hideAllPlacedMessage();
+            this._toggleAllPlacedMessage(false);
             this._addIconsToUnits(units);
           }
 
@@ -518,34 +518,19 @@ YUI.add('machine-view-panel', function(Y) {
         },
 
         /**
-          Show the message for when all units are placed.
-
-          @method _showAllPlacedMessage
-        */
-        _showAllPlacedMessage: function() {
-          this.get('container').one('.column.unplaced .all-placed').show();
-        },
-
-        /**
-          Hide the message for when all units are placed.
-
-          @method _hideAllPlacedMessage
-        */
-        _hideAllPlacedMessage: function() {
-          this.get('container').one('.column.unplaced .all-placed').hide();
-        },
-
-        /**
           Toggle the message for when all units are placed.
 
           @method _toggleAllPlacedMessage
+          @param {Boolean} show Boolean value weather to force the placed
+            message to be visible or not (optional).
         */
-        _toggleAllPlacedMessage: function() {
-          if (this.get('db').units.filterByMachine(null).length > 0) {
-            this._hideAllPlacedMessage();
-          } else {
-            this._showAllPlacedMessage();
+        _toggleAllPlacedMessage: function(show) {
+          if (show !== true && show !== false) {
+            show = !this.get('db').units.filterByMachine(null).length;
           }
+          this.get('container')
+              .one('.column.unplaced .all-placed')
+              .toggleView(show);
         },
 
         /**
@@ -563,9 +548,9 @@ YUI.add('machine-view-panel', function(Y) {
           this.addEvent(
               this._scaleUpView.on('addUnit', this._scaleUpService, this));
           this.addEvent(this._scaleUpView.on('listOpened',
-              this._hideAllPlacedMessage, this));
+              this._toggleAllPlacedMessage.bind(this, false)));
           this.addEvent(this._scaleUpView.on('listClosed',
-              this._toggleAllPlacedMessage, this));
+              this._toggleAllPlacedMessage.bind(this, undefined)));
         },
 
         /**


### PR DESCRIPTION
This is a small branch to clan up the toggling of the unplaced units message. See my comment on PR #300 for the original branch.
#### To QA
- Use il/mv.
- Open the machine view, the unplaced units message should be visible.
- Click the + and the subsequent x for the mass scale up UI and the message should hide/show appropriately.
- Switch to the service view and drag a charm onto the canvas.
- Switch back to the machine view, the message should be hidden.
- Toggle the mass scale up UI, the message should not appear.
- Drag the service to the new machine header and then click Deploy/Confirm - after a bit the unit token will disappear and the unplaced message should show up.
- Close/open the machine view and toggle the mass scale up UI, the message should show/hide appropriately. 
