### PR TITLE
Changed deployer health bar height

### DIFF
--- a/lib/views/juju-inspector.less
+++ b/lib/views/juju-inspector.less
@@ -905,8 +905,8 @@
         .statusbar {
             .create-border-radius(@border-radius);
             width: 250px;
-            height: 30px;
-            margin-top: 12px;
+            height: 10px;
+            margin: 10px 0 -10px 0;
         }
 
 


### PR DESCRIPTION
OK, here goes, I'd set aside a morning for this review.

QA:
- drag a service to the canvas
- click deploy and confirm
- click on the service block
- in the inspector check that the health bar is 10px high
