### PR TITLE
Remove uncommitted units when the ghost service is removed.

### DIFF
--- a/app/utils/environment-change-set.js
+++ b/app/utils/environment-change-set.js
@@ -435,6 +435,11 @@ YUI.add('environment-change-set', function(Y) {
       var db = this.get('db');
       var modelId = this.changeSet[service].command.options.modelId;
       var model = db.services.getById(modelId);
+      var units = model.get('units');
+      // Remove the unplaced service units
+      units.each(function(unit) {
+        db.removeUnits(unit);
+      });
       db.services.remove(model);
       model.destroy();
       this._removeExistingRecord(service);


### PR DESCRIPTION
`_destroyQueuedService` attempts to remove all the items associated with the queued ("ghost") service. While it gets the entries for adding the uncommitted units, it doesn't remove the actual units.

This branch remedies that, and updates the test showing it removes queued service to demonstrate it also removes uncommited units.
