### PR TITLE
Fix uncommitted unit display.

### DIFF
--- a/app/views/viewlets/service-overview.js
+++ b/app/views/viewlets/service-overview.js
@@ -303,7 +303,11 @@ YUI.add('inspector-overview-view', function(Y) {
       var unit = d3.select(this);
       unit.append('a').text(
           function(d) {
-            return d.unit.id;
+            if (d.unit.agent_state) {
+              return d.unit.id;
+            } else {
+              return d.unit.displayName;
+            }
           })
         .attr('data-unit', function(d) {
             return d.unit.service + '/' + d.unit.number;

--- a/test/test_inspector_overview.js
+++ b/test/test_inspector_overview.js
@@ -188,7 +188,7 @@ describe('Inspector Overview', function() {
     window.flags = {};
   });
 
-  it('catches scaleUp cangeState and re-fires', function(done) {
+  it('catches scaleUp changeState and re-fires', function(done) {
     window.flags = {};
     window.flags.mv = true;
     inspector = setUpInspector();
@@ -524,6 +524,8 @@ describe('Inspector Overview', function() {
         uncommittedWrapper.one(SUH).hasClass('closed-unit-list'), true);
     assert.equal(uncommittedWrapper.one(SUC).hasClass('close-unit'), true);
     assert.equal(uncommittedWrapper.one('.unit-qty').getHTML(), 1);
+    var exampleUnit = uncommittedWrapper.all('li').item(1);
+    assert.equal(exampleUnit.get('text'), 'mysql/4');
 
     var errorWrapper = unitListWrappers.item(1);
     assert.equal(errorWrapper.one(SUH).hasClass('error'), true);
@@ -552,6 +554,8 @@ describe('Inspector Overview', function() {
     assert.equal(
         runningWrapper.one('.category-label').getHTML(), 'running units');
     assert.notEqual(runningWrapper.one(SUC).getStyle('maxHeight'), undefined);
+    exampleUnit = runningWrapper.all('li').item(1);
+    assert.equal(exampleUnit.get('text'), 'mysql/3');
 
     units = new Y.LazyModelList();
 


### PR DESCRIPTION
- When a unit is uncommitted, use it's display name.
- Don't use the displayname once the unit exists; it screws up other events
  that aren't applicable to the uncommitted unit.
