### PR TITLE
Added machine, container and unit removed states in the machine view

### DIFF
--- a/app/templates/container-token-units.handlebars
+++ b/app/templates/container-token-units.handlebars
@@ -3,6 +3,9 @@
     <img src="{{icon}}" alt="{{service}}"/>
     <span class="name">
       {{displayName}}
+      <span class="removed">
+        will be destroyed once you have committed your changes
+      </span>
       <span class="unit-uncommitted">&deg;</span>
     </span>
   </li>

--- a/app/templates/container-token.handlebars
+++ b/app/templates/container-token.handlebars
@@ -2,6 +2,9 @@
   <div class="top">
     <span class="title">
       {{ displayName }}
+      <span class="removed">
+        will be destroyed once you have committed your changes
+      </span>
       <span class="token-uncommitted">&deg;</span>
     </span>
     <ul class="service-icons"></ul>

--- a/app/templates/machine-token.handlebars
+++ b/app/templates/machine-token.handlebars
@@ -2,6 +2,9 @@
   <div class="top">
     <span class="title">
       {{ displayName }}
+      <span class="removed">
+        will be destroyed once you have committed your changes
+      </span>
       <span class="token-uncommitted">&deg;</span>
     </span>
     <span class="service-icons"></span>

--- a/app/widgets/machine-view-panel.js
+++ b/app/widgets/machine-view-panel.js
@@ -699,7 +699,7 @@ YUI.add('machine-view-panel', function(Y) {
          */
         deleteMachine: function(e) {
           e.preventDefault();
-          var machineName = e.currentTarget.ancestor().one('.title').getHTML();
+          var machineName = e.currentTarget.ancestor('.token').getData('id');
           this.get('env').destroyMachines([machineName], false, function(data) {
             if (data.err) {
               this.get('db').notifications.add({

--- a/lib/views/machine-view/container-token.less
+++ b/lib/views/machine-view/container-token.less
@@ -24,10 +24,11 @@
                     }
                     img {
                         vertical-align: middle;
+                        float: left;
                         margin: 0 7px 0 0;
                     }
                     .name {
-                        display: inline-block;
+                        display: block;
                     }
                 }
             }

--- a/lib/views/machine-view/machine-view-token-base.less
+++ b/lib/views/machine-view/machine-view-token-base.less
@@ -46,6 +46,13 @@
     .token-uncommitted {
         display: none;
     }
+    .removed {
+        // XXX: Hiding these states until the tokens have 'deleted' flags.
+        // - huwshimi: 31/07/2014
+        display: none;
+        // Once implemented the display should be:
+        //display: inline;
+    }
     .top {
         .display-flex;
         overflow: hidden;

--- a/test/test_machine_view_panel.js
+++ b/test/test_machine_view_panel.js
@@ -833,8 +833,9 @@ describe('machine view panel view', function() {
                    'models are out of sync with displayed list');
       list.each(function(item, index) {
         var m = machines.item(index);
-        assert.equal(item.one('.title').get('text').replace(/\s+/g, ' ').trim(),
-            m.displayName + ' °', 'displayed item does not match model');
+        assert.equal(item.one('.title').get(
+            'text').trim().indexOf(m.displayName) === 0,
+            true, 'displayed item does not match model');
       });
     });
 
@@ -901,17 +902,15 @@ describe('machine view panel view', function() {
           item = container.one(
               selector + '[data-id="' + machineModel.get('id') + '"]');
       assert.notEqual(item, null, 'machine was not initially displayed');
-      assert.equal(
-          item.one('.title').get('text').replace(/\s+/g, ' ').trim(),
-          machineModel.get('displayName') + ' °',
-          'initial machine names do not match');
+      assert.equal(item.one('.title').get(
+          'text').trim().indexOf(machineModel.get('displayName')) === 0,
+          true, 'initial machine names do not match');
       machineModel.set('id', id);
       item = container.one(selector + '[data-id="' + id + '"]');
       assert.notEqual(item, null, 'machine was not displayed post-update');
-      assert.equal(
-          item.one('.title').get('text').replace(/\s+/g, ' ').trim(),
-          machineModel.get('displayName') + ' °',
-          'machine names do not match post-update');
+      assert.equal(item.one('.title').get(
+          'text').trim().indexOf(machineModel.get('displayName')) === 0,
+          true, 'machine names do not match post-update');
     });
 
     it('should set the correct counts in the container header', function(done) {


### PR DESCRIPTION
Display the removed states for machines containers and units in the machine view. These are not currently visible and will be hooked up once the ecs flags machines, containers and units as deleted.
