### PR TITLE
Do not close the inspector when closing the Choose Version viewlet

### DIFF
--- a/app/templates/version-list.handlebars
+++ b/app/templates/version-list.handlebars
@@ -1,5 +1,5 @@
 <div class="unit-list-header">
-  <div class="close link">
+  <div class="change-version-close link">
     <i class="sprite close-inspector-click"></i>
   </div>
   Change {{ name }} version

--- a/app/views/inspectors/service-inspector-utils-extension.js
+++ b/app/views/inspectors/service-inspector-utils-extension.js
@@ -98,6 +98,16 @@ YUI.add('service-inspector-utils-extension', function(Y) {
     },
 
     /**
+      Handles showing the overview viewlet when the user closes the change
+      version pane.
+
+      @method _closeChangeVersion
+    */
+    _closeChangeVersion: function() {
+      this.showViewlet('overview');
+    },
+
+    /**
       React to the user clicking on or otherwise activating the cancel button
       on the "destroy this service" prompt.
 

--- a/app/views/inspectors/service-inspector.js
+++ b/app/views/inspectors/service-inspector.js
@@ -65,7 +65,8 @@ YUI.add('service-inspector', function(Y) {
       '.initiate-destroy': {click: '_onInitiateDestroy'},
       '.cancel-destroy': {click: '_onCancelDestroy'},
       '.destroy-service-trigger span': {click: '_onDestroyClick'},
-      '.change-version-trigger span': {click: '_onChangeVersionClick'}
+      '.change-version-trigger span': {click: '_onChangeVersionClick'},
+      '.change-version-close': {click: '_closeChangeVersion'}
     },
 
     /**

--- a/lib/views/juju-inspector.less
+++ b/lib/views/juju-inspector.less
@@ -1059,7 +1059,7 @@
         .unit-list-header {
             position: relative;
 
-            .close {
+            .change-version-close {
                 position: absolute;
                 right: 20px;
             }

--- a/test/test_change_version_viewlet.js
+++ b/test/test_change_version_viewlet.js
@@ -132,6 +132,16 @@ describe('Change version viewlet', function() {
     assert.equal(container.all('.upgrade-link').size(), 14);
   });
 
+  it('closes when clicking the x leaving the inspector open', function() {
+    container.one('.change-version-trigger span').simulate('click');
+    assert.equal(container.all('.upgrade-link').size(), 14);
+    var showViewlet = utils.makeStubMethod(inspector, 'showViewlet');
+    this._cleanups.push(showViewlet.reset);
+    container.one('.change-version-close').simulate('click');
+    assert.equal(showViewlet.callCount(), 1);
+    assert.equal(showViewlet.lastArguments()[0], 'overview');
+  });
+
   it('attempts to upgrade on click', function(done) {
     // Ensure that get_charm is called to get the new charm.
     env.setCharm = function(serviceName, upgradeTo, force, callback) {


### PR DESCRIPTION
When closing the Choose version viewlet the the overview viewlet should be shown by default.
