### PR TITLE
Prevent DOM updates after unbinding.

### DIFF
--- a/app/views/databinding.js
+++ b/app/views/databinding.js
@@ -604,7 +604,10 @@ YUI.add('juju-databinding', function(Y) {
       var self = this;
       // Make sure we don't try to update the DOM after everything has been
       // unbound.
-      this._updateTimeout.cancel();
+      if (this._updateTimeout) {
+        this._updateTimeout.cancel();
+        this._updateTimeout = null;
+      }
       // Unbind each model
       Y.each(this._models, function(handles) {
         handles.forEach(function(handle) {


### PR DESCRIPTION
Corrects bug https://launchpad.net/bugs/1368560. DOM updates were happening on a timeout for debouncing purposes, but that meant that they might happen after the DOM elements being updated (i.e., the databound DOM elements) were removed/destroyed. This change makes sure the timeout is also canceled as part of destruction.
