### PR TITLE
Disable destroy links

### DIFF
--- a/app/widgets/container-token.js
+++ b/app/widgets/container-token.js
@@ -99,7 +99,7 @@ YUI.add('container-token', function(Y) {
          */
         handleDelete: function(e) {
           e.preventDefault();
-          this.fire('deleteToken');
+          this.fire('deleteToken', {machineId: this.get('machine').id});
         },
 
         /**
@@ -110,7 +110,8 @@ YUI.add('container-token', function(Y) {
          */
         handleDeleteUnit: function(e) {
           e.preventDefault();
-          this.fire('deleteContainerUnit');
+          this.fire('deleteContainerUnit',
+              {unitId: e.currentTarget.ancestor('.unit').getData('id')});
         },
 
         /**

--- a/app/widgets/machine-token.js
+++ b/app/widgets/machine-token.js
@@ -90,7 +90,7 @@ YUI.add('machine-token', function(Y) {
          */
         handleDelete: function(e) {
           e.preventDefault();
-          this.fire('deleteToken');
+          this.fire('deleteToken', {machineId: this.get('machine').id});
         },
 
         /**

--- a/app/widgets/machine-view-panel.js
+++ b/app/widgets/machine-view-panel.js
@@ -54,15 +54,6 @@ YUI.add('machine-view-panel', function(Y) {
           '.container-token .token': {
             click: 'handleContainerTokenSelect'
           },
-          '.machine-token .moreMenuItem-0': {
-            click: 'deleteMachine'
-          },
-          '.container-token .token > .more-menu .moreMenuItem-0': {
-            click: 'deleteMachine'
-          },
-          '.container-token .unit .more-menu .moreMenuItem-0': {
-            click: 'deleteContainerUnit'
-          },
           '.unplaced-unit .moreMenuItem-0': {
             click: '_cancelUnitPlacement'
           },
@@ -103,9 +94,7 @@ YUI.add('machine-view-panel', function(Y) {
           this.supportedContainerTypes = [];
           // Turn machine models into tokens and store internally.
           this.set('machineTokens', {});
-          machines.forEach(function(machine) {
-            this._createMachineToken(machine);
-          }, this);
+          machines.forEach(this._createMachineToken, this);
           this.set('containerTokens', {});
           // Turn unit models into tokens and store internally.
           this._addIconsToUnits(units);
@@ -162,6 +151,10 @@ YUI.add('machine-view-panel', function(Y) {
           // When the environment name becomes available, display it.
           this.get('env').after('environmentNameChange',
               this._displayEnvironmentName, this);
+
+          // Token event handers
+          this.on('*:deleteToken', this.deleteMachine, this);
+          this.on('*:deleteContainerUnit', this.deleteContainerUnit, this);
         },
 
         /**
@@ -906,7 +899,7 @@ YUI.add('machine-view-panel', function(Y) {
          * @param {Object} e The event
          */
         deleteMachine: function(e) {
-          var machineName = e.currentTarget.ancestor('.token').getData('id');
+          var machineName = e.machineId;
           var db = this.get('db');
           var machine = db.machines.getById(machineName);
           var token = this.get(machine.parentId ?
@@ -953,7 +946,7 @@ YUI.add('machine-view-panel', function(Y) {
           @param {Object} e The click event
         */
         deleteContainerUnit: function(e) {
-          var unitId = e.currentTarget.ancestor('.unit').getData('id');
+          var unitId = e.unitId;
           var db = this.get('db');
           var unit = db.units.getById(unitId);
           var machineId = unit.machine;
@@ -1341,7 +1334,7 @@ YUI.add('machine-view-panel', function(Y) {
           var token = new views.MachineToken({
             containerTemplate: '<li/>',
             machine: machine,
-            committed: machine.id.indexOf('new') !== 0,
+            committed: this._isMachineCommitted(machine.id),
             constraintsVisible: this.get('tokenConstraintsVisible')
           });
           this.get('machineTokens')[machine.id] = token;

--- a/test/test_container_token.js
+++ b/test/test_container_token.js
@@ -76,6 +76,7 @@ describe('container token view', function() {
   it('fires the delete event', function(done) {
     view.on('deleteToken', function(e) {
       assert.isObject(e);
+      assert.equal(e.machineId, machine.id);
       done();
     });
     view.showMoreMenu();
@@ -155,5 +156,15 @@ describe('container token view', function() {
     assert.equal(container.one('.unit') !== null, true);
     view.setUnitDeleted({id: 'test/1'});
     assert.equal(container.one('.unit'), null);
+  });
+
+  it('fires a delete event for units', function(done) {
+    view.on('deleteContainerUnit', function(e) {
+      assert.isObject(e);
+      assert.equal(e.unitId, 'test/1');
+      done();
+    });
+    view.showUnitMoreMenu({halt: utils.makeStubFunction()}, 'test/1');
+    container.one('.unit .moreMenuItem-0').simulate('click');
   });
 });

--- a/test/test_machine_token.js
+++ b/test/test_machine_token.js
@@ -82,6 +82,7 @@ describe('machine token view', function() {
     var view = makeView(this, machine);
     view.on('deleteToken', function(e) {
       assert.isObject(e);
+      assert.equal(e.machineId, machine.id);
       done();
     });
     view.showMoreMenu();

--- a/test/test_machine_view_panel.js
+++ b/test/test_machine_view_panel.js
@@ -1882,6 +1882,9 @@ describe('machine view panel view', function() {
         destroy: function() {},
         get: function() {
           return {remove: function() {}};
+        },
+        on: function() {
+          return {detach: function() {}};
         }
       });
       this._cleanups.push(viewStub.reset);
@@ -1912,6 +1915,9 @@ describe('machine view panel view', function() {
         destroy: function() {},
         get: function() {
           return {remove: function() {}};
+        },
+        on: function() {
+          return {detach: function() {}};
         }
       });
       this._cleanups.push(viewStub.reset);


### PR DESCRIPTION
Fixes bug #1368592: disabled links were still working due to events being attached to click instead of listening for the fired event.

The machine token creation and rendering code has also been refactored to remove duplication and allow the event attaching code to only be added once.
