### PR TITLE
Allow dropping units on the root container of a machine.

### DIFF
--- a/app/widgets/machine-view-panel.js
+++ b/app/widgets/machine-view-panel.js
@@ -593,21 +593,24 @@ YUI.add('machine-view-panel', function(Y) {
           @param {Object} evt The custom drop event facade.
         */
         _unitTokenDropHandler: function(evt) {
-          var db = this.get('db');
-          var selected = this.get('selectedMachine');
+          var db = this.get('db'),
+              selected = this.get('selectedMachine'),
+              dropAction = evt.dropAction,
+              parentId = evt.targetId,
+              rootDrop = false;
 
-          var dropAction = evt.dropAction;
-          var parentId = evt.targetId;
           // When an unplaced unit is dropped on the container header drop
           // target, we need to pull the parentId from the currently selected
           // machine.
           if (dropAction === 'container' && !parentId) {
             parentId = selected;
           }
+
           // Before proceeding, rename the machine in the case the top level
           // container has been selected.
           if (parentId === selected + '/' + ROOT_CONTAINER_PLACEHOLDER) {
             parentId = selected;
+            rootDrop = true;
           }
 
           var machine = db.machines.getById(parentId);
@@ -626,7 +629,7 @@ YUI.add('machine-view-panel', function(Y) {
           var unit = db.units.getById(evt.unit);
           this._hideDraggingUI();
           if (dropAction === 'container' &&
-              (parentId && parentId.indexOf('/') !== -1)) {
+              (rootDrop || (parentId && parentId.indexOf('/') !== -1))) {
             // If the user drops a unit on an already created container then
             // place the unit.
             // We need to store this ID because it's the ID that we use to

--- a/test/test_machine_view_panel.js
+++ b/test/test_machine_view_panel.js
@@ -601,6 +601,40 @@ describe('machine view panel view', function() {
         }
     );
 
+    it('places the unit on and selects the existing root conatiner',
+        function() {
+          var toggleStub = utils.makeStubMethod(
+              view, '_toggleAllPlacedMessage');
+          this._cleanups.push(toggleStub.reset);
+          var selectStub = utils.makeStubMethod(view, '_selectContainerToken');
+          this._cleanups.push(selectStub.reset);
+          view._machinesHeader = {
+            setNotDroppable: utils.makeStubFunction(),
+            updateLabelCount: utils.makeStubFunction()
+          };
+          view._containersHeader = {
+            setNotDroppable: utils.makeStubFunction()
+          };
+          view.set('selectedMachine', 0);
+          view.render();
+          assert.equal(selectStub.callCount(), 1); // called once by render
+          view._unitTokenDropHandler({
+            dropAction: 'container',
+            targetId: '0/root-container',
+            unit: 'test/1'
+          });
+          var env = view.get('env');
+          // The machine is already created so we don't create a new one.
+          assert.equal(env.addMachines.callCount(), 0);
+          var placeArgs = env.placeUnit.lastArguments();
+          assert.strictEqual(placeArgs[0].id, 'test/1');
+          assert.equal(placeArgs[1], '0');
+          // selectContainerToken called once by selectMachineToken and once
+          // directly.
+          assert.equal(selectStub.callCount(), 3);
+        }
+    );
+
     it('does not allow placement on machines being deleted', function() {
       var notes;
       view.render();


### PR DESCRIPTION
The changes to block dropping unplaced units on deleted machines broke the check for dropping on an existing container; this corrects that check so dropping on a not deleted root container works.
