### PR TITLE
WIP: Abort and notify if charm data doesn't exist in service-config.

### DIFF
--- a/app/subapps/browser/browser.js
+++ b/app/subapps/browser/browser.js
@@ -323,7 +323,7 @@ YUI.add('subapp-browser', function(Y) {
         });
         this.get('db').notifications.add({
           title: 'Could not load service inspector.',
-          message: 'There is no deployed service named ' + metadata.id + '.',
+          message: 'The service named ' + metadata.id + 'has not yet loaded.',
           level: 'error'
         });
       }


### PR DESCRIPTION
This is a WIP review to get some eyeballs.

For some reason the changeState on line 101 of service-config.js doesn't propogate up to the browser. Service-inspector is listed as the target for service-config.js in this context (e.g. by calling `getTargets`), and changeState events fired by other viewlets or by the inspector in this context seem to work.
