### PR TITLE
Fixed drag and drop of unplaced units

### DIFF
--- a/app/widgets/serviceunit-token.js
+++ b/app/widgets/serviceunit-token.js
@@ -129,7 +129,7 @@ YUI.add('juju-serviceunit-token', function(Y) {
         var dataTransfer = evt.dataTransfer;
         dataTransfer.effectAllowed = 'move';
         var dragData = {
-          id: attrs.id
+          id: attrs.unit.id
         };
         dataTransfer.setData('Text', JSON.stringify(dragData));
         // This event is registered on many nested elements, but we only have

--- a/test/test_serviceunit_token.js
+++ b/test/test_serviceunit_token.js
@@ -62,7 +62,7 @@ describe('Service unit token', function() {
   });
 
   it('adds the unit id to the drag data', function() {
-    var handler = view._makeDragStartHandler({ id: 'foo' });
+    var handler = view._makeDragStartHandler({unit: { id: 'foo' }});
     var dragData = {
       _event: {
         dataTransfer: {


### PR DESCRIPTION
Drag and drop of unplaced units was broken. This fixes it.

Bug: https://bugs.launchpad.net/juju-gui/+bug/1323199

QA:
- drag a service to the canvas
- open the machine view
- drag the unplaced unit to 'create a machine'
- open the javascript console and check there are no errors.
- click deploy and confirm
  The unit should be on a new machine. Adding more units and dropping them on existing containers should work as well.
