### PR TITLE
Only show the destroy and change version controls on the inspector overview

### DIFF
--- a/app/views/inspectors/service-inspector.js
+++ b/app/views/inspectors/service-inspector.js
@@ -194,7 +194,13 @@ YUI.add('service-inspector', function(Y) {
       ev.halt();
       var target = ev.currentTarget,
           viewName = target.getData('viewlet');
+      var footerNode = this.get('container').one('.viewlet-manager-footer');
       this.switchTab(viewName);
+      if (viewName === 'overview') {
+        footerNode.removeClass('hidden');
+      } else {
+        footerNode.addClass('hidden');
+      }
     },
 
     /**

--- a/app/views/viewlet-manager.js
+++ b/app/views/viewlet-manager.js
@@ -442,7 +442,7 @@ YUI.add('juju-viewlet-manager', function(Y) {
     /**
       Switch tab viewlet.
 
-      @method _switchTab
+      @method switchTab
       @param {String} viewName the name of the new active tab.
     */
     switchTab: function(viewName) {

--- a/test/test_service_inspector.js
+++ b/test/test_service_inspector.js
@@ -204,4 +204,21 @@ describe('Service Inspector', function() {
     inspector.get('container').one('span[dismiss]').simulate('click');
     assert.equal(stubDismiss.callCount(), 1);
   });
+
+  it('shows the footer for the overview', function() {
+    var inspector = setUpInspector();
+    inspector.render();
+    container.one('.tab').simulate('click');
+    assert.equal(container.one('.viewlet-manager-footer').hasClass('hidden'),
+        false);
+  });
+
+  it('does not show the footer for non-overview tabs', function() {
+    var inspector = setUpInspector();
+    inspector.render();
+    container.one('.viewlet-manager-navigation li:last-child .tab').simulate(
+        'click');
+    assert.equal(container.one('.viewlet-manager-footer').hasClass('hidden'),
+        true);
+  });
 });


### PR DESCRIPTION
In the inspector the destroy and change version controls should only be visible on the overview.
