### PR TITLE
Remove initState call for the charmbrowser since it's all handled by the state class now

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -1309,11 +1309,6 @@ YUI.add('juju-gui', function(Y) {
     */
     showRootView: function() {
       this._navigate('/', { overrideAllNamespaces: true });
-      // Reset the view state of the subapps.
-      var subapps = this.get('subApps');
-      if (subapps.charmbrowser) {
-        subapps.charmbrowser.initState();
-      }
     },
 
     /**


### PR DESCRIPTION
This is the fix for: https://bugs.launchpad.net/juju-gui/+bug/1327424

The initState call was left in the app but it's no longer needed because the charmbrowser controls are all handled directly by the state class.
#### To QA

Click the Juju icon in the to left, no error? OK!
