### PR TITLE
Sort names by number

### DIFF
--- a/app/models/models.js
+++ b/app/models/models.js
@@ -1351,14 +1351,16 @@ YUI.add('juju-models', function(Y) {
           break;
         case 'name':
           sortMethod = function(model) {
+            // A fairly arbitrary string length to pad out the strings
+            // to. If there are sort issues, try increasing this value.
+            var maxLength = 50;
             var name = model.displayName;
-            var nameAsNumber = parseInt(name, 10);
-            // Check that the name is a number by checking that the
-            // parsed value matches the name.
-            var isNumber = nameAsNumber.toString() === name;
-            // If the name is a number return it as a number so that it
-            // will be sorted as such.
-            return isNumber ? nameAsNumber : name;
+            // Pad the string out to our max value so that the numbers
+            // inside the strings sort correctly.
+            for (var i = 0; i < maxLength - name.length; i += 1) {
+              name = '0' + name;
+            }
+            return name;
           };
           break;
         case 'disk':

--- a/test/test_machine_view_panel.js
+++ b/test/test_machine_view_panel.js
@@ -1769,7 +1769,7 @@ describe('machine view panel view', function() {
       assert.equal(machineTokens.item(2).getData('id'), '12');
     });
 
-    it('can sort the machines by names as numbers', function() {
+    it('can correctly sort numbers', function() {
       view.render();
       var moreMenuNode = container.one('.column.machines .head .more-menu');
       var openMenu = moreMenuNode.one('.open-menu');
@@ -1777,11 +1777,13 @@ describe('machine view panel view', function() {
       machines.reset();
       machines.add([
         {id: '10'},
-        {id: '0'},
         {id: 'new1'},
         {id: '1'},
         {id: '2'},
-        {id: 'new0'}
+        {id: 'new0'},
+        {id: '0'},
+        {id: 'new12'},
+        {id: 'new3'}
       ]);
       openMenu.simulate('click');
       moreMenuNode.one('.moreMenuItem-3').simulate('click');
@@ -1792,6 +1794,10 @@ describe('machine view panel view', function() {
       assert.equal(machineTokens.item(3).getData('id'), '10');
       assert.equal(machineTokens.item(4).getData('id'), 'new0');
       assert.equal(machineTokens.item(5).getData('id'), 'new1');
+      // new12 and new3 can not be sorted correctly as the number
+      // padding only helps with strings that contain only integers.
+      assert.equal(machineTokens.item(6).getData('id'), 'new12');
+      assert.equal(machineTokens.item(7).getData('id'), 'new3');
     });
 
     it('can sort the machines by the number of services', function() {

--- a/test/test_model.js
+++ b/test/test_model.js
@@ -1013,7 +1013,7 @@ describe('test_model.js', function() {
           assertMachinesNames(machines.filterByAncestor('1'), ['1/lxc/0']);
           assertMachinesNames(
               machines.filterByAncestor('2'),
-              ['2/kvm/0', '2/kvm/0/lxc/0', '2/kvm/0/lxc/1', '2/lxc/42']);
+              ['2/kvm/0', '2/lxc/42', '2/kvm/0/lxc/0', '2/kvm/0/lxc/1']);
         });
 
         it('filters machines by container ancestor', function() {


### PR DESCRIPTION
Fixes bug #1369794: if machine names are numbers then sort them as numbers.
