### PR TITLE
Ensure charmbrowser is fully removed on destroy.

### DIFF
--- a/app/subapps/browser/views/charmbrowser.js
+++ b/app/subapps/browser/views/charmbrowser.js
@@ -413,6 +413,9 @@ YUI.add('juju-charmbrowser', function(Y) {
     */
     destructor: function() {
       this._cleanUp();
+      if (window.flags && window.flags.il) {
+        this.get('container').remove(true);
+      }
       this.get('store').cancelInFlightRequest(this.activeRequestId);
     }
   },

--- a/test/test_charmbrowser_view.js
+++ b/test/test_charmbrowser_view.js
@@ -465,11 +465,31 @@ describe('charmbrowser view', function() {
   });
 
   describe('destroy', function() {
-    it('calls the cleanup method', function() {
-      var cleanup = utils.makeStubMethod(charmBrowser, '_cleanUp');
+    var shouldRender, renderSearch, indicator, cleanup;
+
+    beforeEach(function() {
+      shouldRender = utils.makeStubMethod(charmBrowser, '_shouldRender', true);
+      this._cleanups.push(shouldRender.reset);
+      renderSearch = utils.makeStubMethod(charmBrowser, '_renderSearch');
+      this._cleanups.push(renderSearch.reset);
+      indicator = utils.makeStubMethod(charmBrowser, 'showIndicator');
+      this._cleanups.push(indicator.reset);
+      cleanup = utils.makeStubMethod(charmBrowser, '_cleanUp');
       this._cleanups.push(cleanup.reset);
+    });
+
+    it('calls the cleanup method', function() {
       charmBrowser.destroy();
       assert.equal(cleanup.calledOnce(), true);
+    });
+
+    it('removes the container from the DOM', function() {
+      window.flags = {};
+      window.flags.il = true;
+      charmBrowser.render();
+      charmBrowser.destroy();
+      assert.equal(charmBrowser.get('container').getDOMNode(), null);
+      window.flags = null;
     });
 
     it('calls to abort any in flight store requests', function() {


### PR DESCRIPTION
### QA

With the `il` flag.
1. Drag a service to the canvas
2. Click on the service and open the inspector
3. Close the inspector
4. Inspect the HTML of the sidebar

You should only see one set of charmbrowser HTML. You should **not** see anything like this:

```
<div id="yui_3_11_0_1_1401404489618_1020" ...
    <div class="search-widget"...
    <div class="charm-list"...
<div id="yui_3_11_0_1_1401404489618_1020" ...
    <div class="search-widget"...
    <div class="charm-list"...
```
