### PR TITLE
Show open scale up in ghost inspector

### DIFF
--- a/app/templates/scale-up.handlebars
+++ b/app/templates/scale-up.handlebars
@@ -1,4 +1,4 @@
-<h2>Add Units</h2>
+<h2>Add units</h2>
 <div class="view-container scale-up-view state-default">
   <div class="add-units">
     <div class="add button inverse orange">

--- a/app/views/viewlets/scale-up.js
+++ b/app/views/viewlets/scale-up.js
@@ -28,12 +28,12 @@ YUI.add('scale-up-view', function(Y) {
   ns.ScaleUp = Y.Base.create(name, Y.View, [], {
     template: templates['scale-up'],
     events: {
-      '.add.button': { click: '_showScaleUp' },
-      '.placement .cancel.button': { click: '_hideScaleUp' },
+      '.add.button': { click: 'showScaleUp' },
+      '.placement .cancel.button': { click: 'hideScaleUp' },
       'input[name="placement"]': { change: '_toggleConstraints' },
       'form': { submit: '_preventFormSubmit' },
       '.edit.link': { click: '_toggleEditConstraints' },
-      '.inspector-buttons .cancel': { click: '_hideScaleUp' },
+      '.inspector-buttons .cancel': { click: 'hideScaleUp' },
       '.inspector-buttons .confirm': { click: '_submitScaleUp' }
     },
 
@@ -77,21 +77,23 @@ YUI.add('scale-up-view', function(Y) {
     /**
       Calls to set the class on the container to show the scale-up UI.
 
-      @method _showScaleUp
+      @method showScaleUp
       @param {Object} e The click event facade.
     */
-    _showScaleUp: function(e) {
-      e.preventDefault();
+    showScaleUp: function(e) {
+      if (e && e.preventDefault) {
+        e.preventDefault();
+      }
       this.updateStateClass('per-machine');
     },
 
     /**
       Calls to set the class on the container to hide the scale-up UI.
 
-      @method _hideScaleUp
+      @method hideScaleUp
       @param {Object} e The click event facade.
     */
-    _hideScaleUp: function(e) {
+    hideScaleUp: function(e) {
       if (e && e.preventDefault) {
         e.preventDefault();
       }
@@ -160,7 +162,7 @@ YUI.add('scale-up-view', function(Y) {
       } else {
         this._createMachinesPlaceUnits(numUnits, service);
       }
-      this._hideScaleUp();
+      this.hideScaleUp();
     },
 
     /**

--- a/app/views/viewlets/service-overview.js
+++ b/app/views/viewlets/service-overview.js
@@ -434,16 +434,22 @@ YUI.add('inspector-overview-view', function(Y) {
     render: function(attributes) {
       var container = this.get('container'),
           rendered = this.get('rendered');
+      var pending = this.viewletManager.get('model').get('pending');
       if (window.flags && window.flags.mv) {
         this._instantiateScaleUp();
         if (!rendered) {
           container.append(this.scaleUp.render());
         }
+        if (pending) {
+          this.scaleUp.showScaleUp();
+        } else {
+          this.scaleUp.hideScaleUp();
+        }
       }
       if (!rendered) {
         this.set('rendered', true);
         container.append(this.template(attributes.model.getAttrs()));
-      } else if (!this.viewletManager.get('model').get('pending')) {
+      } else if (!pending) {
         // If the inspector is open when the service is deployed we need
         // to update the inspector.
         container.one('.expose').removeClass('hidden');

--- a/test/test_inspector_overview.js
+++ b/test/test_inspector_overview.js
@@ -183,9 +183,29 @@ describe('Inspector Overview', function() {
     var ScaleUp = Y.juju.viewlets.ScaleUp;
     var render = utils.makeStubMethod(ScaleUp.prototype, 'render');
     this._cleanups.push(render.reset);
+    var hideScaleUp = utils.makeStubMethod(ScaleUp.prototype, 'hideScaleUp');
+    this._cleanups.push(hideScaleUp.reset);
     inspector = setUpInspector();
     assert.equal(inspector.views.overview.scaleUp instanceof ScaleUp, true);
     assert.equal(render.calledOnce(), true, 'render not called once');
+    window.flags = {};
+  });
+
+  it('opens the scale up view on a pending service', function() {
+    window.flags = {};
+    window.flags.mv = true;
+    inspector = setUpInspector({pending: true});
+    assert.equal(container.one('.scale-up-view').hasClass('state-per-machine'),
+        true);
+    window.flags = {};
+  });
+
+  it('closes the scale up view on a deployed service', function() {
+    window.flags = {};
+    window.flags.mv = true;
+    inspector = setUpInspector({pending: false});
+    assert.equal(container.one('.scale-up-view').hasClass('state-default'),
+        true);
     window.flags = {};
   });
 

--- a/test/test_scale_up_view.js
+++ b/test/test_scale_up_view.js
@@ -88,14 +88,14 @@ describe('scale-up view', function() {
 
   it('clicking the + calls to open the scale up options', function() {
     testEventBinding({
-      stubMethod: '_showScaleUp',
+      stubMethod: 'showScaleUp',
       buttonSelector: '.add.button'
     }, this);
   });
 
   it('clicking the x calls to close the scale up options', function() {
     testEventBinding({
-      stubMethod: '_hideScaleUp',
+      stubMethod: 'hideScaleUp',
       buttonSelector: '.placement .cancel.button'
     }, this);
   });
@@ -118,7 +118,7 @@ describe('scale-up view', function() {
 
   it('clicking the cancel button calls to close the scale-up UI', function() {
     testEventBinding({
-      stubMethod: '_hideScaleUp',
+      stubMethod: 'hideScaleUp',
       buttonSelector: '.inspector-buttons .cancel'
     }, this);
   });
@@ -138,16 +138,16 @@ describe('scale-up view', function() {
     }, this);
   });
 
-  it('_showScaleUp calls to set the proper state class', function() {
+  it('showScaleUp calls to set the proper state class', function() {
     testSetStateClass({
-      method: '_showScaleUp',
+      method: 'showScaleUp',
       className: 'per-machine'
     }, this);
   });
 
-  it('_hideScaleUp calls to the proper state class', function() {
+  it('hideScaleUp calls to the proper state class', function() {
     testSetStateClass({
-      method: '_hideScaleUp',
+      method: 'hideScaleUp',
       className: 'default'
     }, this);
   });
@@ -198,7 +198,7 @@ describe('scale-up view', function() {
       eventObj = { preventDefault: utils.makeStubFunction() };
       create = utils.makeStubMethod(view, '_createMachinesPlaceUnits');
       this._cleanups.push(create.reset);
-      hide = utils.makeStubMethod(view, '_hideScaleUp');
+      hide = utils.makeStubMethod(view, 'hideScaleUp');
       this._cleanups.push(hide.reset);
       addGhost = utils.makeStubMethod(jujuUtils, 'addGhostAndEcsUnits');
       this._cleanups.push(addGhost.reset);


### PR DESCRIPTION
Fixes bug #1360180 and #1360179: Has the scale up options open in the inspector for a undeployed service.
