### PR TITLE
Non-drag-and-drop unit placing workflow

### DIFF
--- a/app/templates/serviceunit-token.handlebars
+++ b/app/templates/serviceunit-token.handlebars
@@ -1,5 +1,4 @@
 <div class="unplaced-unit">
-  <div class="main">
   <span class="unit-icon">
     <img src="{{icon}}" alt="{{displayName}}">
   </span>
@@ -9,28 +8,36 @@
   <span class="token-move">
     <i class="sprite mv-placement-arrow"></i>
   </span>
-  </div>
-  <!-- XXX these HTML selects (machines and containers) will likely need to be
-       generated dynamically, rather than show/hidden -->
-  <div class="machines hidden">
-    <select placeholder="Move to&#8230;">
-      <option value="new">New machine</option>
-      {{#each machines}}
-      <option value="{{id}}">{{displayName}}</option>
-      {{/each}}
+  <div class="machines">
+    <select>
+      <option value="" selected disabled class="hidden default">
+        Move to&hellip;
+      </option>
+      <option value="new" class="default">New machine</option>
     </select>
   </div>
-  <div class="containers hidden">
-    <select placeholder="Choose location">
-      {{#each containers}}
-      <option value="{{id}}">{{displayName}}</option>
-      {{/each}}
-      <option value="new-lxc">new lxc</option>
-      <option value="new-kvm">new kvm</option>
+  <div class="new-machine">
+    Define constaints
+  </div>
+  <div class="containers">
+    <select>
+      <option value="" selected disabled class="hidden default">
+        Choose location
+      </option>
+      <option value="new-lxc" class="default">new lxc</option>
+      <option value="new-kvm" class="default">new kvm</option>
     </select>
   </div>
-  <div class="actions hidden">
-    <span class="cancel secondary-action">Cancel</span>
+  <form class="constraints">
+    <input type="text" name="cpu">
+    <label>CPU (GHz)</label>
+    <input type="text" name="ram">
+    <label>RAM (GB)</label>
+    <input type="text" name="disk">
+    <label>Disk (TB)</label>
+  </form>
+  <div class="actions">
+    <span class="cancel secondary-action">Cancel</span> |
     <span class="move primary-action">Move</span>
   </div>
 </div>

--- a/lib/views/machine-view/machine-view-panel.less
+++ b/lib/views/machine-view/machine-view-panel.less
@@ -10,6 +10,17 @@
     padding: 10px 0 0 0;
     background-color: #fff;
 
+    input[type="text"] {
+        // Using a variable here because LESS strips commas in mixin args.
+        @box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.4);
+        .create-box-shadow(@box-shadow);
+        .create-border-radius(@border-radius);
+        margin: 0;
+        padding: 7px 10px;
+        background:  #eee;
+        border: none;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+    }
     .column {
         .customize-scrollbar;
         .display-flex;

--- a/lib/views/machine-view/service-scale-up-view.less
+++ b/lib/views/machine-view/service-scale-up-view.less
@@ -55,18 +55,12 @@
                 vertical-align: middle;
             }
             .service-units {
-                // Using a variable here because LESS strips commas in mixin args.
-                @box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.4);
-                .create-box-shadow(@box-shadow);
-                .create-border-radius(@border-radius);
                 display: inline-block;
                 float: right;
                 width: 30px;
                 margin: 0;
-                padding: 4px 10px;
-                background:  #eee;
-                border: none;
-                border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+                padding-top: 4px;
+                padding-bottom: 4px;
                 text-align: right;
             }
         }

--- a/lib/views/machine-view/serviceunit-token.less
+++ b/lib/views/machine-view/serviceunit-token.less
@@ -1,13 +1,76 @@
-.serviceunit-token {
-    height: 38px;
+.machine-view-panel .serviceunit-token {
+    position: relative;
+    min-height: 38px;
     margin: 10px 10px 0 10px;
     padding: 0 10px;
+    background-color: #eee;
     border: 1px solid @machine-view-border-colour;
     line-height: 38px;
-    cursor: move;
 
+    // States
+    &.state-initial {
+        background-color: transparent;
+        cursor: move;
+
+        .token-move {
+            display: block;
+        }
+        .title {
+            display: inline;
+        }
+    }
+    &.state-select-machine {
+        .machines {
+            display: block;
+        }
+    }
+    &.state-new-machine {
+        .machines,
+        .actions,
+        .constraints,
+        .new-machines {
+            display: block;
+        }
+    }
+    &.state-new-kvm,
+    &.state-select-container {
+        .machines,
+        .actions,
+        .containers {
+            display: block;
+        }
+    }
+    &.state-new-kvm {
+        .constraints {
+            display: block;
+        }
+    }
     &:last-child {
         margin-bottom: 10px;
+    }
+    input[type="text"],
+    select {
+        width: 100%;
+    }
+    input[type="text"] {
+        .border-box;
+        margin-bottom: 6px;
+        background-color: #fff;
+
+        &:last-of-type {
+            margin-bottom: 0;
+        }
+    }
+    form label {
+        position: relative;
+        float: right;
+        margin: -37px 10px 0 0;
+        color: #c6c1bb;
+        line-height: 30px;
+
+        &:last-of-type {
+            margin-top: -34px;
+        }
     }
     .unplaced-unit {
         .details {
@@ -27,5 +90,30 @@
             margin-top: -1px;
             cursor: pointer;
         }
+    }
+    .machines {
+        position: absolute;
+        top: 0;
+        left: 38px;
+        right: 10px;
+    }
+    .actions {
+        text-align: right;
+
+        span {
+            cursor: pointer;
+        }
+        .primary-action {
+            color: @charm-panel-orange;
+        }
+    }
+    .token-move,
+    .title,
+    .new-machine,
+    .containers,
+    .constraints,
+    .actions,
+    .machines {
+        display: none;
     }
 }


### PR DESCRIPTION
This is the click-through unit placement workflow.

Question: can we use constraints for creating machines/containers? If so I need to add that, if not I can remove that for now.

QA:
Use il and mv flags.
- Drag a service to the canvas. Click Deploy and Confim.
- Drag a different service to the canvas. Do not deploy.
- Open the machine view.
- In the "Unplaced units" column there should be one unit. Click the icon on the right hand side.
- A select box should appear and you should now be able to follow through with adding to a machine/container, creating new machines/containers etc. All the paths should work.
