### PR TITLE
Remove caching ability

### DIFF
--- a/app/store/charmworld.js
+++ b/app/store/charmworld.js
@@ -59,31 +59,15 @@ YUI.add('juju-charm-store', function(Y) {
         apiEndpoint = apiEndpoint + '?' + Y.QueryString.stringify(args);
       }
 
-      // XXX the following is commented out due to an issue with the UI thread
-      // locking up when rendering the charm token widgets; the cache makes
-      // this very evident. Uncomment when a path forward is found for the
-      // widget rendering. Note that this also involves a skipped test in
-      // test/test_charmworld.js - Makyo 2014-06-04
-      /*
-      var cachedResults = this.get('cachedResults')[apiEndpoint];
-      if (cachedResults) {
-        callbacks.success(cachedResults);
-        // If we do not return from here, we will wind up making another
-        // request below.
-        return;
-      }
-      */
-
       return this.sendRequest({
         request: apiEndpoint,
         callback: {
-          'success': Y.bind(function(io_request) {
+          'success': function(io_request) {
             var res = Y.JSON.parse(
                 io_request.response.results[0].responseText
                 );
-            this.get('cachedResults')[io_request.request] = res;
             callbacks.success(res);
-          }, this),
+          },
 
           'failure': function(io_request) {
             var respText = io_request.response.results[0].responseText,
@@ -130,16 +114,6 @@ YUI.add('juju-charm-store', function(Y) {
 
   }, {
     ATTRS: {
-      /**
-       * Cached results from non-charm requests.
-       *
-       * @attribute cachedResults
-       * @default empty
-       * @type {Object}
-       */
-      cachedResults: {
-        value: {}
-      }
     }
   });
 

--- a/test/test_charmworld.js
+++ b/test/test_charmworld.js
@@ -105,55 +105,6 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       api.destroy();
     });
 
-    // XXX Skip until widget rendering issue is taken care of; see comment
-    // in app/store/charmworld.js for more info. Makyo 2014-06-04
-    it.skip('caches data loaded from charmworld', function(done) {
-      var data = [];
-      var stubSendRequest;
-      var self = this;
-
-      data.push({responseText: Y.JSON.stringify({summary: 'wowza'})});
-      api.set('datasource', new Y.DataSource.Local({source: data}));
-
-      // Make a first call to interesting, which should request the data
-      // from the data source.
-      api.interesting({
-        success: function(data) {
-          stubSendRequest = utils.makeStubMethod(api.apiHelper,
-              'sendRequest');
-          this._cleanups.push(stubSendRequest.reset);
-          setTimeout(function() {
-            assert.deepEqual(api.apiHelper.get('cachedResults'), {
-              'search/interesting': { summary: 'wowza' }
-            });
-            requestAgain.call(this);
-          }, 0);
-        },
-        failure: function(data, request) {
-        }
-      }, this);
-
-      // Ensure that the sendRequest method is not called a second time.
-      // Additionally, make sure that we still receive the same data from
-      // the cache.
-      function requestAgain() {
-        api.interesting({
-          success: function(data) {
-            setTimeout(function() {
-              assert.deepEqual(api.apiHelper.get('cachedResults'), {
-                'search/interesting': { summary: 'wowza' }
-              });
-              // Cached results were returned without a request being made.
-              assert.equal(stubSendRequest.callCount(), 0);
-              done();
-            }, 0);
-          },
-          failure: function(data, request) {
-          }
-        }, self);
-      }
-    });
-
     it('provides an in flight request abort method', function() {
       var transaction = {
         abort: utils.makeStubFunction()


### PR DESCRIPTION
This hides caching ability until the UI lockup involved in rendering the charm token widgets is cleared up.  QA to ensure that search, interesting, and inspectors transition as expected.
