### PR TITLE
Support namespaced bundle id's with deploy-target

### DIFF
--- a/app/subapps/browser/browser.js
+++ b/app/subapps/browser/browser.js
@@ -220,7 +220,10 @@ YUI.add('subapp-browser', function(Y) {
     _deployTargetDispatcher: function(entityId) {
       var store = this.get('store');
       var charmstore = this.get('charmstore');
-      if (entityId.indexOf('bundle') === 0) {
+      // The charmstore apiv4 format can have the bundle keyword either at the
+      // start, for charmers bundles, or after the username, for namespaced
+      // bundles. ex) bundle/swift & ~jorge/bundle/swift
+      if (entityId.indexOf('bundle/') > -1) {
         charmstore.getBundleYAML(
             entityId,
             function(yaml) {

--- a/test/test_browser_app.js
+++ b/test/test_browser_app.js
@@ -634,6 +634,29 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
                 [bundleYAML, bundleId]);
           });
 
+          it('requests bundle id from charmstore then deploys (namespaced)',
+              function() {
+                var bundleId = '~jorge/bundle/elasticsearch';
+                app.set('charmstore', {
+                  getBundleYAML: utils.makeStubFunction()
+                });
+                app.set('deployBundle', utils.makeStubFunction());
+                app._deployTargetDispatcher(bundleId);
+                var charmstore = app.get('charmstore');
+                assert.equal(charmstore.getBundleYAML.callCount(), 1);
+                var bundleArgs = charmstore.getBundleYAML.lastArguments();
+                assert.equal(bundleArgs[0], bundleId);
+                // The second param is the callback for the store response. So
+                // we need to manually trigger it to test it.
+                var bundleYAML = 'foo:';
+                bundleArgs[1].call(app, bundleYAML);
+                var deploy = app.get('deployBundle');
+                assert.equal(deploy.callCount(), 1);
+                assert.deepEqual(
+                    deploy.lastArguments(),
+                    [bundleYAML, bundleId]);
+              });
+
           it('requests charm id from store then deploys', function() {
             app.setAttrs({
               store: { charm: utils.makeStubFunction() },


### PR DESCRIPTION
Bundles can have two different formats for their id's `bundle/django` and namespaced `~jorge/bundle/django`