### PR TITLE
Add change count to commit summary

### DIFF
--- a/app/templates/deployer-bar-summary.handlebars
+++ b/app/templates/deployer-bar-summary.handlebars
@@ -172,7 +172,7 @@
     <div class="changes open">
     {{/if}}
       <div class="toggle">
-          View the complete change log
+          View the complete change log ({{changeCount}})
           <span class="expand">
               <i class="sprite expand_icon"></i>
           </span>


### PR DESCRIPTION
Fixes bug #1371018: on the commit summary the number of changes is now displayed.
