### PR TITLE
Fix bundle deploying

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -651,9 +651,7 @@ YUI.add('juju-gui', function(Y) {
         // The other views will hand us an Object vs a YAML string. The import
         // helpers want the yaml string instead.
         importHelpers.deployBundle(
-            Y.JSON.stringify({
-              bundle: bundle
-            }),
+            bundle,
             bundleId,
             env,
             db

--- a/app/assets/javascripts/bundle-import-helpers.js
+++ b/app/assets/javascripts/bundle-import-helpers.js
@@ -66,8 +66,13 @@ YUI.add('bundle-import-helpers', function(Y) {
       };
 
       if (Y.Lang.isFunction(env.deployerImport)) {
+        // XXX For now, the deployer is expecting the original bundle basket
+        // format, and requires the bundle name to be the top level YAML
+        // element, so grab that naively.  Future deployer work will allow the
+        // new bundle format.  Makyo - 2012-12-19
+        var bundleName = bundle.split(':', 1)[0];
         var bundleData = {
-          name: null,
+          name: bundleName,
           id: bundleId
         };
 

--- a/app/models/bundle.js
+++ b/app/models/bundle.js
@@ -210,11 +210,11 @@ YUI.add('juju-bundle-models', function(Y) {
       /**
         The url which can be used by the deployer to deploy the bundle file.
 
-        @attribute deployerFileURL
+        @attribute deployerFileUrl
         @default undefined
         @type {String}
       */
-      deployerFileURL: {},
+      deployerFileUrl: {},
 
       /**
         A collection of files in the bundle.

--- a/app/subapps/browser/views/bundle.js
+++ b/app/subapps/browser/views/bundle.js
@@ -92,7 +92,14 @@ YUI.add('subapp-browser-bundleview', function(Y) {
           component: 'charmbrowser',
           metadata: { id: null }
         }});
-      this.get('deployBundle')(bundle, bundle.get('id'));
+      this.get('charmstore')._makeRequest(bundle.get('deployerFileUrl'),
+          function(data) {
+            var bundle = data.target.responseText;
+            var bundleName = bundle.split(':', 1)[0];
+            this.get('deployBundle')(bundle, bundleName);
+          }.bind(this), function(error) {
+            console.error(error);
+          });
     },
 
     /**

--- a/app/views/topology/service.js
+++ b/app/views/topology/service.js
@@ -927,9 +927,9 @@ YUI.add('juju-topology-service', function(Y) {
           var charm = new models.Charm(entityData);
           Y.fire('initiateDeploy', charm, ghostAttributes);
         } else {
-          // For now, simply send the bundles.yaml.orig file contents to the
-          // deployer.  Future deployer work will allow us to use the bundle
-          // file as returned by the charmstore. Makyo - 2012-12-19
+          // XXX For now, simply send the bundles.yaml.orig file contents to
+          // the deployer.  Future deployer work will allow us to use the
+          // bundle file as returned by the charmstore. Makyo - 2012-12-19
           topo.get('charmstore')._makeRequest(entityData.deployerFileUrl,
               function(data) {
                 bundleImportHelpers.deployBundle(

--- a/app/views/topology/service.js
+++ b/app/views/topology/service.js
@@ -927,17 +927,20 @@ YUI.add('juju-topology-service', function(Y) {
           var charm = new models.Charm(entityData);
           Y.fire('initiateDeploy', charm, ghostAttributes);
         } else {
-          // The deployer format requires a top-level key to hold the bundle
-          // data, so we wrap the entity data in a mapping. The deployer
-          // format is YAML, but JSON is a subset of YAML, so we can just
-          // encode it this way.
-          bundleImportHelpers.deployBundle(
-              Y.JSON.stringify({
-                bundle: entityData.data
-              }),
-              entityData.id,
-              topo.get('env'),
-              topo.get('db')
+          // For now, simply send the bundles.yaml.orig file contents to the
+          // deployer.  Future deployer work will allow us to use the bundle
+          // file as returned by the charmstore. Makyo - 2012-12-19
+          topo.get('charmstore')._makeRequest(entityData.deployerFileUrl,
+              function(data) {
+                bundleImportHelpers.deployBundle(
+                    data.target.responseText,
+                    entityData.id,
+                    topo.get('env'),
+                    topo.get('db')
+                );
+              }, function(error) {
+                console.error(error);
+              }
           );
         }
       }

--- a/app/widgets/token.js
+++ b/app/widgets/token.js
@@ -140,10 +140,6 @@ YUI.add('browser-token', function(Y) {
     _addDraggability: function() {
       var tokenData,
           container = this.get('boundingBox');
-      // Adjust the ID to meet model expectations.
-      if (this.tokenData.type === 'charm') {
-        this.tokenData.id = this.tokenData.url;
-      }
       // Since the browser's dataTransfer mechanism only accepts string values
       // we have to JSON encode the data.  This passed-in config includes
       // charm/bundle attributes.

--- a/test/test_bundle_details_view.js
+++ b/test/test_bundle_details_view.js
@@ -187,9 +187,14 @@ describe('Browser bundle detail view', function() {
         // app.js sets this to its deploy bundle method so
         // as long as it's called it's successful.
         view.set('deployBundle', function(data) {
-          assert.isObject(data);
+          assert.equal(data, 'bundle: data');
           assert.equal(changeStateFired, true);
           done();
+        });
+        view.set('charmstore', {
+          _makeRequest: function(url, cb) {
+            cb({target: {responseText: 'bundle: data'}});
+          }
         });
         view.set('entity', new models.Bundle(data));
         view.render();

--- a/test/test_bundle_import_helpers.js
+++ b/test/test_bundle_import_helpers.js
@@ -97,11 +97,11 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       // Stub out the env call to make sure we check the params and call the
       // provided callback.
       env.deployerImport = function(bundle, bundleData, callback) {
-        assert.equal(bundle, 'test bundle');
+        assert.equal(bundle, 'test: bundle');
         assert.equal(bundleData.id, '~jorge/wiki/wiki');
         assert.equal(
-            bundleData.name, null,
-            'The name is not currently supported or passed.');
+            bundleData.name, 'test',
+            'The name was not pulled from the bundle.');
         // This is the default callback from the deployBundle method.
         callback({
           err: undefined,
@@ -124,7 +124,8 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       };
 
       // Start the process by deploying the bundle.
-      ns.BundleHelpers.deployBundle('test bundle', '~jorge/wiki/wiki', env, db);
+      ns.BundleHelpers.deployBundle('test: bundle', '~jorge/wiki/wiki',
+          env, db);
     });
 
     it('provides a notification when a deploy watch updates', function(done) {

--- a/test/test_service_module.js
+++ b/test/test_service_module.js
@@ -392,6 +392,12 @@ describe('service module events', function() {
           }
         };
 
+    var _charmstore = view.topo.get('charmstore');
+    view.topo.set('charmstore', {
+      _makeRequest: function(url, cb) {
+        cb({target: {responseText: 'bundle: BUNDLE DATA'}});
+      }
+    });
     // mock out the Y.BundleHelpers call.
     var _deployBundle = juju.BundleHelpers.deployBundle;
     juju.BundleHelpers.deployBundle = function(deployerData, id, env, db) {
@@ -399,6 +405,7 @@ describe('service module events', function() {
       assert.equal(id, '~jorge/bundle/thing');
       // Restore the deployBundle call for future tests.
       juju.BundleHelpers.deployBundle = _deployBundle;
+      view.topo.set('charmstore', _charmstore);
       done();
     };
 

--- a/test/test_token_drag_and_drop.js
+++ b/test/test_token_drag_and_drop.js
@@ -93,7 +93,7 @@ describe('token drag and drop', function() {
     draggable = Y.Array.dedupe(draggable);
     assert.equal(draggable.length, 1);
     // All of the tokens are made draggable.
-    assert.deepEqual(draggable, ['cs:test']);
+    assert.deepEqual(draggable, ['test']);
   });
 
   it('can make an element draggable', function() {
@@ -214,7 +214,7 @@ describe('token drag and drop', function() {
 
   it('fixes the charm id in _addDraggability', function() {
     var cfg = {
-      id: 'test',
+      id: 'cs:test',
       url: 'cs:test',
       boundingBox: container
     };


### PR DESCRIPTION
This branch utilizes the bundles.yaml.orig file to deploy the bundles, rather than the bundle data as returned by the charm store.  It also fixes the inability to drag-and-drop a bundle.