### PR TITLE
Re-instate autocomplete styling.

### DIFF
--- a/lib/views/browser/bws-searchbox.less
+++ b/lib/views/browser/bws-searchbox.less
@@ -54,44 +54,6 @@
       }
     }
 
-    /* Override styles for the autocomplete results */
-    .yui3-aclist-item {
-
-        .yui3-token {
-            border-bottom: 1px solid #efefef;
-            margin-left: 5px;
-            margin-right: 5px;
-
-            .token.tiny.category {
-                .icon,
-                .icon img {
-                    width: 27px;
-                    height: 27px;
-                }
-
-                .title {
-                  .type13;
-                }
-            }
-
-            .token.tiny {
-                padding: 8px 0;
-
-                .title {
-                    .type15;
-                    margin-top: 2px;
-                }
-
-                .icon,
-                .icon img {
-                    width: 32px;
-                    height: 32px;
-                }
-
-            }
-        }
-    }
-
     /* Make sure we don't draw a border on the last one in the list */
     .yui3-aclist-list .yui3-aclist-item:last-child .yui3-token {
         border-bottom: 0;
@@ -139,5 +101,46 @@
     .with-home .browser-nav {
         display: block;
     }
+
+    /* Override styles for the autocomplete results */
+    #bws-sidebar .yui3-aclist-item {
+
+        .yui3-token {
+            border-bottom: 1px solid #efefef;
+            border-top: none;
+            width: auto;
+            margin-left: 5px;
+            margin-right: 5px;
+
+            .token.tiny.category {
+                .icon,
+                .icon img {
+                    width: 27px;
+                    height: 27px;
+                }
+
+                .title {
+                  .type13;
+                }
+            }
+
+            .token.tiny {
+                padding: 8px 0;
+
+                .title {
+                    .type15;
+                    margin-top: 2px;
+                }
+
+                .icon,
+                .icon img {
+                    width: 32px;
+                    height: 32px;
+                }
+
+            }
+        }
+    }
+
 }
 

--- a/lib/views/browser/main.less
+++ b/lib/views/browser/main.less
@@ -56,9 +56,6 @@
     border-right: 1px solid #a5a5a5;
     box-shadow: 0 0 2px rgba(0, 0, 0, 0.3);
 
-    .bws-searchbox {
-        width: 100%;
-    }
     .bws-content {
       overflow-x: hidden;
 
@@ -105,7 +102,7 @@
         }
       }
       .search-widget {
-        padding: 20px 30px;
+        padding: 20px;
         position: absolute;
         border-bottom: 1px solid #b7b7b9;
       }


### PR DESCRIPTION
### QA

Click into the charmbrowser search box, so the autocomplete pops up with categories. Ensure that each token is centered in the list and has only one border. Here's what it used to look like:

http://cl.ly/image/0N0C120C1Z3o
