### PR TITLE
Display actual time for each ECS record.

### DIFF
--- a/app/utils/environment-change-set.js
+++ b/app/utils/environment-change-set.js
@@ -140,7 +140,8 @@ YUI.add('environment-change-set', function(Y) {
           return !!parent;
         }),
         executed: false,
-        command: command
+        command: command,
+        timestamp: Date.now()
       };
       this.fire('changeSetModified');
       this._wrapCallback(this.changeSet[key]);

--- a/app/widgets/deployer-bar.js
+++ b/app/widgets/deployer-bar.js
@@ -452,7 +452,7 @@ YUI.add('deployer-bar', function(Y) {
       if (skipTime) {
         changeItem.time = '00:00';
       } else {
-        changeItem.time = this._formatAMPM(new Date());
+        changeItem.time = this._formatAMPM(new Date(change.timestamp));
       }
       return changeItem;
     },

--- a/test/test_deployer_bar.js
+++ b/test/test_deployer_bar.js
@@ -199,7 +199,8 @@ describe('deployer bar view', function() {
           method: '_deploy',
           args: ['foo', 'bar']
         }
-      }
+      },
+      time: '12:34 PM'
     }, {
       icon: 'changes-service-added',
       msg: ' 1 foo unit has been added.',
@@ -292,7 +293,11 @@ describe('deployer bar view', function() {
       var change = view._generateChangeDescription(test.change, true);
       assert.equal(change.icon, test.icon);
       assert.equal(change.description, test.msg);
-      assert.equal(change.time, '00:00');
+      if (test.timestamp) {
+        assert.equal(change.time, test.time);
+      } else {
+        assert.equal(change.time, '00:00');
+      }
     });
   });
 

--- a/test/test_env_change_set.js
+++ b/test/test_env_change_set.js
@@ -156,17 +156,21 @@ describe('Environment Change Set', function() {
         this._cleanups.push(wrapCallback.reset);
         var key = ecs._createNewRecord('service', command);
         assert.equal(wrapCallback.calledOnce(), true);
+        // Note that we cannot guarantee the duration of the tests, so we
+        // need to assert against the record's timestamp below.
         assert.deepEqual(wrapCallback.lastArguments()[0], {
           id: key,
           parents: [],
           executed: false,
-          command: command
+          command: command,
+          timestamp: ecs.changeSet[key].timestamp
         });
         assert.deepEqual(ecs.changeSet[key], {
           id: key,
           parents: [],
           executed: false,
-          command: command
+          command: command,
+          timestamp: ecs.changeSet[key].timestamp
         });
       });
 
@@ -178,17 +182,21 @@ describe('Environment Change Set', function() {
         var parent = ['service-123'];
         var key = ecs._createNewRecord('service', command, parent);
         assert.equal(wrapCallback.calledOnce(), true);
+        // Note that we cannot guarantee the duration of the tests, so we
+        // need to assert against the record's timestamp below.
         assert.deepEqual(wrapCallback.lastArguments()[0], {
           id: key,
           parents: parent,
           executed: false,
-          command: command
+          command: command,
+          timestamp: ecs.changeSet[key].timestamp
         });
         assert.deepEqual(ecs.changeSet[key], {
           id: key,
           parents: parent,
           executed: false,
-          command: command
+          command: command,
+          timestamp: ecs.changeSet[key].timestamp
         });
       });
     });
@@ -571,6 +579,8 @@ describe('Environment Change Set', function() {
       it('can add a remove relation record into the changeset', function() {
         var record = ecs._lazyRemoveRelation(['args1', 'args2']);
         assert.equal(record.split('-')[0], 'removeRelation');
+        // Note that we cannot guarantee the duration of the tests, so we
+        // need to assert against the record's timestamp below.
         assert.deepEqual(ecs.changeSet[record], {
           command: {
             args: ['args1', 'args2'],
@@ -578,7 +588,8 @@ describe('Environment Change Set', function() {
           },
           executed: false,
           id: record,
-          parents: []
+          parents: [],
+          timestamp: ecs.changeSet[record].timestamp
         });
       });
     });


### PR DESCRIPTION
Every time an ECS record is created, its time should be recorded as well.
