### PR TITLE
Only allow one unit token to be in placement mode

### DIFF
--- a/app/widgets/machine-view-panel.js
+++ b/app/widgets/machine-view-panel.js
@@ -47,6 +47,9 @@ YUI.add('machine-view-panel', function(Y) {
           },
           '.container-token .token': {
             click: 'handleContainerTokenSelect'
+          },
+          '.unplaced-unit .token-move': {
+            click: '_cancelUnitPlacement'
           }
         },
 
@@ -117,6 +120,24 @@ YUI.add('machine-view-panel', function(Y) {
           this.on('*:unit-token-drop', this._unitTokenDropHandler, this);
 
           this.on('*:moveToken', this._placeServiceUnit, this);
+        },
+
+        /**
+          Cancel placing units as only one unit should display the
+          placement form at a time.
+
+         @method _cancelUnitPlacement
+         @param {Object} e Custom model change event facade.
+        */
+        _cancelUnitPlacement: function(e) {
+          var unitTokens = this.get('unitTokens');
+          var clickedId = e.currentTarget.ancestor(
+              '.unplaced-unit').getData('id');
+          Object.keys(unitTokens).forEach(function(id) {
+            if (id.toString() !== clickedId) {
+              unitTokens[id].reset();
+            }
+          });
         },
 
         /**

--- a/app/widgets/serviceunit-token.js
+++ b/app/widgets/serviceunit-token.js
@@ -118,10 +118,7 @@ YUI.add('juju-serviceunit-token', function(Y) {
      */
     _handleCancelClick: function(e) {
       e.preventDefault();
-      var container = this.get('container');
-      // In lieu of resetting every element, just re-render the HTML.
-      container.setHTML(this.template(this.get('unit')));
-      this._setStateClass('initial');
+      this.reset();
     },
 
     /**
@@ -308,22 +305,39 @@ YUI.add('juju-serviceunit-token', function(Y) {
     },
 
     /**
+      Reset the token to the initial state.
+
+      @method reset
+    */
+    reset: function() {
+      // In lieu of resetting every element, just re-render the HTML.
+      this._renderTemplate();
+    },
+
+    /**
+      Render the template and set the appropriate classes.
+
+      @method _renderTemplate
+    */
+    _renderTemplate: function() {
+      var container = this.get('container');
+      var unit = this.get('unit');
+      container.setHTML(this.template(unit));
+      // This must be setAttribute, not setData, as setData does not
+      // manipulate the dom, which we need for our namespaced code
+      // to read.
+      container.one('.unplaced-unit').setAttribute('data-id', unit.id);
+      this._setStateClass('initial');
+    },
+
+    /**
      * Sets up the DOM nodes and renders them to the DOM.
      *
      * @method render
      */
     render: function() {
-      var container = this.get('container'),
-          unit = this.get('unit'),
-          token;
-      container.setHTML(this.template(unit));
-      container.addClass('serviceunit-token');
-      this._setStateClass('initial');
-      token = container.one('.unplaced-unit');
-      // This must be setAttribute, not setData, as setData does not
-      // manipulate the dom, which we need for our namespaced code
-      // to read.
-      token.setAttribute('data-id', unit.id);
+      this.get('container').addClass('serviceunit-token');
+      this._renderTemplate();
       this._makeDraggable();
       return this;
     },

--- a/test/test_machine_view_panel.js
+++ b/test/test_machine_view_panel.js
@@ -772,6 +772,21 @@ describe('machine view panel view', function() {
         constraints: {}
       });
     });
+
+    it('does not show more than one placement form at once', function() {
+      view.render();
+      units.add([{id: 'test/5'}]);
+      var firstToken = container.all('.serviceunit-token').item(0);
+      var secondToken = container.all('.serviceunit-token').item(1);
+      firstToken.one('.token-move').simulate('click');
+      assert.equal(firstToken.hasClass('state-select-machine'), true);
+      assert.equal(secondToken.hasClass('state-select-machine'), false);
+      // Clicking on a different token should make the second token
+      // active, and reset the first token.
+      secondToken.one('.token-move').simulate('click');
+      assert.equal(firstToken.hasClass('state-select-machine'), false);
+      assert.equal(secondToken.hasClass('state-select-machine'), true);
+    });
   });
 
 


### PR DESCRIPTION
To prevent the list of machines and containers getting outdated by starting the move form on multiple unit tokens this branch makes it so you can only show the form on once token at once.

See: https://bugs.launchpad.net/juju-gui/+bug/1329224

QA:
- drag several charms to the canvas
- open the machine view
- click the 'move to' icon on one of the tokens
- now click on a different 'move to' icon
- the second token should now display the placement form and the first token should be reset to its initial state
- subsequent clicks on 'move to' icons should continue to only display the form on the last clicked token
