### PR TITLE
Disable containerization when not supported.

### DIFF
--- a/app/store/env/go.js
+++ b/app/store/env/go.js
@@ -2176,6 +2176,43 @@ YUI.add('juju-env-go', function(Y) {
   environments.cleanUpJSON = cleanUpJSON;
   environments.machineJobs = machineJobs;
 
+  var KVM = {label: 'LXC', value: 'lxc'},
+      LXC = {label: 'KVM', value: 'kvm'};
+
+  // Define features exposed by each Juju provider type.
+  // To enable/disable containerization in the machine view, just add/remove
+  // supportedContainerTypes to the provider types below.
+  environments.providerFeatures = {
+    // Microsoft Azure.
+    azure: {
+      supportedContainerTypes: []
+    },
+    // Sandbox mode.
+    demonstration: {
+      supportedContainerTypes: [KVM, LXC]
+    },
+    // Amazon EC2.
+    ec2: {
+      supportedContainerTypes: []
+    },
+    // Joyent Cloud.
+    joyent: {
+      supportedContainerTypes: []
+    },
+    // Local (LXC).
+    local: {
+      supportedContainerTypes: []
+    },
+    // Canonical MAAS.
+    maas: {
+      supportedContainerTypes: [KVM, LXC]
+    },
+    // OpenStack or HP Public Cloud.
+    openstack: {
+      supportedContainerTypes: []
+    }
+  };
+
 }, '0.1.0', {
   requires: [
     'base',

--- a/app/templates/container-type-form.partial
+++ b/app/templates/container-type-form.partial
@@ -1,7 +1,8 @@
 <div class="containers">
   <select>
     <option value="" selected disabled class="default">Choose container type&hellip;</option>
-    <option value="lxc" class="default">lxc</option>
-    <option value="kvm" class="default">kvm</option>
+    {{#each containerTypes}}
+        <option value="{{value}}" class="default">{{label}}</option>
+    {{/each}}
   </select>
 </div>

--- a/app/templates/serviceunit-token.handlebars
+++ b/app/templates/serviceunit-token.handlebars
@@ -1,10 +1,10 @@
 <div class="unplaced-unit">
   {{>more-menu}}
   <span class="unit-icon">
-    <img src="{{icon}}" alt="{{displayName}}">
+    <img src="{{unit.icon}}" alt="{{unit.displayName}}">
   </span>
   <span class="title">
-    {{ displayName }}
+    {{ unit.displayName }}
   </span>
   <div class="machines">
     <select>

--- a/app/widgets/create-machine-view.js
+++ b/app/widgets/create-machine-view.js
@@ -134,7 +134,9 @@ YUI.add('create-machine-view', function(Y) {
         */
         render: function() {
           var container = this.get('container');
-          container.setHTML(this.template());
+          container.setHTML(this.template({
+            containerTypes: this.get('supportedContainerTypes')
+          }));
           container.addClass('create-machine-view');
           // If this is a container (i.e., has a parent machine), show the
           // container type select and hide the constraints.
@@ -159,6 +161,8 @@ YUI.add('create-machine-view', function(Y) {
 
         ATTRS: {
           /**
+            The optional unit to assign to the newly created machine.
+
             @attribute unit
             @default undefined
             @type {Object}
@@ -166,6 +170,8 @@ YUI.add('create-machine-view', function(Y) {
           unit: {},
 
           /**
+            The optional parent machine into which create a new container.
+
             @attribute parentId
             @default undefined
             @type {String}
@@ -173,11 +179,24 @@ YUI.add('create-machine-view', function(Y) {
           parentId: {},
 
           /**
+            The optional container type.
+
             @attribute containerType
             @default undefined
             @type {String}
           */
-          containerType: {}
+          containerType: {},
+
+          /**
+            The environment's provider supported container types.
+            Each container type is an object with a label and a value, e.g.
+              [{label: 'LXC', value: 'lxc'}, {label: 'KVM', value: 'kvm'}].
+
+            @attribute supportedContainerTypes
+            @default undefined
+            @type {Array}
+          */
+          supportedContainerTypes: {}
         }
       });
 

--- a/app/widgets/machine-view-panel-header.js
+++ b/app/widgets/machine-view-panel-header.js
@@ -62,8 +62,8 @@ YUI.add('machine-view-panel-header', function(Y) {
         /**
           Show the more menu.
 
-         @method showMoreMenu
-         @param {Object} e Click event facade.
+          @method showMoreMenu
+          @param {Object} e Click event facade.
         */
         showMoreMenu: function(e) {
           if (!this._moreMenu.get('rendered')) {
@@ -74,12 +74,12 @@ YUI.add('machine-view-panel-header', function(Y) {
         },
 
         /**
-           Disable items in the header menu.
+          Disable items in the header menu.
 
-           @method disableHeaderMenuItem
-           @param {String} label The label of the item to disable.
-           @param {Bool} disabled Whether the item is disabled.
-         */
+          @method disableHeaderMenuItem
+          @param {String} label The label of the item to disable.
+          @param {Bool} disabled Whether the item is disabled.
+        */
         disableHeaderMenuItem: function(label, disabled) {
           this._moreMenu.setItemDisabled(label, disabled);
         },
@@ -105,7 +105,7 @@ YUI.add('machine-view-panel-header', function(Y) {
         /**
          * Update a particular label's count.
          *
-         * @method _updateLabelCount
+         * @method updateLabelCount
          * @param {String} label the label to update
          * @param {Integer} delta the amount to change the label count
          */
@@ -168,49 +168,149 @@ YUI.add('machine-view-panel-header', function(Y) {
 
   MachineViewPanelHeaderView.ATTRS = {
     /**
-    @attribute title
-    @default undefined
-    @type {String}
+      @attribute title
+      @default undefined
+      @type {String}
     */
     title: {},
 
     /**
-    @attribute label
-    @default undefined
-    @type {String}
+      @attribute label
+      @default undefined
+      @type {String}
     */
     label: {},
 
     /**
-    @attribute action
-    @default undefined
-    @type {String}
+      @attribute action
+      @default undefined
+      @type {String}
     */
     action: {},
 
     /**
-    @attribute menuItems
-    @default undefined
-    @type {String}
+      @attribute menuItems
+      @default undefined
+      @type {String}
     */
     menuItems: {},
 
     /**
-    @attribute dropLabel
-    @default undefined
-    @type {String}
+      @attribute dropLabel
+      @default undefined
+      @type {String}
     */
     dropLabel: {},
 
     /**
-    @attribute customTemplate
-    @default undefined
-    @type {String}
+      @attribute customTemplate
+      @default undefined
+      @type {String}
     */
     customTemplate: {}
   };
 
+  /**
+    A disabled panel header.
+    This view basically does nothing but rendering the given title, but it
+    implements the machine view header interface.
+
+    @class MachineViewPanelNoopHeaderView
+  */
+  var MachineViewPanelNoopHeaderView = Y.Base.create(
+      'MachineViewPanelNoopHeaderView', Y.View, [], {
+
+        /**
+          See MachineViewPanelHeaderView.addEvent.
+
+          @method addEvent
+          @param {Object} handler The event handler.
+        */
+        addEvent: function(handler) {},
+
+        /**
+          See MachineViewPanelHeaderView.template.
+
+          @method template
+          @param {Object} context The template context.
+        */
+        template: function(context) {},
+
+        /**
+          See MachineViewPanelHeaderView.labelTemplate.
+
+          @method labelTemplate
+          @param {Object} context The template context.
+        */
+        labelTemplate: function(context) {},
+
+        /**
+          See MachineViewPanelHeaderView.showMoreMenu.
+
+          @method showMoreMenu
+          @param {Object} evt Click event facade.
+        */
+        showMoreMenu: function(evt) {},
+
+        /**
+          See MachineViewPanelHeaderView.disableHeaderMenuItem.
+
+          @method disableHeaderMenuItem
+          @param {String} label The label of the item to disable.
+          @param {Bool} disabled Whether the item is disabled.
+        */
+        disableHeaderMenuItem: function(label, disabled) {},
+
+        /**
+          See MachineViewPanelHeaderView.updateLabelCount.
+
+          @method updateLabelCount
+          @param {String} label the label to update
+          @param {Integer} delta the amount to change the label count
+        */
+        updateLabelCount: function(label, delta) {},
+
+        /**
+          See MachineViewPanelHeaderView.setDroppable.
+
+          @method setDroppable
+        */
+        setDroppable: function() {},
+
+        /**
+          See MachineViewPanelHeaderView.setNotDroppable.
+
+          @method setNotDroppable
+        */
+        setNotDroppable: function() {},
+
+        /**
+          Render the header title.
+
+          @method render
+        */
+        render: function() {
+          var label = Y.Node.create('<a3>').addClass('title');
+          label.setContent(this.get('title'));
+          var container = this.get('container');
+          container.setHTML(label);
+          return this;
+        }
+      });
+
+  MachineViewPanelNoopHeaderView.ATTRS = {
+    /**
+      The title displayed in the header.
+
+      @attribute title
+      @default undefined
+      @type {String}
+    */
+    title: {}
+  };
+
   views.MachineViewPanelHeaderView = MachineViewPanelHeaderView;
+  views.MachineViewPanelNoopHeaderView = MachineViewPanelNoopHeaderView;
 
 }, '0.1.0', {
   requires: [

--- a/app/widgets/serviceunit-token.js
+++ b/app/widgets/serviceunit-token.js
@@ -342,7 +342,10 @@ YUI.add('juju-serviceunit-token', function(Y) {
     _renderTemplate: function() {
       var container = this.get('container');
       var unit = this.get('unit');
-      container.setHTML(this.template(unit));
+      container.setHTML(this.template({
+        unit: unit,
+        containerTypes: this.get('supportedContainerTypes')
+      }));
       // This must be setAttribute, not setData, as setData does not
       // manipulate the dom, which we need for our namespaced code
       // to read.
@@ -402,7 +405,7 @@ YUI.add('juju-serviceunit-token', function(Y) {
       unit: {},
 
       /**
-        Reference to the application db
+        Reference to the application db.
 
         @attribute db
         @type {Object}
@@ -410,12 +413,15 @@ YUI.add('juju-serviceunit-token', function(Y) {
       db: {},
 
       /**
-        Reference to the application env
+        The environment's provider supported container types.
+        Each container type is an object with a label and a value, e.g.
+          [{label: 'LXC', value: 'lxc'}, {label: 'KVM', value: 'kvm'}].
 
-        @attribute env
-        @type {Object}
-       */
-      env: {}
+        @attribute supportedContainerTypes
+        @default undefined
+        @type {Array}
+      */
+      supportedContainerTypes: {}
     }
   });
 

--- a/test/test_machine_view_panel_extension.js
+++ b/test/test_machine_view_panel_extension.js
@@ -20,17 +20,14 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
 describe('machine view panel extension', function() {
-  var Y, container, utils, models, view, View, db, env;
+  var container, db, env, models, utils, View, view, Y;
+  var requirements = [
+    'event-simulate', 'juju-models', 'juju-tests-utils', 'juju-views',
+    'machine-view-panel-extension', 'node', 'node-event-simulate'
+  ];
 
   before(function(done) {
-    Y = YUI(GlobalConfig).use(['machine-view-panel-extension',
-                               'juju-tests-utils',
-                               'event-simulate',
-                               'node-event-simulate',
-                               'juju-models',
-                               'juju-views',
-                               'node'], function(Y) {
-
+    Y = YUI(GlobalConfig).use(requirements, function(Y) {
       utils = Y.namespace('juju-tests.utils');
       models = Y.namespace('juju.models');
       db = {
@@ -41,13 +38,12 @@ describe('machine view panel extension', function() {
       env = {
         after: utils.makeStubFunction(),
         get: function(arg) {
-          var returnVal;
           switch (arg) {
             case 'environmentName':
-              returnVal = 'Test env';
-              break;
+              return 'Test env';
+            case 'providerType':
+              return 'demonstration';
           }
-          return returnVal;
         }
       };
       View = Y.Base.create('machine-view-panel', Y.View, [

--- a/test/test_machine_view_panel_header.js
+++ b/test/test_machine_view_panel_header.js
@@ -20,90 +20,132 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
 describe('machine view panel header view', function() {
-  var Y, container, utils, views, view, View;
+  var container, utils, views, view, Y;
+  var requirements = [
+    'event-simulate', 'juju-tests-utils', 'juju-views',
+    'machine-view-panel-header', 'node', 'node-event-simulate'
+  ];
 
   before(function(done) {
-    Y = YUI(GlobalConfig).use(['machine-view-panel-header',
-                               'juju-views',
-                               'juju-tests-utils',
-                               'event-simulate',
-                               'node-event-simulate',
-                               'node'], function(Y) {
-
+    Y = YUI(GlobalConfig).use(requirements, function(Y) {
       utils = Y.namespace('juju-tests.utils');
       views = Y.namespace('juju.views');
-      View = views.MachineViewPanelHeaderView;
       done();
     });
   });
 
   beforeEach(function() {
     container = utils.makeContainer(this, 'machine-view-panel-header');
-    view = new View({
-      container: container,
-      title: 'test title',
-      dropLabel: 'test drop label',
-      action: 'test action',
-      menuItems: [
-        {label: 'test label', callback: function() {}}
-      ]
-    }).render();
   });
 
   afterEach(function() {
     container.remove(true);
-    view.destroy();
   });
 
-  it('should apply the wrapping class to the container', function() {
-    assert.equal(container.hasClass('machine-view-panel-header'), true);
+  describe('MachineViewPanelHeaderView', function() {
+
+    beforeEach(function() {
+      view = new views.MachineViewPanelHeaderView({
+        container: container,
+        title: 'test title',
+        dropLabel: 'test drop label',
+        action: 'test action',
+        menuItems: [
+          {label: 'test label', callback: function() {}}
+        ]
+      }).render();
+    });
+
+    afterEach(function() {
+      view.destroy();
+    });
+
+    it('should apply the wrapping class to the container', function() {
+      assert.equal(container.hasClass('machine-view-panel-header'), true);
+    });
+
+    it('should have the correct attributes set', function() {
+      assert.equal(container.one('.title').get('text'), 'test title');
+      assert.equal(container.one('.drop span').get('text'), 'test drop label');
+    });
+
+    it('can set the label', function() {
+      view.set('labels', [{label: 'label', count: 0}]);
+      assert.equal(container.one('.label').get('text').trim(), '0 labels');
+      view.set('labels', [{label: 'label', count: 1}]);
+      assert.equal(container.one('.label').get('text').trim(), '1 label');
+    });
+
+    it('can increment a label', function() {
+      view.set('labels', [{label: 'test', count: 0}]);
+      assert.equal(container.one('.label').get('text').trim(), '0 tests');
+      view.updateLabelCount('test', 1);
+      assert.equal(container.one('.label').get('text').trim(), '1 test');
+      view.updateLabelCount('test', 1);
+      assert.equal(container.one('.label').get('text').trim(), '2 tests');
+    });
+
+    it('can decrement a label', function() {
+      view.set('labels', [{label: 'test', count: 2}]);
+      assert.equal(container.one('.label').get('text').trim(), '2 tests');
+      view.updateLabelCount('test', -1);
+      assert.equal(container.one('.label').get('text').trim(), '1 test');
+      view.updateLabelCount('test', -1);
+      assert.equal(container.one('.label').get('text').trim(), '0 tests');
+    });
+
+    it('can be set to the droppable state', function() {
+      view.setDroppable();
+      assert.equal(container.hasClass('droppable'), true);
+    });
+
+    it('can be set from the droppable state back to the default', function() {
+      view.setDroppable();
+      assert.equal(container.hasClass('droppable'), true);
+      view.setNotDroppable();
+      assert.equal(container.hasClass('droppable'), false);
+    });
+
+    it('can display the more menu', function() {
+      assert.equal(container.one('.yui3-moremenu'), null);
+      view.showMoreMenu();
+      assert.equal(container.one('.yui3-moremenu') !== null, true);
+    });
+
   });
 
-  it('should have the correct attributes set', function() {
-    assert.equal(container.one('.title').get('text'), 'test title');
-    assert.equal(container.one('.drop span').get('text'), 'test drop label');
+  describe('MachineViewPanelNoopHeaderView', function() {
+
+    beforeEach(function() {
+      view = new views.MachineViewPanelNoopHeaderView({
+        container: container,
+        title: 'test title'
+      }).render();
+    });
+
+    afterEach(function() {
+      view.destroy();
+    });
+
+    it('renders the given title into the header', function() {
+      var title = container.one('a3.title');
+      assert.strictEqual(title.getContent(), 'test title');
+    });
+
+    it('implements the machine panel header view interface', function() {
+      var panelHeaderView = new views.MachineViewPanelHeaderView();
+      Y.Object.each(panelHeaderView, function(value, key) {
+        if (typeof value === 'function' && key.indexOf('_') !== 0) {
+          // Ensure MachineViewPanelNoopHeaderView and
+          // MachineViewPanelHeaderView instances share the same public
+          // interface.
+          assert.property(view, key);
+          assert.strictEqual(typeof view[key], 'function', key);
+        }
+        // Include prototype properties (last true argument).
+      }, null, true);
+    });
+
   });
 
-  it('can set the label', function() {
-    view.set('labels', [{label: 'label', count: 0}]);
-    assert.equal(container.one('.label').get('text').trim(), '0 labels');
-    view.set('labels', [{label: 'label', count: 1}]);
-    assert.equal(container.one('.label').get('text').trim(), '1 label');
-  });
-
-  it('can increment a label', function() {
-    view.set('labels', [{label: 'test', count: 0}]);
-    assert.equal(container.one('.label').get('text').trim(), '0 tests');
-    view.updateLabelCount('test', 1);
-    assert.equal(container.one('.label').get('text').trim(), '1 test');
-    view.updateLabelCount('test', 1);
-    assert.equal(container.one('.label').get('text').trim(), '2 tests');
-  });
-
-  it('can decrement a label', function() {
-    view.set('labels', [{label: 'test', count: 2}]);
-    assert.equal(container.one('.label').get('text').trim(), '2 tests');
-    view.updateLabelCount('test', -1);
-    assert.equal(container.one('.label').get('text').trim(), '1 test');
-    view.updateLabelCount('test', -1);
-    assert.equal(container.one('.label').get('text').trim(), '0 tests');
-  });
-
-  it('can be set to the droppable state', function() {
-    view.setDroppable();
-    assert.equal(container.hasClass('droppable'), true);
-  });
-
-  it('can be set from the droppable state back to the default', function() {
-    view.setDroppable();
-    assert.equal(container.hasClass('droppable'), true);
-    view.setNotDroppable();
-    assert.equal(container.hasClass('droppable'), false);
-  });
-
-  it('can display the more menu', function() {
-    assert.equal(container.one('.yui3-moremenu'), null);
-    view.showMoreMenu();
-    assert.equal(container.one('.yui3-moremenu') !== null, true);
-  });
 });

--- a/test/test_serviceunit_token.js
+++ b/test/test_serviceunit_token.js
@@ -50,10 +50,10 @@ describe('Service unit token', function() {
         machines: new models.MachineList(),
         units: units
       },
-      env: {
-        addMachines: utils.makeStubFunction({id: '7'}),
-        placeUnit: utils.makeStubFunction()
-      }
+      supportedContainerTypes: [
+        {label: 'LXC', value: 'lxc'},
+        {label: 'KVM', value: 'kvm'}
+      ]
     }).render();
     view.get('db').machines.add([{id: '0'}, {id: '0/lxc/12'}]);
   });
@@ -141,8 +141,10 @@ describe('Service unit token', function() {
     var selectedMachineStub = utils.makeStubMethod(view,
         '_getSelectedMachine', '0');
     this._cleanups.push(selectedMachineStub.reset);
-    assert.equal(containersSelect.all('option').size(), 3,
-        'The defaults should exist');
+    var options = containersSelect.all('option:not([disabled])');
+    assert.equal(options.size(), 2, 'the default options should exist');
+    assert.deepEqual(options.getContent(), ['LXC', 'KVM']);
+    assert.deepEqual(options.get('value'), ['lxc', 'kvm']);
     // Select a machine option.
     container.one('.machines select').simulate('change');
     var containerOptions = containersSelect.all('option');
@@ -158,6 +160,17 @@ describe('Service unit token', function() {
                  'root container value is not the second option');
     assert.equal(containerOptions.item(1).get('text'), '0/root container',
                  'root container text is not the second option');
+  });
+
+  it('does not show container options if containers are disabled', function() {
+    view.set('supportedContainerTypes', []);
+    view.render();
+    var containersSelect = container.one('.containers select');
+    var selectedMachineStub = utils.makeStubMethod(view,
+        '_getSelectedMachine', '0');
+    this._cleanups.push(selectedMachineStub.reset);
+    var options = containersSelect.all('option:not([disabled])');
+    assert.equal(options.size(), 0, 'the default options should not exist');
   });
 
   it('orders the containers list correctly', function() {


### PR DESCRIPTION
Implement an infrastructure to dynamically disable
containers support in the machine view based on the
environment's provider type.

A list of supported containers is defined at
environment level, and used to check containerization
support.

Avoid hard-coding the list of container types in the
create machine view.

Update the service unit token to accept a list of
available container types.
Also removed the env from the service usint token:
it doesn't appear to be used at all.

This branch also includes some drive-by fixes to
methods' docstrings and comments.
