### PR TITLE
Style uncommitted units in status bar

### DIFF
--- a/lib/views/stylesheet.less
+++ b/lib/views/stylesheet.less
@@ -682,6 +682,10 @@ g.unit {
   .running {
     fill: rgb(56, 180, 74);
   }
+
+  .uncommitted {
+    fill: #19b6ee;
+  }
 }
 
 /*


### PR DESCRIPTION
Minor CSS fix to ensure that uncommitted units are shown in the status bar styled in the uncommitted color.
