### PR TITLE
Send null values in config and params as `null`

### DIFF
--- a/app/store/env/go.js
+++ b/app/store/env/go.js
@@ -88,26 +88,6 @@ YUI.add('juju-env-go', function(Y) {
     return newObj;
   };
 
-  /**
-     JSON replacer converting values to be serialized into that suitable
-     to be sent to the juju-core API server. This function can be passed to
-     Y.JSON.stringify in order to clean up data before serialization.
-
-     @method cleanUpJSON
-     @static
-     @param {Object} key The key in the key/value pair passed by
-      Y.JSON.stringify.
-     @param {Object} value The value corresponding to the provided key.
-     @return {Object} A value that will be serialized in place of the raw value.
-   */
-  var cleanUpJSON = function(key, value) {
-    // Blacklist null values.
-    if (value === null) {
-      return undefined;
-    }
-    return value;
-  };
-
   // The jobs that can be associated to a machine.
   // See state/api/params/constants.go.
   var machineJobs = {
@@ -212,7 +192,6 @@ YUI.add('juju-env-go', function(Y) {
       if (!op.Params) {
         op.Params = {};
       }
-      // Serialize the operation using the cleanUpJSON replacer function.
       var msg = Y.JSON.stringify(op);
       this.ws.send(msg);
     },
@@ -2259,7 +2238,6 @@ YUI.add('juju-env-go', function(Y) {
   environments.GoEnvironment = GoEnvironment;
   environments.lowerObjectKeys = lowerObjectKeys;
   environments.stringifyObjectValues = stringifyObjectValues;
-  environments.cleanUpJSON = cleanUpJSON;
   environments.machineJobs = machineJobs;
 
   var KVM = {label: 'LXC', value: 'lxc'},

--- a/test/test_env_go.js
+++ b/test/test_env_go.js
@@ -55,32 +55,6 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
   });
 
-
-  describe('Go Juju JSON replacer', function() {
-    var cleanUpJSON, Y;
-
-    before(function(done) {
-      Y = YUI(GlobalConfig).use(['juju-env-go'], function(Y) {
-        cleanUpJSON = Y.namespace('juju.environments').cleanUpJSON;
-        done();
-      });
-    });
-
-    it('blacklists null values', function() {
-      assert.isUndefined(cleanUpJSON('mykey', null));
-    });
-
-    it('returns other allowed values as they are', function() {
-      var data = [
-        'mystring', undefined, true, false, 42, ['list', 47.2, true]
-      ];
-      Y.each(data, function(item) {
-        assert.strictEqual(item, cleanUpJSON('mykey', item));
-      });
-    });
-
-  });
-
   describe('Go Juju environment', function() {
     var cleanups, conn, endpointA, endpointB, ecs, env, juju, machineJobs, msg,
         utils, Y;


### PR DESCRIPTION
Now that Juju supports null configuration values the GUI needs to stop converting `null` values to "null". As a side effect all params for websocket rpc calls also send nulls for values which don't exist. This doesn't appear to have any negative side effects.

This is a fix for: https://bugs.launchpad.net/charms/+source/postgresql/+bug/1390858
