### PR TITLE
Visual changes from design review

### DIFF
--- a/app/templates/environment-header.handlebars
+++ b/app/templates/environment-header.handlebars
@@ -5,21 +5,5 @@
     <li class="tab machines">
         <a href="" data-view="machineView">Machines</a>
     </li>
-    <li class="search">
-        <form>
-            <input type="search" />
-            <input type="submit" value="" />
-        </form>
-    </li>
-    <li class="small">
-        <a href="">
-            <i class="sprite environment_share"></i>
-        </a>
-    </li>
-    <li class="tiny">
-        <a href="">
-            <i class="sprite environment_bubble"></i>
-            10
-        </a>
-    </li>
+    <li class="spacer"></li>
 </ul>

--- a/app/templates/inspector-header.handlebars
+++ b/app/templates/inspector-header.handlebars
@@ -11,10 +11,8 @@
         <div data-bind="displayName" class="service-name">{{displayName}}</div>
       {{/if}}
       <div {{#unless ghost}}data-bind="charm"{{/unless}}
-           data-charmid="{{charmUrl}}">{{charmUrl}}</div>
-      {{#unless pending}}
-        <div class="charm-url" data-charmid="{{charmUrl}}">Charm details</div>
-      {{/unless}}
+           data-charmid="{{charmUrl}}"
+           class="charm-url">{{charmUrl}}</div>
     </div>
     <div class="close">
         <i class="sprite inspector-close"></i>

--- a/lib/views/browser/main.less
+++ b/lib/views/browser/main.less
@@ -75,7 +75,7 @@
         z-index: 602;
         position: fixed;
         overflow: hidden;
-        top: 149px;
+        top: 89px + @navbar-height;
         height: 53px;
 
         &.current {

--- a/lib/views/dropdown.less
+++ b/lib/views/dropdown.less
@@ -1,7 +1,7 @@
 .dropdown-menu {
     position: relative;
     display: block;
-    margin: -20px -20px 0 -20px;
+    margin: -14px -20px 0 -20px;
 
     &.open {
         .menu-link {
@@ -24,7 +24,7 @@
         .border-box;
         display: block;
         height: @navbar-height;
-        padding: 20px 20px 0 20px;
+        padding: 14px 20px 0 20px;
         color: #d7d3d0;
 
         .expand {

--- a/lib/views/environment-header.less
+++ b/lib/views/environment-header.less
@@ -14,78 +14,43 @@
         list-style: none;
 
         li {
-            .environment-header-li(20px);
+            @spacer: 20px;
+
+            .flex-basis(auto);
+            padding: 0 @spacer;
             background-color: #eee;
+            border-width: 0 1px 1px 0;
+            border-style: solid;
+            border-right-color: #d9d9d9;
+            border-bottom-color: #cdcdcd;
+            line-height: @environment-header-height;
 
-            &.small {
-                .environment-header-li(15px);
+            &:last-child {
+                border-right: none;
             }
-            &.tiny {
-                .environment-header-li(10px);
+            &.tab {
+                &.active {
+                    &.services {
+                        background-color: transparent;
+                        border-bottom: none;
+                    }
+                    &.machines a {
+                        background-color: #fff;
+                    }
+                    a {
+                        height: @environment-header-height;
+                    }
+                }
             }
-        }
-    }
-}
-
-/* Mixins */
-
-.environment-header-li(@spacer) {
-    // The following styles are in a mixin so the styles can be munipulated
-    // by parent classes.
-    .flex-basis(auto);
-    padding: 0 @spacer;
-    border-width: 0 1px 1px 0;
-    border-style: solid;
-    border-right-color: #d9d9d9;
-    border-bottom-color: #cdcdcd;
-    line-height: @environment-header-height;
-
-    &:last-child {
-        border-right: none;
-    }
-    &.tab {
-        &.active {
-            &.services {
-                background-color: transparent;
-                border-bottom: none;
-            }
-            &.machines a {
-                background-color: #fff;
+            &.spacer {
+                .flex(1);
             }
             a {
-                height: @environment-header-height;
+                display: block;
+                margin: 0 (-@spacer);
+                padding: 0 @spacer;
+                color: @text-colour;
             }
         }
-    }
-    &.search {
-      .flex(1);
-      position: relative;
-      padding: 0;
-
-      input[type=search] {
-          box-sizing: border-box;
-          width: 100%;
-          height: @environment-header-height - 1;
-          padding-left: 40px;
-          background-color: transparent;
-          border: none;
-      }
-      input[type=submit] {
-          position: absolute;
-          top: 0;
-          left: 0;
-          width: @environment-header-height;
-          height: @environment-header-height - 1;
-          background: transparent
-              url(/juju-ui/assets/images/non-sprites/environment_search.png)
-              no-repeat center center;
-          border: none;
-      }
-    }
-    a {
-        display: block;
-        margin: 0 (-@spacer);
-        padding: 0 @spacer;
-        color: @text-colour;
     }
 }

--- a/lib/views/juju-inspector.less
+++ b/lib/views/juju-inspector.less
@@ -487,6 +487,10 @@
                 padding-top: 20px;
                 border-top: 1px solid @inspector-divider-top;
             }
+            .header-slot header .service-charm .charm-url {
+                cursor: auto;
+                text-decoration: none;
+            }
         }
 
         .control-description,
@@ -537,12 +541,13 @@
                     .icon,
                     .icon img {
                         /* Required for sizing images in IE10 */
-                        width: 30px;
-                        height: 30px;
+                        width: 50px;
+                        height: 50px;
 
                     }
                     .details-wrapper {
                         width: 180px;
+                        margin-top: 3px;
                         overflow: hidden;
                         white-space: nowrap;
                         text-overflow: ellipsis;
@@ -555,7 +560,7 @@
                         }
                         input.service-name {
                             display: block;
-                            width: 170px;
+                            width: 160px;
                             margin-bottom: 5px;
                         }
                     }
@@ -565,7 +570,9 @@
                     }
                     .close {
                         display: block;
-                        float: right;
+                        position: absolute;
+                        top: 20px;
+                        right: 20px;
                         cursor: pointer;
 
                         .sprite {

--- a/lib/views/stylesheet.less
+++ b/lib/views/stylesheet.less
@@ -51,7 +51,7 @@ This is a general guide on how to structure your classes.
 @environment-header-height: 40px;
 @left-panel-width: 290px;
 @machine-view-border-colour: #d9d9d9;
-@navbar-height: 60px;
+@navbar-height: 48px;
 @navbar-border-dark: #191514;
 @navbar-border-light: #2d2928;
 @text-colour: #505050;
@@ -200,7 +200,7 @@ th {
             .border-box;
             display: block;
             height: @navbar-height;
-            padding: 20px 20px 0 20px;
+            padding: 14px 20px 0 20px;
         }
         & > li {
             float: left;
@@ -235,7 +235,7 @@ th {
                 }
             }
             &.tab a {
-                margin: -20px -20px 0 -20px;
+                margin: -14px -20px 0 -20px;
 
                 &.active {
                     border-bottom: 3px solid @charm-panel-orange;
@@ -245,7 +245,7 @@ th {
                 }
             }
             &.import-export {
-                padding: 24px 0 0 0;
+                padding: 17px 0 0 0;
 
                 a {
                     .sprite-hover;


### PR DESCRIPTION
Made header 48px high.
QA:
- check the height of the main header
- check the Notifications and Help & feedback dropdowns are correctly positioned
- check the sticky headers in the sidebar are correctly positioned

Removed old items from environment header.
QA: The environment header should only have service and machine tabs.

Open unit details from charm name.
QA:
- drag a service to the canvas
- click deploy and confirm
- click on the service block
- click on the charm name below the service title (e.g. cs:precise/wordpress-22)
- the charm details should appear

Made inspector service icon larger
QA:
- drag a service to the canvas
- click deploy and confirm
- click on the service block
- the service icon should be 50x50px
