### PR TITLE
Add back in latestChange, but more clearly mark it as a notification.

### DIFF
--- a/app/templates/deployer-bar.handlebars
+++ b/app/templates/deployer-bar.handlebars
@@ -30,9 +30,9 @@
             </a>
         </li>
         <li class="change">
-          <i class="sprite {{ latestChangeDescription.icon }}"></i>
-          {{ latestChangeDescription.description }}
-          <time>{{ latestChangeDescription.time }}</time>
+          <i class="sprite {{ changeNotification.icon }}"></i>
+          {{ changeNotification.description }}
+          <time>{{ changeNotification.time }}</time>
         </li>
     </ul>
 </div>

--- a/app/widgets/deployer-bar.js
+++ b/app/widgets/deployer-bar.js
@@ -305,7 +305,7 @@ YUI.add('deployer-bar', function(Y) {
       if (container && container.get('parentNode')) {
         container.one('.panel.summary section').setHTML(this.summaryTemplate({
           changeCount: this._getChangeCount(ecs),
-          latestChangeDescription: '',
+          changeNotification: '',
           deployServices: changes.deployedServices,
           destroyedServices: changes.destroyedServices,
           addedRelations: changes.addRelations,
@@ -363,16 +363,15 @@ YUI.add('deployer-bar', function(Y) {
       var container = this.get('container'),
           ecs = this.get('ecs');
       var changes = this._getChangeCount(ecs);
+      var changeNotification = this._getChangeNotification(ecs);
       // XXX  Tests start to fail on this update without the parent of the
       // container to address. This should be setup in the factory for env
       // and app to be better mocked out to not pick up changes when not
       // wanted.
       if (container && container.get('parentNode')) {
         container.setHTML(this.template({
-          // There is no need to update the container with the latest change
-          // descriptions: this is done each time the user opens the panel.
-          // For now we just need to update the changes count and the button.
           changeCount: changes,
+          changeNotification: changeNotification,
           deployed: this._deployed
         }));
         this._toggleDeployButtonStatus(changes > 0);
@@ -457,10 +456,10 @@ YUI.add('deployer-bar', function(Y) {
     /**
       Return the latest change description.
 
-      @method _getLatestChangeDescription
+      @method _getChangeNotification
       @param {Object} ecs The environment change set.
     */
-    _getLatestChangeDescription: function(ecs) {
+    _getChangeNotification: function(ecs) {
       var latest = ecs.changeSet[this._getLatestChange()];
       return this._generateChangeDescription(latest);
     },

--- a/test/test_deployer_bar.js
+++ b/test/test_deployer_bar.js
@@ -212,6 +212,24 @@ describe('deployer bar view', function() {
                  'summary-open class still present');
   });
 
+  it('updates when the change set is modified', function(done) {
+    var called = false;
+    view.update = function(evt) {
+      called = true;
+      done();
+    };
+    view.render();
+    view.get('ecs').fire('changeSetModified');
+    assert.equal(called, true);
+  });
+
+  it('displays the most recent change as a notification on update', function() {
+    var stubGet = utils.makeStubMethod(view, '_getChangeNotification');
+    view.render();
+    view.update();
+    assert.equal(stubGet.calledOnce(), true);
+  });
+
   it('closes the summary', function() {
     view.hideSummary(mockEvent);
     assert.equal(container.hasClass('summary-open'), false);


### PR DESCRIPTION
`latestChangeDescription` is the piece of data previously provided to the
to the template to make notifications work. Because it wasn't clear it was a notification,
it was incorrectly identified as redundant code and removed. This adds it back in,
with tests, and renames it to make its purpose clearer.
