### PR TITLE
Display an error if Juju will not allow a subordinate relation.

### DIFF
--- a/app/store/env/go.js
+++ b/app/store/env/go.js
@@ -1932,7 +1932,7 @@ YUI.add('juju-env-go', function(Y) {
     handleAddRelation: function(userCallback, endpoint_a, endpoint_b, data) {
       var result = {};
       var response = data.Response;
-      if (response) {
+      if (response && response.Endpoints) {
         var serviceNameA = endpoint_a.split(':')[0];
         var serviceNameB = endpoint_b.split(':')[0];
         result.endpoints = [];

--- a/app/views/topology/relation.js
+++ b/app/views/topology/relation.js
@@ -1000,7 +1000,7 @@ YUI.add('juju-topology-relation', function(Y) {
             new models.Notification({
               title: 'Error adding relation',
               message: 'Relation ' + ev.endpoint_a +
-                  ' to ' + ev.endpoint_b,
+                  ' to ' + ev.endpoint_b + ': ' + ev.err,
               level: 'error'
             })
         );

--- a/test/test_topology_relation.js
+++ b/test/test_topology_relation.js
@@ -147,6 +147,39 @@ describe('topology relation module', function() {
         'canceled or completed');
   });
 
+  it('gracefully handles errors on creation', function() {
+    var stubNotification = utils.makeStubFunction();
+    var topo = {
+      get: function() {
+        return {
+          get: function() {
+            return {
+              relations: {
+                remove: function() {},
+                getById: function() {}
+              },
+              notifications: {
+                add: stubNotification
+              }
+            };
+          },
+          vis: {
+            select: function() {
+              return {
+                remove: function() {}
+              };
+            }
+          },
+          update: function() {},
+          bindAllD3Events: function() {}
+        };
+      }
+    };
+    view._addRelationCallback(topo, 'foo', {err: 'Oh no!'});
+    assert.equal(stubNotification.calledOnce(), true,
+        'Notification of error not created');
+  });
+
   it('has a list of relations', function() {
     assert.deepEqual(view.relations, []);
   });


### PR DESCRIPTION
Check for endpoints in response, displaying error message properly; fixes 1369606
