### PR TITLE
Don't show containers in deployment summary.

### DIFF
--- a/app/templates/deployer-bar.handlebars
+++ b/app/templates/deployer-bar.handlebars
@@ -102,7 +102,7 @@
     <section>
         <div class="content">
             <h2 class="title">Deployment summary</h2>
-            {{#unless noChange}}
+            {{#if majorChange}}
             <div class="summary-panel">
                 {{#if changeCount}}
                     {{#if deployServices.length}}
@@ -245,22 +245,20 @@
                     <p>No uncommitted changes</p>
                 {{/if}}
             </div>
-            {{/unless}}
-            {{#if noChange}}
-              <div class="changes open">
+            <div class="changes">
             {{else}}
-              <div class="changes">
+            <div class="changes open">
             {{/if}}
-                <div class="toggle">
-                    View the complete change log
-                    <span class="expand">
-                        <i class="sprite expand_icon"></i>
-                    </span>
-                    <span class="contract">
-                        <i class="sprite contract_icon"></i>
-                    </span>
-                </div>
-                <div class="list"></div>
+              <div class="toggle">
+                  View the complete change log
+                  <span class="expand">
+                      <i class="sprite expand_icon"></i>
+                  </span>
+                  <span class="contract">
+                      <i class="sprite contract_icon"></i>
+                  </span>
+              </div>
+              <div class="list"></div>
             </div>
         </div>
     </section>

--- a/app/widgets/deployer-bar.js
+++ b/app/widgets/deployer-bar.js
@@ -236,7 +236,7 @@ YUI.add('deployer-bar', function(Y) {
           destroyedMachines: changes.destroyMachines,
           configsChanged: changes.setConfigs,
           deployed: this._deployed,
-          noChange: this._noMajorChanges(changes)
+          majorChange: this._hasMajorChanges(changes)
         }));
       }
       container.addClass('summary-open');
@@ -248,19 +248,19 @@ YUI.add('deployer-bar', function(Y) {
 
 
     /**
-       Determines if there are no major changes in the change set.
+       Determines if there are "major" changes in the change set.
 
-       @method _noMajorChanges
+       @method _hasMajorChanges
        @param {Object} changes The change set for the summary.
      */
-    _noMajorChanges: function(changes) {
-      var noChange = true;
+    _hasMajorChanges: function(changes) {
+      var hasChange = false;
       Object.keys(changes).forEach(function(change) {
         if (changes[change].length !== 0) {
-          noChange = false;
+          hasChange = true;
         }
       });
-      return noChange;
+      return hasChange;
     },
 
     /**

--- a/test/test_deployer_bar.js
+++ b/test/test_deployer_bar.js
@@ -148,24 +148,17 @@ describe('deployer bar view', function() {
     );
   });
 
-  it('can open the recent changes in the summary panel', function() {
+  it('can toggle the recent changes in the summary panel', function() {
+    var majorChangeStub = utils.makeStubMethod(view, '_hasMajorChanges', true);
+    this._cleanups.push(majorChangeStub);
+    view._showSummary();
     var changesNode = container.one('.panel.summary .changes');
     var toggleNode = changesNode.one('.toggle');
-    container.one('.deploy-button').simulate('click');
     assert.equal(changesNode.hasClass('open'), false,
         'The changes should initially be closed');
     toggleNode.simulate('click');
     assert.equal(changesNode.hasClass('open'), true,
         'The changes node should have had the open class added');
-  });
-
-  it('can hide the recent changes in the summary panel', function() {
-    var changesNode = container.one('.panel.summary .changes');
-    var toggleNode = changesNode.one('.toggle');
-    container.one('.deploy-button').simulate('click');
-    toggleNode.simulate('click');
-    assert.equal(changesNode.hasClass('open'), true,
-        'The changes should set to open');
     toggleNode.simulate('click');
     assert.equal(changesNode.hasClass('open'), false,
         'The changes node should have had the open class removed');


### PR DESCRIPTION
- Filter out container only changes in the `_addMachines` case of
  `_getChanges`
- Added `_noMajorChanges`, which determines if there are any so-called "major"
  changes in a given change set.
- Updated the handlebars template to show the summary only for "major"
- and to toggle the changelog by default if there are only "minor" changes.
- Updated tests.
