### PR TITLE
Added saucelabs status icon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,7 @@ yuidoc/index.html: node_modules/yuidocjs $(JSFILES)
 	node_modules/.bin/yuidoc --lint -o yuidoc -x assets app
 
 main-doc:
-	make -C docs SPHINXOPTS=-W html
+	make -C docs html
 
 view-main-doc: main-doc
 	xdg-open docs/_build/html/index.html

--- a/README.rst
+++ b/README.rst
@@ -7,6 +7,9 @@
 README
 ======
 
+.. image:: https://saucelabs.com/buildstatus/juju-gui
+   :alt: SauceLabs Status
+
 Welcome. Juju-GUI is a web-based GUI for `Juju <https://juju.ubuntu.com/>`_.
 Juju lets you deploy connected services to the cloud in a convenient,
 vendor-neutral, and powerful way. The GUI lets you visualize and manage


### PR DESCRIPTION
Note: this causes a Warning for a nonlocal image.  First I tried switching to
html from image for nonlocal image, but GitHub would not display it.  I tried
removing styled P tags, but that didn't help, so instead, I settled on removing
-W from SPHINXOPTS.
