### PR TITLE
Add in relations from v4; driveby fix for subordinates

### DIFF
--- a/app/store/charmstore-api.js
+++ b/app/store/charmstore-api.js
@@ -147,6 +147,9 @@ YUI.add('charmstore-api', function(Y) {
         object in place.
     */
     _lowerCaseKeys: function(obj, host) {
+      if (!obj) {
+        return;
+      }
       Object.keys(obj).forEach(function(key) {
         host[key.toLowerCase()] =
             typeof obj[key] === 'object' ? Y.merge(obj[key]) : obj[key];
@@ -218,6 +221,14 @@ YUI.add('charmstore-api', function(Y) {
             this.apiPath + '/' +
             processed.id.replace('cs:', '') +
             '/archive/bundles.yaml.orig';
+      } else {
+        processed.relations = {
+          provides: processed.provides === undefined ? {} : processed.provides,
+          requires: processed.requires === undefined ? {} : processed.requires
+        };
+        delete processed.provides;
+        delete processed.requires;
+        processed.is_subordinate = !!metadata.Subordinate;
       }
       return processed;
     },

--- a/test/test_charmstore_apiv4.js
+++ b/test/test_charmstore_apiv4.js
@@ -175,7 +175,17 @@ describe('Charmstore API v4', function() {
         Id: 'cs:trusty/mongodb-9',
         Meta: {
           'charm-metadata': {
-            Name: 'mongodb'
+            Name: 'mongodb',
+            Provides: {
+              db: {
+                'Name': 'db',
+                'Role': 'requirer',
+                'Interface': 'mongo',
+                'Optional': false,
+                'Limit': 1,
+                'Scope': 'global'
+              }
+            }
           },
           'extra-info': {
             'bzr-owner': 'hatch',
@@ -189,16 +199,30 @@ describe('Charmstore API v4', function() {
       };
       var processed = charmstore._processEntityQueryData(data);
       assert.deepEqual(processed, {
+        id: 'cs:trusty/mongodb-9',
+        downloads: 10,
+        entityType: 'charm',
+        is_approved: true,
+        is_subordinate: false,
+        owner: 'hatch',
+        revisions: 5,
         code_source: {
           location: 'cs:precise/mongodb'
         },
-        downloads: 10,
-        entityType: 'charm',
-        id: 'cs:trusty/mongodb-9',
-        is_approved: true,
         name: 'mongodb',
-        owner: 'hatch',
-        revisions: 5
+        relations: {
+          provides: {
+            db: {
+              'name': 'db',
+              'role': 'requirer',
+              'interface': 'mongo',
+              'optional': false,
+              'limit': 1,
+              'scope': 'global'
+            }
+          },
+          requires: {}
+        }
       });
     });
 


### PR DESCRIPTION
Fixes release blocker of not being able to add relations between services due to misplaced provides/requires.  Drive by fix for 1369576.