### PR TITLE
Display the new quickstart bundle deploy id on the deploy details page

### DIFF
--- a/app/subapps/browser/views/bundle.js
+++ b/app/subapps/browser/views/bundle.js
@@ -204,6 +204,10 @@ YUI.add('subapp-browser-bundleview', function(Y) {
       templateData.bugsLink = this._getBugsLink(sourceLocation);
       templateData.prettyCommits = this._formatCommitsForHtml(
           templateData.revisions, templateData.sourceLink);
+      templateData.quickstartId = templateData.id.replace('cs:', '')
+                                  // Add u/ if there is a username in the id.
+                                                 .replace('~', 'u/')
+                                                 .replace('bundle/', '');
       var content = this.template(templateData);
       var node = this.get('container').setHTML(content);
       var renderTo = this.get('renderTo');

--- a/app/subapps/browser/views/bundle.js
+++ b/app/subapps/browser/views/bundle.js
@@ -207,7 +207,10 @@ YUI.add('subapp-browser-bundleview', function(Y) {
       templateData.quickstartId = templateData.id.replace('cs:', '')
                                   // Add u/ if there is a username in the id.
                                                  .replace('~', 'u/')
-                                                 .replace('bundle/', '');
+                                                 .replace('bundle/', '')
+                                  // Grab the last - and replace it with a /
+                                  // because the following value is the revno.
+                                                 .replace(/-(?!.*-)/g, '/');
       var content = this.template(templateData);
       var node = this.get('container').setHTML(content);
       var renderTo = this.get('renderTo');

--- a/app/templates/bundle.handlebars
+++ b/app/templates/bundle.handlebars
@@ -83,7 +83,7 @@
                             <pre>sudo apt-get install juju-quickstart</pre>
                         </p>
                         <p>Step 2 - Deploy bundle
-                            <pre>juju-quickstart {{id}} [-e &lt;JUJU_ENV&gt;]</pre>
+                            <pre>juju-quickstart {{quickstartId}} [-e &lt;JUJU_ENV&gt;]</pre>
                         </p>
                         <h3>Deploy via the deployer</h3>
                         <p>The Juju deployer is a tool that the quickstart plugin (above) uses.  It can also be used standalone to give you more control.</p>

--- a/test/test_bundle_details_view.js
+++ b/test/test_bundle_details_view.js
@@ -334,7 +334,7 @@ describe('Browser bundle detail view', function() {
     view.set('entity', new models.Bundle(data));
     view.render();
     var text = view.get('container').one('#deploy').get('text');
-    assert.equal(text.indexOf('juju-quickstart mongodb-cluster-4') > 0, true);
+    assert.equal(text.indexOf('juju-quickstart mongodb-cluster/4') > 0, true);
   });
 
   it('can generate a namespaced quickstart deploy id', function() {
@@ -343,7 +343,7 @@ describe('Browser bundle detail view', function() {
     view.render();
     var text = view.get('container').one('#deploy').get('text');
     assert.equal(
-        text.indexOf('juju-quickstart u/jorge/mongodb-cluster-4') > 0, true);
+        text.indexOf('juju-quickstart u/jorge/mongodb-cluster/4') > 0, true);
   });
 
   it('can generate a bugs link', function() {

--- a/test/test_bundle_details_view.js
+++ b/test/test_bundle_details_view.js
@@ -330,6 +330,22 @@ describe('Browser bundle detail view', function() {
     assert.equal(revnoLink, expected + '/1');
   });
 
+  it('can generate a quickstart deploy id', function() {
+    view.set('entity', new models.Bundle(data));
+    view.render();
+    var text = view.get('container').one('#deploy').get('text');
+    assert.equal(text.indexOf('juju-quickstart mongodb-cluster-4') > 0, true);
+  });
+
+  it('can generate a namespaced quickstart deploy id', function() {
+    data.id = 'cs:~jorge/bundle/mongodb-cluster-4';
+    view.set('entity', new models.Bundle(data));
+    view.render();
+    var text = view.get('container').one('#deploy').get('text');
+    assert.equal(
+        text.indexOf('juju-quickstart u/jorge/mongodb-cluster-4') > 0, true);
+  });
+
   it('can generate a bugs link', function() {
     view.set('entity', new models.Bundle(data));
     var branchUrl = view.get('entity').get('code_source').location;


### PR DESCRIPTION
Quickstart will support the new bundle id format very soon so this updates the deploy page on the bundle details page to this new id format.