### PR TITLE
Fixed bug 1321345

### DIFF
--- a/app/models/models.js
+++ b/app/models/models.js
@@ -409,15 +409,25 @@ YUI.add('juju-models', function(Y) {
           } else {
             // Because the packageName is not set if the
             // model was created from the core delta.
-            var charm = this.get('charm');
+            var charmUrl = this.get('charm'),
+                charmName;
             // If there is no charm as well, well you have bigger problems :)
             // but this helps so that we don't need to provide charm data
             // for every test suite.
-            if (charm) {
-              charm = charm.split('/');
-              charm = charm[charm.length - 1].split('-')[0];
+            if (charmUrl) {
+              var urlParts = charmUrl.split('/');
+              var nameParts = urlParts[urlParts.length - 1].split('-');
+              var possibleVersion = nameParts[nameParts.length - 1];
+              // Expected === and instead saw ==
+              /* jshint -W116 */
+              if (possibleVersion == parseInt(possibleVersion, 10)) {
+                // The charmUrl contains the version so we can drop that and
+                // reconstruct the name.
+                nameParts.pop();
+              }
+              charmName = nameParts.join('-');
             }
-            return charm || undefined;
+            return charmName;
           }
         }
       }

--- a/test/test_model.js
+++ b/test/test_model.js
@@ -1455,6 +1455,15 @@ describe('test_model.js', function() {
       assert.equal(services.length, 1);
       assert.deepEqual(services, [rails]);
     });
+
+    it('can properly parse the charm url for the package name', function() {
+      assert.equal(rails.get('packageName'), 'rails');
+      var jujuGui = new models.Service({
+        id: 'juju-gui',
+        charm: 'cs:/trusty/juju-gui-90'
+      });
+      assert.equal(jujuGui.get('packageName'), 'juju-gui');
+    });
   });
 
   describe('db.charms.addFromCharmData', function() {


### PR DESCRIPTION
When charm urls contained a hyphenated name and a charm version number the package name was not parsed correctly when creating a new model.
#### To QA
- Use the il and mv flags (This bug only presented itself using these flags).
- Search for the `juju-gui`.
- Drag and drop it onto the canvas.
- Click the service icon to open the inspector.
- Close the inspector
- The service token should still read `juju-gui`
