### PR TITLE
Hide help text when opened from canvas.

### DIFF
--- a/app/subapps/browser/browser.js
+++ b/app/subapps/browser/browser.js
@@ -586,6 +586,7 @@ YUI.add('subapp-browser', function(Y) {
     renderServiceInspector: function(metadata) {
       var clientId = metadata.id,
           model = this._findModelInServices(clientId),
+          hideHelp = (metadata.flash && metadata.flash.hideHelp) || false,
           charm,
           previousInspector,
           activeInspector;
@@ -600,7 +601,8 @@ YUI.add('subapp-browser', function(Y) {
         ecs: this.get('ecs'),
         topo: topo,
         store: topo.get('store'),
-        activeTab: metadata.hash
+        activeTab: metadata.hash,
+        hideHelp: hideHelp
       };
 
       if (model) {

--- a/app/templates/inspector-header.handlebars
+++ b/app/templates/inspector-header.handlebars
@@ -28,8 +28,18 @@
   <div data-bind="life" class="inspector-header-message hidden">
     <p>This service is being destroyed</p>
   </div>
-  <div class="inspector-header-message ghost-message hidden">
+{{/unless}}
+{{!--
+  Only display this message if 1) the inspector is for a pending service
+  and 2) the hideHelp flag is not set. See the comments in
+  app/views/topology/service.js in the showServiceDetails function for
+  more details.
+--}}
+{{#if pending}}
+{{#unless hideHelp}}
+  <div class="inspector-header-message ghost-message">
     Your service has been added. Configure using the tabs below.
     <span dismiss>Dismiss</span>
   </div>
 {{/unless}}
+{{/if}}

--- a/app/views/inspector-base.js
+++ b/app/views/inspector-base.js
@@ -57,6 +57,17 @@ YUI.add('inspector-base', function(Y) {
         'valueFn': function() {
           return Y.Node.create(ns.Templates['service-inspector']());
         }
+      },
+
+      /**
+         Determines whether the help text needs to be hidden.
+
+         @attribute hideHelp
+         @default false
+         @type {Boolean}
+       */
+      hideHelp: {
+        value: false
       }
     }
   });

--- a/app/views/state.js
+++ b/app/views/state.js
@@ -123,7 +123,7 @@ YUI.add('juju-app-state', function(Y) {
       }, this);
       // Reset flash, because we don't want arbitrary potentially large objects
       // (e.g. files from local charm upload) hanging out.
-      this.set('flash', {});
+      this.set('flash', undefined);
     },
 
     /**
@@ -458,7 +458,6 @@ YUI.add('juju-app-state', function(Y) {
         return;
       } else if (parts[0] === 'local') {
         metadata.localType = parts[1];
-        metadata.flash = this.get('flash');
       } else {
         // The first index is the service id except in the above cases.
         metadata.id = parts[0];
@@ -466,6 +465,7 @@ YUI.add('juju-app-state', function(Y) {
           metadata[parts[1]] = parts[2] || true;
         }
       }
+      metadata.flash = this.get('flash');
       if (hash) {
         metadata.hash = hash;
       }

--- a/app/views/topology/service.js
+++ b/app/views/topology/service.js
@@ -1466,10 +1466,20 @@ YUI.add('juju-topology-service', function(Y) {
       @param {Object} topo The reference to the topology object.
     */
     showServiceDetails: function(box, topo) {
+      // We set the hideHelp flag when the user clicks on an existing service in
+      // the canvas; in otherwords, we're not in the "create a service"
+      // workflow, which is the only one where we want to display the help
+      // notification. Right now there are multiple entrances to the "create a
+      // service" workflow, but only one to "show details for existing service",
+      // so it was easier to hide the help on that one entrance and then show it
+      // by default for all the rest.
       topo.fire('changeState', {
         sectionA: {
           component: 'inspector',
-          metadata: { id: box.id }
+          metadata: {
+            id: box.id,
+            flash: { hideHelp: true }
+          }
         }});
       this.showServiceMenu(box);
     },

--- a/app/views/viewlets/inspector-header.js
+++ b/app/views/viewlets/inspector-header.js
@@ -91,11 +91,10 @@ YUI.add('inspector-header-view', function(Y) {
           pojoModel.invalidName = 'valid';
         }
       }
+      // Just passing this value on through from the containing view.
+      pojoModel.hideHelp = viewContainerAttrs.hideHelp;
       var container = this.get('container');
       container.setHTML(this.template(pojoModel));
-      if (window.flags && window.flags.mv && pojoModel.pending) {
-        container.one('.ghost-message').removeClass('hidden');
-      }
     },
 
     /**

--- a/test/test_service_module.js
+++ b/test/test_service_module.js
@@ -193,6 +193,17 @@ describe('service module events', function() {
     serviceModule.update();
   });
 
+  it('hides onboarding for existing services', function(done) {
+    topo.on('changeState', function(e) {
+      var state = e.details[0];
+      assert.equal(true, state.sectionA.metadata.flash.hideHelp);
+      done();
+    });
+    var menuStub = utils.makeStubMethod(serviceModule, 'showServiceMenu');
+    this._cleanups.push(menuStub.reset);
+    serviceModule.showServiceDetails({id: 'test'}, topo);
+  });
+
   // Click the provided service so that the service menu is shown.
   // Return the service menu.
   var clickService = function(service) {

--- a/test/test_ui_state.js
+++ b/test/test_ui_state.js
@@ -237,7 +237,7 @@ describe('UI State object', function() {
         var newState = { sectionA: {}, sectionB: {} };
         state.set('flash', {foo: 'bar'});
         state.dispatch(newState);
-        assert.deepEqual({}, state.get('flash'));
+        assert.deepEqual(undefined, state.get('flash'));
       });
 
       it('_dispatchSection: calls registered sectionB dispatcher', function() {
@@ -264,40 +264,39 @@ describe('UI State object', function() {
   describe('url part parsing', function() {
 
     describe('_parseInspectorUrl', function() {
+      var flash = {
+        file: 'foo',
+        services: ['bar', 'baz']
+      };
+
       var parts = {
         'inspector': undefined,
         'inspector/service123': {
-          id: 'service123'
+          id: 'service123',
+          flash: flash
         },
         'inspector/service123/charm': {
           id: 'service123',
-          charm: true
+          charm: true,
+          flash: flash
         },
         'inspector/service123/unit/13': {
           id: 'service123',
-          unit: '13'
+          unit: '13',
+          flash: flash
         },
         'inspector/local/new': {
           localType: 'new',
-          flash: {
-            file: 'foo',
-            services: ['bar', 'baz']
-          }
+          flash: flash
         },
         'inspector/local/upgrade': {
           localType: 'upgrade',
-          flash: {
-            file: 'foo',
-            services: ['bar', 'baz']
-          }
+          flash: flash
         }
       };
 
       it('can parse the inspector url parts', function() {
-        state.set('flash', {
-          file: 'foo',
-          services: ['bar', 'baz']
-        });
+        state.set('flash', flash);
         Object.keys(parts).forEach(function(key) {
           assert.deepEqual(
               state._parseInspectorUrl(key),
@@ -311,7 +310,7 @@ describe('UI State object', function() {
             'inspector/service123/charm', '#code');
         assert.deepEqual(
             data,
-            { id: 'service123', charm: true, hash: '#code' });
+            { id: 'service123', charm: true, hash: '#code', flash: {} });
       });
     });
 
@@ -609,7 +608,8 @@ describe('UI State object', function() {
         sectionA: {
           component: 'inspector',
           metadata: {
-            id: 'service123'
+            id: 'service123',
+            flash: {}
           }
         }, sectionB: {}
       },
@@ -618,7 +618,8 @@ describe('UI State object', function() {
           component: 'inspector',
           metadata: {
             id: 'service123',
-            charm: true
+            charm: true,
+            flash: {}
           }
         }, sectionB: {}
       },
@@ -627,7 +628,8 @@ describe('UI State object', function() {
           component: 'inspector',
           metadata: {
             id: 'service123',
-            unit: '13'
+            unit: '13',
+            flash: {}
           }
         }, sectionB: {}
       },
@@ -675,7 +677,8 @@ describe('UI State object', function() {
         sectionA: {
           component: 'inspector',
           metadata: {
-            id: 'apache2'
+            id: 'apache2',
+            flash: {}
           }
         },
         sectionB: {
@@ -690,7 +693,8 @@ describe('UI State object', function() {
         sectionA: {
           component: 'inspector',
           metadata: {
-            id: 'apache2'
+            id: 'apache2',
+            flash: {}
           }
         },
         sectionB: {


### PR DESCRIPTION
We only want to display the help text in the inspector when a service is initially deployed. Or, put differently: we want to hide the text when a user is clicking on an existing service in the canvas.
