### PR TITLE
Tests for container token rendering in machine panel.

### DIFF
--- a/app/widgets/machine-view-panel.js
+++ b/app/widgets/machine-view-panel.js
@@ -180,8 +180,8 @@ YUI.add('machine-view-panel', function(Y) {
           var container = this.get('container'),
               machineTokens = container.all('.machines .content .items .token'),
               selected = e.currentTarget,
-              parentId = selected.getData('id'),
-              containers = this.get('db').machines.filterByParent(parentId);
+              parentId = selected.getData('id');
+          var containers = this.get('db').machines.filterByParent(parentId);
           e.preventDefault();
           // A lot of things in the machine view rely on knowing when the user
           // selects a machine.
@@ -270,19 +270,9 @@ YUI.add('machine-view-panel', function(Y) {
               containers.length + ' container' + containersPlural + ', ' +
               numUnits + ' unit' + unitsPlural);
 
-          var token;
-
           if (containers.length > 0) {
             Y.Object.each(containers, function(container) {
-              var containerUnits = db.units.filterByMachine(container.id);
-              this._updateMachineWithUnitData(container, containerUnits);
-              token = new views.ContainerToken({
-                containerTemplate: '<li/>',
-                containerParent: containerParent,
-                machine: container
-              });
-              token.render();
-              token.addTarget(this);
+              this._createContainerToken(containerParent, container);
             }, this);
           }
 
@@ -290,15 +280,31 @@ YUI.add('machine-view-panel', function(Y) {
           var units = db.units.filterByMachine(parentId);
           if (units.length > 0) {
             var machine = {displayName: 'Bare metal'};
-            this._updateMachineWithUnitData(machine, units);
-            token = new views.ContainerToken({
-              containerTemplate: '<li/>',
-              containerParent: containerParent,
-              machine: machine
-            });
-            token.render();
-            token.addTarget(this);
+            this._createContainerToken(containerParent, machine, units);
           }
+        },
+
+        /**
+           Create a container token
+           @param {Y.Node} containerParent The parent node for the token's
+             container
+           @param {Object} container The lxc or kvm container object
+           @param {Array} units Optional list of units on the container.
+             If not provided, the container's units will be looked up.
+           @method _createContainerToken
+         */
+        _createContainerToken: function(containerParent, container, units) {
+          if (!units) {
+            units = this.get('db').units.filterByMachine(container.id);
+          }
+          this._updateMachineWithUnitData(container, units);
+          var token = new views.ContainerToken({
+            containerTemplate: '<li/>',
+            containerParent: containerParent,
+            machine: container
+          });
+          token.render();
+          token.addTarget(this);
         },
 
         /**


### PR DESCRIPTION
There have been minor changes to machine-panel-view to make it easier to tests;
specifically, the duped code rendering container tokens in the regular and the
bare metal case has been broken out into its own method, which can be stubbed.

The test file, test_machine_view_panel.js, has been modified a lot.
- Tests have been reordered to put similar tests together, so it's easier to
  determine what has and has not been tested, and test like things via one
  describe block. e.g. all the drag/drop tests (including those about listening
  to events) are now part of a 'token drag and drop' describe block. I've noted
  inline where tests have just been moved without being altered.
- Many tests have been added for the machine panel view's rendering of
  containers.
