### PR TITLE
Permanently dismiss the "service added" message in the inspector.

### DIFF
--- a/app/views/inspector-base.js
+++ b/app/views/inspector-base.js
@@ -57,17 +57,6 @@ YUI.add('inspector-base', function(Y) {
         'valueFn': function() {
           return Y.Node.create(ns.Templates['service-inspector']());
         }
-      },
-
-      /**
-         Determines whether the help text needs to be hidden.
-
-         @attribute hideHelp
-         @default false
-         @type {Boolean}
-       */
-      hideHelp: {
-        value: false
       }
     }
   });

--- a/app/views/viewlets/inspector-header.js
+++ b/app/views/viewlets/inspector-header.js
@@ -91,8 +91,6 @@ YUI.add('inspector-header-view', function(Y) {
           pojoModel.invalidName = 'valid';
         }
       }
-      // Just passing this value on through from the containing view.
-      pojoModel.hideHelp = viewContainerAttrs.hideHelp;
       var container = this.get('container');
       container.setHTML(this.template(pojoModel));
     },
@@ -156,6 +154,9 @@ YUI.add('inspector-header-view', function(Y) {
     _dismissMessage: function(e) {
       e.preventDefault();
       e.currentTarget.get('parentElement').addClass('hidden');
+      // Remember the user dismissed the "service added" message for this
+      // model, so that it's not displayed again in this session.
+      this.options.model.set('hideHelp', true);
     }
   });
 

--- a/test/test_service_inspector.js
+++ b/test/test_service_inspector.js
@@ -205,6 +205,38 @@ describe('Service Inspector', function() {
     assert.equal(stubDismiss.callCount(), 1);
   });
 
+  it('actually dismisses the "added service" message', function() {
+    // Create a ghost service with a fake charm.
+    var charm = new models.Charm(charmData.charm);
+    db.charms.add(charm);
+    service = db.services.ghostService(charm);
+    var inspector = setUpInspector(service);
+    inspector.render();
+    var message = container.one('.ghost-message');
+    // The message is initially displayed.
+    assert.strictEqual(message.hasClass('hidden'), false);
+    // Click the "Dismiss" button.
+    inspector.get('container').one('span[dismiss]').simulate('click');
+    // The message is now hidden.
+    assert.strictEqual(message.hasClass('hidden'), true);
+    // The model has been annotated so that the message will not be displayed
+    // in the future.
+    assert.strictEqual(service.get('hideHelp'), true);
+  });
+
+  it('does not show the "added service" message if dismissed', function() {
+    // Create a ghost service with a fake charm.
+    var charm = new models.Charm(charmData.charm);
+    db.charms.add(charm);
+    service = db.services.ghostService(charm);
+    service.set('hideHelp', true);
+    var inspector = setUpInspector(service);
+    inspector.render();
+    var message = container.one('.ghost-message');
+    // The message is not displayed.
+    assert.isNull(message);
+  });
+
   it('shows the footer for the overview', function() {
     var inspector = setUpInspector();
     inspector.render();


### PR DESCRIPTION
As suggested by Luca, the message is dismissed per-model, meaning
it's not shown again for the single service inspector.
