### PR TITLE
Allow removing multiple units through the ECS

### DIFF
--- a/app/utils/environment-change-set.js
+++ b/app/utils/environment-change-set.js
@@ -696,14 +696,18 @@ YUI.add('environment-change-set', function(Y) {
       Object.keys(changeSet).forEach(function(key) {
         command = changeSet[key].command;
         if (command.method === '_add_units') {
-          var unitIndex = toRemove.indexOf(command.args[0]);
+          // XXX Currently, modelId is a single unit's name.  In the future,
+          // this will likely be an array and an intersection between the two
+          // will need to be found. Makyo 2014-08-15
+          var unitName = command.options.modelId;
+          var unitIndex = toRemove.indexOf(unitName);
           // If there is a matching ecs unit then remove it from the queue.
           if (unitIndex !== -1) {
             toRemove.splice(unitIndex, 1);
             this._removeExistingRecord(key);
             // Remove the unit from the units DB. Even the ghost units are
             // stored in the DB.
-            units.remove({id: key});
+            units.remove({id: unitName});
           }
         }
       }, this);

--- a/test/test_env_change_set.js
+++ b/test/test_env_change_set.js
@@ -797,7 +797,8 @@ describe('Environment Change Set', function() {
         ecs.changeSet['addUnit-982'] = {
           command: {
             args: ['arg1'],
-            method: '_add_units' }};
+            method: '_add_units' ,
+            options: {modelId: 'arg1'}}};
         var record = ecs._lazyRemoveUnit([['arg1']]);
         var remove = ecs.get('db').units.remove;
         assert.strictEqual(record, undefined);


### PR DESCRIPTION
The Remove Units call allows removing multiple units by passing an array to be removed.  The ECS was not taking this into account, and now does.

Note: there currently isn't a way to remove ghost units in the UI.  This functionality is tested with a unit test, however, and that work passes.
