### PR TITLE
Implement create container workflow

### DIFF
--- a/app/templates/container-type-form.partial
+++ b/app/templates/container-type-form.partial
@@ -1,0 +1,7 @@
+<div class="containers hidden">
+  <select>
+    <option value="" selected disabled class="default">Choose location</option>
+    <option value="lxc" class="default">New LXC</option>
+    <option value="kvm" class="default">New KVM</option>
+  </select>
+</div>

--- a/app/templates/create-machine-view.handlebars
+++ b/app/templates/create-machine-view.handlebars
@@ -1,4 +1,4 @@
-Define constraints
+{{>container-type-form}}
 {{>constraints-form}}
 <div class="actions">
   <span class="cancel secondary-action">Cancel</span> |

--- a/app/templates/machine-view-panel.handlebars
+++ b/app/templates/machine-view-panel.handlebars
@@ -19,6 +19,7 @@
 <div class="column containers">
   <div class="head"></div>
   <div class="content">
+    <div class="create-container"></div>
     <ul class="items"></ul>
   </div>
 </div>

--- a/app/templates/serviceunit-token.handlebars
+++ b/app/templates/serviceunit-token.handlebars
@@ -19,15 +19,7 @@
   <div class="new-machine">
     Define constraints
   </div>
-  <div class="containers">
-    <select>
-      <option value="" selected disabled class="hidden default">
-        Choose location
-      </option>
-      <option value="new-lxc" class="default">new lxc</option>
-      <option value="new-kvm" class="default">new kvm</option>
-    </select>
-  </div>
+  {{>container-type-form}}
   {{>constraints-form}}
   <div class="actions">
     <span class="cancel secondary-action">Cancel</span> |

--- a/app/utils/mv-drop-target-view-extension.js
+++ b/app/utils/mv-drop-target-view-extension.js
@@ -60,9 +60,11 @@ YUI.add('mv-drop-target-view-extension', function(Y) {
     */
     _unitDropHandler: function(e) {
       var dragData = JSON.parse(e._event.dataTransfer.getData('Text')),
-          target = e.currentTarget.ancestor();
+          target = e.currentTarget,
+          token = target.ancestor('.token'),
+          targetId = token ? token.getData('id') : null;
       this.fire('unit-token-drop', {
-        targetId: target.getData('id'),
+        targetId: targetId,
         dropAction: target.getData('drop-action'),
         unit: dragData.id,
         machine: this.get('machine')

--- a/app/views/viewlets/charm-details.js
+++ b/app/views/viewlets/charm-details.js
@@ -87,7 +87,9 @@ YUI.add('charm-details-view', function(Y) {
       var panel = Y.one('.charmbrowser'),
           container = this.get('container');
       panel.removeClass('animate-in');
-      window.location.hash = '';
+      if (window.location.hash) {
+        window.location.hash = '';
+      }
       this.viewletManager.hideSlot(ev);
       container.empty();
       this.destroy();

--- a/app/widgets/container-token.js
+++ b/app/widgets/container-token.js
@@ -120,7 +120,7 @@ YUI.add('container-token', function(Y) {
           // Tells the machine view panel drop handler where the unplaced unit
           // token was dropped.
           var token = container.one('.token');
-          token.setData('drop-action', 'container');
+          token.one('.drop').setData('drop-action', 'container');
           // This must be setAttribute, not setData, as setData does not
           // munipulate the dom, which we need for our namespaced code
           // to read.

--- a/app/widgets/create-machine-view.js
+++ b/app/widgets/create-machine-view.js
@@ -47,6 +47,9 @@ YUI.add('create-machine-view', function(Y) {
           },
           '.create': {
             click: '_handleCreate'
+          },
+          '.containers select': {
+            change: '_handleContainerTypeChange'
           }
         },
 
@@ -74,9 +77,32 @@ YUI.add('create-machine-view', function(Y) {
           e.preventDefault();
           this.fire('createMachine', {
             unit: this.get('unit'),
+            containerType: this.get('containerType'),
+            parentId: this.get('parentId'),
             constraints: this._getConstraints()
           });
           this.destroy();
+        },
+
+        /**
+          Handle display/hiding constraints depending
+          on containerType
+
+          @method _handleContainerTypeChange
+          @param {Event} ev the click event created.
+        */
+        _handleContainerTypeChange: function(e) {
+          e.preventDefault();
+          var constraints = this.get('container').one('.constraints'),
+              select = e.currentTarget,
+              selectedIndex = select.get('selectedIndex'),
+              newVal = select.get('options').item(selectedIndex).get('value');
+          this.set('containerType', newVal);
+          if (newVal === 'kvm') {
+            constraints.removeClass('hidden');
+          } else {
+            constraints.addClass('hidden');
+          }
         },
 
         /**
@@ -102,6 +128,12 @@ YUI.add('create-machine-view', function(Y) {
           var container = this.get('container');
           container.setHTML(this.template());
           container.addClass('create-machine-view');
+          // If this is a container (i.e., has a parent machine), show the
+          // container type select and hide the constraints.
+          if (this.get('parentId')) {
+            container.one('.containers').removeClass('hidden');
+            container.one('.constraints').addClass('hidden');
+          }
           return this;
         },
 
@@ -122,7 +154,21 @@ YUI.add('create-machine-view', function(Y) {
             @default undefined
             @type {Object}
           */
-          unit: {}
+          unit: {},
+
+          /**
+            @attribute parentId
+            @default undefined
+            @type {String}
+          */
+          parentId: {},
+
+          /**
+            @attribute containerType
+            @default undefined
+            @type {String}
+          */
+          containerType: {}
         }
       });
 

--- a/app/widgets/machine-token.js
+++ b/app/widgets/machine-token.js
@@ -163,7 +163,7 @@ YUI.add('machine-token', function(Y) {
           var token = container.one('.token');
           // Even though this is a machine we want it to create a container
           // when something is dropped on it.
-          token.setData('drop-action', 'container');
+          token.one('.drop').setData('drop-action', 'container');
           // This must be setAttribute, not setData, as setData does not
           // manipulate the dom, which we need for our namespaced code
           // to read.

--- a/app/widgets/machine-view-panel-header.js
+++ b/app/widgets/machine-view-panel-header.js
@@ -74,14 +74,15 @@ YUI.add('machine-view-panel-header', function(Y) {
         },
 
         /**
-         * Fire the action event.
+         * Fire the action event; the action attached to the event will either
+         * be 'machine' (create machine), or 'container (create container).
          *
          * @method clickAction
          * @param {Event} ev the click event created.
          */
         clickAction: function(e) {
-          e.preventDefault();
-          this.fire('createMachine');
+          e.halt();
+          this.fire('createMachine', {action: this.get('action')});
         },
 
         /**

--- a/app/widgets/serviceunit-token.js
+++ b/app/widgets/serviceunit-token.js
@@ -82,7 +82,7 @@ YUI.add('juju-serviceunit-token', function(Y) {
       var containerValue = this._getSelectedContainer();
       var constraints = {};
 
-      if (machineValue === 'new' || containerValue === 'new-kvm') {
+      if (machineValue === 'new' || containerValue === 'kvm') {
         constraints = this._getConstraints();
       } else if (!containerValue) {
         // Do nothing, the user has not yet selected a container.
@@ -139,6 +139,10 @@ YUI.add('juju-serviceunit-token', function(Y) {
       } else {
         this._populateContainers(machineValue);
         this._setStateClass('select-container');
+        // XXX kadams54 20/06/2014 This is a kludge - other places that use the
+        // container type form don't have the state class. Need to either
+        // settle on one approach or the other.
+        this.get('container').one('.containers').removeClass('hidden');
       }
     },
 
@@ -152,7 +156,7 @@ YUI.add('juju-serviceunit-token', function(Y) {
       e.preventDefault();
       var containerValue = this._getSelectedContainer();
 
-      if (containerValue === 'new-kvm') {
+      if (containerValue === 'kvm') {
         this._setStateClass(containerValue);
       } else {
         this._setStateClass('select-container');

--- a/lib/views/machine-view/serviceunit-token.less
+++ b/lib/views/machine-view/serviceunit-token.less
@@ -32,7 +32,7 @@
             display: block;
         }
     }
-    &.state-new-kvm,
+    &.state-kvm,
     &.state-select-container {
         .machines,
         .actions,
@@ -40,7 +40,7 @@
             display: block;
         }
     }
-    &.state-new-kvm {
+    &.state-kvm {
         .constraints {
             display: block;
         }

--- a/test/test_drop_target_view_extension.js
+++ b/test/test_drop_target_view_extension.js
@@ -69,8 +69,9 @@ describe('MV drop target view extension', function() {
     var eventData = {
       currentTarget: {
         ancestor: utils.makeStubFunction({
-          getData: utils.makeStubFunction('targetid', 'dropaction')
-        })
+          getData: utils.makeStubFunction('targetid')
+        }),
+        getData: utils.makeStubFunction('dropaction')
       },
       _event: {
         dataTransfer: {

--- a/test/test_serviceunit_token.js
+++ b/test/test_serviceunit_token.js
@@ -143,14 +143,18 @@ describe('Service unit token', function() {
     // Select a machine option.
     container.one('.machines select').simulate('change');
     var containerOptions = containersSelect.all('option');
-    assert.equal(containerOptions.size(), 5);
-    assert.equal(containerOptions.item(2).get('value'), '0/lxc/12');
+    assert.equal(containerOptions.size(), 5,
+                 'unexpected number of containers present');
+    assert.equal(containerOptions.item(2).get('value'), '0/lxc/12',
+                 'unexpected container value in list');
     // Check the "Choose location" item is still at the top of the list.
     assert.equal(containerOptions.item(0).get('text').trim(),
-        'Choose location');
+        'Choose location', 'default container text incorrect');
     // Check the bare metal option is the second item.
-    assert.equal(containerOptions.item(1).get('value'), 'bare-metal');
-    assert.equal(containerOptions.item(1).get('text'), '0/bare metal');
+    assert.equal(containerOptions.item(1).get('value'), 'bare-metal',
+                 'bare metal value is not the second option');
+    assert.equal(containerOptions.item(1).get('text'), '0/bare metal',
+                 'bare metal text is not the second option');
   });
 
   it('orders the containers list correctly', function() {
@@ -174,7 +178,7 @@ describe('Service unit token', function() {
     // Select the kvm option.
     containersSelect.set('selectedIndex', 2);
     containersSelect.simulate('change');
-    assert.equal(container.hasClass('state-new-kvm'), true);
+    assert.equal(container.hasClass('state-kvm'), true);
   });
 
   it('does not show the constraints for non kvm containers', function() {
@@ -267,7 +271,7 @@ describe('Service unit token', function() {
         '_getSelectedMachine', '0');
     this._cleanups.push(selectedMachineStub.reset);
     var selectedContainerStub = utils.makeStubMethod(view,
-        '_getSelectedContainer', 'new-kvm');
+        '_getSelectedContainer', 'kvm');
     this._cleanups.push(selectedContainerStub.reset);
     var constraintsStub = utils.makeStubMethod(view,
         '_getConstraints', constraints);
@@ -275,7 +279,7 @@ describe('Service unit token', function() {
     view.on('moveToken', function(e) {
       assert.equal(e.unit, view.get('unit'));
       assert.equal(e.machine, '0');
-      assert.equal(e.container, 'new-kvm');
+      assert.equal(e.container, 'kvm');
       assert.deepEqual(e.constraints, constraints);
       done();
     });
@@ -288,12 +292,12 @@ describe('Service unit token', function() {
         '_getSelectedMachine', '0');
     this._cleanups.push(selectedMachineStub.reset);
     var selectedContainerStub = utils.makeStubMethod(view,
-        '_getSelectedContainer', 'new-lxc');
+        '_getSelectedContainer', 'lxc');
     this._cleanups.push(selectedContainerStub.reset);
     view.on('moveToken', function(e) {
       assert.equal(e.unit, view.get('unit'));
       assert.equal(e.machine, '0');
-      assert.equal(e.container, 'new-lxc');
+      assert.equal(e.container, 'lxc');
       assert.deepEqual(e.constraints, {});
       done();
     });


### PR DESCRIPTION
Adds support for creating different types of containers, including KVMs with constraints. Regardless of how you get into the workflow (dropping on a header drop target, using the header link, dropping on an existing container or machine), the full workflow should now occur, rather than the previous abbreviated one that assumed an LXC container.
## QA

With the `mv` flag. Test all the various entry points for creating a container:

1) Click on the "Add container" link. (Note: should this link be hidden when a machine is not selected?)
2) Drag and drop an unplaced service on the container header (when a machine is selected).
3) Drag and drop an unplaced service on an existing container (should add directly, no need for the create form).
4) Drag and drop an unplaced service on an existing machine (should bring up the create container form).
5) Click on the move icon for an unplaced service - try with both existing containers and new containers.

Aside from the above, just try to break things in various ways. Be sure to verify that any bugs found are not present on upcoming.jujucharms.com, as there are still a lot dragons to be slayed. For example, the container column is not great about updating if you have one machine selected and then drag and drop onto another machine.
