### PR TITLE
Add custom user settings UI.

### DIFF
--- a/app/assets/javascripts/app-cookies-extension.js
+++ b/app/assets/javascripts/app-cookies-extension.js
@@ -42,7 +42,8 @@ YUI.add('app-cookies-extension', function(Y) {
     */
     check: function() {
       var self = this;
-      if (Y.Cookie.get('_cookies_accepted') !== 'true') {
+      if (Y.Cookie.get('_cookies_accepted') !== 'true' &&
+          !localStorage.getItem('disable-cookie')) {
         this.node.setStyle('display', 'block');
         Y.one('.link-cta').once('click', function(evt) {
           evt.preventDefault();

--- a/app/store/env/go.js
+++ b/app/store/env/go.js
@@ -467,7 +467,11 @@ YUI.add('juju-env-go', function(Y) {
         var response = data.Response;
         this.set('defaultSeries', response.DefaultSeries);
         this.set('providerType', response.ProviderType);
-        this.set('environmentName', response.Name);
+        if (localStorage.getItem('environmentName')) {
+          this.set('environmentName', localStorage.getItem('environmentName'));
+        } else {
+          this.set('environmentName', response.Name);
+        }
       }
     },
 

--- a/app/templates/shortcuts.handlebars
+++ b/app/templates/shortcuts.handlebars
@@ -1,3 +1,4 @@
+<div class="left">
 <h2>Keyboard Shortcuts</h2>
 
 <table>
@@ -16,5 +17,48 @@
     </tr>
   {{/bindings}}
   </tbody>
-
 </table>
+</div>
+
+
+<div class="left">
+    <h2>Custom GUI Settings</h2>
+    <table>
+      <tbody>
+        <tr>
+          <td class="binding">
+            <input type="checkbox" name="disable-cookie" id="disable-cookie"
+              {{#if disable-cookie}}
+                  checked="checked"
+              {{/if}}
+            />
+          </td>
+          <td><label for="disable-cookie">Disable the EU cookie warning.</label></td>
+        </tr>
+
+        <tr>
+          <td class="binding">
+            <input type="checkbox" name="force-containers" id="force-containers"
+              {{#if force-containers}}
+                  checked="checked"
+              {{/if}}
+            />
+          </td>
+          <td><label for="force-containers">Enable container control for this provider.</label></td>
+        </tr>
+        <tr>
+            <td class="binding">
+              <input type="input" name="environmentName" id="environmentName" value="{{environmentName}}"/>
+            </td>
+            <td><label for="environment-name">Change the name of this environment in the GUI.</label></td>
+        </tr>
+        <tr>
+            <td class="binding">
+              <input type="button" class="button" name="save-settings" id="save-settings" value="Save"/>
+            </td>
+            <td>NOTE: saving will reload the GUI so the settings take effect.</td>
+        </tr>
+
+      </tbody>
+    </table>
+</div>

--- a/app/widgets/machine-view-panel.js
+++ b/app/widgets/machine-view-panel.js
@@ -1002,8 +1002,10 @@ YUI.add('machine-view-panel', function(Y) {
           }).render();
           this._machinesHeader.addTarget(this);
 
-          // Check containerization support based on provided feature flags.
-          if (window.flags.containers) {
+          // Check containerization support based on provided feature flags
+          // and custom settings.
+          if (window.flags.containers ||
+              localStorage.getItem('force-containers')) {
             this._containersHeader = this._renderContainerHeader('all');
             return;
           }

--- a/lib/views/stylesheet.less
+++ b/lib/views/stylesheet.less
@@ -352,6 +352,11 @@ th {
     border-radius: @border-radius;
     color: #fff;
 
+    .left {
+        float: left;
+        width: 45%;
+    }
+
     table {
         margin-top: 20px;
 

--- a/test/test_app.js
+++ b/test/test_app.js
@@ -223,6 +223,27 @@ function injectData(app, data) {
       assert.equal(container.one('.environment-name').get('text'), 'Sandbox');
     });
 
+    it('should show the environment name override when requested', function() {
+      constructAppInstance({
+        env: juju.newEnvironment({
+          conn: {
+            send: function() {},
+            close: function() {}
+          }
+        })
+      }, this);
+      var name = 'Sandbox';
+      localStorage.setItem('environmentName', 'not sandbox');
+      assert.equal(
+          'Environment',
+          container.one('.environment-name').get('text'));
+      app.env.set('environmentName', name);
+      assert.equal(
+          container.one('.environment-name').get('text'),
+          'not sandbox');
+      localStorage.removeItem('environmentName');
+    });
+
     it('hides the browser subapp on some urls', function() {
       constructAppInstance({
         env: juju.newEnvironment({

--- a/test/test_cookies_app_extension.js
+++ b/test/test_cookies_app_extension.js
@@ -43,6 +43,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
     afterEach(function() {
       Y.Cookie.remove('_cookies_accepted');
+      localStorage.removeItem('disable-cookie');
     });
 
     it('calling check makes the node visible', function() {
@@ -60,6 +61,12 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
     it('the cookie prevents the node from getting visible', function() {
       Y.Cookie.set('_cookies_accepted', 'true');
+      cookieHandler.check();
+      assert.equal(node.getStyle('display'), 'none');
+    });
+
+    it('the custom setting also does', function() {
+      localStorage.setItem('disable-cookie', 'true');
       cookieHandler.check();
       assert.equal(node.getStyle('display'), 'none');
     });

--- a/test/test_machine_view_panel.js
+++ b/test/test_machine_view_panel.js
@@ -369,6 +369,7 @@ describe('machine view panel view', function() {
       this._cleanups.push(function() {
         window.flags = {};
       });
+      localStorage.removeItem('force-containers');
     });
 
     it('disables containers if no container types are supported', function() {
@@ -403,6 +404,21 @@ describe('machine view panel view', function() {
           view._containersHeader.name, 'MachineViewPanelHeaderView');
       assert.deepEqual(view.supportedContainerTypes, [KVM, LXC, VMW]);
     });
+
+    it('enables all containers types if user sets it', function() {
+      localStorage.setItem('force-containers', 'true');
+      mockProviderType(this, 'all', [KVM, LXC, VMW]);
+      mockProviderType(this, 'testing', []);
+      providerType = 'testing';
+      view.render();
+      // All the container types are enabled even if the current provider type
+      // does not support containerization.
+      assert.strictEqual(
+          view._containersHeader.name, 'MachineViewPanelHeaderView');
+      assert.deepEqual(view.supportedContainerTypes, [KVM, LXC, VMW]);
+    });
+
+
 
     it('uses the supported container when creating machines', function() {
       mockProviderType(this, 'testing', [KVM, LXC, VMW]);


### PR DESCRIPTION
- Adds UI in the keyboard help menu for setting custom GUI settings remembered
  through localStorage.
- Adds option for force container support regardless of provider.
- Adds option to set the environmentName regardless of the deployment.
- Adds option to disable the EU cookie notice.
