### PR TITLE
Cleans up unplaced service unit code.

### DIFF
--- a/app/widgets/machine-view-panel.js
+++ b/app/widgets/machine-view-panel.js
@@ -92,7 +92,7 @@ YUI.add('machine-view-panel', function(Y) {
               this._updateMachine(machineChanged.newVal);
             }
           }
-          this._renderUnits();
+          this._renderUnplacedUnits();
         },
 
         /**
@@ -518,13 +518,12 @@ YUI.add('machine-view-panel', function(Y) {
         },
 
         /**
-         * Render the undeployed service unit tokens.
-         *
-         * @method _renderUnits
+           Render the undeployed service unit tokens.
+
+           @method _renderUnplacedUnits
          */
-        _renderUnits: function() {
-          var self = this,
-              container = this.get('container'),
+        _renderUnplacedUnits: function() {
+          var container = this.get('container'),
               units = this.get('db').units.filterByMachine(null),
               unitList = container.one('.unplaced .content .items');
 
@@ -535,20 +534,29 @@ YUI.add('machine-view-panel', function(Y) {
             this._addIconsToUnits(units);
           }
 
-          this._smartUpdateList(units, unitList, function(model, list) {
-            var node = Y.Node.create('<li></li>');
-            var token = new views.ServiceUnitToken({
-              container: node,
-              title: model.displayName,
-              id: model.id,
-              icon: model.icon,
-              machines: self.get('db').machines.filterByParent(null),
-              containers: [] // XXX Need to find query for getting containers
-            });
-            token.render();
-            token.addTarget(self);
-            return node;
+          this._smartUpdateList(
+              units, unitList,
+              this._renderUnplacedUnitToken.bind(this)
+          );
+        },
+
+        /**
+           Render a serviceunit token.
+
+           @method _renderUnplacedUnitToken
+           @param {Object} model The model data for the unplaced unit
+         */
+        _renderUnplacedUnitToken: function(model) {
+          var node = Y.Node.create('<li></li>');
+          var token = new views.ServiceUnitToken({
+            container: node,
+            title: model.displayName,
+            id: model.id,
+            icon: model.icon
           });
+          token.render();
+          token.addTarget(this);
+          return node;
         },
 
         /**
@@ -608,7 +616,7 @@ YUI.add('machine-view-panel', function(Y) {
           container.addClass('machine-view-panel');
           this._renderHeaders();
           this._renderMachines();
-          this._renderUnits();
+          this._renderUnplacedUnits();
           this._renderScaleUp();
           this._clearContainerColumn();
           return this;

--- a/app/widgets/serviceunit-token.js
+++ b/app/widgets/serviceunit-token.js
@@ -169,24 +169,7 @@ YUI.add('juju-serviceunit-token', function(Y) {
        * @attribute container
        * @type {Object}
        */
-      id: '',
-
-      /**
-       * All available machines.
-       *
-       * @attribute container
-       * @type {Object}
-       */
-      machines: [],
-
-      /**
-       * All available containers.
-       *
-       * @attribute container
-       * @type {Object}
-       */
-      // XXX this should get loaded as required from the db
-      containers: []
+      id: ''
     }
   });
 


### PR DESCRIPTION
This is a trivial branch landing some minor refactors to the unplaced service
unit code.
- Service unit token rendering is broken out into its own method, both for
  consistency with other tokens and to work more cleanly with _smartUpdateList
- The unused machine and containers attr from the service units has been
  removed; containers was never populated and neither were used, nor appear to
  need to be used.

If I'm wrong on the last assertion I'll happily revert that change.

Service unit rendering is well tested; as this just moves functionality out of
an anonymous function and removes unused and untested bits, no new tests are
needed.
