### PR TITLE
Remove unplaced units with service

### DIFF
--- a/app/utils/environment-change-set.js
+++ b/app/utils/environment-change-set.js
@@ -537,9 +537,11 @@ YUI.add('environment-change-set', function(Y) {
       } else {
         var service = this.get('db').services.getById(args[0]);
         // Remove any unplaced units.
+        var units = [];
         service.get('units').each(function(unit) {
-          this._lazyRemoveUnit([[unit.id]]);
+          units.push(unit.id);
         }, this);
+        this._lazyRemoveUnit([units]);
         service.set('deleted', true);
         return this._createNewRecord('destroyService', command, []);
       }

--- a/test/test_env_change_set.js
+++ b/test/test_env_change_set.js
@@ -746,11 +746,11 @@ describe('Environment Change Set', function() {
         assert.deepEqual(ecs.changeSet, {});
       });
 
-      it('destroys unplaced units', function(done) {
+      it('destroys unplaced units when the service is removed', function(done) {
         var args = ['foo', done, {modelId: 'baz'}];
         var units = new Y.juju.models.ServiceUnitList();
-        var unitId = 'test/1';
-        units.add([{id: unitId}]);
+        var unitIds = ['test/1', 'test/2'];
+        units.add([{id: unitIds[0]}, {id: unitIds[1]}]);
         ecs.set('db', {
           services: {
             getById: function(arg) {
@@ -767,7 +767,7 @@ describe('Environment Change Set', function() {
         this._cleanups.push(removeStub.reset);
         ecs._lazyDestroyService(args);
         assert.equal(removeStub.calledOnce(), true);
-        assert.deepEqual(removeStub.lastArguments()[0], [[unitId]]);
+        assert.deepEqual(removeStub.lastArguments()[0], [unitIds]);
         done();
       });
     });


### PR DESCRIPTION
Fixes bug #1368566: when a committed service is removed it should also remove unplaced units and their entries in the changelog.
