### PR TITLE
Hide drop targets when unit is dropped on a header

### DIFF
--- a/app/widgets/machine-view-panel.js
+++ b/app/widgets/machine-view-panel.js
@@ -328,6 +328,7 @@ YUI.add('machine-view-panel', function(Y) {
           var unit = db.units.getById(evt.unit);
           var placeId;
 
+          this._hideDraggingUI();
           if (dropAction === 'container' &&
               (parentId && parentId.indexOf('/') !== -1)) {
             // If the user drops a unit on an already created container then

--- a/test/test_machine_view_panel.js
+++ b/test/test_machine_view_panel.js
@@ -273,6 +273,25 @@ describe('machine view panel view', function() {
       assert.equal(view._containersHeader.setNotDroppable.calledOnce(), true);
     });
 
+    it('converts headers to non-drop targets when dropped on a header',
+        function() {
+          view.render();
+          view._machinesHeader = {
+            setNotDroppable: utils.makeStubFunction(),
+            updateLabelCount: utils.makeStubFunction()
+          };
+          view._containersHeader = {
+            setNotDroppable: utils.makeStubFunction()
+          };
+          view._unitTokenDropHandler({
+            dropAction: 'machine',
+            unit: 'test/1'
+          });
+          assert.equal(view._machinesHeader.setNotDroppable.calledOnce(), true);
+          assert.equal(view._containersHeader.setNotDroppable.calledOnce(),
+              true);
+        });
+
     it('creates a new machine when dropped on machine header', function() {
       var toggleStub = utils.makeStubMethod(view, '_toggleAllPlacedMessage');
       this._cleanups.push(toggleStub.reset);
@@ -341,6 +360,13 @@ describe('machine view panel view', function() {
     it('places the unit on an already existing container', function() {
       var toggleStub = utils.makeStubMethod(view, '_toggleAllPlacedMessage');
       this._cleanups.push(toggleStub.reset);
+      view._machinesHeader = {
+        setNotDroppable: utils.makeStubFunction(),
+        updateLabelCount: utils.makeStubFunction()
+      };
+      view._containersHeader = {
+        setNotDroppable: utils.makeStubFunction()
+      };
       view._unitTokenDropHandler({
         dropAction: 'container',
         targetId: '0/lxc/1',


### PR DESCRIPTION
This branch fixes a bug where dropping a unit on a header would leave the drop targets visible.

https://bugs.launchpad.net/juju-gui/+bug/1326240

QA:
- drag a service to the canvas
- open the machine view
- drag a unit to "Create new machine"
- the header should return to "Environment" (with the machine count etc.) and a new machine should be created

Dropping a unit on the containers header should also return the headers to the correct states.
