### PR TITLE
Added new drag hover and drop states.

### DIFF
--- a/app/templates/container-token.handlebars
+++ b/app/templates/container-token.handlebars
@@ -13,4 +13,7 @@
   <span class="delete">
     <i class="sprite mv-token-destroy"></i>
   </span>
+  <div class="drop">
+    <span>Add to container {{ displayName }}</span>
+  </div>
 </div>

--- a/app/templates/machine-token.handlebars
+++ b/app/templates/machine-token.handlebars
@@ -25,4 +25,7 @@
   <span class="delete">
     <i class="sprite mv-token-destroy"></i>
   </span>
+  <div class="drop">
+    <span>Add to machine {{ displayName }}</span>
+  </div>
 </div>

--- a/app/utils/mv-drop-target-view-extension.js
+++ b/app/utils/mv-drop-target-view-extension.js
@@ -42,12 +42,12 @@ YUI.add('mv-drop-target-view-extension', function(Y) {
 
       @method _attachDragEvents
     */
-    _attachDragEvents: function(spec) {
+    _attachDragEvents: function() {
       var container = this.get('container');
-      // .token is the container of the machine/container token
-      spec = spec || '.token';
+      var spec = '.drop';
       container.delegate('drop', this._unitDropHandler, spec, this);
-      container.delegate('dragenter', this._ignore, spec, this);
+      container.delegate('dragenter', this._startHover, spec, this);
+      container.delegate('dragleave', this._stopHover, spec, this);
       container.delegate('dragover', this._ignore, spec, this);
     },
 
@@ -60,13 +60,40 @@ YUI.add('mv-drop-target-view-extension', function(Y) {
     */
     _unitDropHandler: function(e) {
       var dragData = JSON.parse(e._event.dataTransfer.getData('Text')),
-          currentTarget = e.currentTarget;
+          target = e.currentTarget.ancestor();
       this.fire('unit-token-drop', {
-        targetId: currentTarget.getData('id'),
-        dropAction: currentTarget.getData('drop-action'),
+        targetId: target.getData('id'),
+        dropAction: target.getData('drop-action'),
         unit: dragData.id,
         machine: this.get('machine')
       });
+      // Remove the hover state from the target.
+      this._stopHover(e);
+    },
+
+    /**
+      Handle a token dragged over a drop target.
+
+      @method _startHover
+      @param {Object} e The drop event object.
+    */
+    _startHover: function(e) {
+      // To allow a drop, we have to prevent the default handling by
+      // cancelling the dragenter event. See:
+      // https://developer.mozilla.org/en-US/docs/DragDrop
+      // /Drag_Operations#droptargets
+      this._ignore(e);
+      this.get('container').addClass('drop-hover');
+    },
+
+    /**
+      Handle a token stopping hovering a drop target.
+
+      @method _stopHover
+      @param {Object} e The drop event object.
+    */
+    _stopHover: function(e) {
+      this.get('container').removeClass('drop-hover');
     },
 
     /**

--- a/app/widgets/container-token.js
+++ b/app/widgets/container-token.js
@@ -48,6 +48,15 @@ YUI.add('container-token', function(Y) {
         },
 
         /**
+          Initialize events.
+
+          @method initializer
+        */
+        initializer: function() {
+          this._attachDragEvents(); // drop-target-view-extension
+        },
+
+        /**
          * Fire the delete event.
          *
          * @method handleDelete
@@ -79,6 +88,24 @@ YUI.add('container-token', function(Y) {
         },
 
         /**
+         * Change the token to the drop state.
+         *
+         * @method setDroppable
+         */
+        setDroppable: function() {
+          this.get('container').addClass('droppable');
+        },
+
+        /**
+         * Change the token back from drop state to the default state.
+         *
+         * @method setNotDroppable
+         */
+        setNotDroppable: function() {
+          this.get('container').removeClass('droppable');
+        },
+
+        /**
          * Sets up the DOM nodes and renders them to the DOM.
          *
          * @method render
@@ -98,7 +125,6 @@ YUI.add('container-token', function(Y) {
           // munipulate the dom, which we need for our namespaced code
           // to read.
           token.setAttribute('data-id', machine.id);
-          this._attachDragEvents(); // drop-target-view-extension
           this.get('containerParent').append(container);
           return this;
         }

--- a/app/widgets/machine-token.js
+++ b/app/widgets/machine-token.js
@@ -52,6 +52,15 @@ YUI.add('machine-token', function(Y) {
         },
 
         /**
+          Initialize events.
+
+          @method initializer
+        */
+        initializer: function() {
+          this._attachDragEvents(); // drop-target-view-extension
+        },
+
+        /**
          * Fire the delete event.
          *
          * @method handleDelete
@@ -91,6 +100,24 @@ YUI.add('machine-token', function(Y) {
         setCommitted: function() {
           this.set('committed', true);
           this.get('container').one('.token').removeClass('uncommitted');
+        },
+
+        /**
+         * Change the token to the drop state.
+         *
+         * @method setDroppable
+         */
+        setDroppable: function() {
+          this.get('container').addClass('droppable');
+        },
+
+        /**
+         * Change the token back from drop state to the default state.
+         *
+         * @method setNotDroppable
+         */
+        setNotDroppable: function() {
+          this.get('container').removeClass('droppable');
         },
 
         /**
@@ -141,7 +168,6 @@ YUI.add('machine-token', function(Y) {
           // manipulate the dom, which we need for our namespaced code
           // to read.
           token.setAttribute('data-id', machine.id);
-          this._attachDragEvents(); // drop-target-view-extension
           return this;
         },
 

--- a/app/widgets/machine-view-panel-header.js
+++ b/app/widgets/machine-view-panel-header.js
@@ -107,7 +107,7 @@ YUI.add('machine-view-panel-header', function(Y) {
          *
          * @method setDroppable
          */
-        setDroppable: function(label) {
+        setDroppable: function() {
           this.get('container').addClass('droppable');
         },
 
@@ -116,7 +116,7 @@ YUI.add('machine-view-panel-header', function(Y) {
          *
          * @method setNotDroppable
          */
-        setNotDroppable: function(label) {
+        setNotDroppable: function() {
           this.get('container').removeClass('droppable');
         },
 
@@ -131,7 +131,7 @@ YUI.add('machine-view-panel-header', function(Y) {
           container.setHTML(this.template(attrs));
           container.one('.drop').setData('drop-action', this.get('action'));
           container.addClass('machine-view-panel-header');
-          this._attachDragEvents('.drop');
+          this._attachDragEvents();
           return this;
         }
       });

--- a/app/widgets/machine-view-panel.js
+++ b/app/widgets/machine-view-panel.js
@@ -65,6 +65,7 @@ YUI.add('machine-view-panel', function(Y) {
           // Turn machine models into tokens and store internally.
           machines.forEach(function(machine) {
             var token = new views.MachineToken({
+              containerTemplate: '<li/>',
               machine: machine,
               committed: machine.id.indexOf('new') !== 0
             });
@@ -304,12 +305,23 @@ YUI.add('machine-view-panel', function(Y) {
           @param {Object} e Custom drag start event facade.
         */
         _showDraggingUI: function(e) {
+          var machineTokens = this.get('machineTokens');
+          var containerTokens = this.get('containerTokens');
           this._machinesHeader.setDroppable();
           // We only show that the container header is droppable if the user
           // has selected a machine as a parent already.
           if (this.get('selectedMachine')) {
             this._containersHeader.setDroppable();
           }
+          // Show the drop states for all visible machines and containers.
+          Object.keys(machineTokens).forEach(function(id) {
+            var token = machineTokens[id];
+            token.setDroppable();
+          }, this);
+          Object.keys(containerTokens).forEach(function(id) {
+            var token = containerTokens[id];
+            token.setDroppable();
+          }, this);
         },
 
         /**
@@ -319,8 +331,19 @@ YUI.add('machine-view-panel', function(Y) {
           @param {Object} e Custom drag end event facade.
         */
         _hideDraggingUI: function(e) {
+          var machineTokens = this.get('machineTokens');
+          var containerTokens = this.get('containerTokens');
           this._machinesHeader.setNotDroppable();
           this._containersHeader.setNotDroppable();
+          // Hide the drop states for all visible machines and containers.
+          Object.keys(machineTokens).forEach(function(id) {
+            var token = machineTokens[id];
+            token.setNotDroppable();
+          }, this);
+          Object.keys(containerTokens).forEach(function(id) {
+            var token = containerTokens[id];
+            token.setNotDroppable();
+          }, this);
         },
 
         /**
@@ -706,13 +729,11 @@ YUI.add('machine-view-panel', function(Y) {
 
           // Render each of the machine tokens out to a list
           machineIds.forEach(function(id) {
-            var token = machineTokens[id],
-                node = Y.Node.create('<li></li>');
-            token.set('container', node);
+            var token = machineTokens[id];
             this._updateMachineWithUnitData(token.get('machine'));
             token.render();
             token.addTarget(this);
-            nodeContainer.append(node);
+            nodeContainer.append(token.get('container'));
           }, this);
         },
 
@@ -726,9 +747,8 @@ YUI.add('machine-view-panel', function(Y) {
         _createMachineToken: function(machine, committed) {
           var token;
           var machineTokens = this.get('machineTokens');
-          var node = Y.Node.create('<li></li>');
           token = new views.MachineToken({
-            container: node,
+            containerTemplate: '<li/>',
             machine: machine,
             committed: committed
           });
@@ -736,7 +756,8 @@ YUI.add('machine-view-panel', function(Y) {
           this._updateMachineWithUnitData(machine);
           token.render();
           token.addTarget(this);
-          this.get('container').one('.machines .items').append(node);
+          this.get('container').one('.machines .items').append(
+              token.get('container'));
         },
 
         /**

--- a/lib/views/machine-view/machine-view-panel.less
+++ b/lib/views/machine-view/machine-view-panel.less
@@ -7,7 +7,7 @@
     bottom: 0;
     left: @bws-sidebar-width;
     right: 0;
-    padding: 10px 0 0 0;
+    padding: 0;
     background-color: #fff;
 
     input[type="text"] {
@@ -39,15 +39,29 @@
                 }
             }
         }
+        &.machines {
+            .content {
+                // Allow the token borders to overlap the column borders
+                // that would otherwise be hidden by overflow: hidden.
+                margin-left: -1px;
+                margin-right: -1px;
+                padding-left: 1px;
+                padding-right: 1px;
+            }
+        }
+        &.containers {
+            .content {
+                // Allow the token borders to overlap the column borders
+                // that would otherwise be hidden by overflow: hidden.
+                margin-left: -1px;
+                padding-left: 1px;
+            }
+        }
         .head {
             .flex-basis(auto);
             position: relative;
             padding: 20px;
-            border-bottom: 1px solid @machine-view-border-colour;
 
-            &.droppable .drop {
-                display: block;
-            }
             h3 {
                 .type3;
                 display: block;
@@ -68,24 +82,9 @@
             }
             .drop {
                 .type4;
-                display: none;
-                position: absolute;
-                top: 0;
-                bottom: 0;
-                left: 0;
-                right: 0;
-                background-color: #fff;
 
                 span {
-                    position: absolute;
-                    top: 0;
-                    bottom: 10px;
-                    left: 10px;
-                    right: 10px;
-                    display: block;
-                    border: 2px dashed #d6d3cf;
-                    text-align: center;
-                    line-height: 72px;
+                    margin-top: -13px;
                 }
             }
         }
@@ -93,11 +92,46 @@
             .flex(1);
             overflow-x: hidden;
             overflow-y: auto;
+            border-top: 1px solid @machine-view-border-colour;
 
             ul.items {
                 margin: 0;
                 list-style: none;
             }
+        }
+    }
+    .droppable {
+        &.drop-hover .drop {
+            background-color: #eee;
+        }
+        .drop {
+            display: block;
+
+            * {
+                // Set the children to not fire pointer events, specifically to
+                // not fire the enter events otherwise the parent will fire an
+                // exit event and the highlight will be removed.
+                pointer-events: none;
+            }
+        }
+    }
+    .drop {
+        display: none;
+        position: absolute;
+        top: -1px;
+        bottom: -1px;
+        left: -1px;
+        right: -1px;
+        background-color: #fff;
+        border: 1px dashed #d9d9d9;
+        text-align: center;
+
+        span {
+            position: absolute;
+            top: 50%;
+            left: 0;
+            right: 0;
+            margin-top: -13px;
         }
     }
 }

--- a/lib/views/machine-view/machine-view-token-base.less
+++ b/lib/views/machine-view/machine-view-token-base.less
@@ -71,4 +71,9 @@
             height: 20px;
         }
     }
+    .drop {
+        span {
+            margin-top: -9px;
+        }
+    }
 }

--- a/recess.json
+++ b/recess.json
@@ -2,6 +2,7 @@
   "compile": false,
   "noIDs": false,
   "noOverqualifying": false,
+  "noUniversalSelectors": false,
   "strictPropertyOrder": false,
   "zeroUnits": false
 }

--- a/test/test_container_token.js
+++ b/test/test_container_token.js
@@ -46,6 +46,7 @@ describe('container token view', function() {
     };
     view = new View({
       containerParent: container,
+      container: utils.makeContainer(this, 'container'),
       machine: machine
     }).render();
   });
@@ -56,7 +57,7 @@ describe('container token view', function() {
   });
 
   it('should apply the wrapping class to the container', function() {
-    assert.equal(container.one('> div').hasClass('container-token'), true);
+    assert.equal(view.get('container').hasClass('container-token'), true);
   });
 
   it('fires the delete event', function(done) {
@@ -89,10 +90,23 @@ describe('container token view', function() {
     assert.equal(typeof view._attachDragEvents, 'function');
   });
 
-  it('attaches the drag events on render', function() {
+  it('attaches the drag events on init', function() {
     var attachDragStub = utils.makeStubMethod(view, '_attachDragEvents');
     this._cleanups.push(attachDragStub.reset);
-    view.render();
+    view.init();
     assert.equal(attachDragStub.calledOnce(), true);
+  });
+
+  it('can be set to the droppable state', function() {
+    view.setDroppable();
+    assert.equal(view.get('container').hasClass('droppable'), true);
+  });
+
+  it('can be set from the droppable state back to the default', function() {
+    var viewContainer = view.get('container');
+    view.setDroppable();
+    assert.equal(viewContainer.hasClass('droppable'), true);
+    view.setNotDroppable();
+    assert.equal(viewContainer.hasClass('droppable'), false);
   });
 });

--- a/test/test_machine_token.js
+++ b/test/test_machine_token.js
@@ -155,4 +155,16 @@ describe('machine token view', function() {
     assert.isObject(service_icons);
     assert.equal(2, service_icons.all('img').size());
   });
+
+  it('can be set to the droppable state', function() {
+    view.setDroppable();
+    assert.equal(container.hasClass('droppable'), true);
+  });
+
+  it('can be set from the droppable state back to the default', function() {
+    view.setDroppable();
+    assert.equal(container.hasClass('droppable'), true);
+    view.setNotDroppable();
+    assert.equal(container.hasClass('droppable'), false);
+  });
 });

--- a/test/test_machine_view_panel.js
+++ b/test/test_machine_view_panel.js
@@ -259,55 +259,84 @@ describe('machine view panel view', function() {
       assert.deepEqual(onStubArgs[2][1], view._unitTokenDropHandler);
     });
 
-    it('converts the headers to drop targets when dragging', function() {
-      // This tests assumes the previous test passed.
-      // 'listens for the drag start, end, drop events'
-      var onStub = utils.makeStubMethod(view, 'on');
-      this._cleanups.push(onStub.reset);
-      view._bindEvents();
-      view._machinesHeader = { setDroppable: utils.makeStubFunction() };
-      view._containersHeader = { setDroppable: utils.makeStubFunction() };
-      // unit-drag start handler _showDraggingUI
-      onStub.allArguments()[0][1].call(view);
-      assert.equal(view._machinesHeader.setDroppable.calledOnce(), true);
-      // The user hasn't selected a machine so this header should not be
-      // a drop target.
-      assert.equal(view._containersHeader.setDroppable.calledOnce(), false);
-    });
+    it('converts the headers and tokens to drop targets when dragging',
+        function() {
+          // This tests assumes the previous test passed.
+          // 'listens for the drag start, end, drop events'
+          var onStub = utils.makeStubMethod(view, 'on');
+          this._cleanups.push(onStub.reset);
+          var machineToken = view.get('machineTokens')['0'];
+          view._bindEvents();
+          view._machinesHeader = { setDroppable: utils.makeStubFunction() };
+          view._containersHeader = { setDroppable: utils.makeStubFunction() };
+          machineToken.setDroppable = utils.makeStubFunction();
+          // unit-drag start handler _showDraggingUI
+          onStub.allArguments()[0][1].call(view);
+          assert.equal(view._machinesHeader.setDroppable.calledOnce(), true);
+          assert.equal(machineToken.setDroppable.calledOnce(), true);
+          // The user hasn't selected a machine so this header should not be
+          // a drop target.
+          assert.equal(view._containersHeader.setDroppable.calledOnce(), false);
+        });
 
-    it('converts headers to drop targets when machine selected', function() {
-      // This tests assumes the previous test passed.
-      // 'listens for the drag start, end, drop events'
-      var onStub = utils.makeStubMethod(view, 'on');
-      this._cleanups.push(onStub.reset);
-      view._bindEvents();
-      view._machinesHeader = { setDroppable: utils.makeStubFunction() };
-      view._containersHeader = { setDroppable: utils.makeStubFunction() };
-      view.set('selectedMachine', 1);
-      // unit-drag start handler _showDraggingUI
-      onStub.allArguments()[0][1].call(view);
-      assert.equal(view._machinesHeader.setDroppable.calledOnce(), true);
-      // The user selected a machine so this header should be a drop target.
-      assert.equal(view._containersHeader.setDroppable.calledOnce(), true);
-    });
+    it('converts headers and tokens to drop targets when machine selected',
+        function() {
+          // This tests assumes the previous test passed.
+          // 'listens for the drag start, end, drop events'
+          var onStub = utils.makeStubMethod(view, 'on');
+          this._cleanups.push(onStub.reset);
+          container.append(Y.Node.create('<div class="containers">' +
+              '<div class="content"><div class="items"></div></div></div>'));
+          // Add a container.
+          machines.add([{id: '0/lxc/3'}]);
+          var machineToken = view.get('machineTokens')['0'];
+          var containerToken = view.get('containerTokens')['0/lxc/3'];
+          view._bindEvents();
+          view._machinesHeader = { setDroppable: utils.makeStubFunction() };
+          view._containersHeader = { setDroppable: utils.makeStubFunction() };
+          machineToken.setDroppable = utils.makeStubFunction();
+          containerToken.setDroppable = utils.makeStubFunction();
+          view.set('selectedMachine', 1);
+          // unit-drag start handler _showDraggingUI
+          onStub.allArguments()[0][1].call(view);
+          assert.equal(view._machinesHeader.setDroppable.calledOnce(), true);
+          assert.equal(machineToken.setDroppable.calledOnce(), true);
+          // The user selected a machine so this header should be a drop target.
+          assert.equal(view._containersHeader.setDroppable.calledOnce(), true);
+          assert.equal(containerToken.setDroppable.calledOnce(), true);
+        });
 
     it('converts headers to non-drop targets when drag stopped', function() {
       // This tests assumes the previous test passed.
       // 'listens for the drag start, end, drop events'
       var onStub = utils.makeStubMethod(view, 'on');
       this._cleanups.push(onStub.reset);
+      container.append(Y.Node.create('<div class="containers">' +
+          '<div class="content"><div class="items"></div></div></div>'));
+      machines.add([{id: '0/lxc/3'}]);
+      var machineToken = view.get('machineTokens')['0'];
+      var containerToken = view.get('containerTokens')['0/lxc/3'];
       view._bindEvents();
       view._machinesHeader = { setNotDroppable: utils.makeStubFunction() };
       view._containersHeader = { setNotDroppable: utils.makeStubFunction() };
+      machineToken.setNotDroppable = utils.makeStubFunction();
+      containerToken.setNotDroppable = utils.makeStubFunction();
       // unit-drag end handler _hideDraggingUI
       onStub.allArguments()[1][1].call(view);
       assert.equal(view._machinesHeader.setNotDroppable.calledOnce(), true);
       assert.equal(view._containersHeader.setNotDroppable.calledOnce(), true);
+      assert.equal(machineToken.setNotDroppable.calledOnce(), true);
+      assert.equal(containerToken.setNotDroppable.calledOnce(), true);
     });
 
     it('converts headers to non-drop targets when dropped on a header',
         function() {
           view.render();
+          machines.add([{id: '0/lxc/3'}]);
+          var machineToken = view.get('machineTokens')['0'];
+          var containerToken = view.get('containerTokens')['0/lxc/3'];
+          machineToken.setNotDroppable = utils.makeStubFunction();
+          containerToken.setNotDroppable = utils.makeStubFunction();
           view._machinesHeader = {
             setNotDroppable: utils.makeStubFunction(),
             updateLabelCount: utils.makeStubFunction()
@@ -322,6 +351,8 @@ describe('machine view panel view', function() {
           assert.equal(view._machinesHeader.setNotDroppable.calledOnce(), true);
           assert.equal(view._containersHeader.setNotDroppable.calledOnce(),
               true);
+          assert.equal(machineToken.setNotDroppable.calledOnce(), true);
+          assert.equal(containerToken.setNotDroppable.calledOnce(), true);
         });
 
     it('creates a new machine when dropped on machine header', function() {


### PR DESCRIPTION
Added new drop states and highlighting when tokens are dragged over drop targets.

QA:
- drag two charms to the canvas
- open the machine view
- start dragging one of the units
- the 'Create new machine' should appear in the header with new styling
- hover the unit over the drop area
- the background should go grey
- drop the unit on the header and click create in the constraints form
- click on the 'new0' machine
- start dragging the second unit
- the 'Create new machine' and 'Create new container' headers' targets should appear
- the machine and container tokens should show the 'Add to machine new0' and 'Add to container Bare metal' respectively
- hovering the unit over the headers and tokens should turn them grey
- dropping the unit on a header or token should make the drop areas disappear
