### PR TITLE
Show a link to the MAAS server.

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -511,6 +511,14 @@ YUI.add('juju-gui', function(Y) {
       // Once the user logs in, we need to redraw.
       this.env.after('login', this.onLogin, this);
 
+      // Once we know about MAAS server, update the header accordingly.
+      var maasServer = this.env.get('maasServer');
+      if (maasServer === undefined) {
+        this.env.once('maasServerChange', this._onMaasServer, this);
+      } else {
+        this._displayMaasLink(maasServer);
+      }
+
       // Feed environment changes directly into the database.
       this.env.on('delta', this.db.onDelta, this.db);
 
@@ -1213,6 +1221,34 @@ YUI.add('juju-gui', function(Y) {
       } else {
         this.showLogin();
       }
+    },
+
+    /**
+      If we are in a MAAS environment, react to the MAAS server address
+      retrieval adding a link to the header pointing to the MAAS server.
+
+      @method _onMaasServer
+      @param {Object} evt An event object (with a "newVal" attribute).
+    */
+    _onMaasServer: function(evt) {
+      this._displayMaasLink(evt.newVal);
+    },
+
+    /**
+      If the given maasServer is not null, create a link to the MAAS server
+      in the GUI header.
+
+      @method _displayMaasLink
+      @param {String} maasServer The MAAS server URL (or null if not in MAAS).
+    */
+    _displayMaasLink: function(maasServer) {
+      if (maasServer === null) {
+        // The current environment is not MAAS.
+        return;
+      }
+      var maasContainer = Y.one('#maas-server');
+      maasContainer.one('a').set('href', maasServer);
+      maasContainer.show();
     },
 
     /**

--- a/app/index.html
+++ b/app/index.html
@@ -161,6 +161,9 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
             <li>
               <span id="help-dropdown"></span>
             </li>
+            <li id="maas-server" style="display:none">
+              <a href="" target="_blank">MAAS UI</a>
+            </li>
             <li>
               <a href="" id="logout-trigger" class="button inverse">Logout</a>
             </li>

--- a/app/store/env/fakebackend.js
+++ b/app/store/env/fakebackend.js
@@ -47,13 +47,14 @@ YUI.add('juju-env-fakebackend', function(Y) {
 
   FakeBackend.NAME = 'fake-backend';
   FakeBackend.ATTRS = {
-    authorizedUsers: {value: {'admin': 'password'}},
-    token: {value: 'demoToken'},
     authenticated: {value: false},
-    store: {required: true},
+    authorizedUsers: {value: {'admin': 'password'}},
     defaultSeries: {value: 'precise'},
+    name: {value: 'Environment'},
+    maasServer: {value: null},
     providerType: {value: 'demonstration'},
-    name: {value: 'Environment'}
+    store: {required: true},
+    token: {value: 'demoToken'}
   };
 
   Y.extend(FakeBackend, Y.Base, {

--- a/app/store/env/go.js
+++ b/app/store/env/go.js
@@ -475,6 +475,10 @@ YUI.add('juju-env-go', function(Y) {
         // For now we only need to call environmentGet if the provider is MAAS.
         if (response.ProviderType === 'maas') {
           this.environmentGet();
+        } else {
+          // Set the MAAS server to null, so that subscribers waiting for this
+          // attribute to be set can be released.
+          this.set('maasServer', null);
         }
       }
     },

--- a/app/store/env/sandbox.js
+++ b/app/store/env/sandbox.js
@@ -846,7 +846,7 @@ YUI.add('juju-env-sandbox', function(Y) {
     },
 
     /**
-    Handle EnvironmentView messages.
+    Handle EnvironmentInfo messages.
 
     @method handleClientEnvironmentInfo
     @param {Object} data The contents of the API arguments.
@@ -861,6 +861,24 @@ YUI.add('juju-env-sandbox', function(Y) {
           ProviderType: state.get('providerType'),
           DefaultSeries: state.get('defaultSeries'),
           Name: 'Sandbox'
+        }
+      });
+    },
+
+    /**
+    Handle EnvironmentGet messages.
+
+    @method handleClientEnvironmentGet
+    @param {Object} data The contents of the API arguments.
+    @param {Object} client The active ClientConnection.
+    @param {Object} state An instance of FakeBackend.
+    */
+    handleClientEnvironmentGet: function(data, client, state) {
+      client.receive({
+        RequestId: data.RequestId,
+        Response: {
+          // For now only the MAAS server is required by the GUI.
+          Config: {'maas-server': state.get('maasServer')}
         }
       });
     },

--- a/test/test_app.js
+++ b/test/test_app.js
@@ -347,6 +347,77 @@ function injectData(app, data) {
         done();
       });
     });
+
+    describe('MAAS support', function() {
+      var env, maasNode;
+
+      beforeEach(function() {
+        // Set up the MAAS link node.
+        maasNode = Y.Node.create(
+            '<div id="maas-server" style="display:none">' +
+            '  <a href="">MAAS UI</a>' +
+            '</div>');
+        container.appendChild(maasNode);
+        // Create the environment.
+        env = new juju.environments.GoEnvironment({
+          conn: new utils.SocketStub(),
+          ecs: new juju.EnvironmentChangeSet()
+        });
+      });
+
+      // Ensure the given MAAS node is shown and includes a link to the given
+      // address.
+      var assertMaasLinkExists = function(node, address) {
+        assert.strictEqual(node.getStyle('display'), 'block');
+        assert.strictEqual(node.one('a').get('href'), address);
+      };
+
+      it('shows a link to the MAAS server if provider is MAAS', function() {
+        constructAppInstance({env: env});
+        // The MAAS node is initially hidden.
+        assert.strictEqual(maasNode.getStyle('display'), 'none');
+        env.set('maasServer', 'http://1.2.3.4/MAAS');
+        // Once the MAAS server becomes available, the node is activated and
+        // includes a link to the server.
+        assertMaasLinkExists(maasNode, 'http://1.2.3.4/MAAS');
+        // Further changes to the maasServer attribute don't change the link.
+        env.set('maasServer', 'http://example.com/MAAS');
+        assertMaasLinkExists(maasNode, 'http://1.2.3.4/MAAS');
+      });
+
+      it('shows a link to the MAAS server if already in the env', function() {
+        env.set('maasServer', 'http://1.2.3.4/MAAS');
+        constructAppInstance({env: env});
+        // The link to the MAAS server should be already activated.
+        assertMaasLinkExists(maasNode, 'http://1.2.3.4/MAAS');
+        // Further changes to the maasServer attribute don't change the link.
+        env.set('maasServer', 'http://example.com/MAAS');
+        assertMaasLinkExists(maasNode, 'http://1.2.3.4/MAAS');
+      });
+
+      it('does not show the MAAS link if provider is not MAAS', function() {
+        constructAppInstance({env: env});
+        // The MAAS node is initially hidden.
+        assert.strictEqual(maasNode.getStyle('display'), 'none');
+        env.set('maasServer', null);
+        // The MAAS node is still hidden.
+        assert.strictEqual(maasNode.getStyle('display'), 'none');
+        // Further changes to the maasServer attribute don't activate the link.
+        env.set('maasServer', 'http://1.2.3.4/MAAS');
+        assert.strictEqual(maasNode.getStyle('display'), 'none');
+      });
+
+      it('does not show the MAAS link if already null in the env', function() {
+        env.set('maasServer', null);
+        constructAppInstance({env: env});
+        assert.strictEqual(maasNode.getStyle('display'), 'none');
+        // Further changes to the maasServer attribute don't activate the link.
+        env.set('maasServer', 'http://1.2.3.4/MAAS');
+        assert.strictEqual(maasNode.getStyle('display'), 'none');
+      });
+
+    });
+
   });
 })();
 

--- a/test/test_app_hotkeys.js
+++ b/test/test_app_hotkeys.js
@@ -28,6 +28,7 @@ describe('application hotkeys', function() {
             after: function() {},
             get: function() {},
             on: function() {},
+            once: function() {},
             set: function() {}
           };
           windowNode = Y.one(window);

--- a/test/test_env_go.js
+++ b/test/test_env_go.js
@@ -507,6 +507,8 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     });
 
     it('does not call EnvironmentGet after Info when not on MAAS', function() {
+      // The MAAS server attribute is initially undefined.
+      assert.isUndefined(env.get('maasServer'));
       // Simulate an EnvironmentInfo request/response.
       env.environmentInfo();
       conn.msg({
@@ -518,6 +520,8 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
         }
       });
       assert.lengthOf(conn.messages, 1);
+      // The MAAS server attribute has been set to null.
+      assert.isNull(env.get('maasServer'));
     });
 
     it('sends the correct AddServiceUnits message', function() {

--- a/test/test_sandbox_go.js
+++ b/test/test_sandbox_go.js
@@ -245,6 +245,26 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       client.send(Y.JSON.stringify(data));
     });
 
+    it('returns EnvironmentGet responses', function(done) {
+      var data = {
+        RequestId: 42,
+        Type: 'Client',
+        Request: 'EnvironmentGet'
+      };
+      client.onmessage = function(received) {
+        var expected = {
+          RequestId: 42,
+          Response: {
+            Config: {'maas-server': state.get('maasServer')}
+          }
+        };
+        assert.deepEqual(Y.JSON.parse(received.data), expected);
+        done();
+      };
+      client.open();
+      client.send(Y.JSON.stringify(data));
+    });
+
     it('can start the AllWatcher', function(done) {
       var data = {
         Type: 'Client',


### PR DESCRIPTION
When the provider is MAAS, display a link
to the MAAS management interface in the
header.

Also implemented the EnvironmentGet call
in sandbox mode.
