### PR TITLE
Show local charm icon in inspector

### DIFF
--- a/app/views/viewlets/charm-details.js
+++ b/app/views/viewlets/charm-details.js
@@ -83,7 +83,7 @@ YUI.add('charm-details-view', function(Y) {
        @param {Event} ev The event.
      */
     close: function(ev) {
-      ev.halt();
+      ev.preventDefault();
       var panel = Y.one('.charmbrowser'),
           container = this.get('container');
       panel.removeClass('animate-in');
@@ -94,6 +94,10 @@ YUI.add('charm-details-view', function(Y) {
       this.viewletManager.hideSlot(ev);
       container.empty();
       this.destroy();
+      // When this close method is called multiple times the destructor stops
+      // being called. This appears to be a bug in the YUI implementation so
+      // we need to call the destructor manually here.
+      this.destructor();
     },
     /**
       Removes the class from the left breakout panel saying there is a charm.

--- a/app/views/viewlets/charm-details.js
+++ b/app/views/viewlets/charm-details.js
@@ -67,7 +67,7 @@ YUI.add('charm-details-view', function(Y) {
         container.setHTML(this.templateWrapper({ initial: 'Loading...'}));
         panel.addClass('animate-in');
         container.show();
-        cfg.renderTo = container.one('.content')
+        cfg.renderTo = container.one('.content');
         // Browser Charm View uses the id to fetch the charm details if one
         // isn't provided.
         this.charmView = new browserViews.BrowserCharmView(cfg);

--- a/app/views/viewlets/charm-details.js
+++ b/app/views/viewlets/charm-details.js
@@ -50,7 +50,8 @@ YUI.add('charm-details-view', function(Y) {
         forInspector: true,
         store: store,
         charmstore: viewletManagerAttrs.charmstore,
-        activeTab: activeTab
+        activeTab: activeTab,
+        entityId: charm.get('id')
       };
 
       if (this.get('rendered')) {
@@ -60,36 +61,17 @@ YUI.add('charm-details-view', function(Y) {
         this.charmView.setAttrs(cfg);
       } else {
         container.delegate('click', this.close, '.close-slot', this);
-        panel.removeClass('animate-in');
-        container.hide();
-
-        store.charm(charm.get('storeId'), {
-          'success': function(data, storeCharm) {
-            // We must set renderTo in the callback--it doesn't exist before
-            // then.
-            cfg.renderTo = container.one('.content');
-            // The cfg.entity settings is being commented out because it will
-            // need to be re-enabled in a shortly upcoming branch.
-            // cfg.entity = storeCharm;
-            cfg.entityId = (data.charm && data.charm.id) ||
-                storeCharm.get('id');
-            this.charmView = new browserViews.BrowserCharmView(cfg);
-            this.charmView.render();
-          },
-          'failure': function(data) {
-            // We must set renderTo in the callback--it doesn't exist before
-            // then.
-            cfg.renderTo = container.one('.content');
-            // The cfg.entity settings is being commented out because it will
-            // need to be re-enabled in a shortly upcoming branch.
-            // cfg.entity = charm;
-            this.charmView = new browserViews.BrowserCharmView(cfg);
-            this.charmView.render();
-          }
-        }, this, viewletManagerAttrs.db.charms);
+        if (charm.get('scheme') === 'local') {
+          cfg.entity = charm;
+        }
         container.setHTML(this.templateWrapper({ initial: 'Loading...'}));
         panel.addClass('animate-in');
         container.show();
+        cfg.renderTo = container.one('.content')
+        // Browser Charm View uses the id to fetch the charm details if one
+        // isn't provided.
+        this.charmView = new browserViews.BrowserCharmView(cfg);
+        this.charmView.render();
         this.set('rendered', true);
       }
     },

--- a/app/views/viewlets/inspector-header.js
+++ b/app/views/viewlets/inspector-header.js
@@ -67,7 +67,7 @@ YUI.add('inspector-header-view', function(Y) {
 
       @method render
       @param {Object} charm the charm model to display the details of.
-      @param {Object} viewletManagerAttrs the attributes passed to the
+      @param {Object} viewContainerAttrs the attributes passed to the
         viewlet manager.
     */
     render: function(model, viewContainerAttrs) {
@@ -76,7 +76,8 @@ YUI.add('inspector-header-view', function(Y) {
       // Manually add the icon url for the charm since we don't have access to
       // the browser handlebars helper at this location.
       pojoModel.icon = utils.getIconPath(
-          pojoModel.charmUrl, false, viewContainerAttrs.charmstore);
+          pojoModel.charmUrl, false,
+          viewContainerAttrs.charmstore, viewContainerAttrs.env);
       if (pojoModel.pending) {
         // Check if there is already a service using the default name to
         // trigger the name ux.

--- a/test/test_inspector_charm.js
+++ b/test/test_inspector_charm.js
@@ -194,7 +194,7 @@ describe('Inspector Charm', function() {
     var fakeManager = {'hideSlot': hideSlot};
 
     var fakeEvent = {
-      halt: function() {},
+      preventDefault: function() {},
       currentTarget: {
         getData: function() { return 'left-hand-panel'; }
       }
@@ -203,6 +203,7 @@ describe('Inspector Charm', function() {
     view = new viewlets.charmDetails();
     view.container = testContainer;
     view.viewletManager = fakeManager;
+    var destructor = utils.makeStubMethod(view, 'destructor');
 
     view.render(fakeCharm, viewletAttrs);
     view.close(fakeEvent);
@@ -210,7 +211,8 @@ describe('Inspector Charm', function() {
     assert.equal(hideSlot.calledOnce(), true);
     assert.equal(Y.one('.charmbrowser').hasClass('animate-in'), false);
     assert.equal(view.get('container').getHTML(), '');
-
+    assert.equal(destructor.callCount(), 1);
+    destructor.passThroughToOriginalMethod.call(view);
   });
 });
 


### PR DESCRIPTION
Bug: https://bugs.launchpad.net/juju-gui/+bug/1427162

Fixes:
- Local charms icons are not shown in their inspectors. 
- Opening the charm details pane of a local charm would throw error.
- Opening and closing the charm details pane 4x would cause the defailt pane to stop opening.
