### PR TITLE
Using a search category with an empty input no longer uses the previously searched for query

### DIFF
--- a/app/utils/search-widget-mgmt-extension.js
+++ b/app/utils/search-widget-mgmt-extension.js
@@ -112,7 +112,7 @@ YUI.add('search-widget-mgmt-extension', function(Y) {
       // might come from places, such as autocomplete, which are a search
       // change, but also want to select a charm id as well.
       if (e.change) {
-        change = Y.merge(change, e.change);
+        change = Y.mix(change, e.change, false, null, 0, true);
       }
       this.fire('changeState', {
         sectionA: {

--- a/test/test_charmbrowser_view.js
+++ b/test/test_charmbrowser_view.js
@@ -249,7 +249,9 @@ describe('charmbrowser view', function() {
 
       it('fires a changeState event when the search changes', function(done) {
         var change = {
-          filter: 'foo',
+          filter: {
+            text: 'foo'
+          },
           charmID: 'bar'
         };
         charmBrowser._renderSearchWidget();
@@ -265,6 +267,7 @@ describe('charmbrowser view', function() {
         });
         var searchWidget = charmBrowser.searchWidget;
         searchWidget.fire(searchWidget.EVT_SEARCH_CHANGED, {
+          newVal: 'foo',
           change: change
         });
       });


### PR DESCRIPTION
Fixes bug https://bugs.launchpad.net/juju-gui/+bug/1375123
