### PR TITLE
Containers with no units should still be shown.

### DIFF
--- a/app/widgets/container-token.js
+++ b/app/widgets/container-token.js
@@ -203,14 +203,7 @@ YUI.add('container-token', function(Y) {
         render: function() {
           var container = this.get('container'),
               machine = this.get('machine');
-          var showMachine = Y.Array.some(machine.units, function(unit) {
-            return !unit.hide;
-          });
-          if (!showMachine) {
-            container.addClass('hidden');
-          } else {
-            container.removeClass('hidden');
-          }
+
           container.setHTML(this.template(machine));
           if (machine.deleted) {
             this.setDeleted();

--- a/test/test_container_token.js
+++ b/test/test_container_token.js
@@ -73,17 +73,6 @@ describe('container token view', function() {
     assert.equal(container.one('.delete'), null);
   });
 
-  it('hides the container if all units are hidden', function() {
-    container = utils.makeContainer(this, 'container-token');
-    machine.units[0].hide = true;
-    view = new View({
-      containerParent: container,
-      container: utils.makeContainer(this, 'container'),
-      machine: machine
-    }).render();
-    assert.equal(view.get('container').hasClass('hidden'), true);
-  });
-
   it('fires the delete event', function(done) {
     view.on('deleteToken', function(e) {
       assert.isObject(e);


### PR DESCRIPTION
Fixes issue: https://bugs.launchpad.net/juju-gui/+bug/1390165

As per the latest spec the machine view is a literal representation of the hardware in the environment so if a machine has no units it should still be shown.
