### PR TITLE
Hide sidebar shortcut

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -178,6 +178,13 @@ YUI.add('juju-gui', function(Y) {
         help: 'Center the Environment overview',
         label: 'Shift + 0'
       },
+      'C-A-h': {
+        callback: function(e) {
+          this._toggleSidebar();
+        },
+        help: 'Show or hide the sidebar',
+        label: 'Control + Alt + h'
+      },
       'esc': {
         fire: 'clearState',
         callback: function() {
@@ -214,8 +221,6 @@ YUI.add('juju-gui', function(Y) {
         help: 'Save the websocket log to a file',
         label: 'Control + Shift + s'
       }
-
-
     },
 
     /**
@@ -846,6 +851,15 @@ YUI.add('juju-gui', function(Y) {
         env: this.env,
         db: this.db
       }).render();
+    },
+
+    /**
+     * Toggle the visibility of the sidebar.
+     *
+     * @method _toggleSidebar
+     */
+    _toggleSidebar: function() {
+      Y.one('body').toggleClass('state-sidebar-hidden');
     },
 
     /**

--- a/lib/views/browser/main.less
+++ b/lib/views/browser/main.less
@@ -129,7 +129,6 @@
     animation: sidebar-details-slide-in 0.5s;
   }
 }
-
 #subapp-browser.no-search {
   #bws-sidebar {
     .bws-content {
@@ -142,7 +141,9 @@
     }
   }
 }
-
+body.state-sidebar-hidden #subapp-browser {
+    display: none;
+}
 .flag-mv #subapp-browser {
   .bws-view-data {
       top: @environment-header-height - 1px;

--- a/lib/views/environment-header.less
+++ b/lib/views/environment-header.less
@@ -54,3 +54,6 @@
         }
     }
 }
+body.state-sidebar-hidden .environment-header {
+    left: 0;
+}

--- a/lib/views/machine-view/machine-view-panel.less
+++ b/lib/views/machine-view/machine-view-panel.less
@@ -138,3 +138,6 @@
 .flag-mv .machine-view-panel {
     bottom: @deployer-bar-height;
 }
+body.state-sidebar-hidden .machine-view-panel {
+    left: 0;
+}

--- a/test/test_app_hotkeys.js
+++ b/test/test_app_hotkeys.js
@@ -71,7 +71,7 @@ describe('application hotkeys', function() {
         found = false;
     bindings.each(function(node) {
       var text = node.getDOMNode().textContent;
-      if (text === 'S-?') {
+      if (text === 'Shift + ?') {
         found = true;
       }
     });
@@ -108,5 +108,15 @@ describe('application hotkeys', function() {
     });
   });
 
+  it('should listen for ctrl+alt+h events', function() {
+    var body = Y.one('body');
+    assert.equal(body.hasClass('state-sidebar-hidden'), false);
+    windowNode.simulate('keydown', {
+      keyCode: 104, // "h" key.
+      ctrlKey: true,
+      altKey: true
+    });
+    assert.equal(body.hasClass('state-sidebar-hidden'), true);
+  });
 });
 


### PR DESCRIPTION
This allows you to hide the sidebar with Ctrl+Alt+h.

I also did a drive-by in the shortcuts panel to expand all the shortcuts to display "Alt" instead of "A" etc.
