### PR TITLE
Fixed machines and containers so that they can only be deleted once

### DIFF
--- a/app/widgets/machine-view-panel.js
+++ b/app/widgets/machine-view-panel.js
@@ -732,19 +732,23 @@ YUI.add('machine-view-panel', function(Y) {
          */
         deleteMachine: function(e) {
           var machineName = e.currentTarget.ancestor('.token').getData('id');
-          var machine = this.get('db').machines.getById(machineName);
+          var db = this.get('db');
+          var machine = db.machines.getById(machineName);
           var token = this.get(machine.parentId ?
               'containerTokens' : 'machineTokens')[machineName];
-          token.setDeleted();
-          this.get('env').destroyMachines([machineName], false, function(data) {
-            if (data.err) {
-              this.get('db').notifications.add({
-                title: 'Error destroying machine or container',
-                message: data.err,
-                level: 'error'
-              });
-            }
-          }.bind(this), {modelId: machineName});
+          if (!db.machines.getById(machineName).deleted) {
+            token.setDeleted();
+            this.get('env').destroyMachines([machineName], false,
+                function(data) {
+                  if (data.err) {
+                    db.notifications.add({
+                      title: 'Error destroying machine or container',
+                      message: data.err,
+                      level: 'error'
+                    });
+                  }
+                }.bind(this), {modelId: machineName});
+          }
         },
 
         /**

--- a/test/test_machine_view_panel.js
+++ b/test/test_machine_view_panel.js
@@ -1002,6 +1002,20 @@ describe('machine view panel view', function() {
       assert.equal(token.hasClass('deleted'), true);
     });
 
+    it('should not try to remove a machine more than once', function() {
+      view.render();
+      var deleteNode = container.one('.machine-token .delete');
+      view.set('env', {
+        destroyMachines: utils.makeStubFunction()
+      });
+      deleteNode.simulate('click');
+      // Manually set the deleted flag as we've stubbed out the
+      // destroyMachines method that would do this.
+      view.get('db').machines.getById('0').deleted = true;
+      deleteNode.simulate('click');
+      assert.equal(view.get('env').destroyMachines.calledOnce(), true);
+    });
+
     it('should re-render token when machine is updated', function() {
       view.render();
       var id = 999,
@@ -1342,6 +1356,23 @@ describe('machine view panel view', function() {
       token.simulate('click');
       token.one('.delete').simulate('click');
       assert.equal(token.hasClass('deleted'), true);
+    });
+
+    it('should not try to remove a container more than once', function() {
+      var id = '0/lxc/0';
+      view.render();
+      machines.add([{id: id}]);
+      container.one('.container-token:last-child .token').simulate('click');
+      var deleteNode = container.one('.container-token:last-child .delete');
+      view.set('env', {
+        destroyMachines: utils.makeStubFunction()
+      });
+      deleteNode.simulate('click');
+      // Manually set the deleted flag as we've stubbed out the
+      // destroyMachines method that would do this.
+      machines.getById(id).deleted = true;
+      deleteNode.simulate('click');
+      assert.equal(view.get('env').destroyMachines.calledOnce(), true);
     });
 
     describe('functional tests', function() {


### PR DESCRIPTION
When you click the delete icon on a machine or container in the machine view it should only register the first delete per machine/container.
