### PR TITLE
ECS reflects changes to the ghost service name.

### DIFF
--- a/app/models/handlers.js
+++ b/app/models/handlers.js
@@ -217,6 +217,10 @@ YUI.add('juju-delta-handlers', function(Y) {
     serviceInfo: function(db, action, change) {
       var data = {
         id: change.Name,
+        // The name attribute is used to store the temporary name of ghost
+        // services. We set it here for consistency, even if the name of a
+        // real service can never be changed.
+        name: change.Name,
         charm: change.CharmURL,
         exposed: change.Exposed,
         life: change.Life,

--- a/app/models/models.js
+++ b/app/models/models.js
@@ -285,7 +285,21 @@ YUI.add('juju-models', function(Y) {
           }
         }
       },
-      name: {},
+      /**
+        The name of the service.
+        If not set, the charm name is returned.
+
+        @attribute name
+        @type {String}
+      */
+      name: {
+        'getter': function(value) {
+          if (value) {
+            return value;
+          }
+          return this.get('packageName');
+        }
+      },
       charm: {},
       icon: {},
       config: {},

--- a/app/templates/inspector-header.handlebars
+++ b/app/templates/inspector-header.handlebars
@@ -6,7 +6,7 @@
     <div class="details-wrapper">
       {{#if pending}}
         <input type="text" class="service-name config-field {{invalidName}}" name="service-name"
-               value="{{packageName}}">
+               value="{{name}}">
       {{else}}
         <div data-bind="displayName" class="service-name">{{displayName}}</div>
       {{/if}}

--- a/app/views/viewlets/inspector-header.js
+++ b/app/views/viewlets/inspector-header.js
@@ -100,23 +100,36 @@ YUI.add('inspector-header-view', function(Y) {
 
     /**
       Updates the ghost service name when the user changes it in the inspector.
+      Also update the display name of the corresponding ghost units.
 
       @method updateGhostName
-      @param {Y.EventFacade} e event object from valuechange.
+      @param {Y.EventFacade} evt event object from valuechange.
     */
-    updateGhostName: function(e) {
+    updateGhostName: function(evt) {
       // The render method expects these parentheses around the model
       // displayName.  If you change this format, or this code, make sure you
       // look at that method too.  Hopefully the associated tests will catch it
       // as well. Also see(grep for) the resetCanvas method too.
-      var name = e.newVal,
-          options = this.options,
-          db = options.db,
-          serviceName = '(' + name + ')';
-
+      var name = evt.newVal;
+      var options = this.options;
+      var db = options.db;
+      var model = options.model;
+      var serviceName = '(' + name + ')';
+      // Validate the service name.
       var isValid = utils.validateServiceName(name, db);
-      options.model.set('displayName', serviceName);
-      this.serviceNameInputStatus(isValid, e.currentTarget);
+      if (isValid) {
+        model.set('name', name);
+        // Change the display name of all the ghost units belonging to this
+        // service.
+        var modelId = model.get('id');
+        db.units.filter(function(unit) {
+          return unit.service === modelId;
+        }).forEach(function(unit) {
+          unit.displayName = name + '/' + unit.number;
+        });
+      }
+      model.set('displayName', serviceName);
+      this.serviceNameInputStatus(isValid, evt.currentTarget);
     },
 
     /**

--- a/test/test_ghost_deployer_extension.js
+++ b/test/test_ghost_deployer_extension.js
@@ -177,21 +177,23 @@ describe('Ghost Deployer Extension', function() {
 
   it('sets the proper annotations in the deploy handler', function() {
     var ghostService = new Y.Model({
-      id: 'ghostid'
+      id: 'ghostid',
+      name: 'django',
+      config: {}
     });
     var topo = ghostDeployer.views.environment.instance.topo;
     topo.annotateBoxPosition = utils.makeStubFunction();
     topo.service_boxes.ghostid = {};
-    ghostDeployer._deployCallbackHandler('foo', {}, {}, ghostService, {});
+    ghostDeployer._deployCallbackHandler(ghostService, {});
     var attrs = ghostService.getAttrs();
-    assert.equal(attrs.id, 'foo');
+    assert.equal(attrs.id, 'django');
     assert.equal(attrs.displayName, undefined);
     assert.equal(attrs.pending, false, 'pending');
     assert.equal(attrs.loading, false, 'loading');
     assert.deepEqual(attrs.config, {}, 'config');
     assert.deepEqual(attrs.constraints, {}, 'constraints');
-    assert.deepEqual(topo.service_boxes.foo, {
-      id: 'foo',
+    assert.deepEqual(topo.service_boxes.django, {
+      id: 'django',
       pending: false
     });
     assert.equal(topo.annotateBoxPosition.calledOnce(), true);
@@ -199,18 +201,19 @@ describe('Ghost Deployer Extension', function() {
 
   it('fires serviceDeployed in the deploy handler', function() {
     var ghostService = new Y.Model({
-      id: 'ghostid'
+      id: 'ghostid',
+      name: 'django'
     });
     var topo = ghostDeployer.views.environment.instance.topo;
     topo.annotateBoxPosition = utils.makeStubFunction();
     topo.service_boxes.ghostid = {clientId: 'ghostid'};
     var stubFire = ghostDeployer.get('subApps').charmbrowser.fire;
-    ghostDeployer._deployCallbackHandler('ghostid', {}, {}, ghostService, {});
+    ghostDeployer._deployCallbackHandler(ghostService, {});
     assert.deepEqual(stubFire.lastArguments(), [
       'serviceDeployed',
       {
         clientId: 'ghostid',
-        serviceName: 'ghostid'
+        serviceName: 'django'
       }
     ], 'Event not fired.');
   });

--- a/test/test_model.js
+++ b/test/test_model.js
@@ -1595,6 +1595,23 @@ describe('test_model.js', function() {
       assert.deepEqual(services, [rails]);
     });
 
+    it('returns the service name if set', function() {
+      var service = new models.Service({
+        id: 'django',
+        charm: 'cs:/trusty/django-42',
+        name: 'my-personal-django'
+      });
+      assert.strictEqual(service.get('name'), 'my-personal-django');
+    });
+
+    it('returns a default name if the name attr is not set', function() {
+      var service = new models.Service({
+        id: 'django',
+        charm: 'cs:/trusty/django-42'
+      });
+      assert.strictEqual(service.get('name'), 'django');
+    });
+
     it('can properly parse the charm url for the package name', function() {
       assert.equal(rails.get('packageName'), 'rails');
       var jujuGui = new models.Service({


### PR DESCRIPTION
```
   When changing the name of a ghost service, the ECS
    records are properly updated, so that when changes
    are committed the resulting service is given the desired
    name.

    This also includes ghost unit names.

    QA:
    Use the mv flag.
    Drag a service and click commit: the service and its
    unit should be deployed as usual.
    Now drag a new service, and use the inspector to rename it.
    Open and close the service inspectore multiple times to ensure
    the inspectore reflects the new service name.
    Open the deployer panel to show the changes: both the service and
    the unit have the correct customized name.
    Switch to the machine view and check the service units is also
    renamed.
    Commit the changes: the deployment summary shows the proper names.
    When the ghost is deployed, the resulting service should
    have the desired name.
```
