### PR TITLE
Add environment UUID support to socket requests

### DIFF
--- a/app/config-debug.js
+++ b/app/config-debug.js
@@ -37,14 +37,7 @@ var juju_config = {
   // Path to the charmstore. This property supersedes the charmworldURL
   // property above.
   charmstoreURL: 'https://api.jujucharms.com/charmstore/',
-  // The config has three socket settings.  socket_port and socket_protocol
-  // modify the current application url to determine the websocket url (always
-  // adding "/ws" as the final path).  socket_url sets the entire websocket
-  // url.  For backwards compatibility in the GUI charm, if you provide the
-  // socket port and/or protocol *and* the socket_url, the socket_url will be
-  // ignored (the port/protocol behavior overrides socket_url).
   socket_protocol: 'ws',
-  socket_port: 8081,
   user: 'admin',
   password: 'admin',
   sandbox: true,

--- a/app/config-prod.js
+++ b/app/config-prod.js
@@ -37,14 +37,7 @@ var juju_config = {
   // Path to the charmstore. This property supersedes the charmworldURL
   // property above.
   charmstoreURL: 'https://api.jujucharms.com/charmstore/',
-  // The config has three socket settings.  socket_port and socket_protocol
-  // modify the current application url to determine the websocket url (always
-  // adding "/ws" as the final path).  socket_url sets the entire websocket
-  // url.  For backwards compatibility in the GUI charm, if you provide the
-  // socket port and/or protocol *and* the socket_url, the socket_url will be
-  // ignored (the port/protocol behavior overrides socket_url).
   socket_protocol: 'ws',
-  socket_port: 8081,
   user: 'admin',
   password: 'admin',
   sandbox: true,

--- a/test/test_app.js
+++ b/test/test_app.js
@@ -139,6 +139,7 @@ function injectData(app, data) {
                 password: the_password,
                 viewContainer: container,
                 conn: {close: function() {}},
+                jujuCoreVersion: '1.21.1.1-trusty-amd64',
                 ecs: new juju.EnvironmentChangeSet()});
           app.after('ready', function() {
             var credentials = app.env.getCredentials();
@@ -157,6 +158,7 @@ function injectData(app, data) {
         readOnly: true,
         viewContainer: container,
         conn: {close: function() {}},
+        jujuCoreVersion: '1.21.1.1-trusty-amd64',
         ecs: new juju.EnvironmentChangeSet()
       });
       assert.isTrue(app.env.get('readOnly'));
@@ -254,7 +256,8 @@ function injectData(app, data) {
             send: function() {},
             close: function() {}
           },
-          ecs: new juju.EnvironmentChangeSet()
+          ecs: new juju.EnvironmentChangeSet(),
+          jujuCoreVersion: '1.21.1.1-trusty-amd64'
         })
       }, this);
 
@@ -283,7 +286,9 @@ function injectData(app, data) {
     });
 
     it('attaches a handler for autoplaceAndCommitAll event', function(done) {
-      constructAppInstance({}, this);
+      constructAppInstance({
+        jujuCoreVersion: '1.21.1.1-trusty-amd64'
+      }, this);
       app._autoplaceAndCommitAll = function() {
         // This test will hang if this method is not called from the following
         // event being fired.
@@ -295,7 +300,9 @@ function injectData(app, data) {
     });
 
     it('autoplaceAndCommitAll places and deploys', function() {
-      constructAppInstance({}, this);
+      constructAppInstance({
+        jujuCoreVersion: '1.21.1.1-trusty-amd64'
+      }, this);
       app.deployerBar = {
         _autoPlaceUnits: utils.makeStubFunction(),
         deploy: utils.makeStubFunction(),
@@ -1261,6 +1268,7 @@ describe('File drag over notification system', function() {
             consoleEnabled: true,
             user: 'admin',
             password: 'admin',
+            jujuCoreVersion: '1.21.1.1-trusty-amd64',
             store: new Y.juju.charmworld.APIv3({})
           });
       app.showView(new Y.View());
@@ -1274,6 +1282,7 @@ describe('File drag over notification system', function() {
         container: container,
         viewContainer: container,
         sandbox: true,
+        jujuCoreVersion: '1.21.1.1-trusty-amd64',
         store: new Y.juju.charmworld.APIv3({})
       });
       app.showView(new Y.View());
@@ -1314,78 +1323,18 @@ describe('File drag over notification system', function() {
       app.destroy();
     });
 
-    it('should honor socket_url', function() {
-      // The app passes it through to the environment.
-      app = new Y.juju.App(
-          { container: container,
-            viewContainer: container,
-            socket_url: 'wss://example.com/',
-            conn: {close: function() {}} });
-      app.showView(new Y.View());
-      assert.equal(app.env.get('socket_url'), 'wss://example.com/');
-    });
-
-    it('should honor socket_port', function() {
-      app = new Y.juju.App(
-          { container: container,
-            viewContainer: container,
-            socket_port: '8080' ,
-            conn: {close: function() {}} });
-      app.showView(new Y.View());
-      assert.equal(
-          app.env.get('socket_url'),
-          'wss://example.net:8080/ws');
-    });
-
-    it('should honor socket_protocol', function() {
+    it('should honor socket_protocol and uuid', function() {
       app = new Y.juju.App(
           { container: container,
             viewContainer: container,
             socket_protocol: 'ws',
+            jujuCoreVersion: '1.21.1.1-trusty-amd64',
+            jujuEnvUUID: '1234-1234',
             conn: {close: function() {}} });
       app.showView(new Y.View());
       assert.equal(
           app.env.get('socket_url'),
-          'ws://example.net:71070/ws');
-    });
-
-    it('should support combining socket_port and socket_protocol', function() {
-      app = new Y.juju.App(
-          { container: container,
-            viewContainer: container,
-            socket_protocol: 'ws',
-            socket_port: '8080',
-            conn: {close: function() {}} });
-      app.showView(new Y.View());
-      assert.equal(
-          app.env.get('socket_url'),
-          'ws://example.net:8080/ws');
-    });
-
-    it('should allow socket_port to override socket_url', function() {
-      app = new Y.juju.App(
-          { container: container,
-            viewContainer: container,
-            socket_port: '8080',
-            socket_url: 'fnord',
-            conn: {close: function() {}} });
-      app.showView(new Y.View());
-      assert.equal(
-          app.env.get('socket_url'),
-          'wss://example.net:8080/ws');
-    });
-
-    it('should allow socket_protocol to override socket_url', function() {
-      app = new Y.juju.App(
-          { container: container,
-            viewContainer: container,
-            socket_protocol: 'ws',
-            socket_url: 'fnord',
-            conn: {close: function() {}} });
-      app.showView(new Y.View());
-      assert.equal(
-          app.env.get('socket_url'),
-          'ws://example.net:71070/ws');
+          'ws://example.net:71070/ws/environment/1234-1234/api');
     });
   });
 

--- a/test/test_routing.js
+++ b/test/test_routing.js
@@ -29,7 +29,9 @@ describe('Namespaced Routing', function() {
   });
 
   beforeEach(function() {
-    app = new juju.App({conn: {close: function() {}}});
+    app = new juju.App({
+      jujuCoreVersion: '1.21.1.1-trusty-amd64',
+      conn: {close: function() {}}});
     app.showView(new Y.View());
   });
 


### PR DESCRIPTION
The newer versions of Juju core support us sending the environment UUID in the socket requests. This branch also removes some old unsupported configuration options from the socket attributes.