### PR TITLE
Make the notifications and their tests more resilient by properly destroying them

### DIFF
--- a/app/widgets/notifier.js
+++ b/app/widgets/notifier.js
@@ -136,17 +136,33 @@ YUI.add('notifier', function(Y) {
       this.timer = null;
       if (this.get('boundingBox').getDOMNode()) {
         // Animate and destroy the notification if it still exists in the DOM.
-        var anim = new Y.Anim({
+        this.anim = new Y.Anim({
           node: this.get('boundingBox'),
           to: {opacity: 0},
           easing: 'easeIn',
           duration: 0.2
         });
-        anim.on('end', this.destroy, this);
-        anim.run();
+        this.anim.on('end', this.destroy, this);
+        this.anim.run();
       } else {
         // Otherwise, just destroy the notification.
         this.destroy();
+      }
+    },
+
+    /**
+      Stops the timer on destroy.
+
+      @method destructor
+    */
+    destructor: function() {
+      if (this.timer) {
+        this.timer.stop();
+        this.timer = null;
+      }
+      if (this.anim && this.anim.stop) {
+        this.anim.stop();
+        this.anim = null;
       }
     }
 

--- a/test/test_notifier_widget.js
+++ b/test/test_notifier_widget.js
@@ -20,7 +20,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
 describe('notifier widget', function() {
-  var makeContainer, Notifier, notifierBox, Y;
+  var makeContainer, Notifier, notifiers, notifierBox, utils, Y;
 
   // These tests relying on crazy timing to work properly. We cannot clean up
   // the containers automatically as this will cause things to blow up when
@@ -40,14 +40,22 @@ describe('notifier widget', function() {
       'juju-tests-utils',
       'node-event-simulate'], function(Y) {
       Notifier = Y.namespace('juju.widgets').Notifier;
+      utils = Y.namespace('juju-tests.utils');
       done();
     });
   });
 
   // Create the notifier box and attach it as first element of the body.
   beforeEach(function() {
+    notifiers = [];
     notifierBox = makeContainer();
     notifierBox.addClass('notifier-box');
+  });
+
+  afterEach(function() {
+    notifiers.forEach(function(notifier) {
+      notifier.destroy();
+    });
   });
 
   // Factory rendering and returning a notifier instance.
@@ -58,6 +66,7 @@ describe('notifier widget', function() {
       timeout: timeout || 10000
     });
     notifier.render(notifierBox);
+    notifiers.push(notifier);
     return notifier;
   };
 
@@ -124,6 +133,22 @@ describe('notifier widget', function() {
       assertNumNotifiers(1);
       done();
     }, 500);
+  });
+
+  it('stops the timer and animations on destroy', function() {
+    var notify = new Notifier({
+      title: 'foo',
+      message: 'bar',
+      timeout: 10000
+    });
+    notifiers.push(notify);
+    notify.timer = {};
+    notify.anim = {};
+    var timer = utils.makeStubMethod(notify.timer, 'stop');
+    var anim = utils.makeStubMethod(notify.anim, 'stop');
+    notify.destroy();
+    assert.equal(timer.callCount(), 1);
+    assert.equal(anim.callCount(), 1);
   });
 
 });


### PR DESCRIPTION
There is a spurious failure in IE in CI around the notifications timeout. I believe it's because the notifications aren't being properly destroyed. This branch adds in a proper destroy cycle to the notifications and to the tests for it.
