### PR TITLE
Cache unit tokens internally for easy rendering.

### DIFF
--- a/app/templates/serviceunit-token.handlebars
+++ b/app/templates/serviceunit-token.handlebars
@@ -4,7 +4,7 @@
     <img src="{{icon}}" alt="{{displayName}}">
   </span>
   <span class="title">
-    {{ title }}
+    {{ displayName }}
   </span>
   <span class="token-move">
     <i class="sprite mv-placement-arrow"></i>

--- a/app/widgets/machine-token.js
+++ b/app/widgets/machine-token.js
@@ -134,7 +134,7 @@ YUI.add('machine-token', function(Y) {
           // when something is dropped on it.
           token.setData('drop-action', 'container');
           // This must be setAttribute, not setData, as setData does not
-          // munipulate the dom, which we need for our namespaced code
+          // manipulate the dom, which we need for our namespaced code
           // to read.
           token.setAttribute('data-id', machine.id);
           this._attachDragEvents(); // drop-target-view-extension

--- a/app/widgets/service-scale-up-view.js
+++ b/app/widgets/service-scale-up-view.js
@@ -32,7 +32,7 @@ YUI.add('service-scale-up-view', function(Y) {
   /**
    * The view associated with the machine token.
    *
-   * @class ServiceUnitToken
+   * @class ServicesScaleUpView
    */
   var ServiceScaleUpView = Y.Base.create('service-scale-up-view', Y.View, [], {
 

--- a/app/widgets/serviceunit-token.js
+++ b/app/widgets/serviceunit-token.js
@@ -146,30 +146,35 @@ YUI.add('juju-serviceunit-token', function(Y) {
      */
     render: function() {
       var container = this.get('container'),
-          attrs = this.getAttrs();
-      container.setHTML(this.template(attrs));
+          unit = this.get('unit'),
+          token;
+      container.setHTML(this.template(unit));
       container.addClass('serviceunit-token');
-      container.setAttribute('data-id', this.get('id'));
+      token = container.one('.unplaced-unit');
+      // This must be setAttribute, not setData, as setData does not
+      // manipulate the dom, which we need for our namespaced code
+      // to read.
+      token.setAttribute('data-id', unit.id);
       this._makeDraggable();
       return this;
     },
 
     ATTRS: {
       /**
-       * The displayed name for the unit.
-       *
-       * @attribute container
-       * @type {Object}
+        The Node instance that contains this token.
+
+        @attribute container
+        @type {Object}
        */
-      title: '',
+      container: {},
 
       /**
-       * The unit's ID.
-       *
-       * @attribute container
-       * @type {Object}
+        The model wrapped by this token.
+
+        @attribute unit
+        @type {Object}
        */
-      id: ''
+      unit: {}
     }
   });
 

--- a/test/test_serviceunit_token.js
+++ b/test/test_serviceunit_token.js
@@ -38,8 +38,10 @@ describe('Service unit token', function() {
     title = 'test';
     view = new views.ServiceUnitToken({
       container: container,
-      id: 'test/0',
-      title: 'test'
+      unit: {
+        id: 'test/0',
+        displayName: 'test'
+      }
     }).render();
   });
 


### PR DESCRIPTION
### QA

With `/:flags:/il/mv`.
1. Deploy the Wikimedia bundle.
2. Drag-n-drop the Wordpress charm over, but don't deploy it.
3. Switch to machine view.
4. Run this in your console:

```
var u = app.db.units.item(2), m = app.db.units.revive(u); m.set('machine', '0');
```

You should see the Wordpress icon added to the 0 machine and removed from the unplaced units column. Additionally the "All units placed" message should appear.
