### PR TITLE
Pass the charmstore into the charm details views

### DIFF
--- a/app/views/viewlets/charm-details.js
+++ b/app/views/viewlets/charm-details.js
@@ -49,6 +49,7 @@ YUI.add('charm-details-view', function(Y) {
       var cfg = {
         forInspector: true,
         store: store,
+        charmstore: viewletManagerAttrs.charmstore,
         activeTab: activeTab
       };
 
@@ -70,6 +71,8 @@ YUI.add('charm-details-view', function(Y) {
             // The cfg.entity settings is being commented out because it will
             // need to be re-enabled in a shortly upcoming branch.
             // cfg.entity = storeCharm;
+            cfg.entityId = (data.charm && data.charm.id) ||
+                storeCharm.get('id');
             this.charmView = new browserViews.BrowserCharmView(cfg);
             this.charmView.render();
           },


### PR DESCRIPTION
The charm details views when being rendered from the inspector still need access to the new charmstore so that it can fetch things like the readme and other static files.
Also fixed a bug where the entityId wasn't being set when loaded from within the inspector.
