### PR TITLE
Change to state classes rather than adding hidden class

### DIFF
--- a/app/templates/container-type-form.partial
+++ b/app/templates/container-type-form.partial
@@ -1,4 +1,4 @@
-<div class="containers hidden">
+<div class="containers">
   <select>
     <option value="" selected disabled class="default">Choose location</option>
     <option value="lxc" class="default">New LXC</option>

--- a/app/views/utils.js
+++ b/app/views/utils.js
@@ -306,6 +306,24 @@ YUI.add('juju-view-utils', function(Y) {
   };
   utils.removeSVGClass = removeSVGClass;
 
+  /**
+    Set a state class on a node.
+
+    @method setStateClass
+    @param {String} newState the new state to set.
+  */
+  var setStateClass = function(node, newState) {
+    var existing = node.get('className').split(' ');
+    // Remove old state classes.
+    existing.forEach(function(className) {
+      if (className.indexOf('state-') === 0) {
+        node.removeClass(className);
+      }
+    });
+    node.addClass('state-' + newState);
+  };
+  utils.setStateClass = setStateClass;
+
   var consoleManager = function() {
     var noop = function() {};
     var winConsole = window.console,

--- a/app/widgets/create-machine-view.js
+++ b/app/widgets/create-machine-view.js
@@ -28,6 +28,7 @@ YUI.add('create-machine-view', function(Y) {
 
   var views = Y.namespace('juju.views'),
       widgets = Y.namespace('juju.widgets'),
+      utils = views.utils,
       Templates = views.Templates;
 
   /**
@@ -93,15 +94,15 @@ YUI.add('create-machine-view', function(Y) {
         */
         _handleContainerTypeChange: function(e) {
           e.preventDefault();
-          var constraints = this.get('container').one('.constraints'),
-              select = e.currentTarget,
+          var container = this.get('container');
+          var select = e.currentTarget,
               selectedIndex = select.get('selectedIndex'),
               newVal = select.get('options').item(selectedIndex).get('value');
           this.set('containerType', newVal);
           if (newVal === 'kvm') {
-            constraints.removeClass('hidden');
+            utils.setStateClass(container, 'container-constraints');
           } else {
-            constraints.addClass('hidden');
+            utils.setStateClass(container, 'containers');
           }
         },
 
@@ -131,8 +132,9 @@ YUI.add('create-machine-view', function(Y) {
           // If this is a container (i.e., has a parent machine), show the
           // container type select and hide the constraints.
           if (this.get('parentId')) {
-            container.one('.containers').removeClass('hidden');
-            container.one('.constraints').addClass('hidden');
+            utils.setStateClass(container, 'containers');
+          } else {
+            utils.setStateClass(container, 'constraints');
           }
           return this;
         },

--- a/app/widgets/serviceunit-token.js
+++ b/app/widgets/serviceunit-token.js
@@ -28,6 +28,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 YUI.add('juju-serviceunit-token', function(Y) {
 
   var views = Y.namespace('juju.views'),
+      utils = views.utils,
       Templates = views.Templates;
 
   /**
@@ -67,7 +68,7 @@ YUI.add('juju-serviceunit-token', function(Y) {
     _handleMoveIconClick: function(e) {
       e.preventDefault();
       this._populateMachines();
-      this._setStateClass('select-machine');
+      utils.setStateClass(this.get('container'), 'select-machine');
     },
 
     /**
@@ -132,14 +133,10 @@ YUI.add('juju-serviceunit-token', function(Y) {
       var machineValue = this._getSelectedMachine();
 
       if (machineValue === 'new') {
-        this._setStateClass('new-machine');
+        utils.setStateClass(this.get('container'), 'new-machine');
       } else {
         this._populateContainers(machineValue);
-        this._setStateClass('select-container');
-        // XXX kadams54 20/06/2014 This is a kludge - other places that use the
-        // container type form don't have the state class. Need to either
-        // settle on one approach or the other.
-        this.get('container').one('.containers').removeClass('hidden');
+        utils.setStateClass(this.get('container'), 'select-container');
       }
     },
 
@@ -154,9 +151,9 @@ YUI.add('juju-serviceunit-token', function(Y) {
       var containerValue = this._getSelectedContainer();
 
       if (containerValue === 'kvm') {
-        this._setStateClass(containerValue);
+        utils.setStateClass(this.get('container'), containerValue);
       } else {
-        this._setStateClass('select-container');
+        utils.setStateClass(this.get('container'), 'select-container');
       }
     },
 
@@ -287,24 +284,6 @@ YUI.add('juju-serviceunit-token', function(Y) {
     },
 
     /**
-      Set the state classes on the widget.
-
-      @method _setStateClass
-      @param {String} newState the new state.
-    */
-    _setStateClass: function(newState) {
-      var container = this.get('container');
-      var existing = container.get('className').split(' ');
-      // Remove old state classes.
-      existing.forEach(function(className) {
-        if (className.indexOf('state-') === 0) {
-          container.removeClass(className);
-        }
-      });
-      container.addClass('state-' + newState);
-    },
-
-    /**
       Reset the token to the initial state.
 
       @method reset
@@ -327,7 +306,7 @@ YUI.add('juju-serviceunit-token', function(Y) {
       // manipulate the dom, which we need for our namespaced code
       // to read.
       container.one('.unplaced-unit').setAttribute('data-id', unit.id);
-      this._setStateClass('initial');
+      utils.setStateClass(container, 'initial');
     },
 
     /**
@@ -394,6 +373,7 @@ YUI.add('juju-serviceunit-token', function(Y) {
     'event-tracker',
     'node',
     'juju-templates',
+    'juju-view-utils',
     'handlebars'
   ]
 });

--- a/lib/views/machine-view/create-machine-view.less
+++ b/lib/views/machine-view/create-machine-view.less
@@ -7,6 +7,26 @@
     border-color: @machine-view-border-colour;
     line-height: 38px;
 
+    &.state-containers {
+        .containers {
+            display: block;
+        }
+    }
+    &.state-constraints {
+        .constraints {
+            display: block;
+        }
+    }
+    &.state-container-constraints {
+        .containers,
+        .constraints {
+            display: block;
+        }
+    }
+    .constraints,
+    .containers {
+        display: none;
+    }
     input[type="text"],
     select {
         width: 100%;

--- a/test/test_machine_view_panel.js
+++ b/test/test_machine_view_panel.js
@@ -222,8 +222,8 @@ describe('machine view panel view', function() {
                    'expected class is not present');
       assert.equal(createMachine.getHTML() === '', false,
                    'HTML is not present');
-      assert.equal(createMachine.one('.containers').hasClass('hidden'), true,
-                   'container types are visible');
+      assert.equal(createMachine.hasClass('state-constraints'), true,
+                   'the constraints should be visible');
     });
 
     it('displays when the container header action is clicked', function() {
@@ -235,8 +235,8 @@ describe('machine view panel view', function() {
                    'expected class is not present');
       assert.equal(createContainer.getHTML() === '', false,
                    'HTML is not present');
-      assert.equal(createContainer.one('.containers').hasClass('hidden'), false,
-                   'container types are hidden');
+      assert.equal(createContainer.hasClass('state-containers'), true,
+                   'the container types should be visible');
     });
 
     it('creates an unplaced unit when cancelled with a unit', function() {


### PR DESCRIPTION
Instead of adding the `hidden` class to show the correct parts of the UI, this branch tracks the state on the container, allowing the UI to be set correctly through CSS.

QA: Try placing units and creating containers and machines and check that the appropriate bits of UI are shown.
