### PR TITLE
Move "Destroy Service" link and icon into the inspector footer.

### DIFF
--- a/app/templates/service-config-wrapper.handlebars
+++ b/app/templates/service-config-wrapper.handlebars
@@ -32,5 +32,7 @@
     </li>
   </ul>
   <div class="viewlet-container"></div>
-  <div class="viewlet-manager-footer"></div>
+  <div class="viewlet-manager-footer">
+    {{>service-destroy}}
+  </div>
 </div>

--- a/app/templates/serviceOverview.handlebars
+++ b/app/templates/serviceOverview.handlebars
@@ -17,5 +17,4 @@
     </ul>
   {{/unless}}
   {{>service-expose}}
-  {{>service-destroy}}
 </div>


### PR DESCRIPTION
This ticket moves the link into the footer for the service inspector. This change is consistent with the ghost inspector, which already has the same link in the footer.
### QA
1. Drag a charm to the canvas and deploy it.
2. Drag a second charm to the canvas, but don't deploy it.
3. Click on the deployed service and verify that the "Destroy Service" link is anchored to the bottom of the inspector (expand some of the unit info so that you activate scrolling).
4. Click on the ghost service and verify that the location and appearance of this link is consistent between the two different types of inspectors.
5. Verify that the link and icon work as expected in both types of inspectors.
