### PR TITLE
Fixed sidebar header capitalisation

### DIFF
--- a/lib/views/browser/main.less
+++ b/lib/views/browser/main.less
@@ -65,6 +65,7 @@
         height: 53px;
         padding-left: 20px;
         padding-right: 20px;
+        text-transform: capitalize;
       }
       .header-placement,
       .stickable {


### PR DESCRIPTION
Part of @hatched's refactoring left the headers with lower case titles, this branch fixes that with CSS.
