### PR TITLE
Render token types separately.

### DIFF
--- a/app/subapps/browser/views/charmbrowser.js
+++ b/app/subapps/browser/views/charmbrowser.js
@@ -151,6 +151,9 @@ YUI.add('juju-charmbrowser', function(Y) {
           tokenContainer = {},
           container = this.get('container'),
           charmList = container.one('.charm-list');
+      // Append the content of the template to the charmlist ahead of time
+      // so that we can render the token containers to the DOM as they're
+      // generated.
       charmList.append(content);
 
       tokenTypes.forEach(function(tokenType) {
@@ -163,6 +166,9 @@ YUI.add('juju-charmbrowser', function(Y) {
           side: 'small',
           isDraggable: true
         });
+        // Render the token container to the DOM as it is generated in order
+        // to reduce visible lag as the browser works on generating each
+        // token.
         tokenContainer.render(charmList.one('.' + tokenType));
         tokenContainers.push(tokenContainer);
       }, this);


### PR DESCRIPTION
Render each token container to the DOM separately for a quick win in speed on loading curated, etc.

QA with the frames timeline, ensure that FPS doesn't drop too far below 15.
