### PR TITLE
Implement UI for autoplacing units on deploy.

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -859,6 +859,7 @@ YUI.add('juju-gui', function(Y) {
         env: this.env,
         db: this.db
       }).render();
+      this.deployerBar.addTarget(this);
     },
 
     /**

--- a/app/templates/deployer-bar.handlebars
+++ b/app/templates/deployer-bar.handlebars
@@ -102,6 +102,14 @@
     <section>
         <div class="content">
             <h2 class="title">Confirm your changes</h2>
+            {{#if unplacedCount}}
+            <div class="unplaced-panel">
+              <p>You have {{unplacedCount}} unplaced {{pluralize 'unit' unplacedCount}}, do you want to:</p>
+              <label><input type="radio" name="unplaced-units" value="leave" checked> Leave unplaced</label>
+              <label><input type="radio" name="unplaced-units" value="autodeploy"> Automatically place</label>
+              <a href="" class="view-machines link">View machines</a>
+            </div>
+            {{/if}}
             {{#if majorChange}}
             <div class="summary-panel">
                 {{#if changeCount}}

--- a/app/widgets/deployer-bar.js
+++ b/app/widgets/deployer-bar.js
@@ -79,6 +79,9 @@ YUI.add('deployer-bar', function(Y) {
       },
       '.action-list .change-mode': {
         click: '_setMode'
+      },
+      '.view-machines': {
+        click: '_viewMachines'
       }
     },
 
@@ -136,7 +139,11 @@ YUI.add('deployer-bar', function(Y) {
     deploy: function(evt) {
       evt.halt();
       var container = this.get('container'),
-          ecs = this.get('ecs');
+          ecs = this.get('ecs'),
+          autodeploy = container.one('input[value="autodeploy"]');
+      if (autodeploy && autodeploy.get('checked')) {
+        this._autoPlaceUnits();
+      }
       container.removeClass('summary-open');
       ecs.commit(this.get('env'));
       //this.update();
@@ -222,10 +229,12 @@ YUI.add('deployer-bar', function(Y) {
       // Hide the changes panel if it is visible.
       this.hideChanges();
       var container = this.get('container'),
-          ecs = this.get('ecs');
-      var delta = this._getChanges(ecs),
+          ecs = this.get('ecs'),
+          db = this.get('db'),
+          delta = this._getChanges(ecs),
           changes = delta.changes,
-          totalUnits = delta.totalUnits;
+          totalUnits = delta.totalUnits,
+          unplacedCount = db.units.filterByMachine(null).length;
       if (container && container.get('parentNode')) {
         container.setHTML(this.template({
           changeCount: this._getChangeCount(ecs),
@@ -241,7 +250,8 @@ YUI.add('deployer-bar', function(Y) {
           destroyedMachines: changes.destroyMachines,
           configsChanged: changes.setConfigs,
           deployed: this._deployed,
-          majorChange: this._hasMajorChanges(changes)
+          majorChange: this._hasMajorChanges(changes),
+          unplacedCount: unplacedCount
         }));
       }
       container.addClass('summary-open');
@@ -753,6 +763,22 @@ YUI.add('deployer-bar', function(Y) {
           this.get('env'),
           this.get('db')
       );
+    },
+
+    /**
+      Navigate to the machine view.
+
+      @method _viewMachine
+      @param {Object} e The event object.
+    */
+    _viewMachines: function(e) {
+      e.halt();
+      this.hideSummary(e);
+      this.fire('changeState', {
+        sectionB: {
+          component: 'machine'
+        }
+      });
     }
 
   });

--- a/lib/views/deployer-bar.less
+++ b/lib/views/deployer-bar.less
@@ -230,6 +230,22 @@
                 vertical-align: middle;
             }
         }
+        .unplaced-panel {
+            @box-shadow: 0 2px 2px rgba(0, 0, 0, 0.1);
+            .create-box-shadow(@box-shadow);
+            .create-border-radius(@border-radius);
+            background: #ffffff;
+            padding: 20px;
+            margin-top: 5px;
+            label {
+                display: inline-block;
+                margin-right: 20px;
+            }
+            p {
+              margin: 0;
+              margin-bottom: 10px;
+            }
+        }
         .changes {
             margin-top: 20px;
             background: @paper-dark;

--- a/test/test_deployer_bar.js
+++ b/test/test_deployer_bar.js
@@ -522,4 +522,31 @@ describe('deployer bar view', function() {
     view.render();
     assert.equal(deployButton.get('text').trim(), 'Commit');
   });
+
+  it('should display if there are unplaced units', function() {
+    addEntities(db);
+    ecs.lazyAddUnits(['django', 1], {modelId: 'django/0'});
+    container.one('.deploy-button').simulate('click');
+    assert.notEqual(container.one('.unplaced-panel'), null);
+  });
+
+  it('should not display if there are no unplaced units', function() {
+    addEntities(db);
+    var unit = db.units.getById('django/0');
+    unit.machine = '0';
+    ecs.lazyAddUnits(['django', 1, '0'], {modelId: 'django/0'});
+    container.one('.deploy-button').simulate('click');
+    assert.equal(container.one('.unplaced-panel'), null);
+  });
+
+  it('should autodeploy unplaced units if instructed', function() {
+    addEntities(db);
+    var autoplaceStub = utils.makeStubMethod(view, '_autoPlaceUnits');
+    utils.makeStubMethod(view.get('ecs'), 'commit');
+    ecs.lazyAddUnits(['django', 1], {modelId: 'django/0'});
+    container.one('.deploy-button').simulate('click');
+    container.one('input[value="autodeploy"]').set('checked', true);
+    view.deploy({halt: utils.makeStubFunction()});
+    assert.equal(autoplaceStub.calledOnce(), true);
+  });
 });


### PR DESCRIPTION
If there are unplaced units when a user clicks on the deploy button, they will now see a notification in the deploy summary panel and have the option to autoplace the units at that time.
