### PR TITLE
Change version now shows the most recent version in the list

### DIFF
--- a/app/views/viewlets/change-version.js
+++ b/app/views/viewlets/change-version.js
@@ -64,7 +64,7 @@ YUI.add('change-version-view', function(Y) {
       if (maxVersion > 1) {
         // XXX Use the list of available versions from Charmworld
         // Makyo - #1246928 - 2014-06-24
-        for (var version = maxVersion - 1; version > 0; version -= 1) {
+        for (var version = maxVersion; version > 0; version -= 1) {
           if (version === currVersion) {
             continue;
           }

--- a/test/test_change_version_viewlet.js
+++ b/test/test_change_version_viewlet.js
@@ -129,7 +129,7 @@ describe('Change version viewlet', function() {
 
   it('loads versions on click', function() {
     container.one('.change-version-trigger span').simulate('click');
-    assert.equal(container.all('.upgrade-link').size(), 13);
+    assert.equal(container.all('.upgrade-link').size(), 14);
   });
 
   it('attempts to upgrade on click', function(done) {


### PR DESCRIPTION
Users were never able to upgrade to the latest version of the GUI because we started the counter off by 1.
