### PR TITLE
Remove the unplaced unit when it has been placed

### DIFF
--- a/app/widgets/machine-view-panel.js
+++ b/app/widgets/machine-view-panel.js
@@ -316,24 +316,25 @@ YUI.add('machine-view-panel', function(Y) {
           var dropAction = e.dropAction;
           var parentId = e.targetId;
           var containerType = (dropAction === 'container') ? 'lxc' : undefined;
-          var env = this.get('env');
           var db = this.get('db');
           var unit = db.units.getById(e.unit);
+          var placeId;
 
           if (dropAction === 'container' &&
               (parentId && parentId.indexOf('/') !== -1)) {
             // If the user drops a unit on an already created container then
             // place the unit.
-            env.placeUnit(unit, parentId);
+            placeId = parentId;
           } else {
             var machine = this._createMachine(containerType,
                 parentId || selected, {});
-            env.placeUnit(unit, machine.id);
+            placeId = machine.id;
           }
+          this._placeUnit(unit, placeId);
         },
 
         /**
-         * Handles placing an unplaced unit
+         * Handles placing an unplaced unit.
          *
          * @method _placeServiceUnit
          * @param {Y.Event} e EventFacade object.
@@ -361,7 +362,19 @@ YUI.add('machine-view-panel', function(Y) {
           }
           // Place the unit onto the existing or newly created
           // machine/container.
-          this.get('env').placeUnit(e.unit, placeId);
+          this._placeUnit(e.unit, placeId);
+        },
+
+        /**
+         * Handles placing unit and updating the UI.
+         *
+         * @method _placeUnit
+         * @param {Object} unit The unit to be placed.
+         * @param {String} parentId The machine/container id to place on.
+         */
+        _placeUnit: function(unit, parentId) {
+          this.get('env').placeUnit(unit, parentId);
+          this._removeUnit(unit.id);
         },
 
         /**

--- a/test/test_machine_view_panel.js
+++ b/test/test_machine_view_panel.js
@@ -187,8 +187,11 @@ describe('machine view panel view', function() {
     });
 
     it('creates a new machine when dropped on machine header', function() {
+      var toggleStub = utils.makeStubMethod(view, '_toggleAllPlacedMessage');
+      this._cleanups.push(toggleStub.reset);
       view._unitTokenDropHandler({
-        dropAction: 'machine'
+        dropAction: 'machine',
+        unit: 'test/1'
       });
       var env = view.get('env');
       assert.deepEqual(env.addMachines.lastArguments()[0], [{
@@ -197,14 +200,17 @@ describe('machine view panel view', function() {
         constraints: {}
       }]);
       var placeArgs = env.placeUnit.lastArguments();
-      assert.strictEqual(placeArgs[0], null);
+      assert.strictEqual(placeArgs[0].id, 'test/1');
       assert.equal(placeArgs[1], 'foo');
     });
 
     it('creates new container when dropped on container header', function() {
+      var toggleStub = utils.makeStubMethod(view, '_toggleAllPlacedMessage');
+      this._cleanups.push(toggleStub.reset);
       view.set('selectedMachine', '5');
       view._unitTokenDropHandler({
-        dropAction: 'container'
+        dropAction: 'container',
+        unit: 'test/1'
       });
       var env = view.get('env');
       assert.deepEqual(env.addMachines.lastArguments()[0], [{
@@ -213,14 +219,17 @@ describe('machine view panel view', function() {
         constraints: {}
       }]);
       var placeArgs = env.placeUnit.lastArguments();
-      assert.strictEqual(placeArgs[0], null);
+      assert.strictEqual(placeArgs[0].id, 'test/1');
       assert.equal(placeArgs[1], 'foo');
     });
 
     it('creates a new container when dropped on a machine', function() {
+      var toggleStub = utils.makeStubMethod(view, '_toggleAllPlacedMessage');
+      this._cleanups.push(toggleStub.reset);
       view._unitTokenDropHandler({
         dropAction: 'container',
-        targetId: '0'
+        targetId: '0',
+        unit: 'test/1'
       });
       var env = view.get('env');
       assert.deepEqual(env.addMachines.lastArguments()[0], [{
@@ -229,20 +238,23 @@ describe('machine view panel view', function() {
         constraints: {}
       }]);
       var placeArgs = env.placeUnit.lastArguments();
-      assert.strictEqual(placeArgs[0], null);
+      assert.strictEqual(placeArgs[0].id, 'test/1');
       assert.equal(placeArgs[1], 'foo');
     });
 
     it('places the unit on an already existing container', function() {
+      var toggleStub = utils.makeStubMethod(view, '_toggleAllPlacedMessage');
+      this._cleanups.push(toggleStub.reset);
       view._unitTokenDropHandler({
         dropAction: 'container',
-        targetId: '0/lxc/1'
+        targetId: '0/lxc/1',
+        unit: 'test/1'
       });
       var env = view.get('env');
       // The machine is already created so we don't need to create a new one.
       assert.equal(env.addMachines.callCount(), 0);
       var placeArgs = env.placeUnit.lastArguments();
-      assert.strictEqual(placeArgs[0], null);
+      assert.strictEqual(placeArgs[0].id, 'test/1');
       assert.equal(placeArgs[1], '0/lxc/1');
     });
   });
@@ -346,7 +358,7 @@ describe('machine view panel view', function() {
           constraints: constraints
         }], 'A new machine should have been created');
         var placeArgs = env.placeUnit.lastArguments();
-        assert.strictEqual(placeArgs[0].id, 'test/0',
+        assert.strictEqual(placeArgs[0].id, 'test/1',
             'The correct unit should be placed');
         assert.equal(placeArgs[1], '7',
             'The unit should be placed on the new machine');
@@ -354,7 +366,7 @@ describe('machine view panel view', function() {
       });
       // Move the unit.
       unplacedUnit.fire('moveToken', {
-        unit: {id: 'test/0'},
+        unit: {id: 'test/1'},
         machine: 'new',
         container: undefined,
         constraints: constraints
@@ -378,7 +390,7 @@ describe('machine view panel view', function() {
           constraints: constraints
         }], 'A new machine should have been created');
         var placeArgs = env.placeUnit.lastArguments();
-        assert.strictEqual(placeArgs[0].id, 'test/0',
+        assert.strictEqual(placeArgs[0].id, 'test/1',
             'The correct unit should be placed');
         assert.equal(placeArgs[1], '7',
             'The unit should be placed on the new machine');
@@ -386,7 +398,7 @@ describe('machine view panel view', function() {
       });
       // Move the unit.
       unplacedUnit.fire('moveToken', {
-        unit: {id: 'test/0'},
+        unit: {id: 'test/1'},
         machine: 'new',
         container: undefined,
         constraints: constraints
@@ -410,7 +422,7 @@ describe('machine view panel view', function() {
           constraints: constraints
         }], 'A new container should have been created');
         var placeArgs = env.placeUnit.lastArguments();
-        assert.strictEqual(placeArgs[0].id, 'test/0',
+        assert.strictEqual(placeArgs[0].id, 'test/1',
             'The correct unit should be placed');
         assert.equal(placeArgs[1], '7',
             'The unit should be placed on the new container');
@@ -418,7 +430,7 @@ describe('machine view panel view', function() {
       });
       // Move the unit.
       unplacedUnit.fire('moveToken', {
-        unit: {id: 'test/0'},
+        unit: {id: 'test/1'},
         machine: '4',
         container: 'new-kvm',
         constraints: constraints
@@ -437,7 +449,7 @@ describe('machine view panel view', function() {
           constraints: {}
         }], 'A new container should have been created');
         var placeArgs = env.placeUnit.lastArguments();
-        assert.strictEqual(placeArgs[0].id, 'test/0',
+        assert.strictEqual(placeArgs[0].id, 'test/1',
             'The correct unit should be placed');
         assert.equal(placeArgs[1], '7',
             'The unit should be placed on the new container');
@@ -445,7 +457,7 @@ describe('machine view panel view', function() {
       });
       // Move the unit.
       unplacedUnit.fire('moveToken', {
-        unit: {id: 'test/0'},
+        unit: {id: 'test/1'},
         machine: '4',
         container: 'new-lxc',
         constraints: {}
@@ -466,7 +478,7 @@ describe('machine view panel view', function() {
         assert.equal(env.addMachines.lastArguments(), undefined,
             'No machines or containers should have been created');
         var placeArgs = env.placeUnit.lastArguments();
-        assert.strictEqual(placeArgs[0].id, 'test/0',
+        assert.strictEqual(placeArgs[0].id, 'test/1',
             'The correct unit should be placed');
         assert.equal(placeArgs[1], '4',
             'The unit should be placed on the bare metal of the machine');
@@ -474,7 +486,7 @@ describe('machine view panel view', function() {
       });
       // Move the unit.
       unplacedUnit.fire('moveToken', {
-        unit: {id: 'test/0'},
+        unit: {id: 'test/1'},
         machine: '4',
         container: 'bare-metal',
         constraints: constraints
@@ -495,7 +507,7 @@ describe('machine view panel view', function() {
         assert.equal(env.addMachines.lastArguments(), undefined,
             'No machines or containers should have been created');
         var placeArgs = env.placeUnit.lastArguments();
-        assert.strictEqual(placeArgs[0].id, 'test/0',
+        assert.strictEqual(placeArgs[0].id, 'test/1',
             'The correct unit should be placed');
         assert.equal(placeArgs[1], '4/lxc/2',
             'The unit should be placed on the container');
@@ -503,10 +515,30 @@ describe('machine view panel view', function() {
       });
       // Move the unit.
       unplacedUnit.fire('moveToken', {
-        unit: {id: 'test/0'},
+        unit: {id: 'test/1'},
         machine: '4',
         container: '4/lxc/2',
         constraints: constraints
+      });
+    });
+
+    it('removes the unit token when it has been placed', function(done) {
+      view.render();
+      var unplacedUnit = container.one('.unplaced .unplaced-unit');
+      var unitTokens = view.get('unitTokens');
+      assert.equal(Object.keys(unitTokens).length, 1);
+      unplacedUnit.on('moveToken', function(e) {
+        view._placeServiceUnit(e);
+        assert.equal(Object.keys(unitTokens).length, 0);
+        assert.equal(container.one('.unplaced .unplaced-unit'), null);
+        done();
+      });
+      // Move the unit.
+      unplacedUnit.fire('moveToken', {
+        unit: {id: 'test/1'},
+        machine: 'new',
+        container: undefined,
+        constraints: {}
       });
     });
   });


### PR DESCRIPTION
This branch removes the unplaced unit token once it has been placed. A followup branch will create the new token once placeUnit has been fixed.

I had to fix up a bunch of tests so that the removal worked in those tests.

QA:
- Drag a service to the canvas.
- Open the machine view.
- Drag and drop the unplaced unit on 'Create new machine'.
- The unplaced unit token should disappear.
