### PR TITLE
Local inspectors properly display in sidebar

### DIFF
--- a/app/templates/local-new-upgrade.handlebars
+++ b/app/templates/local-new-upgrade.handlebars
@@ -1,4 +1,4 @@
-<div class="view-container">
+<div class="view-container local-new-upgrade">
 <h2>Upgrade Services</h2>
 <div class="view-content">
   <div class="settings-wrapper">

--- a/lib/views/juju-inspector.less
+++ b/lib/views/juju-inspector.less
@@ -108,6 +108,24 @@
             border-width: 0 1px;
             border-color: #1c1815;
         }
+        // XXX: Fix for local charm inspectors, can be removed when the
+        // new designs are implemented. huwshimi, 12 June 2014.
+        & > .viewlet-container {
+            position: absolute;
+            top: 0;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            background-color: @inspector-background-color;
+
+            .local-new-upgrade {
+                border-top: 1px solid rgba(0, 0, 0, 0.3);
+
+                h2 {
+                    border-top: 1px solid rgba(255, 255, 255, 0.05);
+                }
+            }
+        }
         form {
             margin: 0;
         }


### PR DESCRIPTION
Set the correct wrapping elements on the local charm inspectors so they display in the sidebar correctly.

QA:
- drop a zip of a charm onto the canvas
- check that the inspector that appears is the full height of the sidebar with the buttons at the bottom
- click "Upload"
- drop the same zip on the canvas again
- check that the new inspector that appears is the full height of the sidebar with the buttons at the bottom
