### PR TITLE
Update machine view with new hover and drop states

### DIFF
--- a/app/templates/container-token-units.handlebars
+++ b/app/templates/container-token-units.handlebars
@@ -1,0 +1,6 @@
+{{#units}}
+  <li class="unit {{#unless agent_state }}uncommitted{{/unless}}">
+    <img src="{{icon}}" alt="{{service}}"/>
+    <span class="name">{{displayName}}</span>
+  </li>
+{{/units}}

--- a/app/templates/container-token.handlebars
+++ b/app/templates/container-token.handlebars
@@ -1,14 +1,7 @@
 <div class="token">
   <div class="top">
     <span class="title">{{ displayName }}</span>
-    <ul class="service-icons">
-      {{#units}}
-        <li class="unit">
-          <img src="{{icon}}" alt="{{service}}"/>
-          <span class="name">{{displayName}}</span>
-        </li>
-      {{/units}}
-    </ul>
+    <ul class="service-icons"></ul>
   </div>
   <span class="delete">
     <i class="sprite mv-token-destroy"></i>

--- a/app/widgets/container-token.js
+++ b/app/widgets/container-token.js
@@ -40,6 +40,7 @@ YUI.add('container-token', function(Y) {
         views.MVDropTargetViewExtension
       ], {
         template: Templates['container-token'],
+        unitsTemplate: Templates['container-token-units'],
 
         events: {
           '.delete': {
@@ -106,6 +107,16 @@ YUI.add('container-token', function(Y) {
         },
 
         /**
+         * Render the units.
+         *
+         * @method renderTemplate
+         */
+        renderUnits: function() {
+          this.get('container').one('.service-icons').setHTML(
+              this.unitsTemplate(this.get('machine')));
+        },
+
+        /**
          * Sets up the DOM nodes and renders them to the DOM.
          *
          * @method render
@@ -114,6 +125,7 @@ YUI.add('container-token', function(Y) {
           var container = this.get('container'),
               machine = this.get('machine');
           container.setHTML(this.template(machine));
+          this.renderUnits();
           container.addClass('container-token');
           container.one('.token').addClass(
               this.get('committed') ? 'committed' : 'uncommitted');

--- a/app/widgets/machine-view-panel.js
+++ b/app/widgets/machine-view-panel.js
@@ -151,14 +151,21 @@ YUI.add('machine-view-panel', function(Y) {
               changed = e.changed,
               target = e.target;
           if (changed) {
-            // Need to update any machines that now have new units
+            // Need to update any machines and containers that now have
+            // new units.
             if (changed.machine) {
               var machineTokens = this.get('machineTokens'),
+                  containerTokens = this.get('containerTokens'),
                   id = changed.machine.newVal,
-                  machineToken = machineTokens[id];
+                  machineToken = machineTokens[id],
+                  containerToken = containerTokens[id];
               if (machineToken) {
                 this._updateMachineWithUnitData(machineToken.get('machine'));
                 machineToken.render();
+              }
+              if (containerToken) {
+                this._updateMachineWithUnitData(containerToken.get('machine'));
+                containerToken.renderUnits();
               }
             }
             if (target.get('machine')) {

--- a/lib/views/machine-view/container-token.less
+++ b/lib/views/machine-view/container-token.less
@@ -10,8 +10,12 @@
 
                 .unit {
                     float: none;
-                    margin: 0 0 10px 0;
+                    margin: 0 -20px;
+                    padding: 5px 20px;
 
+                    &.uncommitted {
+                        background-color: #ddf4fc;
+                    }
                     &:last-child {
                         margin-bottom: 0;
                     }

--- a/lib/views/machine-view/machine-view-panel.less
+++ b/lib/views/machine-view/machine-view-panel.less
@@ -101,9 +101,6 @@
         }
     }
     .droppable {
-        &.drop-hover .drop {
-            background-color: #eee;
-        }
         .drop {
             display: block;
 
@@ -122,8 +119,7 @@
         bottom: -1px;
         left: -1px;
         right: -1px;
-        background-color: #fff;
-        border: 1px dashed #d9d9d9;
+        border: 1px dashed #fff;
         text-align: center;
 
         span {
@@ -132,6 +128,26 @@
             left: 0;
             right: 0;
             margin-top: -13px;
+        }
+    }
+    .token .drop span {
+        display: none;
+    }
+    .drop-hover .token .drop {
+        background-color: rgba(250, 250, 250, 0.85);
+        border-color: #b2b2b2;
+
+        span {
+            display: inline-block;
+        }
+    }
+    .machine-view-panel-header {
+        .drop {
+            background-color: #fff;
+            border-color: #b2b2b2;
+        }
+        &.drop-hover .drop {
+            background-color: #f8f8f8;
         }
     }
 }

--- a/lib/views/machine-view/machine-view-token-base.less
+++ b/lib/views/machine-view/machine-view-token-base.less
@@ -12,6 +12,9 @@
     border-color: @machine-view-border-colour;
     cursor: pointer;
 
+    &:hover {
+        background-color: #f6f6f6;
+    }
     &:last-child {
         border-bottom-width: 1px;
     }
@@ -30,10 +33,13 @@
             display: block;
         }
     }
-    // Needs to be after &.active so that when both are applied the active
-    // background is the uncommitted colour.
     &.uncommitted {
         background-color: #ddf4fc;
+
+        &:hover,
+        &.active {
+            background-color: #c5edfb;
+        }
     }
     span {
         display: block;

--- a/lib/views/machine-view/serviceunit-token.less
+++ b/lib/views/machine-view/serviceunit-token.less
@@ -12,6 +12,9 @@
         background-color: transparent;
         cursor: move;
 
+        &:hover {
+            box-shadow: 0 0 3px rgba(0, 0, 0, 0.3);
+        }
         .token-move {
             display: block;
         }


### PR DESCRIPTION
Updated with new hover and drop states as seen here: https://docs.google.com/a/canonical.com/file/d/0B7XG_QBXNwY1eF82Z3d5MllQNHM/edit

When dropping a unit on a container it would not update the token so that has been fixed also.
