### PR TITLE
Disable the deploy button if there are no changes.

### DIFF
--- a/app/widgets/deployer-bar.js
+++ b/app/widgets/deployer-bar.js
@@ -100,6 +100,7 @@ YUI.add('deployer-bar', function(Y) {
         changeCount: changes
       }));
       container.addClass('deployer-bar');
+      this._toggleDeployButtonStatus(changes > 0);
       ecs.on('changeSetModified', Y.bind(this.update, this));
       return this;
     },
@@ -153,7 +154,9 @@ YUI.add('deployer-bar', function(Y) {
     */
     showDeployConfirmation: function(evt) {
       evt.halt();
-      this._showSummary();
+      if (this._getChangeCount(this.get('ecs')) > 0) {
+        this._showSummary();
+      }
     },
 
     /**
@@ -198,6 +201,7 @@ YUI.add('deployer-bar', function(Y) {
           changeCount: changes,
           latestChangeDescription: latest
         }));
+        this._toggleDeployButtonStatus(changes > 0);
         // XXX frankban 2014-05-12: the code below makes the changeset
         // description disappear the first time the panel is visited. Why
         // do we want this? This breaks the user experience, and after removing
@@ -218,6 +222,8 @@ YUI.add('deployer-bar', function(Y) {
       evt.halt();
       var container = this.get('container');
       container.removeClass('summary-open');
+
+      this._toggleDeployButtonStatus(this._getChangeCount(this.get('ecs')) > 0);
     },
 
     /**
@@ -258,6 +264,19 @@ YUI.add('deployer-bar', function(Y) {
     */
     _getChangeCount: function(ecs) {
       return Object.keys(ecs.changeSet).length;
+    },
+
+    /**
+      Toggle the status of the deploy button.
+
+      @method _toggleDeployButtonStatus
+    */
+    _toggleDeployButtonStatus: function(enabled) {
+      if (enabled) {
+        this.get('container').one('.deploy-button').removeClass('disabled');
+      } else {
+        this.get('container').one('.deploy-button').addClass('disabled');
+      }
     },
 
     /**

--- a/lib/views/deployer-bar.less
+++ b/lib/views/deployer-bar.less
@@ -29,6 +29,11 @@
             background-color: @charm-panel-orange;
             color: #fff;
             line-height: 30px;
+
+            &.disabled {
+                background: #999;
+                cursor: default;
+            }
         }
         .expand {
             margin-left: 10px;

--- a/test/test_deployer_bar.js
+++ b/test/test_deployer_bar.js
@@ -69,6 +69,26 @@ describe('deployer bar view', function() {
     assert.equal(view._getChangeCount(ecs), 1);
   });
 
+  it('should disabled the deploy button if there are no changes', function() {
+    assert.equal(container.one('.deploy-button').hasClass('disabled'), true);
+  });
+
+  it('should enable the deploy button if there are changes', function() {
+    ecs.lazyAddUnits(['django', 1]);
+    assert.equal(container.one('.deploy-button').hasClass('disabled'), false);
+  });
+
+  it('should not show the summary panel when there are no changes', function() {
+    container.one('.deploy-button').simulate('click');
+    assert.equal(container.hasClass('summary-open'), false);
+  });
+
+  it('should show the summary panel when there are changes', function() {
+    ecs.lazyAddUnits(['django', 1]);
+    container.one('.deploy-button').simulate('click');
+    assert.equal(container.hasClass('summary-open'), true);
+  });
+
   it('can show a summary of uncommitted changes for deployment', function() {
     var changesStub = utils.makeStubMethod(view, '_getChangeCount', 0),
         deployStub = utils.makeStubMethod(view, '_getDeployedServices', []),


### PR DESCRIPTION
The deploy button should be disabled when there is nothing to deploy.

QA:
- load the gui with the mv flag
- check that the deploy button is grey and that clicking on it does nothing
- drag a charm to the canvas
- the deploy button should be orange and clicking on it should open the summary panel
