### PR TITLE
Switch to Ctrl+Shift+h for toggling sidebar

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -209,12 +209,17 @@ YUI.add('juju-gui', function(Y) {
         help: 'Center the Environment overview',
         label: 'Shift + 0'
       },
-      'C-A-h': {
+      'C-S-h': {
         callback: function(e) {
           this._toggleSidebar();
         },
         help: 'Show or hide the sidebar',
-        label: 'Control + Alt + h'
+        label: 'Control + Shift + h'
+      },
+      'C-A-h': {
+        callback: function(e) {
+          this._toggleSidebar();
+        }
       },
       'esc': {
         fire: 'clearState',


### PR DESCRIPTION
This leaves the old shortcut in place as a fallback, but doesn't display it in the help menu.
