### PR TITLE
Fixes the issues causing the local charm deployment story to be broken

### DIFF
--- a/app/subapps/browser/browser.js
+++ b/app/subapps/browser/browser.js
@@ -719,7 +719,6 @@ YUI.add('subapp-browser', function(Y) {
         env: this.get('env'),
         db: this.get('db')
       }).render();
-      inspector.recalculateHeight();
       inspector.addTarget(this);
       return inspector;
     },
@@ -736,7 +735,6 @@ YUI.add('subapp-browser', function(Y) {
         env: this.get('env'),
         db: this.get('db')
       }).render();
-      inspector.recalculateHeight();
       inspector.addTarget(this);
       return inspector;
     },

--- a/app/views/topology/service.js
+++ b/app/views/topology/service.js
@@ -696,6 +696,7 @@ YUI.add('juju-topology-service', function(Y) {
         sectionA: {
           component: 'inspector',
           metadata: {
+            id: null,
             localType: 'new',
             flash: {
               file: file
@@ -834,6 +835,7 @@ YUI.add('juju-topology-service', function(Y) {
         sectionA: {
           component: 'inspector',
           metadata: {
+            id: null,
             localType: 'update',
             flash: {
               file: file,

--- a/lib/views/juju-inspector.less
+++ b/lib/views/juju-inspector.less
@@ -520,10 +520,6 @@
         .viewlet-container {
             overflow-x: hidden;
             overflow-y: auto;
-            /* overwritten by the recalculateHeight() method in
-               viewlet-manager.js. Important to avoid flash of incorrectly
-               calculated height */
-            max-height: 250px;
         }
 
         .header-slot {

--- a/test/test_service_module.js
+++ b/test/test_service_module.js
@@ -675,10 +675,37 @@ describe('service module events', function() {
       sectionA: {
         component: 'inspector',
         metadata: {
+          id: null,
           localType: 'update',
           flash: {
             file: fileObj,
             services: services
+          }}}
+    });
+  });
+
+  it('_deployLocalCharm: calls to show the inspector', function() {
+    var dbObj = { db: 'db' };
+    var fileObj = { name: 'foo' };
+    var envObj = { env: 'env' };
+
+    serviceModule.set('component', {
+      fire: utils.makeStubFunction()
+    });
+
+    var fireStub = serviceModule.get('component').fire;
+
+    serviceModule._deployLocalCharm(fileObj, envObj, dbObj);
+    assert.equal(fireStub.callCount(), 1);
+    assert.equal(fireStub.lastArguments()[0], 'changeState');
+    assert.deepEqual(fireStub.lastArguments()[1], {
+      sectionA: {
+        component: 'inspector',
+        metadata: {
+          id: null,
+          localType: 'new',
+          flash: {
+            file: fileObj
           }}}
     });
   });


### PR DESCRIPTION
Fixes part of https://bugs.launchpad.net/juju-gui/+bug/1328941

This branch fixes some of the major issues with the local charm deployment story after switching to the new state system and left sidebar. The local charm inspectors need to be styled to fill up 100% of the height of the left side bar but that will be done in a follow-up
#### To QA

Make sure that the issues mentioned in the above bug are resolved and that the local charm deploy/upgrade story works as expected.
