### PR TITLE
Track the committed state on tokens

### DIFF
--- a/app/widgets/container-token.js
+++ b/app/widgets/container-token.js
@@ -64,6 +64,7 @@ YUI.add('container-token', function(Y) {
          * @method setUncommitted
          */
         setUncommitted: function() {
+          this.set('committed', false);
           this.get('container').one('.token').addClass('uncommitted');
         },
 
@@ -73,6 +74,7 @@ YUI.add('container-token', function(Y) {
          * @method setCommitted
          */
         setCommitted: function() {
+          this.set('committed', true);
           this.get('container').one('.token').removeClass('uncommitted');
         },
 
@@ -86,6 +88,8 @@ YUI.add('container-token', function(Y) {
               machine = this.get('machine');
           container.setHTML(this.template(machine));
           container.addClass('container-token');
+          container.one('.token').addClass(
+              this.get('committed') ? 'committed' : 'uncommitted');
           // Tells the machine view panel drop handler where the unplaced unit
           // token was dropped.
           var token = container.one('.token');
@@ -112,7 +116,16 @@ YUI.add('container-token', function(Y) {
            * @default undefined
            * @type {Object}
           */
-          containerParent: {}
+          containerParent: {},
+
+          /**
+           * @attribute committed
+           * @default true
+           * @type {Bool}
+          */
+          committed: {
+            value: true
+          }
         }
       });
 

--- a/app/widgets/machine-token.js
+++ b/app/widgets/machine-token.js
@@ -79,6 +79,7 @@ YUI.add('machine-token', function(Y) {
          * @method setUncommitted
          */
         setUncommitted: function() {
+          this.set('committed', false);
           this.get('container').one('.token').addClass('uncommitted');
         },
 
@@ -88,6 +89,7 @@ YUI.add('machine-token', function(Y) {
          * @method setCommitted
          */
         setCommitted: function() {
+          this.set('committed', true);
           this.get('container').one('.token').removeClass('uncommitted');
         },
 
@@ -127,6 +129,8 @@ YUI.add('machine-token', function(Y) {
           }
           container.setHTML(this.template(machine));
           container.addClass('machine-token');
+          container.one('.token').addClass(
+              this.get('committed') ? 'committed' : 'uncommitted');
           // Tells the machine view panel drop handler where the unplaced unit
           // token was dropped.
           var token = container.one('.token');
@@ -147,7 +151,16 @@ YUI.add('machine-token', function(Y) {
            * @default undefined
            * @type {Object}
           */
-          machine: {}
+          machine: {},
+
+          /**
+           * @attribute committed
+           * @default true
+           * @type {Bool}
+          */
+          committed: {
+            value: true
+          }
         }
       });
 

--- a/app/widgets/machine-view-panel.js
+++ b/app/widgets/machine-view-panel.js
@@ -65,7 +65,8 @@ YUI.add('machine-view-panel', function(Y) {
           // Turn machine models into tokens and store internally.
           machines.forEach(function(machine) {
             var token = new views.MachineToken({
-              machine: machine
+              machine: machine,
+              committed: true
             });
             machineTokens[machine.id] = token;
           });
@@ -250,7 +251,8 @@ YUI.add('machine-view-panel', function(Y) {
           }
           token = new views.MachineToken({
             container: node,
-            machine: machine
+            machine: machine,
+            committed: true
           });
           machineTokens[machine.id] = token;
           this._updateMachineWithUnitData(machine);
@@ -476,6 +478,7 @@ YUI.add('machine-view-panel', function(Y) {
           var containerParent = this.get('container').one(
               '.containers .content .items');
           var numUnits = db.units.filterByMachine(parentId, true).length;
+          var committed = true;
 
           this._clearContainerColumn();
           this._containersHeader.set('labels', [
@@ -485,7 +488,7 @@ YUI.add('machine-view-panel', function(Y) {
 
           if (containers.length > 0) {
             Y.Object.each(containers, function(container) {
-              this._createContainerToken(containerParent, container);
+              this._createContainerToken(containerParent, container, committed);
             }, this);
           }
 
@@ -493,7 +496,8 @@ YUI.add('machine-view-panel', function(Y) {
           var units = db.units.filterByMachine(parentId);
           if (units.length > 0) {
             var machine = {displayName: 'Bare metal'};
-            this._createContainerToken(containerParent, machine, units);
+            this._createContainerToken(containerParent, machine,
+                committed, units);
           }
         },
 
@@ -502,11 +506,13 @@ YUI.add('machine-view-panel', function(Y) {
            @param {Y.Node} containerParent The parent node for the token's
              container
            @param {Object} container The lxc or kvm container object
+           @param {Bool} committed The committed state.
            @param {Array} units Optional list of units on the container.
              If not provided, the container's units will be looked up.
            @method _createContainerToken
          */
-        _createContainerToken: function(containerParent, container, units) {
+        _createContainerToken: function(containerParent, container,
+            committed, units) {
           if (!units) {
             units = this.get('db').units.filterByMachine(container.id);
           }
@@ -514,7 +520,8 @@ YUI.add('machine-view-panel', function(Y) {
           var token = new views.ContainerToken({
             containerTemplate: '<li/>',
             containerParent: containerParent,
-            machine: container
+            machine: container,
+            committed: committed
           });
           token.render();
           token.addTarget(this);

--- a/test/test_container_token.js
+++ b/test/test_container_token.js
@@ -71,15 +71,18 @@ describe('container token view', function() {
     view.setUncommitted();
     assert.equal(view.get('container').one('.token').hasClass('uncommitted'),
         true);
+    assert.equal(view.get('committed'), false);
   });
 
   it('can be marked as committed', function() {
     view.setUncommitted();
     assert.equal(view.get('container').one('.token').hasClass('uncommitted'),
         true);
+    assert.equal(view.get('committed'), false);
     view.setCommitted();
     assert.equal(view.get('container').one('.token').hasClass('uncommitted'),
         false);
+    assert.equal(view.get('committed'), true);
   });
 
   it('mixes in the DropTargetViewExtension', function() {

--- a/test/test_machine_token.js
+++ b/test/test_machine_token.js
@@ -94,15 +94,18 @@ describe('machine token view', function() {
     view.setUncommitted();
     assert.equal(view.get('container').one('.token').hasClass('uncommitted'),
         true);
+    assert.equal(view.get('committed'), false);
   });
 
   it('can be marked as committed', function() {
     view.setUncommitted();
     assert.equal(view.get('container').one('.token').hasClass('uncommitted'),
         true);
+    assert.equal(view.get('committed'), false);
     view.setCommitted();
     assert.equal(view.get('container').one('.token').hasClass('uncommitted'),
         false);
+    assert.equal(view.get('committed'), true);
   });
 
   it('handles non-number values for hardware when formatting', function() {

--- a/test/test_machine_view_panel.js
+++ b/test/test_machine_view_panel.js
@@ -753,7 +753,7 @@ describe('machine view panel view', function() {
       this._cleanups.push(viewStub.reset);
       var containerParent = utils.makeContainer(this, 'machine-view-panel'),
           container = {};
-      view._createContainerToken(containerParent, container);
+      view._createContainerToken(containerParent, container, true);
       // Verify that units for the container were looked up since they weren't
       // provided
       assert.equal(filterStub.calledOnce(), true);
@@ -780,7 +780,7 @@ describe('machine view panel view', function() {
       var containerParent = utils.makeContainer(this, 'machine-view-panel'),
           units = [{}],
           container = {};
-      view._createContainerToken(containerParent, container, units);
+      view._createContainerToken(containerParent, container, true, units);
       // Verify that units for the container were provided, and not looked up.
       assert.equal(filterStub.calledOnce(), false);
       assert.equal(updateStub.calledOnce(), true);


### PR DESCRIPTION
As part of some broader work to have the machine view correctly show the state for the tokens this branch tracks and sets the committed state of the machine/container tokens.

QA: There are no visual/functionality changes in this branch.
