### PR TITLE
Allow drag-and-drop of charms/bundles

### DIFF
--- a/app/models/bundle.js
+++ b/app/models/bundle.js
@@ -210,11 +210,11 @@ YUI.add('juju-bundle-models', function(Y) {
       /**
         The url which can be used by the deployer to deploy the bundle file.
 
-        @attribute deployerFileURL
+        @attribute deployerFileUrl
         @default undefined
         @type {String}
       */
-      deployerFileURL: {},
+      deployerFileUrl: {},
 
       /**
         A collection of files in the bundle.

--- a/app/views/topology/service.js
+++ b/app/views/topology/service.js
@@ -933,7 +933,7 @@ YUI.add('juju-topology-service', function(Y) {
           // encode it this way.
           bundleImportHelpers.deployBundle(
               Y.JSON.stringify({
-                bundle: entityData.data
+                bundle: entityData
               }),
               entityData.id,
               topo.get('env'),

--- a/app/widgets/token.js
+++ b/app/widgets/token.js
@@ -140,10 +140,6 @@ YUI.add('browser-token', function(Y) {
     _addDraggability: function() {
       var tokenData,
           container = this.get('boundingBox');
-      // Adjust the ID to meet model expectations.
-      if (this.tokenData.type === 'charm') {
-        this.tokenData.id = this.tokenData.url;
-      }
       // Since the browser's dataTransfer mechanism only accepts string values
       // we have to JSON encode the data.  This passed-in config includes
       // charm/bundle attributes.

--- a/test/test_token_drag_and_drop.js
+++ b/test/test_token_drag_and_drop.js
@@ -93,7 +93,7 @@ describe('token drag and drop', function() {
     draggable = Y.Array.dedupe(draggable);
     assert.equal(draggable.length, 1);
     // All of the tokens are made draggable.
-    assert.deepEqual(draggable, ['cs:test']);
+    assert.deepEqual(draggable, ['test']);
   });
 
   it('can make an element draggable', function() {
@@ -214,7 +214,7 @@ describe('token drag and drop', function() {
 
   it('fixes the charm id in _addDraggability', function() {
     var cfg = {
-      id: 'test',
+      id: 'cs:test',
       url: 'cs:test',
       boundingBox: container
     };


### PR DESCRIPTION
The inability to drag-and-drop charms/bundles from the sidebar was simply a side-effect of the switch to the newer data structures from charmworld to the charmstore.  These have been updated accordingly.