### PR TITLE
Fix bug #1321484

### DIFF
--- a/app/views/ghost-deployer-extension.js
+++ b/app/views/ghost-deployer-extension.js
@@ -54,7 +54,7 @@ YUI.add('ghost-deployer-extension', function(Y) {
 
       this._setupXYAnnotations(ghostAttributes, ghostService);
 
-      if (window.flags && window.flags.il) {
+      if (window.flags && window.flags.mv) {
         var ghostServiceId = ghostService.get('id');
         // XXX frankban 2014-05-11:
         // after the ODS demo, find a smarter way to set a unique service name.
@@ -102,6 +102,12 @@ YUI.add('ghost-deployer-extension', function(Y) {
             // Options used by ECS, ignored by environment.
             {modelId: unitId}
         );
+      } else if (window.flags && window.flags.il) {
+        this.get('subApps').charmbrowser.fire('changeState', {
+          sectionA: {
+            component: 'inspector',
+            metadata: { id: ghostService.get('id') }
+          }});
       } else {
         var environment = this.views.environment.instance;
         environment.createServiceInspector(ghostService);

--- a/test/test_ghost_deployer_extension.js
+++ b/test/test_ghost_deployer_extension.js
@@ -62,6 +62,9 @@ describe('Ghost Deployer Extension', function() {
       addUnits: utils.makeStubFunction(),
       removeUnits: utils.makeStubFunction()
     };
+    ghostDeployer.set('subApps', {
+      charmbrowser: {
+        fire: utils.makeStubFunction() }});
   });
 
   afterEach(function() {
@@ -78,8 +81,8 @@ describe('Ghost Deployer Extension', function() {
     });
   };
 
-  it('calls the env deploy method with the default charm data', function() {
-    window.flags.il = true;
+  it('calls the env deploy method with default charm data', function() {
+    window.flags.mv = true;
     var charm = makeCharm();
     ghostDeployer.deployService(charm);
     assert.strictEqual(ghostDeployer.env.deploy.calledOnce(), true);
@@ -93,7 +96,7 @@ describe('Ghost Deployer Extension', function() {
   });
 
   it('adds the ECS modelId option when deploying the charm', function() {
-    window.flags.il = true;
+    window.flags.mv = true;
     var charm = makeCharm();
     ghostDeployer.deployService(charm);
     assert.strictEqual(ghostDeployer.env.deploy.calledOnce(), true);
@@ -113,10 +116,18 @@ describe('Ghost Deployer Extension', function() {
     var args = services.ghostService.lastArguments();
     assert.lengthOf(args, 1);
     assert.deepEqual(args[0], charm);
+    var fire = ghostDeployer.get('subApps').charmbrowser.fire;
+    assert.equal(fire.calledOnce(), true);
+    var fireArgs = fire.lastArguments();
+    assert.equal(fireArgs[0], 'changeState');
+    assert.deepEqual(fireArgs[1], {
+      sectionA: {
+        component: 'inspector',
+        metadata: { id: 'ghost-service-id' }}});
   });
 
   it('creates a ghost unit', function() {
-    window.flags.il = true;
+    window.flags.mv = true;
     var charm = makeCharm();
     ghostDeployer.deployService(charm);
     var db = ghostDeployer.db;
@@ -133,7 +144,7 @@ describe('Ghost Deployer Extension', function() {
   });
 
   it('deploys the ghost unit using the ECS', function() {
-    window.flags.il = true;
+    window.flags.mv = true;
     var charm = makeCharm();
     ghostDeployer.deployService(charm);
     var env = ghostDeployer.env;


### PR DESCRIPTION
https://launchpad.net/bugs/1321484

Ghost deployer now correctly fires the changeState event when under the il flag. There was a lot of mv code placed under the il flag for the ghost deployer extension. This adds the il flag bag with the correct implementation.
#### To QA

Deploy charms using no flag, il flag and il + mv flag. There should be no errors and it should work as expected.
