### PR TITLE
Fix highlight toggling of ghost service icons

### DIFF
--- a/app/subapps/browser/views/added-services.js
+++ b/app/subapps/browser/views/added-services.js
@@ -165,13 +165,14 @@ YUI.add('juju-added-services', function(Y) {
           tokens = this.get('serviceTokens'),
           keys = Object.keys(tokens),
           services = this.get('db').services;
+      // Key could be a ghost service id which won't match the service name
+      // so we need to parse the supplied service name for it's id.
+      var serviceId = services.getServiceByName(serviceName).get('id');
       keys.forEach(function(key) {
-        // Key could be a ghost service id which won't match the service name
-        // so we need to parse every key to grab the real name.
-        if (services.getServiceByName(key).get('name') !== serviceName) {
+        if (key !== serviceId) {
           tokens[key].unhighlight();
         }
-      }, this);
+      });
     },
 
     /**

--- a/test/test_added_services_view.js
+++ b/test/test_added_services_view.js
@@ -322,7 +322,7 @@ describe('added services view', function() {
         done();
       });
       // Fire the actual event.
-      token.fire('highlight');
+      token.fire('highlight', { serviceName: service.get('name') });
     });
   });
 


### PR DESCRIPTION
Ghost service icons weren't able to be toggled using the added services pane.
