### PR TITLE
Adds unit tests for machine column and machine tokens

### DIFF
--- a/app/widgets/machine-view-panel.js
+++ b/app/widgets/machine-view-panel.js
@@ -67,11 +67,11 @@ YUI.add('machine-view-panel', function(Y) {
         _bindEvents: function() {
           var db = this.get('db');
           this.addEvent(db.machines.after(
-            ['add', 'remove', '*:change'], this._onMachinesChange, this)
+              ['add', 'remove', '*:change'], this._onMachinesChange, this)
           );
 
           this.addEvent(db.units.after(
-            ['add', 'remove', '*:change'], this._onUnitsChange, this));
+              ['add', 'remove', '*:change'], this._onUnitsChange, this));
 
           this.on('*:unit-token-drag-start', this._showDraggingUI, this);
           this.on('*:unit-token-drag-end', this._hideDraggingUI, this);
@@ -370,14 +370,15 @@ YUI.add('machine-view-panel', function(Y) {
          * @param {Node} list the list node to append the machine to.
          */
         _renderMachineToken: function(machineOrId) {
-          var machine;
+          var db = this.get('db'),
+              machine;
           if (typeof machineOrId === 'string') {
-            machine = this.get('db').machines.getById(machineOrId);
+            machine = db.machines.getById(machineOrId);
           } else {
             machine = machineOrId;
           }
           var node = Y.Node.create('<li></li>'),
-              units = this.get('db').units.filterByMachine(machine.id, true);
+              units = db.units.filterByMachine(machine.id, true);
           this._updateMachineWithUnitData(machine, units);
           var token = new views.MachineToken({
             container: node,


### PR DESCRIPTION
app/widgets/machine-panel-view.js 
- `_smartUpdateList` has been refactored, moving its two responsibilities--
  adding and removing tokens as necessary--into two methods. These methods are
  easier to test, and a bit clearer to read.

tests/test_machine_view_panel_view.js
- Unit tests for all inputs and all expected behavior of the components of
  _smartUpdateList have been added.
- Unit tests for _updateMachine and _renderMachineToken have been added

Note to reviewers: machine tokens are also tested in their own file, which has
not been updated. Additionally, invisible in the diff, but available in the
full file, machine column has quite extensive functional testing; I've only
added units to more directly tests private methods that were only implicitly
tested.
