### PR TITLE
Verify that the endpoint exists when parsing related services.

### DIFF
--- a/app/models/models.js
+++ b/app/models/models.js
@@ -2409,7 +2409,11 @@ YUI.add('juju-models', function(Y) {
           unrelated;
       // Compile the list of related services.
       relationData.forEach(function(relation) {
-        related.push(relation.far.service);
+        // Some relations (e.g., peer relations) may not have the far endpoint
+        // defined.
+        if (relation.far && relation.far.service) {
+          related.push(relation.far.service);
+        }
       });
       // Find the unrelated by filtering out the related.
       unrelated = this.services.filter({asList: true}, function(s) {

--- a/test/test_model.js
+++ b/test/test_model.js
@@ -167,6 +167,22 @@ describe('test_model.js', function() {
       assert.equal(unrelated.item(0).get('name'), 'haproxy');
     });
 
+    it('handles undefined endpoints in unrelated services', function() {
+      var db = new models.Database(),
+          service = new models.Service({name: 'mysql'});
+      db.services.add([
+        {id: 'mysql', name: 'mysql'},
+        {id: 'wordpress', name: 'wordpress'},
+        {id: 'haproxy', name: 'haproxy'}
+      ]);
+      var relations = [{}];
+      var stub = utils.makeStubMethod(viewUtils, 'getRelationDataForService',
+                                      relations);
+      this._cleanups.push(stub.reset);
+      var unrelated = db.findUnrelatedServices(service);
+      assert.equal(unrelated.size(), 2);
+    });
+
     describe('setMVVisibility', function() {
       var db;
 


### PR DESCRIPTION
Sometimes the far endpoint doesn't exist (e.g., peer relations) and we need to handle those situations gracefully.
