### PR TITLE
Style the upgrade charm panel and link

### DIFF
--- a/app/templates/ghost-config-wrapper.handlebars
+++ b/app/templates/ghost-config-wrapper.handlebars
@@ -7,6 +7,8 @@
       <button class="cancel">Cancel</button>
       <button class="confirm">Deploy</button>
     </div>
-    {{>service-destroy}}
+    <div class="overview-footer-item">
+      {{>service-destroy}}
+    </div>
   </div>
 </div>

--- a/app/templates/service-config-wrapper.handlebars
+++ b/app/templates/service-config-wrapper.handlebars
@@ -33,7 +33,9 @@
   </ul>
   <div class="viewlet-container"></div>
   <div class="viewlet-manager-footer">
-    {{>service-destroy}}
-    {{>service-version}}
+    <div class="overview-footer-item">
+      {{>service-version}}
+      {{>service-destroy}}
+    </div>
   </div>
 </div>

--- a/app/templates/service-destroy.partial
+++ b/app/templates/service-destroy.partial
@@ -1,17 +1,15 @@
-<div class="overview-footer-item">
-  <div class="destroy-service-trigger">
-    <span>
-      <i class="sprite inspector-destroy-service"></i>
-      Destroy service
-    </span>
+<div class="destroy-service-trigger">
+  <span>
+    <i class="sprite inspector-destroy-service"></i>
+    Destroy service
+  </span>
+</div>
+<div class="destroy-service-prompt closed">
+  <div class="message">
+  Are you sure you want to destroy the service? This cannot be undone.
   </div>
-  <div class="destroy-service-prompt closed">
-    <div class="message">
-    Are you sure you want to destroy the service? This cannot be undone.
-    </div>
-    <div class="inspector-buttons">
-      <a class="cancel-destroy cancel-button">Cancel</a>
-      <a class="initiate-destroy">Destroy</a>
-    </div>
+  <div class="inspector-buttons">
+    <a class="cancel-destroy cancel-button">Cancel</a>
+    <a class="initiate-destroy">Destroy</a>
   </div>
 </div>

--- a/app/templates/service-version.partial
+++ b/app/templates/service-version.partial
@@ -1,7 +1,6 @@
-<div class="overview-footer-item">
-  <div class="change-version-trigger">
-    <span>
-      <i class="sprite inspector-charm-upgrade"></i>
-      Change version
-    </span>
+<div class="change-version-trigger">
+  <span>
+    <i class="sprite inspector-charm-upgrade"></i>
+    Change version
+  </span>
 </div>

--- a/app/templates/version-list.handlebars
+++ b/app/templates/version-list.handlebars
@@ -1,4 +1,10 @@
-<ul>
+<div class="unit-list-header">
+  <div class="close link">
+    <i class="sprite close-inspector-click"></i>
+  </div>
+  Change {{ name }} version
+</div>
+<ul class="unit-list">
   {{#each upgrades}}
   <li>
     <a href="{{link}}">{{id}}</a>

--- a/lib/views/juju-inspector.less
+++ b/lib/views/juju-inspector.less
@@ -845,16 +845,24 @@
         }
         .destroy-service-trigger,
         .change-version-trigger {
+            display: inline-block;
+
             span {
                 cursor: pointer;
 
                 .sprite {
-                    vertical-align: -10%;
-                    margin-right: 7px;
+                    margin-right: 5px;
                 }
             }
         }
-
+        .destroy-service-trigger {
+            .sprite {
+                    vertical-align: -10%;
+            }
+        }
+        .change-version-trigger {
+            float: right
+        }
         .destroy-service-prompt {
             overflow: hidden;
             max-height: 200px;
@@ -921,74 +929,27 @@
                 padding-bottom: 5px;
             }
         }
-
+        .unit-list,
         .overview-unit-list {
             margin: 0;
 
+            .status-unit-header {
+                padding-left: 40px;
+                cursor: pointer;
+            }
             .action-button-wrapper {
                 text-align: center;
                 padding: 20px 0;
             }
-
-            .status-unit-header {
-                padding: 15px 15px 15px 40px;
-                font-size: 14px;
-                cursor: pointer;
-                border-bottom: 1px solid @inspector-divider-bottom;
-                border-top: 1px solid @inspector-divider-top;
-                background-position: 20px center;
-                background-repeat: no-repeat;
-                display: -ms-flexbox;
-                -ms-flex-align: baseline;
-                display: flex;
-                align-content: stretch;
-                align-items: baseline;
-
-                span {
-                    margin-right: 5px;
-                }
-
-                ul {
-                    background: #fff;
-                }
-
-                .category-label {
-                    text-overflow: ellipsis;
-                    white-space: normal;
-                    overflow: hidden;
-                    -webkit-user-select: none;
-                    -moz-user-select: none;
-                    -ms-user-select: none;
-                    user-select: none;
-                }
-
-                .chevron {
-                    display: inline-block;
-                    /* The above rule is required because IE10 does not support
-                    the flexbox rules that we need. It has no effect in the
-                    other supported browsers. */
-                    width: 10px;
-                    height: 5px; // magic number warning see below.
-                    /* For whatever reason this combination of flexbox and inline-block
-                    Does not allow padding-bottom to work in IE10, changing the height
-                    of the element puts the chevron in the appropriate place in all browsers */
-                    margin-left: 5px;
-                    background: url("/juju-ui/assets/images/chevron_up.png") no-repeat;
-                }
-            }
-
             .closed-unit-list .category-label {
                 white-space: nowrap;
             }
-
             .closed-unit-list .chevron {
                 background: url("/juju-ui/assets/images/chevron_down.png") no-repeat;
             }
-
             .status-unit-header {
                 background-position: 15px 19px;
             }
-
             .status-unit-header.error {
                 background-image: url("/juju-ui/assets/images/inspector-charm-error.png");
             }
@@ -1004,7 +965,6 @@
             .status-unit-header.landscape {
                 background-image: url("/juju-ui/assets/images/inspector-charm-landscape.png");
             }
-
             .status-unit-content.running ul li {
                 background: url("/juju-ui/assets/images/inspector-charm-running.png") no-repeat scroll 35px center;
             }
@@ -1019,52 +979,103 @@
                 background: url("/juju-ui/assets/images/inspector-charm-landscape.png") no-repeat scroll 35px center;
             }
         }
+        .unit-list-header,
+        .status-unit-header {
+            padding: 15px;
+            font-size: 14px;
+            border-bottom: 1px solid @inspector-divider-bottom;
+            border-top: 1px solid @inspector-divider-top;
+            background-position: 20px center;
+            background-repeat: no-repeat;
+            display: -ms-flexbox;
+            -ms-flex-align: baseline;
+            display: flex;
+            align-content: stretch;
+            align-items: baseline;
 
-        .overview-unit-list,
-        .relation-wrapper {
-            .unit-action-button {
-                width: 70px;
-                margin: 0 3px 0;
-                background: #CBCBCB;
+            span {
+                margin-right: 5px;
             }
-            .status-unit-content {
-                .transition(.25s, max-height .3s);
+
+            ul {
+                background: #fff;
+            }
+
+            .category-label {
+                text-overflow: ellipsis;
+                white-space: normal;
                 overflow: hidden;
-                background: @charm-panel-background-color;
+                -webkit-user-select: none;
+                -moz-user-select: none;
+                -ms-user-select: none;
+                user-select: none;
+            }
 
-                &.close-unit {
-                    max-height: 0px !important;
+            .chevron {
+                display: inline-block;
+                /* The above rule is required because IE10 does not support
+                the flexbox rules that we need. It has no effect in the
+                other supported browsers. */
+                width: 10px;
+                height: 5px; // magic number warning see below.
+                /* For whatever reason this combination of flexbox and inline-block
+                Does not allow padding-bottom to work in IE10, changing the height
+                of the element puts the chevron in the appropriate place in all browsers */
+                margin-left: 5px;
+                background: url("/juju-ui/assets/images/chevron_up.png") no-repeat;
+            }
+        }
+        .unit-list-header {
+            position: relative;
+
+            .close {
+                position: absolute;
+                right: 20px;
+            }
+        }
+        .unit-action-button {
+            width: 70px;
+            margin: 0 3px 0;
+            background: #CBCBCB;
+        }
+        .unit-list,
+        .status-unit-content {
+            .transition(.25s, max-height .3s);
+            overflow: hidden;
+            background: @charm-panel-background-color;
+
+            &.close-unit {
+                max-height: 0px !important;
+            }
+
+            a {
+                color: @text-colour;
+                text-decoration: underline;
+            }
+
+            a.landscape {
+                font-size: 12px;
+            }
+
+            ul {
+                margin-left: 0;
+                border-bottom: 1px solid #BEBEBE;
+            }
+
+            li {
+                list-style-type: none;
+                padding: 7px 10px 7px 10px;
+                border-top: 1px solid @inspector-status-border-color;
+                clear: both;
+
+                .right-link {
+                    float: right;
+                    color: @confirm-button-color;
                 }
+            }
 
-                a {
-                    color: @text-colour;
-                    text-decoration: underline;
-                }
-
-                a.landscape {
-                    font-size: 12px;
-                }
-
-                ul {
-                    margin-left: 0;
-                    border-bottom: 1px solid #BEBEBE;
-                }
-
-                li {
-                    list-style-type: none;
-                    padding: 7px 10px 7px 10px;
-                    border-top: 1px solid @inspector-status-border-color;
-                    clear: both;
-
-                    .right-link {
-                        float: right;
-                        color: @confirm-button-color;
-                    }
-                }
-
-                input[type="checkbox"] {
-                    margin-right: 30px;
-                }
+            input[type="checkbox"] {
+                margin-right: 30px;
             }
         }
         .relation-wrapper {


### PR DESCRIPTION
Styled the upgrade charm panel.

The close button does not currently work as we do not store the inspector state. There's a card to rectify this.

The header with the close button should not be included in the scrolled area, but the solution to fix this requires the viewlet to have destroy called on it when the panel is closed. There is a card to fix this also.

QA:
- drag a charm to the canvas
- click deploy and confirm
- click on the service block to open the inspector
- click "Change version" in the inspector
- it should be styled the same as the "Change version" section on this mockup: https://docs.google.com/a/canonical.com/file/d/0B7XG_QBXNwY1MlRWZlNQN214WGc/edit
