### PR TITLE
Subordinate lines update properly

### DIFF
--- a/app/views/topology/relation.js
+++ b/app/views/topology/relation.js
@@ -147,6 +147,12 @@ YUI.add('juju-topology-relation', function(Y) {
         */
         servicesRendered: 'updateLinks',
         /**
+          Update data when a service box type has changed.
+
+          @event serviceTypeChanged
+        */
+        serviceTypeChanged: 'update',
+        /**
           Ensure the dragline follows the cursor outside of services.
 
           @event snapOutOfService

--- a/test/test_service_module.js
+++ b/test/test_service_module.js
@@ -185,6 +185,14 @@ describe('service module events', function() {
        assert.isFalse(menu.hasClass('active'));
      });
 
+  it('should notify modules when service type is changed', function(done) {
+    topo.on('serviceTypeChanged', function() {
+      done();
+    });
+    topo.service_boxes.haproxy.model.set('subordinate', true);
+    serviceModule.update();
+  });
+
   // Click the provided service so that the service menu is shown.
   // Return the service menu.
   var clickService = function(service) {


### PR DESCRIPTION
Subordinate relations were not being shown as such in certain instances, such
as when the bundle was deployed through the deployer, since bundles do not
contain subordinate information.  Information about subordinate status was
retrieved once the deploy of the bundle finished and services were associated
with charms.  This adds functionality that informs the whole topology when the
subordinate status of a service changes.
