### PR TITLE
Fixes unit listing with test update.

### DIFF
--- a/app/models/models.js
+++ b/app/models/models.js
@@ -1846,8 +1846,10 @@ YUI.add('juju-models', function(Y) {
       var units = Y.Lang.isArray(unitOrUnits) ? unitOrUnits : [unitOrUnits];
       // Update the units model list included in the corresponding services.
       units.forEach(function(unit) {
-        var serviceUnits = this.services.getById(unit.service).get('units');
+        var service = this.services.getById(unit.service);
+        var serviceUnits = service.get('units');
         serviceUnits.add(unit, true);
+        this.units.update_service_unit_aggregates(service);
       }, this);
       return unitOrUnits;
     },

--- a/app/views/utils.js
+++ b/app/views/utils.js
@@ -1583,8 +1583,8 @@ YUI.add('juju-view-utils', function(Y) {
   utils.simplifyState = function(unit, life) {
     var state = unit.agent_state,
         inError = (/-?error$/).test(state);
-    if (unit.id !== unit.displayName) {
-      // If the ID and the displayName are different, it's an uncommitted unit.
+    if (!state) {
+      //Uncommitted units don't have state.
       return 'uncommitted';
     }
     if (life === 'dying' && !inError) {

--- a/app/views/viewlets/service-overview.js
+++ b/app/views/viewlets/service-overview.js
@@ -381,6 +381,10 @@ YUI.add('inspector-overview-view', function(Y) {
     bindings: {
       aggregated_status: {
         'update': function(node, value) {
+          if (value && value.uncommitted) {
+            // We don't want to update the status bar with uncommitted units.
+            delete value.uncommitted;
+          }
           var bar = this._statusbar;
           if (!bar) {
             bar = this._statusbar = new views.StatusBar({

--- a/test/test_model.js
+++ b/test/test_model.js
@@ -94,18 +94,30 @@ describe('test_model.js', function() {
   });
 
   describe('juju models', function() {
-    var models, Y;
-    var requirements = ['juju-models', 'juju-charm-models'];
+    var models, Y, utils;
+    var requirements = ['juju-models', 'juju-charm-models', 'juju-tests-utils'];
 
     before(function(done) {
       Y = YUI(GlobalConfig).use(requirements, function(Y) {
         models = Y.namespace('juju.models');
+        utils = Y.namespace('juju-tests.utils');
         done();
       });
     });
 
     beforeEach(function() {
       window._gaq = [];
+    });
+
+    it('should aggregate unit info when adding units', function() {
+      var service_unit = {id: 'mysql/0'};
+      var db = new models.Database();
+      var stub = utils.makeStubMethod(
+          db.units, 'update_service_unit_aggregates');
+      this._cleanups.push(stub.reset);
+      db.services.add({id: 'mysql'});
+      db.addUnits(service_unit);
+      assert.equal(stub.calledOnce(), true);
     });
 
     it('should be able to aggregate unit by status', function() {

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -1722,13 +1722,15 @@ describe('utilities', function() {
       assert.equal(units.length, 2);
     }
 
-    it('creates machines, units, and places units', function() {
+    it('creates machines, units; places units; updates unit lists', function() {
       testScaleUp('myService');
     });
 
-    it('creates machines, units, and places units for ghosts', function() {
-      testScaleUp('myGhostService$');
-    });
+    it('creates machines, units; places units; updates unit lists for ghosts',
+        function() {
+          testScaleUp('myGhostService$');
+        }
+    );
 
     it('properly removes the ghost units on env add_unit callback', function() {
       var ghostUnit = { ghostUnit: 'I am' };


### PR DESCRIPTION
- Call aggregate update when we add uncommitted units. The unit list and unit
  count update is dependent on this operation firing off.
- Update tests to ensure this is called.
