### PR TITLE
Fixes errors on dropping units on root container.

### DIFF
--- a/app/widgets/machine-view-panel.js
+++ b/app/widgets/machine-view-panel.js
@@ -667,11 +667,11 @@ YUI.add('machine-view-panel', function(Y) {
               parentId = selected;
             }
             this._placeUnit(unit, parentId);
-            var token = this._findMachineOrContainerToken(tokenId, true);
-            this._selectMachineToken(
-                this.get('machineTokens')[selected]
-                    .get('container').one('.token'));
-            this._selectContainerToken(token);
+            var containerToken = this._findMachineOrContainerToken(
+                tokenId, true);
+            var machineToken = this.get('machineTokens')[selected].get(
+                'container').one('.token');
+            this._selectMachineToken(machineToken, containerToken);
           } else {
             this._displayCreateMachine(unit, dropAction, parentId);
           }
@@ -829,9 +829,10 @@ YUI.add('machine-view-panel', function(Y) {
          * Display containers for the selected machine.
          *
          * @method _selectMachineToken
-         * @param {Object} selected the node for the token that was selected.
+         * @param {Object} selected The node for the token that was selected.
+         * @param {Object} selectedContainer Optional active container.
          */
-        _selectMachineToken: function(selected) {
+        _selectMachineToken: function(selected, selectedContainer) {
           var container = this.get('container'),
               previousActive = container.one(
                   '.column.machines .items .token.active'),
@@ -855,7 +856,11 @@ YUI.add('machine-view-panel', function(Y) {
             machineTokens[parentId].showConstraints();
           }
           this._renderContainerTokens(containers, parentId);
-          this._selectRootContainer(parentId);
+          if (selectedContainer) {
+            this._selectContainerToken(selectedContainer);
+          } else {
+            this._selectRootContainer(parentId);
+          }
         },
 
         /**

--- a/test/test_machine_view_panel.js
+++ b/test/test_machine_view_panel.js
@@ -719,8 +719,6 @@ describe('machine view panel view', function() {
           var toggleStub = utils.makeStubMethod(
               view, '_toggleAllPlacedMessage');
           this._cleanups.push(toggleStub.reset);
-          var selectStub = utils.makeStubMethod(view, '_selectContainerToken');
-          this._cleanups.push(selectStub.reset);
           var selectMachineStub = utils.makeStubMethod(
               view, '_selectMachineToken');
           this._cleanups.push(selectMachineStub.reset);
@@ -743,7 +741,6 @@ describe('machine view panel view', function() {
           var placeArgs = env.placeUnit.lastArguments();
           assert.strictEqual(placeArgs[0].id, 'test/1');
           assert.equal(placeArgs[1], '0/lxc/1');
-          assert.equal(selectStub.callCount(), 1);
           assert.equal(selectMachineStub.callCount(), 1);
         }
     );
@@ -776,11 +773,43 @@ describe('machine view panel view', function() {
           var placeArgs = env.placeUnit.lastArguments();
           assert.strictEqual(placeArgs[0].id, 'test/1');
           assert.equal(placeArgs[1], '0');
-          // selectContainerToken called once by selectMachineToken and once
-          // directly.
-          assert.equal(selectStub.callCount(), 3);
+          // selectContainerToken called once by selectMachineToken.
+          assert.equal(selectStub.callCount(), 2);
         }
     );
+
+    it('can select the root container when selecting the machine', function() {
+      var selectRootStub = utils.makeStubMethod(view, '_selectRootContainer');
+      this._cleanups.push(selectRootStub.reset);
+      var selectContainerStub = utils.makeStubMethod(
+          view, '_selectContainerToken');
+      this._cleanups.push(selectContainerStub.reset);
+      view.set('selectedMachine', 0);
+      view.render();
+      var machineToken = container.one('.column.machines .items .token');
+      assert.equal(selectRootStub.callCount(), 1); // called once by render
+      assert.equal(selectContainerStub.callCount(), 0);
+      view._selectMachineToken(machineToken);
+      assert.equal(selectRootStub.callCount(), 2);
+      assert.equal(selectContainerStub.callCount(), 0);
+    });
+
+    it('can select another container when selecting the machine', function() {
+      var selectRootStub = utils.makeStubMethod(view, '_selectRootContainer');
+      this._cleanups.push(selectRootStub.reset);
+      var selectContainerStub = utils.makeStubMethod(
+          view, '_selectContainerToken');
+      this._cleanups.push(selectContainerStub.reset);
+      view.set('selectedMachine', 0);
+      view.render();
+      var machineToken = container.one('.column.machines .items .token');
+      var fakeContainerToken = {};
+      assert.equal(selectRootStub.callCount(), 1); // called once by render
+      assert.equal(selectContainerStub.callCount(), 0);
+      view._selectMachineToken(machineToken, fakeContainerToken);
+      assert.equal(selectRootStub.callCount(), 1);
+      assert.equal(selectContainerStub.callCount(), 1);
+    });
 
     it('does not allow placement on machines being deleted', function() {
       var notes;


### PR DESCRIPTION
Errors occurred b/c in cases where the root container was the drop target, the code attempted to select a container _after_ `selectMachineToken` had already selected the root container.

This updates `selectMachineToken` to call `selectRootContainer` or `selectContainerToken` depending on an optional containerToken parameter.
