### PR TITLE
Display constraints when creating a machine

### DIFF
--- a/app/modules-debug.js
+++ b/app/modules-debug.js
@@ -263,6 +263,10 @@ var GlobalConfig = {
           fullpath: '/juju-ui/widgets/container-token.js'
         },
 
+        'juju-create-machine-view': {
+          fullpath: '/juju-ui/widgets/create-machine-view.js'
+        },
+
         'juju-deployer-bar': {
           fullpath: '/juju-ui/widgets/deployer-bar.js'
         },
@@ -323,6 +327,7 @@ var GlobalConfig = {
             'juju-templates',
             'juju-notifications',
             'juju-help-dropdown',
+            'juju-create-machine-view',
             'juju-deployer-bar',
             'juju-environment-header',
             'juju-machine-token',

--- a/app/templates/constraints-form.partial
+++ b/app/templates/constraints-form.partial
@@ -1,0 +1,8 @@
+<form class="constraints">
+  <input type="text" name="cpu">
+  <label>CPU (GHz)</label>
+  <input type="text" name="ram">
+  <label>RAM (GB)</label>
+  <input type="text" name="disk">
+  <label>Disk (TB)</label>
+</form>

--- a/app/templates/create-machine-view.handlebars
+++ b/app/templates/create-machine-view.handlebars
@@ -1,0 +1,6 @@
+Define constraints
+{{>constraints-form}}
+<div class="actions">
+  <span class="cancel secondary-action">Cancel</span> |
+  <span class="create primary-action">Create</span>
+</div>

--- a/app/templates/machine-view-panel.handlebars
+++ b/app/templates/machine-view-panel.handlebars
@@ -12,6 +12,7 @@
 <div class="column machines">
   <div class="head"></div>
   <div class="content">
+    <div class="create-machine"></div>
     <ul class="items"></ul>
   </div>
 </div>

--- a/app/templates/serviceunit-token.handlebars
+++ b/app/templates/serviceunit-token.handlebars
@@ -28,14 +28,7 @@
       <option value="new-kvm" class="default">new kvm</option>
     </select>
   </div>
-  <form class="constraints">
-    <input type="text" name="cpu">
-    <label>CPU (GHz)</label>
-    <input type="text" name="ram">
-    <label>RAM (GB)</label>
-    <input type="text" name="disk">
-    <label>Disk (TB)</label>
-  </form>
+  {{>constraints-form}}
   <div class="actions">
     <span class="cancel secondary-action">Cancel</span> |
     <span class="move primary-action">Move</span>

--- a/app/widgets/create-machine-view.js
+++ b/app/widgets/create-machine-view.js
@@ -1,0 +1,140 @@
+/*
+This file is part of the Juju GUI, which lets users view and manage Juju
+environments within a graphical interface (https://launchpad.net/juju-gui).
+Copyright (C) 2012-2013 Canonical Ltd.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU Affero General Public License version 3, as published by
+the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero
+General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along
+with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+'use strict';
+
+/**
+  Provide the create machine view.
+
+  @module views
+*/
+
+YUI.add('create-machine-view', function(Y) {
+
+  var views = Y.namespace('juju.views'),
+      widgets = Y.namespace('juju.widgets'),
+      Templates = views.Templates;
+
+  /**
+    The view associated with creating a machine.
+
+    @class CreateMachineView
+  */
+  var CreateMachineView = Y.Base.create('CreateMachineView', Y.View,
+      [
+        Y.Event.EventTracker
+      ], {
+        template: Templates['create-machine-view'],
+
+        events: {
+          '.cancel': {
+            click: '_handleCancel'
+          },
+          '.create': {
+            click: '_handleCreate'
+          }
+        },
+
+        /**
+          Handle cancelling creating a machine.
+
+          @method _handleCancel
+          @param {Event} ev the click event created.
+        */
+        _handleCancel: function(e) {
+          e.preventDefault();
+          this.fire('cancelCreateMachine', {
+            unit: this.get('unit')
+          });
+          this.destroy();
+        },
+
+        /**
+          Handle firing the event to create a machine.
+
+          @method _handleCreate
+          @param {Event} ev the click event created.
+        */
+        _handleCreate: function(e) {
+          e.preventDefault();
+          this.fire('createMachine', {
+            unit: this.get('unit'),
+            constraints: this._getConstraints()
+          });
+          this.destroy();
+        },
+
+        /**
+          Get the constraints from the form values.
+
+          @method _getConstraints
+        */
+        _getConstraints: function() {
+          var constraintsForm = this.get('container').one('.constraints');
+          return {
+            'cpu-power': constraintsForm.one('input[name="cpu"]').get('value'),
+            mem: constraintsForm.one('input[name="ram"]').get('value'),
+            'root-disk': constraintsForm.one('input[name="disk"]').get('value')
+          };
+        },
+
+        /**
+          Sets up the DOM nodes and renders them to the DOM.
+
+          @method render
+        */
+        render: function() {
+          var container = this.get('container');
+          container.setHTML(this.template());
+          container.addClass('create-machine-view');
+          return this;
+        },
+
+        /**
+          Removes the view container and all its contents.
+
+          @method destructor
+        */
+        destructor: function() {
+          var container = this.get('container');
+          container.setHTML('');
+          container.removeClass('create-machine-view');
+        },
+
+        ATTRS: {
+          /**
+            @attribute unit
+            @default undefined
+            @type {Object}
+          */
+          unit: {}
+        }
+      });
+
+  views.CreateMachineView = CreateMachineView;
+
+}, '0.1.0', {
+  requires: [
+    'view',
+    'juju-view-utils',
+    'event-tracker',
+    'node',
+    'handlebars',
+    'juju-templates'
+  ]
+});

--- a/app/widgets/machine-view-panel.js
+++ b/app/widgets/machine-view-panel.js
@@ -115,6 +115,16 @@ YUI.add('machine-view-panel', function(Y) {
         },
 
         /**
+          Handle the action in the machines header being fired.
+
+         @method _handleMachinesHeaderAction
+         @param {Y.Event} e EventFacade object.
+        */
+        _handleMachinesHeaderAction: function(e) {
+          this._displayCreateMachine();
+        },
+
+        /**
           Handle changes to the units in the db unit model list.
 
          @method _onUnitChange
@@ -152,14 +162,22 @@ YUI.add('machine-view-panel', function(Y) {
          @param {Object} e Custom model change event facade.
         */
         _onUnitAdd: function(e) {
+          var unit = e.model;
+          if (!unit.machine) {
+            this._createServiceUnitToken(unit);
+          }
+        },
+
+        /**
+          Handle creating and rendering the token for the unit.
+
+         @method _createServiceUnitToken
+         @param {Object} unit The unit to create the token for.
+        */
+        _createServiceUnitToken: function(unit) {
           var token,
               unitTokens = this.get('unitTokens'),
-              unit = e.model,
               node = Y.Node.create('<li></li>');
-          // Ignore placed units
-          if (unit.machine) {
-            return;
-          }
           this._addIconToUnit(unit);
           token = new views.ServiceUnitToken({
             container: node,
@@ -320,19 +338,64 @@ YUI.add('machine-view-panel', function(Y) {
           var containerType = (dropAction === 'container') ? 'lxc' : undefined;
           var db = this.get('db');
           var unit = db.units.getById(evt.unit);
-          var placeId;
 
           if (dropAction === 'container' &&
               (parentId && parentId.indexOf('/') !== -1)) {
             // If the user drops a unit on an already created container then
             // place the unit.
-            placeId = parentId;
-          } else {
+            this._placeUnit(unit, parentId);
+          } else if (dropAction === 'container') {
             var machine = this._createMachine(containerType,
                 parentId || selected, {});
-            placeId = machine.id;
+            this._placeUnit(unit, machine.id);
+          } else {
+            this._displayCreateMachine(unit);
           }
-          this._placeUnit(unit, placeId);
+        },
+
+        /**
+          Show the widget to create a machine with constraints.
+
+          @method _displayCreateMachine
+          @param {Object} unit The unit to place on the machine.
+        */
+        _displayCreateMachine: function(unit) {
+          var createMachine = new views.CreateMachineView({
+            container: this.get('container').one('.create-machine'),
+            unit: unit
+          }).render();
+          if (unit) {
+            this._removeUnit(unit.id);
+          }
+          this.addEvent(createMachine.on(
+              'createMachine', this._handleCreateMachine, this));
+          this.addEvent(createMachine.on(
+              'cancelCreateMachine', this._handleCancelCreateMachine, this));
+        },
+
+        /**
+          Handle creating a machine from a createMachine event.
+
+          @method _handleCreateMachine
+          @param {Object} unit The event.
+        */
+        _handleCreateMachine: function(e) {
+          var machine = this._createMachine(undefined, null, e.constraints);
+          if (e.unit) {
+            this.get('env').placeUnit(e.unit, machine.id);
+          }
+        },
+
+        /**
+          Handle cancelling creating a machine.
+
+          @method _handleCancelCreateMachine
+          @param {Object} unit The event.
+        */
+        _handleCancelCreateMachine: function(e) {
+          if (e.unit) {
+            this._createServiceUnitToken(e.unit);
+          }
         },
 
         /**
@@ -498,6 +561,8 @@ YUI.add('machine-view-panel', function(Y) {
                 dropLabel: 'Create new machine'
               });
           this._machinesHeader.addTarget(this);
+          this.addEvent(this._machinesHeader.on(
+              'actionFired', this._handleMachinesHeaderAction, this));
           this._containersHeader = this._renderHeader(
               '.column.containers .head', {
                 action: 'container',
@@ -870,6 +935,7 @@ YUI.add('machine-view-panel', function(Y) {
     'juju-templates',
     'juju-view-utils',
     'container-token',
+    'create-machine-view',
     'machine-token',
     'machine-view-panel-header',
     'node',

--- a/lib/views/machine-view/create-machine-view.less
+++ b/lib/views/machine-view/create-machine-view.less
@@ -1,0 +1,44 @@
+.machine-view-panel .create-machine-view {
+    margin: 10px;
+    padding: 0 10px;
+    background-color: #eee;
+    border-width: 1px 0;
+    border-style: solid;
+    border-color: @machine-view-border-colour;
+    line-height: 38px;
+
+    input[type="text"],
+    select {
+        width: 100%;
+    }
+    input[type="text"] {
+        .border-box;
+        margin-bottom: 6px;
+        background-color: #fff;
+
+        &:last-of-type {
+            margin-bottom: 0;
+        }
+    }
+    form label {
+        position: relative;
+        float: right;
+        margin: -36px 10px 0 0;
+        color: #c6c1bb;
+        line-height: 30px;
+
+        &:last-of-type {
+            margin-top: -33px;
+        }
+    }
+    .actions {
+        text-align: right;
+
+        span {
+            cursor: pointer;
+        }
+        .primary-action {
+            color: @charm-panel-orange;
+        }
+    }
+}

--- a/lib/views/machine-view/machine-view-token-base.less
+++ b/lib/views/machine-view/machine-view-token-base.less
@@ -3,10 +3,18 @@
     position: relative;
     display: block;
     min-height: 40px;
+    // This is so the top border wraps over the header border if there
+    // is nothing about the first token.
+    margin-top: -1px;
     padding: 10px 20px;
-    border-bottom: 1px solid @machine-view-border-colour;
+    border-width: 1px 0 0 0;
+    border-style: solid;
+    border-color: @machine-view-border-colour;
     cursor: pointer;
 
+    &:last-child {
+        border-bottom-width: 1px;
+    }
     &.active {
         background-color: #eee;
 

--- a/lib/views/stylesheet.less
+++ b/lib/views/stylesheet.less
@@ -931,6 +931,7 @@ g.unit {
 @import "browser/tabview.less";
 @import "machine-view/serviceunit-token.less";
 @import "machine-view/container-token.less";
+@import "machine-view/create-machine-view.less";
 @import "machine-view/machine-token.less";
 @import "machine-view/machine-view-panel.less";
 @import "machine-view/machine-view-token-base.less";

--- a/test/index.html
+++ b/test/index.html
@@ -99,6 +99,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
   <script src="test_console.js"></script>
   <script src="test_container_token.js"></script>
   <script src="test_cookies_app_extension.js"></script>
+  <script src="test_create_machine_view.js"></script>
   <script src="test_databinding.js"></script>
   <script src="test_d3_components.js"></script>
   <script src="test_d3_status.js"></script>

--- a/test/test_create_machine_view.js
+++ b/test/test_create_machine_view.js
@@ -1,0 +1,105 @@
+/*
+This file is part of the Juju GUI, which lets users view and manage Juju
+environments within a graphical interface (https://launchpad.net/juju-gui).
+Copyright (C) 2012-2013 Canonical Ltd.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU Affero General Public License version 3, as published by
+the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero
+General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along
+with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+'use strict';
+
+
+describe('create machine view', function() {
+  var Y, container, machine, models, utils, views, view, View;
+
+  before(function(done) {
+    Y = YUI(GlobalConfig).use(['create-machine-view',
+                               'juju-models',
+                               'juju-views',
+                               'juju-tests-utils',
+                               'event-simulate',
+                               'node-event-simulate',
+                               'node'], function(Y) {
+
+      models = Y.namespace('juju.models');
+      utils = Y.namespace('juju-tests.utils');
+      views = Y.namespace('juju.views');
+      View = views.CreateMachineView;
+      done();
+    });
+  });
+
+  beforeEach(function() {
+    container = utils.makeContainer(this, 'create-machine-view');
+    view = new View({
+      container: container,
+      unit: {id: 'test/1'}
+    }).render();
+  });
+
+  afterEach(function() {
+    view.destroy();
+    container.remove(true);
+  });
+
+  it('should apply the wrapping class to the container', function() {
+    assert.equal(container.hasClass('create-machine-view'), true);
+  });
+
+  it('should clean up properly on destroy', function() {
+    view.destroy();
+    assert.equal(container.hasClass('create-machine-view'), false);
+    assert.equal(container.getHTML(), '');
+  });
+
+  it('should handle the cancel action', function(done) {
+    var cancelFired = false;
+    var destroyStub = utils.makeStubMethod(view, 'destroy');
+    this._cleanups.push(destroyStub.reset);
+    view.on('cancelCreateMachine', function(e) {
+      cancelFired = true;
+      assert.equal(e.unit.id, 'test/1');
+      done();
+    });
+    container.one('.cancel').simulate('click');
+    assert.equal(destroyStub.calledOnce(), true,
+        'the view should have been destroyed');
+    assert.equal(cancelFired, true,
+        'the event should have been fired');
+  });
+
+  it('should handle the create action', function(done) {
+    var createFired = false;
+    var constraints = {
+      'cpu-power': '2',
+      mem: '4',
+      'root-disk': '7'
+    };
+    var constraintsStub = utils.makeStubMethod(view,
+        '_getConstraints', constraints);
+    this._cleanups.push(constraintsStub.reset);
+    var destroyStub = utils.makeStubMethod(view, 'destroy');
+    this._cleanups.push(destroyStub.reset);
+    view.on('createMachine', function(e) {
+      createFired = true;
+      assert.equal(e.unit.id, 'test/1');
+      assert.deepEqual(e.constraints, constraints);
+      done();
+    });
+    container.one('.create').simulate('click');
+    assert.equal(destroyStub.calledOnce(), true,
+        'the view should have been destroyed');
+    assert.equal(createFired, true,
+        'the event should have been fired');
+  });
+});

--- a/test/test_machine_view_panel.js
+++ b/test/test_machine_view_panel.js
@@ -177,6 +177,38 @@ describe('machine view panel view', function() {
 
   });
 
+  describe('create machine view', function() {
+    beforeEach(function() {
+      view.set('env', {
+        addMachines: utils.makeStubFunction('add-machine-record-key'),
+        placeUnit: utils.makeStubFunction()
+      });
+    });
+
+    it('displays when the machine header action is clicked', function() {
+      view.render();
+      var createMachine = container.one('.create-machine');
+      container.one('.machines .head .action').simulate('click');
+      assert.equal(createMachine.hasClass('create-machine-view'), true);
+      assert.equal(createMachine.getHTML() === '', false);
+    });
+
+    it('creates an unplaced unit when cancelled with a unit', function() {
+      var unitTokens = view.get('unitTokens');
+      var toggleStub = utils.makeStubMethod(view, '_toggleAllPlacedMessage');
+      this._cleanups.push(toggleStub.reset);
+      view.render();
+      view._unitTokenDropHandler({
+        dropAction: 'machine',
+        unit: 'test/1'
+      });
+      assert.equal(Object.keys(unitTokens).length, 0);
+      // Confirm the machine creation.
+      container.one('.create-machine-view .cancel').simulate('click');
+      assert.equal(Object.keys(unitTokens).length, 1);
+    });
+  });
+
   describe('token drag and drop', function() {
     beforeEach(function() {
       view.set('env', {
@@ -253,10 +285,20 @@ describe('machine view panel view', function() {
         unit: 'test/1'
       });
       var env = view.get('env');
+      // The create machine options should be visible.
+      var createMachine = container.one('.create-machine');
+      assert.equal(createMachine.hasClass('create-machine-view'), true);
+      assert.equal(createMachine.getHTML() === '', false);
+      // Confirm the machine creation.
+      container.one('.create-machine-view .create').simulate('click');
       assert.deepEqual(env.addMachines.lastArguments()[0], [{
         containerType: undefined,
-        parentId: undefined,
-        constraints: {}
+        parentId: null,
+        constraints: {
+          'cpu-power': '',
+          mem: '',
+          'root-disk': ''
+        }
       }]);
       // A new ghost machine has been added to the database.
       assert.isNotNull(machines.getById('new0'));


### PR DESCRIPTION
This adds the ability to select the constraints before creating a new machine.

QA:
- open the machine view
- click "Add machine"
- a constraints form should appear
- if you wish fill in some constraints
- click create
- a new machine token "new0" should appear

To test cancel with unplaced units:
- drag a service to the canvas
- open the machine view
- drag the unplaced unit to "Create new machine"
- the unplaced unit token should have been removed and a constraints form should appear
- click cancel
- the unplaced unit token should  reappear
