### PR TITLE
Fixed ATTRS on widgets

### DIFF
--- a/app/widgets/machine-token.js
+++ b/app/widgets/machine-token.js
@@ -222,8 +222,9 @@ YUI.add('machine-token', function(Y) {
           if (this._moreMenu) {
             this._moreMenu.destroy();
           }
-        },
+        }
 
+      }, {
         ATTRS: {
           /**
            * @attribute machine

--- a/app/widgets/machine-view-panel.js
+++ b/app/widgets/machine-view-panel.js
@@ -1315,8 +1315,9 @@ YUI.add('machine-view-panel', function(Y) {
             unitTokens[id].destroy();
             delete unitTokens[id];
           });
-        },
+        }
 
+      }, {
         ATTRS: {
           /**
             The container element for the view.


### PR DESCRIPTION
The ATTRS locations on the machine view and machine token widgets were in the wrong location and so not being picked up.
