### PR TITLE
Machine token unit tooltips

### DIFF
--- a/app/templates/machine-token-units.handlebars
+++ b/app/templates/machine-token-units.handlebars
@@ -1,3 +1,3 @@
 {{#units}}
-  <img src="{{icon}}" alt="{{service}}" class="unit">
+  <img src="{{icon}}" alt="{{service}}" class="unit" title="{{displayName}}">
 {{/units}}


### PR DESCRIPTION
Display units' names as tooltips for unit icons on a machine token.
