### PR TITLE
Improve machine creation and unit placement.

### DIFF
--- a/app/models/models.js
+++ b/app/models/models.js
@@ -991,6 +991,8 @@ YUI.add('juju-models', function(Y) {
 
   var MachineList = Y.Base.create('machineList', Y.LazyModelList, [], {
     model: Machine,
+    _ghostCounter: 0,
+
     /**
      * Create a display name that can be used in the views as an entity label
      * agnostic from juju type.
@@ -1100,6 +1102,33 @@ YUI.add('juju-models', function(Y) {
       }
       var result = MachineList.superclass.add.apply(this, arguments);
       return result;
+    },
+
+    /**
+      Adds a ghost machine to this list.
+
+      @method addGhost
+      @param {String} parentId When adding a new container, this parameter can
+        be used to place it into a specific machine, in which case the
+        containerType must also be specified.
+      @param {String} containerType The container type of the new machine
+        (e.g. "lxc").
+      @param {Object} attrs The initial machine attributes.
+      @return {Object} The newly created model instance.
+    */
+    addGhost: function(parentId, containerType, attrs) {
+      var obj = attrs ? Y.clone(attrs) : Object.create(null);
+      // Define the fully qualified ghost machine identifier.
+      obj.id = 'new' + this._ghostCounter;
+      this._ghostCounter += 1;
+      if (parentId) {
+        if (!containerType) {
+          throw new Error('parent id specified without a container type');
+        }
+        obj.id = parentId + '/' + containerType + '/' + obj.id;
+      }
+      // Add the new machine to the database.
+      return this.add(obj);
     },
 
     /**


### PR DESCRIPTION
Implement an db.machines.addGhost method, used
to create new ghost machines/containers.

Ghost machine creation is then handled by
machine view panel code: when a new machine must be
created the view now is responsible for adding the
new model instance and for executing the corresponding
env/ecs call.

Some docstring drive-by fixes.

QA:
- make devel;
- use the mv flag;
- disable the simulator;
- drag a service and then switch to machine view;
- drag the unplaced unit token on the "Create Machine" header;
- you should see a new0 ghost machine in the machines column;
- click deploy and confirm;
- now you should see a machine 0 in the machines column. 
  Note that the sometimes unit seems not to be there, but it's 
  displayed in "Bare metal" if you click the machine token.
  Switching to service view and back to the machine view seems
  to fix this issue, which fix is outside of this branch scope.
- done, thank you!
