### PR TITLE
Only show create container if a parent id is set

### DIFF
--- a/app/widgets/machine-view-panel.js
+++ b/app/widgets/machine-view-panel.js
@@ -483,6 +483,10 @@ YUI.add('machine-view-panel', function(Y) {
           }
           if (action === 'container') {
             parentId = parentId || this.get('selectedMachine');
+            // Only begin the create container process if we have a parent ID.
+            if (!parentId) {
+              return;
+            }
             createContainer = container.one('.create-container');
           } else {
             createContainer = container.one('.create-machine');

--- a/test/test_machine_view_panel.js
+++ b/test/test_machine_view_panel.js
@@ -267,6 +267,17 @@ describe('machine view panel view', function() {
                    'the container types should be visible');
     });
 
+    it('does not display in the container header when no machine is selected',
+        function() {
+          view.render();
+          view.set('selectedMachine', null);
+          var createContainer = container.one('.create-container');
+          container.one('.containers .head .action').simulate('click');
+          assert.equal(createContainer.getHTML(), '',
+                       'HTML present in container');
+        }
+    );
+
     it('creates an unplaced unit when cancelled with a unit', function() {
       var unitTokens = view.get('unitTokens');
       var toggleStub = utils.makeStubMethod(view, '_toggleAllPlacedMessage');


### PR DESCRIPTION
The user should not be able to create a new container without a machine selected.
