### PR TITLE
Destroy old inspectors when changing state.

### DIFF
--- a/app/subapps/browser/browser.js
+++ b/app/subapps/browser/browser.js
@@ -506,6 +506,10 @@ YUI.add('subapp-browser', function(Y) {
           return true;
         }
       });
+      // In the instance of updating, destroy the existing inspector.
+      if (this._activeInspector) {
+        this._activeInspector.destroy();
+      }
       if (metadata.localType) {
         var file = metadata.flash.file;
         var services = metadata.flash.services;
@@ -546,7 +550,9 @@ YUI.add('subapp-browser', function(Y) {
         this._charmbrowser.destroy();
         this._charmbrowser = null;
       }
-      if (this._sidebar.search) { this._sidebar.hideSearch(); }
+      if (this._sidebar.search) {
+        this._sidebar.hideSearch();
+      }
       if (this._details) {
         this._details.destroy({ remove: true });
         var detailsNode = Y.one('.bws-view-data');
@@ -558,7 +564,9 @@ YUI.add('subapp-browser', function(Y) {
           detailsNode.empty();
         }
       }
-      if (this._activeInspector) {this._activeInspector.destroy(); }
+      if (this._activeInspector) {
+        this._activeInspector.destroy();
+      }
     },
 
     /**

--- a/test/test_browser_app.js
+++ b/test/test_browser_app.js
@@ -434,6 +434,19 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
             assert.equal(requestSeriesStub.callCount(), 0);
             assert.equal(upgradeOrNewStub.callCount(), 1);
           });
+
+          it('removes existing inspectors', function(done) {
+            stubMethods(this);
+            stubDb(app, false);
+            app._inspector({ id: clientId });
+            app._activeInspector = {
+              destroy: function() {
+                // If the inspector is not destroyed, the test will time out.
+                done();
+              }
+            };
+            app._inspector({ id: clientId });
+          });
         });
 
         describe('_machine', function() {


### PR DESCRIPTION
QA with il flag - deploy two services, then click each in turn.  There should be no lingering expose toggle from the previous inspector.
