### PR TITLE
Tweak how machine view renders hidden/faded/highlighted services.

### DIFF
--- a/app/models/models.js
+++ b/app/models/models.js
@@ -2288,6 +2288,29 @@ YUI.add('juju-models', function(Y) {
         this.units.update_service_unit_aggregates(service);
       }, this);
       return unitOrUnits;
+    },
+
+    /**
+      Returns a list of the deployed (both uncommitted and committed) services
+      that are not related to the provided service.
+
+      @method findUnrelatedServices
+      @param {Object} service The origin service.
+      @return {Array} A list of the service names of unrelated services.
+    */
+    findUnrelatedServices: function(service) {
+      var relationData = utils.getRelationDataForService(this, service);
+      var related = [service.get('name')],  // Add own name to related list.
+          unrelated;
+      // Compile the list of related services.
+      relationData.forEach(function(relation) {
+        related.push(relation.far.service);
+      });
+      // Find the unrelated by filtering out the related.
+      unrelated = this.services.filter(function(s) {
+        return related.indexOf(s.get('name')) === -1;
+      });
+      return unrelated;
     }
 
   });

--- a/app/templates/container-token-units.handlebars
+++ b/app/templates/container-token-units.handlebars
@@ -2,7 +2,7 @@
   <li class="unit {{#unless agent_state }}uncommitted{{/unless}} {{#if deleted }}deleted{{/if}} {{#if fade}}fade{{/if}} {{#if hide}}hide{{/if}}"
       data-id="{{id}}">
     {{>more-menu}}
-    <img src="{{icon}}" alt="{{service}}"/>
+    <img src="{{icon}}" alt="{{service}}" title="{{displayName}}"/>
     <span class="name">
       {{displayName}}
       <span class="removed">

--- a/app/templates/container-token.handlebars
+++ b/app/templates/container-token.handlebars
@@ -10,6 +10,7 @@
     <span class="token-uncommitted">&deg;</span>
   </span>
   <ul class="service-icons"></ul>
+  <ul class="service-icons-faded"></ul>
   <div class="drop">
     <span>Add to container {{ displayName }}</span>
   </div>

--- a/app/widgets/container-token.js
+++ b/app/widgets/container-token.js
@@ -164,13 +164,16 @@ YUI.add('container-token', function(Y) {
          */
         renderUnits: function() {
           var machine = this.get('machine');
-          var units = machine.units;
+          // Display shown units and faded units in two different lists.
+          var shownUnits = machine.units.filter(function(u) {
+            return !(u.fade || u.hide);
+          });
           this.get('container').one('.service-icons').setHTML(
-              this.unitsTemplate(machine));
+              this.unitsTemplate({units: shownUnits}));
           // Create the more menus for the units.
-          if (units.length > 0) {
-            Object.keys(units).forEach(function(index) {
-              var id = units[index].id;
+          if (shownUnits.length > 0) {
+            Object.keys(shownUnits).forEach(function(index) {
+              var id = shownUnits[index].id;
               if (!this._unitMoreMenus) {
                 this._unitMoreMenus = [];
               }
@@ -184,6 +187,12 @@ YUI.add('container-token', function(Y) {
               }
             }, this);
           }
+          // Add faded units to the second list.
+          var fadedUnits = machine.units.filter(function(u) {
+            return u.fade;
+          });
+          this.get('container').one('.service-icons-faded').setHTML(
+              this.unitsTemplate({units: fadedUnits}));
         },
 
         /**

--- a/app/widgets/machine-token.js
+++ b/app/widgets/machine-token.js
@@ -172,8 +172,13 @@ YUI.add('machine-token', function(Y) {
           @method renderUnits
         */
         renderUnits: function() {
+          // Only display shown units.
+          // TODO refactor filter method to be reused
+          var shownUnits = this.get('machine').units.filter(function(u) {
+            return !(u.fade || u.hide);
+          });
           this.get('container').one('.service-icons').setHTML(
-              this.unitsTemplate(this.get('machine')));
+              this.unitsTemplate({units: shownUnits}));
         },
 
         /**

--- a/lib/views/machine-view/container-token.less
+++ b/lib/views/machine-view/container-token.less
@@ -11,7 +11,7 @@
         .title {
             margin-right: 10px;
         }
-        .service-icons {
+        .service-icons, .service-icons-faded {
             margin-top: 2px;
             list-style: none;
 
@@ -26,9 +26,6 @@
                 }
                 &.deleted .removed {
                     display: inline;
-                }
-                &.fade {
-                    opacity: 0.2;
                 }
                 &.hide {
                     display: none;
@@ -61,6 +58,23 @@
                     .open-menu {
                         display: none;
                     }
+                }
+            }
+        }
+
+        .service-icons-faded {
+            .unit {
+                display: inline-block;
+                padding: 0;
+                margin: 0;
+                .more-menu {
+                    display: none;
+                }
+                img {
+                  margin: 0;
+                }
+                .name {
+                    display: none;
                 }
             }
         }

--- a/lib/views/machine-view/machine-view-token-base.less
+++ b/lib/views/machine-view/machine-view-token-base.less
@@ -59,7 +59,7 @@
     .token-uncommitted {
         display: none;
     }
-    .service-icons {
+    .service-icons, .service-icons-faded {
         img {
             width: 20px;
             height: 20px;


### PR DESCRIPTION
The specs for how hide/highlight should work in machine view:
## Show/hide
- Machine view is a literal translation of hardware so we can't be so clear cut.
- Hiding a service just de-prioritises the service.
- The hidden service is not populated in the machine column.
- The hidden services is de-prioritised in the container column. They sit at the bottom of their respective containers and stack up horizontally, the name of the service is not shown but can be found out via a tooltip which should appear from hovering over the charm icon.
- The machine and containers never get hidden with show/hide.
## Highlight/unhighlight
- Highlighting a service changes the machine column to only show machines which include the highlighted service. This allows users to use it as a filtering tool.
