### PR TITLE
Add apiv4 bundle id support to deploy-target

### DIFF
--- a/app/store/charmstore-api.js
+++ b/app/store/charmstore-api.js
@@ -345,6 +345,43 @@ YUI.add('charmstore-api', function(Y) {
           this.apiPath, charmId, 'icon.svg'].join('/');
       }
       return path;
+    },
+
+    /**
+      Takes the bundle id and fetches the bundle YAML contents. Required for
+      deploying a bundle via the deployer.
+
+      @method getBundleYAML
+      @param {String} id Bundle id in apiv4 format.
+      @param {Function} successCallback The success callback.
+      @param {Function} failureCallback The failure callback.
+    */
+    getBundleYAML: function(id, successCallback, failureCallback) {
+      this.getEntity(
+          id, this._getBundleYAMLResponse.bind(
+              this, successCallback, failureCallback), failureCallback);
+    },
+
+    /**
+      getEntity success response handler which grabs the deployerFileUrl from
+      the recieved bundle details and requests the YAML.
+
+      @method _getBundleYAMLResponse
+      @param {Function} successCallback The success callback.
+      @param {Function} failureCallback The failure callback.
+      @param {Array} bundle An array containing the requested bundle model.
+    */
+    _getBundleYAMLResponse: function(successCallback, failureCallback, bundle) {
+      // XXX Jeff 17-02-15 The deployerFileUrl is generated after the response
+      // in the _processEntityQueryData method. Once the deployer supports the
+      // new bundle format this can be updated to grab the real yaml not the
+      // 'orig' version.
+      this._makeRequest(
+          bundle[0].get('deployerFileUrl'),
+          function(resp) {
+            successCallback(resp.currentTarget.responseText);
+          },
+          failureCallback);
     }
   };
 

--- a/app/subapps/browser/browser.js
+++ b/app/subapps/browser/browser.js
@@ -219,13 +219,13 @@ YUI.add('subapp-browser', function(Y) {
     */
     _deployTargetDispatcher: function(entityId) {
       var store = this.get('store');
+      var charmstore = this.get('charmstore');
       if (entityId.indexOf('bundle') === 0) {
-        // Query the charmstore for the bundle data
-        store.bundle(entityId.replace(':', '/'), {
-          'success': function(bundle) {
-            this.get('deployBundle')(bundle.data, bundle.id);
-          }
-        }, this);
+        charmstore.getBundleYAML(
+            entityId,
+            function(yaml) {
+              this.get('deployBundle')(yaml, entityId);
+            }.bind(this));
       } else {
         // If it's not a bundle then it's a charm.
         store.charm(entityId.replace('cs:', ''), {

--- a/test/test_browser_app.js
+++ b/test/test_browser_app.js
@@ -612,27 +612,26 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
         });
 
         describe('_deployTargetDispatcher', function() {
-          it('requests bundle id from store then deploys', function() {
-            app.set('store', {
-              bundle: utils.makeStubFunction()
+          it('requests bundle id from charmstore then deploys', function() {
+            var bundleId = 'bundle/elasticsearch';
+            app.set('charmstore', {
+              getBundleYAML: utils.makeStubFunction()
             });
             app.set('deployBundle', utils.makeStubFunction());
-            app._deployTargetDispatcher('bundle:elasticsearch/15/cluster');
-            var store = app.get('store');
-            assert.equal(store.bundle.callCount(), 1);
-            var bundleArgs = store.bundle.lastArguments();
-            assert.equal(bundleArgs[0], 'bundle/elasticsearch/15/cluster',
-                'api requires ids to have \/ instead of the : from the id');
+            app._deployTargetDispatcher(bundleId);
+            var charmstore = app.get('charmstore');
+            assert.equal(charmstore.getBundleYAML.callCount(), 1);
+            var bundleArgs = charmstore.getBundleYAML.lastArguments();
+            assert.equal(bundleArgs[0], bundleId);
             // The second param is the callback for the store response. So
             // we need to manually trigger it to test it.
-            var bundleData = {data: 'foo', id: 'bar'};
-            bundleArgs[1].success.call(app, bundleData);
+            var bundleYAML = 'foo:';
+            bundleArgs[1].call(app, bundleYAML);
             var deploy = app.get('deployBundle');
             assert.equal(deploy.callCount(), 1);
             assert.deepEqual(
                 deploy.lastArguments(),
-                [bundleData.data, bundleData.id]);
-            assert.deepEqual(bundleArgs[2], app);
+                [bundleYAML, bundleId]);
           });
 
           it('requests charm id from store then deploys', function() {


### PR DESCRIPTION
The jujucharms.com website allows users to "add to demo" bundles to play around with. It has had to guess at the apiv3 bundle id for some time now which has caused a number of bugs. This adds apiv4 bundle support to the GUI's deploy-target handler so that jujucharms.com can now use the apiv4 bundle id's.