### PR TITLE
Ensure proper committed status on containers.

### DIFF
--- a/app/widgets/machine-view-panel.js
+++ b/app/widgets/machine-view-panel.js
@@ -1185,7 +1185,7 @@ YUI.add('machine-view-panel', function(Y) {
           var containerParent = this.get('container').one(
               '.containers .content .items');
           var numUnits = db.units.filterByMachine(parentId, true).length;
-          var committed = parentId.indexOf('new') !== 0;
+          var parentCommitted = parentId.indexOf('new') !== 0;
           var rootUnits = db.units.filterByMachine(parentId);
           // To allow sorting create a new model list that contains just
           // the list of containers. This means we don't have to loop over
@@ -1205,8 +1205,10 @@ YUI.add('machine-view-panel', function(Y) {
             displayName: 'Root container',
             id: parentId + '/' + ROOT_CONTAINER_PLACEHOLDER
           };
+          // The root container inherits the committed/uncommitted state of its
+          // parent machine.
           this._createContainerToken(containerParent, rootContainer,
-              committed, rootUnits);
+              parentCommitted, rootUnits);
 
           if (containers.length > 0) {
             machinesModelList.add(containers);
@@ -1215,7 +1217,9 @@ YUI.add('machine-view-panel', function(Y) {
             machinesModelList.each(function(container) {
               // Get the real machine so that we are only dealing with
               // the correct data and so that the events work etc.
-              var machine = db.machines.getById(container.id);
+              var id = container.id,
+                  machine = db.machines.getById(id),
+                  committed = id.indexOf('new') < 0;
               machine.displayDelete = true;
               this._createContainerToken(containerParent, machine, committed);
             }, this);

--- a/test/test_machine_view_panel.js
+++ b/test/test_machine_view_panel.js
@@ -1974,6 +1974,21 @@ describe('machine view panel view', function() {
       assert.equal(tokenArguments[0][1].displayName, 'Root container');
     });
 
+    it('creates container tokens with proper committed state', function() {
+      view.render();
+      machines.add([{ id: '0/lxc/new1' }]);
+      var containers = machines.filterByAncestor('0');
+      var tokenStub = utils.makeStubMethod(view, '_createContainerToken');
+      this._cleanups.push(tokenStub.reset);
+      view._renderContainerTokens(containers, '0');
+      assert.equal(tokenStub.callCount(), 2);
+      var tokenArguments = tokenStub.allArguments();
+      assert.equal(tokenArguments[0][2], true,
+                   'root container does not have expected committed state');
+      assert.equal(tokenArguments[1][2], false,
+                   'new container does not have expected uncommitted state');
+    });
+
     it('displays the container count in the header', function() {
       view.render();
       machines.add([{id: '0/lxc/0'}]);


### PR DESCRIPTION
This fixes bug https://bugs.launchpad.net/juju-gui/+bug/1369601

Containers had been (incorrectly) inheriting their commited status from
their parent machine. That meant that a newly-created container on an
existing machine would show up as committed upon re-render. We now check
for 'new' in the name of each container and set its committed status
based on that. The only exception is root containers, which still
inherit from the parent machine because they _are_ the parent machine.
