### PR TITLE
Move SVG status bar out of hidden div.

### DIFF
--- a/app/templates/serviceOverview.handlebars
+++ b/app/templates/serviceOverview.handlebars
@@ -9,7 +9,7 @@
       <div class="current-unit-num" data-bind="unit_count"></div>
       <div class="unit-constraints-confirm closed"></div>
     </div>
-    <div class="view-content">
+    <div class="view-content status-bar {{#if pending}}hidden{{/if}}">
       <!-- without setting the height of the svg element here it defaults
        to 100% of the available space causing an undesirable flash of
        incorrectly calculated height -->

--- a/app/views/viewlets/service-overview.js
+++ b/app/views/viewlets/service-overview.js
@@ -447,6 +447,7 @@ YUI.add('inspector-overview-view', function(Y) {
         // If the inspector is open when the service is deployed we need
         // to update the inspector.
         container.one('.expose').removeClass('hidden');
+        container.one('.status-bar').removeClass('hidden');
       }
     },
 

--- a/lib/views/juju-inspector.less
+++ b/lib/views/juju-inspector.less
@@ -725,6 +725,10 @@
                     padding-top: 10px;
                     border-top: none;
                 }
+                &.status-bar {
+                    padding-top: 0;
+                    border-top: none;
+                }
             }
             .settings-wrapper {
                 label.uncommitted::after {


### PR DESCRIPTION
After much investigation, it was determined that the SVG was in the wrong div, and thus hidden.
