### PR TITLE
Updated deployer changes panel to match designs

### DIFF
--- a/app/templates/deployer-bar-changes.handlebars
+++ b/app/templates/deployer-bar-changes.handlebars
@@ -1,0 +1,13 @@
+{{#if changeList}}
+  <ul class="change-list">
+    {{#each changeList}}
+      <li>
+        <span class="icon"><i class="sprite {{ icon }}"></i></span>
+        <span>{{ description }}</span>
+        <span class="time"><time>{{ time }}</time></span>
+      </li>
+    {{/each}}
+  </ul>
+{{else}}
+  <p class="none">No recent changes</p>
+{{/if}}

--- a/app/templates/deployer-bar.handlebars
+++ b/app/templates/deployer-bar.handlebars
@@ -7,39 +7,45 @@
             </span>
             <a href="" class="button deploy-button">Deploy</a>
         </div>
-        {{#if confirmDeploy}}
         <div class="post-summary">
             <p>Confirm will deploy all changes</p>
             <a href="" class="button cancel-button">Cancel</a>
             <a href="" class="button confirm-button">Confirm</a>
         </div>
-        {{/if}}
     </div>
     <ul class="action-list">
         <li class="show">
             <a href="" class="link">
                 {{ changeCount }} changes
                 <span class="expand">
-                    <i class="sprite expand_icon more"></i>
-                </span>
-            </a>
-        </li>
-        <li class="hide">
-            <a href="" class="link">
-                {{ changeCount }} changes
-                <span class="contract">
-                    <i class="sprite contract_icon less"></i>
+                    <i class="sprite contract_icon more"></i>
                 </span>
             </a>
         </li>
         <li class="change">
-          {{{ latestChangeDescription }}}
+          <i class="sprite {{ latestChangeDescription.icon }}"></i>
+          {{ latestChangeDescription.description }}
+          <time>{{ latestChangeDescription.time }}</time>
         </li>
     </ul>
 </div>
-<aside class="summary">
+<aside class="panel changes">
+  <header>
+    <ul class="action-list">
+        <li class="hide">
+            <a href="" class="link">
+                {{ changeCount }} changes
+                <span class="contract">
+                    <i class="sprite expand_icon less"></i>
+                </span>
+            </a>
+        </li>
+    </ul>
+  </header>
+  <section></section>
+</aside>
+<aside class="panel summary">
     <header>
-        {{#if confirmDeploy}}
         <h2 class="title">The following changes will be deployed</h2>
         <div class="right">
             <ul class="action-list">
@@ -49,9 +55,7 @@
                 <li><a href="" class="close"><i class="sprite DB-close"></i></a></li>
             </ul>
         </div>
-        {{/if}}
     </header>
-    {{#if confirmDeploy}}
     <section>
         <h2 class="title">Deployment summary</h2>
         <div class="summary-panel">
@@ -147,23 +151,5 @@
             {{/if}}
         </div>
     </section>
-    {{else}}
-    <section>
-        <h2 class="title">Recent changes</h2>
-        <div class="summary-panel">
-          <div class="change-list">
-          {{#if changeList}}
-            <ul>
-            {{#each changeList}}
-            <li>{{{.}}}</li>
-            {{/each}}
-            </ul>
-          {{else}}
-            <p>No recent changes</p>
-          {{/if}}
-          </div>
-        </div>
-    </section>
-    {{/if}}
 </aside>
 <div class="cover"></div>

--- a/lib/views/deployer-bar.less
+++ b/lib/views/deployer-bar.less
@@ -1,4 +1,9 @@
 .deployer-bar {
+    @paper-dark: #ebecee url(/juju-ui/assets/images/non-sprites/paper-bg-dark.jpg) repeat 0 0;
+
+    time {
+        color: #bfbab5;
+    }
     .bar {
         box-sizing: border-box;
         position: absolute;
@@ -7,11 +12,10 @@
         left: 0;
         right: 0;
         height: @deployer-bar-height;
-        background: #ebecee url(/juju-ui/assets/images/non-sprites/paper-bg-dark.jpg) repeat 0 0;
+        background: @paper-dark;
         box-shadow: 0 0 3px rgba(0, 0, 0, 0.15);
 
         time {
-            color: #bfbab5;
             margin-left: 7px;
         }
         a.button {
@@ -78,13 +82,13 @@
     ul.action-list {
         margin: 0;
         list-style: none;
+
         .hide {
             display: none;
         }
         .show {
             display: block;
         }
-
         li {
             float: left;
             height: 50px;
@@ -109,22 +113,79 @@
             }
         }
     }
-    .summary {
+    .panel {
         display: none;
         position: absolute;
-        z-index: 651;
-        bottom: 50px;
+        // Needs to be above .bar so that the shadow does not appear
+        // above the panel.
+        z-index: 652;
+        bottom: @deployer-bar-height;
         left: 0;
-        height: 450px;
-        transistion: height .3s;
-        width:100%;
+        width: 100%;
         background: #ebecee url(/juju-ui/assets/images/non-sprites/paper-bg.jpg) repeat 0 0;
         border: 1px solid #D9D9D9;
+        transistion: height .3s;
 
         header {
-            background: #ebecee url(/juju-ui/assets/images/non-sprites/paper-bg-dark.jpg) repeat 0 0;
-            padding: 5px 20px;
+            background: @paper-dark;
             border-bottom: 1px solid #D9D9D9;
+        }
+    }
+    .panel.changes {
+        .customize-scrollbar;
+
+        header {
+            .action-list .hide {
+                float: none;
+                padding-left: none;
+
+                .less {
+                    margin-left: 10px;
+                }
+            }
+        }
+        .change-list {
+            overflow: auto;
+            max-height: 400px;
+            margin: 0;
+            list-style: none;
+
+            li {
+                border-bottom: 1px solid #D9D9D9;
+
+                &:last-child {
+                    border-bottom: none;
+                }
+                &,
+                span {
+                    height: 40px;
+                }
+                span {
+                    display: block;
+                    float: left;
+                    padding: 0 20px;
+                    line-height: 40px;
+                }
+                .icon {
+                    padding: 0 15px;
+                    border-right: 1px solid #D9D9D9;
+                }
+                .time {
+                    padding: 0 40px;
+                    float: right;
+                    border-left: 1px solid #D9D9D9;
+                }
+            }
+        }
+        p.none {
+            margin: 20px;
+        }
+    }
+    .panel.summary {
+        height: 450px;
+
+        header {
+            padding: 5px 20px;
         }
         section {
             padding: 5px 0;
@@ -141,9 +202,10 @@
                 line-height: 30px;
                 height: auto;
                 padding: 0 5px;
-            }
-            li a.close{
-                margin-left: 10px;
+
+                a.close {
+                    margin-left: 10px;
+                }
             }
         }
         .right {
@@ -186,24 +248,36 @@
         right: 0;
         background-color: rgba(0, 0, 0, 0.7);
     }
+    &.changes-open,
     &.summary-open {
-        .summary,
+        .cover {
+            display: block;
+        }
+        .action-list {
+            .show {
+                display: none;
+            }
+        }
+    }
+    &.changes-open {
+        .panel.changes {
+            display: block;
+
+            .action-list {
+                .hide {
+                    display: block;
+                }
+            }
+        }
+    }
+    &.summary-open {
+        .cover,
+        .panel.summary,
         .bar .post-summary {
             display: block;
         }
         .bar .pre-summary {
             display: none;
-        }
-        .cover {
-            display: block;
-        }
-        .action-list {
-            .hide {
-                display: block;
-            }
-            .show {
-                display: none
-            }
         }
     }
 }


### PR DESCRIPTION
Updated the deployer changes panel to match the visuals (https://drive.google.com/a/canonical.com/?usp=folder#folders/0B7XG_QBXNwY1WGlyVzN2LWtrcmM)

QA:
Drag a service to the canvas.
Click the "2 changes" link in the deployer bar.
Check that the panel matches the visuals.
