### PR TITLE
Tweak service nav tab's background.

### DIFF
--- a/lib/views/environment-header.less
+++ b/lib/views/environment-header.less
@@ -31,7 +31,7 @@
             &.tab {
                 &.active {
                     &.services {
-                        background-color: transparent;
+                        background-color: #f2f2f2;
                         border-bottom: none;
                     }
                     &.machines a {


### PR DESCRIPTION
Set the background to something that blends with the canvas, but won't
allow canvas elements (relations lines, services, etc.) to bleed
through.
