### PR TITLE
Set a default env series for popular charm list queries

### DIFF
--- a/app/subapps/browser/views/charmbrowser.js
+++ b/app/subapps/browser/views/charmbrowser.js
@@ -300,7 +300,7 @@ YUI.add('juju-charmbrowser', function(Y) {
     _loadSearchSuccessHandler: function(data) {
       var recommended = [],
           other = [];
-      var series = this.get('envSeries')() || 'precise';
+      var series = this.get('envSeries')() || 'trusty';
       data.map(function(entity) {
         // If this is a charm, make sure it's approved and is of the
         // correct series to be recommended.
@@ -397,7 +397,7 @@ YUI.add('juju-charmbrowser', function(Y) {
           // If the user visits the application with a hash in the url there is
           // a race condition and the envSeries is not yet populated so we
           // need to default it.
-          series: this.get('envSeries')() || 'precise'
+          series: this.get('envSeries')() || 'trusty'
         }, true);
       } else if (renderType === 'search') {
         this.set('withHome', true);

--- a/test/test_charmbrowser_view.js
+++ b/test/test_charmbrowser_view.js
@@ -192,7 +192,7 @@ describe('charmbrowser view', function() {
         limit: 20,
         owner: '',
         sort: '-downloads',
-        series: 'precise'
+        series: 'trusty'
       });
       assert.equal(charmBrowser.get('withHome'), false);
     });


### PR DESCRIPTION
Without a default series set there is the potential for a race condition and the env series not being set so the charmbrowser popular result list is empty.
