### PR TITLE
Add options parsing for charmstore api v4

### DIFF
--- a/app/store/charmstore-api.js
+++ b/app/store/charmstore-api.js
@@ -152,7 +152,8 @@ YUI.add('charmstore-api', function(Y) {
       }
       Object.keys(obj).forEach(function(key) {
         host[key.toLowerCase()] =
-            typeof obj[key] === 'object' ? Y.merge(obj[key]) : obj[key];
+            (typeof obj[key] === 'object' && obj[key] !== null) ?
+                Y.merge(obj[key]) : obj[key];
         if (typeof obj[key] === 'object' && obj[key] !== null) {
           this._lowerCaseKeys(host[key.toLowerCase()], host[key.toLowerCase()]);
         }
@@ -179,6 +180,7 @@ YUI.add('charmstore-api', function(Y) {
       var meta = data.Meta,
           extraInfo = meta['extra-info'],
           charmMeta = meta['charm-metadata'],
+          charmConfig = meta['charm-config'],
           bundleMeta = meta['bundle-metadata'],
           bzrOwner = extraInfo['bzr-owner'];
       // Singletons and keys which are outside of the common structure
@@ -194,6 +196,11 @@ YUI.add('charmstore-api', function(Y) {
           location: extraInfo['bzr-url']
         }
       };
+      // Convert the options keys to lowercase.
+      if (charmConfig && typeof charmConfig.Options === 'object') {
+        this._lowerCaseKeys(charmConfig.Options, charmConfig.Options);
+        processed.options = charmConfig.Options;
+      }
       // An entity will only have one or the other.
       var metadata = (charmMeta) ? charmMeta : bundleMeta;
       // Convert the remaining metadata keys to lowercase.
@@ -292,6 +299,7 @@ YUI.add('charmstore-api', function(Y) {
       var defaultFilters =
                         '&limit=30&' +
                         'include=charm-metadata&' +
+                        'include=charm-config&' +
                         'include=bundle-metadata&' +
                         'include=extra-info&' +
                         'include=stats';

--- a/test/test_charmstore_apiv4.js
+++ b/test/test_charmstore_apiv4.js
@@ -192,6 +192,15 @@ describe('Charmstore API v4', function() {
             'bzr-revisions': 5,
             'bzr-url': 'cs:precise/mongodb'
           },
+          'charm-config': {
+            Options: {
+              'foo-optn': {
+                Default: 'foo',
+                Description: 'foo is awesome',
+                Type: 'String'
+              }
+            }
+          },
           stats: {
             ArchiveDownloadCount: 10
           }
@@ -222,6 +231,13 @@ describe('Charmstore API v4', function() {
             }
           },
           requires: {}
+        },
+        options: {
+          'foo-optn': {
+            'default': 'foo',
+            description: 'foo is awesome',
+            type: 'String'
+          }
         }
       });
     });
@@ -297,6 +313,7 @@ describe('Charmstore API v4', function() {
         'text=foo&' +
             'limit=30&' +
             'include=charm-metadata&' +
+            'include=charm-config&' +
             'include=bundle-metadata&' +
             'include=extra-info&' +
             'include=stats']);


### PR DESCRIPTION
Fix for bug: https://bugs.launchpad.net/juju-gui/+bug/1416469
 
When the user drag & dropped a charm from the charmbrowser it wasn't requesting and storing any charm configuration options so when trying to export it would fail as the options object was empty.