### PR TITLE
Select the first machine and bare metal container by default.

### DIFF
--- a/app/widgets/machine-view-panel.js
+++ b/app/widgets/machine-view-panel.js
@@ -578,18 +578,27 @@ YUI.add('machine-view-panel', function(Y) {
         },
 
         /**
-         * Display containers for the selected machine.
+         * Handle the click event to show containers for the selected machine.
          *
          * @method handleMachineTokenSelect
          * @param {Event} ev the click event created.
          */
         handleMachineTokenSelect: function(e) {
+          e.preventDefault();
+          this._selectMachineToken(e.currentTarget);
+        },
+
+        /**
+         * Display containers for the selected machine.
+         *
+         * @method _selectMachineToken
+         * @param {Object} selected the node for the token that was selected.
+         */
+        _selectMachineToken: function(selected) {
           var container = this.get('container'),
               machineTokens = container.all('.machines .content .items .token'),
-              selected = e.currentTarget,
               parentId = selected.getData('id');
           var containers = this.get('db').machines.filterByParent(parentId);
-          e.preventDefault();
           // A lot of things in the machine view rely on knowing when the user
           // selects a machine.
           this.set('selectedMachine', parentId);
@@ -597,21 +606,32 @@ YUI.add('machine-view-panel', function(Y) {
           machineTokens.removeClass('active');
           selected.addClass('active');
           this._renderContainerTokens(containers, parentId);
+          this._selectBareMetalContainer(parentId);
         },
 
         /**
-         * Set the active container.
+         * Handle the click event to show the active container.
          *
          * @method handleContainerTokenSelect
          * @param {Event} ev the click event created.
          */
         handleContainerTokenSelect: function(e) {
+          e.preventDefault();
+          this._selectContainerToken(e.currentTarget);
+        },
+
+        /**
+         * Set the active container.
+         *
+         * @method _selectContainerToken
+         * @param {Object} selected the node for the token that was selected.
+         */
+        _selectContainerToken: function(selected) {
           var container = this.get('container');
-          var machineTokens = container.all(
+          var containerTokens = container.all(
               '.containers .content .items .token');
-          var selected = e.currentTarget;
           // Select the active token.
-          machineTokens.removeClass('active');
+          containerTokens.removeClass('active');
           selected.addClass('active');
         },
 
@@ -923,6 +943,34 @@ YUI.add('machine-view-panel', function(Y) {
         },
 
         /**
+          Select the first machine.
+
+          @method _selectFirstMachine
+        */
+        _selectFirstMachine: function() {
+          // Get the first token in the dom. The dom order is the one we
+          // care about.
+          var machineNode = this.get('container').one(
+              '.column.machines .items li .token');
+          if (machineNode) {
+            this._selectMachineToken(machineNode);
+          }
+        },
+
+        /**
+          Select the bare metal container.
+
+          @method _selectBareMetalContainer
+          @param {String} machineId The id of the selected machine.
+        */
+        _selectBareMetalContainer: function(machineId) {
+          var bareMetalId = machineId + '/bare-metal';
+          var containerTokens = this.get('containerTokens');
+          this._selectContainerToken(containerTokens[bareMetalId].get(
+              'container').one('.token'));
+        },
+
+        /**
          * Sets up the DOM nodes and renders them to the DOM.
          *
          * @method render
@@ -936,6 +984,7 @@ YUI.add('machine-view-panel', function(Y) {
           this._renderUnplacedUnits();
           this._renderScaleUp();
           this._clearContainerColumn();
+          this._selectFirstMachine();
           return this;
         },
 

--- a/test/test_machine_view_panel.js
+++ b/test/test_machine_view_panel.js
@@ -810,6 +810,13 @@ describe('machine view panel view', function() {
           'container').one('.label').get('text'), label);
     });
 
+    it('should select the first machine by default', function() {
+      view.render();
+      assert.equal(container.one(
+          '.machines .content li:first-child .token').hasClass('active'),
+          true, 'the first machine token should be selected');
+    });
+
     it('should add new tokens when machines are added', function() {
       view.render();
       var selector = '.machines .token',
@@ -947,14 +954,14 @@ describe('machine view panel view', function() {
           list = container.all(selector),
           id = '2/foo/999',
           initialSize = list.size();
-      assert.equal(initialSize, 0,
+      assert.equal(initialSize, 1,
                    'check the initial size');
       machines.add([
         { id: id }
       ]);
       list = container.all(selector);
-      assert.equal(list.size(), 1, 'list should have updated');
-      assert.equal(container.one(selector).getData('id'), '2/foo/999',
+      assert.equal(list.size(), 2, 'list should have updated');
+      assert.equal(container.all(selector).item(1).getData('id'), '2/foo/999',
           'the container should be in the displayed list');
     });
 
@@ -966,11 +973,11 @@ describe('machine view panel view', function() {
           list = container.all(selector),
           initialSize = list.size(),
           m = machines.getById(id);
-      assert.equal(initialSize, 1,
+      assert.equal(initialSize, 2,
                    'check the initial size');
       machines.remove(m);
       list = container.all(selector);
-      assert.equal(list.size(), 0,
+      assert.equal(list.size(), 1,
                    'list should have changed in size');
       var deletedSelector = selector + '[data-id="' + id + '"]';
       var deletedItem = container.one(deletedSelector);
@@ -987,13 +994,13 @@ describe('machine view panel view', function() {
           initialSize = list.size(),
           m = machines.getById(id);
       var oldItem = container.one(selector + '[data-id="' + id + '"]');
-      assert.equal(initialSize, 1,
+      assert.equal(initialSize, 2,
                    'check the initial size');
       m = machines.revive(m);
       assert.equal(oldItem === null, false, 'the item should exist');
       m.set('id', '2/foo/1000');
       list = container.all(selector);
-      assert.equal(list.size(), 1,
+      assert.equal(list.size(), 2,
                    'list should not have changed in size');
       oldItem = container.one(selector + '[data-id="' + id + '"]');
       assert.equal(oldItem, null,
@@ -1122,9 +1129,9 @@ describe('machine view panel view', function() {
     describe('functional tests', function() {
       it('can render containers on click of machine token', function() {
         view.render();
-        machines.add([{ id: '0/lxc/0' }]);
+        machines.add([{id: '5'}, {id: '5/lxc/0'}]);
         view.get('db').units.add([{id: 'test/2', machine: '0'}]);
-        var token = container.one('.machine-token .token');
+        var token = container.one('.machine-token:last-child .token');
         assert.equal(
             token.hasClass('active'), false,
             'Machine token already selected.');
@@ -1137,7 +1144,7 @@ describe('machine view panel view', function() {
         // We should have one token for the new container and one for the
         // "bare metal".
         assert.equal(containers.size(), 2, 'Containers did not render.');
-        assert.equal(hardware, '1x10.24GHz,1.0GB,1.0GB');
+        assert.equal(hardware, 'Hardwaredetailsnotavailable');
       });
 
       it('can select container tokens', function() {
@@ -1146,7 +1153,8 @@ describe('machine view panel view', function() {
         view.get('db').units.add([{id: 'test/2', machine: '0'}]);
         var machineToken = container.one('.machine-token .token');
         machineToken.simulate('click');
-        var containerToken = container.one('.container-token .token');
+        var containerToken = container.one(
+            '.container-token:last-child .token');
         assert.equal(
             containerToken.hasClass('active'), false,
             'Container token already selected.');
@@ -1154,6 +1162,17 @@ describe('machine view panel view', function() {
         assert.equal(
             containerToken.hasClass('active'), true,
             'Container token not marked as selected.');
+      });
+
+      it('should select the bare metal container by default', function() {
+        view.render();
+        machines.add([{ id: '0/lxc/0' }]);
+        view.get('db').units.add([{id: 'test/2', machine: '0'}]);
+        var machineToken = container.one('.machine-token .token');
+        machineToken.simulate('click');
+        assert.equal(container.one(
+            '.containers .content li:first-child .token').hasClass('active'),
+            true, 'the bare metal token should be selected');
       });
     });
   });


### PR DESCRIPTION
This branch selects the first machine by default when the machine view panel is opened. Additionally, when you select a machine the bare metal container is now selected by default.

QA:
- drag two charms to the canvas
- click deploy and confirm
- open the machine view panel
- the first machine should be selected and the bare metal container should be selected
- click on the unselected machine
- the containers for the second machine should be shown with the bare metal container selected
