### PR TITLE
Fixed unplaced units dropped on existing containers.

### DIFF
--- a/app/utils/environment-change-set.js
+++ b/app/utils/environment-change-set.js
@@ -573,9 +573,7 @@ YUI.add('environment-change-set', function(Y) {
     placeUnit: function(unit, machineId) {
       var record = this._retrieveUnitRecord(unit.id);
       if (!record) {
-        throw new Error(
-            'attempted to place a unit which has not been added: ' + unit.id
-        );
+        throw 'attempted to place a unit which has not been added: ' + unit.id;
       }
       // When placeUnit is called the unit could have been already placed on a
       // ghost machine. In that case the corresponding addMachines parent has


### PR DESCRIPTION
1. Fixes a bug with `ecs.placeUnit` which would cause dropping an unplaced unit on an existing container to fail.
2. Adds tests for `ecs.placeUnit`.
#### To QA
- Open `config-debug.js` and disable `simulateEvents`.
- Open `app.js` and add `this.fakebackend = state` after line 418
- Load the GUI using the mv and il flags.
- Drag and drop a charm to the canvas. 
- Switch to the machine view.
- Drag and drop the unplaced unit to the `New Machine` header.
- Click `deploy` and `confirm`.
- Switch back to the service view.
- Run `app.db.machines.add({id: '0/lxc/0'}); app.fakebackend.db.machines.add({id: '0/lxc/0'})` in the console.
- Drag and drop a new charm to the canvas.
- Switch to the machine view.
- Select the `0` machine. You should now see an empty container and 'Bare Metal' with your previous service.
- Drag the unplaced unit and drop it on the empty container.
- Click `deploy` and `confirm`.
- Switch to service view and back to machine view. You should now have placed your new service on that container.
