### PR TITLE
Change the deploy button to Commit after deploy

### DIFF
--- a/app/templates/deployer-bar.handlebars
+++ b/app/templates/deployer-bar.handlebars
@@ -6,12 +6,18 @@
                 <span class="export link">Export</span>
                 <input type="file" class="import-file" />
             </span>
-            <a href="" class="button deploy-button">Deploy</a>
+            <span class="button deploy-button">
+                {{#if deployed}}
+                    Commit
+                {{else}}
+                    Deploy
+                {{/if}}
+            </span>
         </div>
         <div class="post-summary">
             <p>Confirm will deploy all changes</p>
-            <a href="" class="button cancel-button">Cancel</a>
-            <a href="" class="button confirm-button">Confirm</a>
+            <span class="button cancel-button">Cancel</span>
+            <span class="button confirm-button">Confirm</span>
         </div>
     </div>
     <ul class="action-list">

--- a/app/widgets/deployer-bar.js
+++ b/app/widgets/deployer-bar.js
@@ -92,6 +92,7 @@ YUI.add('deployer-bar', function(Y) {
       this.addEvent(
           this.on('hideChangeDescription', this._hideChangeDescription)
       );
+      this._deployed = false;
     },
 
     /**
@@ -116,7 +117,8 @@ YUI.add('deployer-bar', function(Y) {
           ecs = this.get('ecs');
       var changes = this._getChangeCount(ecs);
       container.setHTML(this.template({
-        changeCount: changes
+        changeCount: changes,
+        deployed: this._deployed
       }));
       container.addClass('deployer-bar');
       this._toggleDeployButtonStatus(changes > 0);
@@ -137,6 +139,19 @@ YUI.add('deployer-bar', function(Y) {
       container.removeClass('summary-open');
       ecs.commit(this.get('env'));
       //this.update();
+      if (this._deployed === false) {
+        this._setDeployed();
+      }
+    },
+
+    /**
+      Set the button state to deployed.
+
+      @method _setDeployed
+    */
+    _setDeployed: function() {
+      this._deployed = true;
+      this.get('container').one('.deploy-button').set('text', 'Commit');
     },
 
     /**
@@ -216,7 +231,8 @@ YUI.add('deployer-bar', function(Y) {
           addedRelations: changes.addRelations,
           addedUnits: changes.addUnits,
           addedMachines: changes.addMachines,
-          configsChanged: changes.setConfigs
+          configsChanged: changes.setConfigs,
+          deployed: this._deployed
         }));
       }
       container.addClass('summary-open');
@@ -253,7 +269,8 @@ YUI.add('deployer-bar', function(Y) {
       if (container && container.get('parentNode')) {
         container.setHTML(this.template({
           changeCount: changes,
-          latestChangeDescription: latest
+          latestChangeDescription: latest,
+          deployed: this._deployed
         }));
         this._toggleDeployButtonStatus(changes > 0);
         // XXX frankban 2014-05-12: the code below makes the changeset

--- a/lib/views/deployer-bar.less
+++ b/lib/views/deployer-bar.less
@@ -35,7 +35,7 @@
         time {
             margin-left: 7px;
         }
-        a.button {
+        .button {
             // Using a variable here because LESS strips commas in mixin args.
             @box-shadow: inset 0 2px 2px rgba(0, 0, 0, 0.3);
             .create-box-shadow(@box-shadow);
@@ -62,7 +62,7 @@
         .right {
             margin-right: 20px;
 
-            a.button {
+            .button {
                 margin-left: 20px;
             }
             .import-export {

--- a/lib/views/mixins.less
+++ b/lib/views/mixins.less
@@ -65,6 +65,7 @@
     padding: 8px 14px;
     border: none;
     font-size: 14px;
+    cursor: pointer;
 
     &:hover {
         background: @charm-panel-orange;

--- a/test/test_deployer_bar.js
+++ b/test/test_deployer_bar.js
@@ -368,4 +368,19 @@ describe('deployer bar view', function() {
     container.one('.action-list .max').simulate('click');
     assert.equal(container.hasClass('mode-max'), true);
   });
+
+  it('changes the deploy label after the first deploy', function() {
+    var deployButton = container.one('.deploy-button');
+    assert.equal(deployButton.get('text').trim(), 'Deploy');
+    view.deploy({halt: utils.makeStubFunction()});
+    assert.equal(deployButton.get('text').trim(), 'Commit');
+  });
+
+  it('shows the commit label after deploy and re-render', function() {
+    var deployButton = container.one('.deploy-button');
+    view.deploy({halt: utils.makeStubFunction()});
+    assert.equal(deployButton.get('text').trim(), 'Commit');
+    view.render();
+    assert.equal(deployButton.get('text').trim(), 'Commit');
+  });
 });


### PR DESCRIPTION
The deploy button should change to "Commit" after the first deploy.

QA:
- drag a charm to the canvas
- the deploy button should have the label "Deploy"
- click Deploy and Confirm
- The button should now say "Commit"
