### PR TITLE
Downconvert apiv4 bundle yaml to apiv3 format temporarily

### DIFF
--- a/app/store/charmstore-api.js
+++ b/app/store/charmstore-api.js
@@ -227,7 +227,7 @@ YUI.add('charmstore-api', function(Y) {
             this.charmstoreURL +
             this.apiPath + '/' +
             processed.id.replace('cs:', '') +
-            '/archive/bundles.yaml.orig';
+            '/archive/bundle.yaml';
       } else {
         processed.relations = {
           provides: processed.provides === undefined ? {} : processed.provides,
@@ -372,16 +372,26 @@ YUI.add('charmstore-api', function(Y) {
       @param {Array} bundle An array containing the requested bundle model.
     */
     _getBundleYAMLResponse: function(successCallback, failureCallback, bundle) {
-      // XXX Jeff 17-02-15 The deployerFileUrl is generated after the response
-      // in the _processEntityQueryData method. Once the deployer supports the
-      // new bundle format this can be updated to grab the real yaml not the
-      // 'orig' version.
       this._makeRequest(
           bundle[0].get('deployerFileUrl'),
           function(resp) {
             successCallback(resp.currentTarget.responseText);
           },
           failureCallback);
+    },
+
+    /**
+      Takes the supplied YAML and wraps it in another layer to simulate the
+      apiv3 format.
+
+      @method downConvertBundleYAML
+      @param {String} bundleYAML The bundle YAML file contents.
+      @return {String} The wrapped bundle YAML.
+    */
+    downConvertBundleYAML: function(bundleYAML) {
+      var bundle = jsyaml.safeLoad(bundleYAML);
+      var wrapped = { 'bundle-deploy': bundle };
+      return jsyaml.safeDump(wrapped);
     }
   };
 

--- a/app/subapps/browser/browser.js
+++ b/app/subapps/browser/browser.js
@@ -227,7 +227,8 @@ YUI.add('subapp-browser', function(Y) {
         charmstore.getBundleYAML(
             entityId,
             function(yaml) {
-              this.get('deployBundle')(yaml, entityId);
+              var bundleYAML = charmstore.downConvertBundleYAML(yaml);
+              this.get('deployBundle')(bundleYAML, entityId);
             }.bind(this));
       } else {
         // If it's not a bundle then it's a charm.

--- a/app/subapps/browser/views/bundle.js
+++ b/app/subapps/browser/views/bundle.js
@@ -92,14 +92,14 @@ YUI.add('subapp-browser-bundleview', function(Y) {
           component: 'charmbrowser',
           metadata: { id: null }
         }});
-      this.get('charmstore')._makeRequest(bundle.get('deployerFileUrl'),
-          function(data) {
-            var bundle = data.target.responseText;
-            var bundleName = bundle.split(':', 1)[0];
-            this.get('deployBundle')(bundle, bundleName);
-          }.bind(this), function(error) {
-            console.error(error);
-          });
+      var charmstore = this.get('charmstore');
+      var bundleId = bundle.get('id').replace('cs:', '');
+      charmstore.getBundleYAML(
+          bundleId,
+          function(yaml) {
+            var bundleYAML = charmstore.downConvertBundleYAML(yaml);
+            this.get('deployBundle')(bundleYAML, bundleId);
+          }.bind(this));
     },
 
     /**

--- a/app/views/topology/service.js
+++ b/app/views/topology/service.js
@@ -927,21 +927,18 @@ YUI.add('juju-topology-service', function(Y) {
           var charm = new models.Charm(entityData);
           Y.fire('initiateDeploy', charm, ghostAttributes);
         } else {
-          // XXX For now, simply send the bundles.yaml.orig file contents to
-          // the deployer.  Future deployer work will allow us to use the
-          // bundle file as returned by the charmstore. Makyo - 2012-12-19
-          topo.get('charmstore')._makeRequest(entityData.deployerFileUrl,
-              function(data) {
+          var charmstore = topo.get('charmstore');
+          charmstore.getBundleYAML(
+              entityData.id.replace('cs:', ''),
+              function(yaml) {
+                var bundleYAML = charmstore.downConvertBundleYAML(yaml);
                 bundleImportHelpers.deployBundle(
-                    data.target.responseText,
+                    bundleYAML,
                     entityData.id,
                     topo.get('env'),
                     topo.get('db')
                 );
-              }, function(error) {
-                console.error(error);
-              }
-          );
+              }.bind(this));
         }
       }
     },

--- a/test/test_browser_app.js
+++ b/test/test_browser_app.js
@@ -612,10 +612,11 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
         });
 
         describe('_deployTargetDispatcher', function() {
-          it('requests bundle id from charmstore then deploys', function() {
+          it('gets bundle yaml from charmstore then deploys', function() {
             var bundleId = 'bundle/elasticsearch';
             app.set('charmstore', {
-              getBundleYAML: utils.makeStubFunction()
+              getBundleYAML: utils.makeStubFunction(),
+              downConvertBundleYAML: utils.makeStubFunction('yamlres')
             });
             app.set('deployBundle', utils.makeStubFunction());
             app._deployTargetDispatcher(bundleId);
@@ -625,20 +626,21 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
             assert.equal(bundleArgs[0], bundleId);
             // The second param is the callback for the store response. So
             // we need to manually trigger it to test it.
-            var bundleYAML = 'foo:';
-            bundleArgs[1].call(app, bundleYAML);
+            bundleArgs[1].call(app, 'yaml');
             var deploy = app.get('deployBundle');
+            assert.equal(charmstore.downConvertBundleYAML.callCount(), 1);
             assert.equal(deploy.callCount(), 1);
             assert.deepEqual(
                 deploy.lastArguments(),
-                [bundleYAML, bundleId]);
+                ['yamlres', bundleId]);
           });
 
           it('requests bundle id from charmstore then deploys (namespaced)',
               function() {
                 var bundleId = '~jorge/bundle/elasticsearch';
                 app.set('charmstore', {
-                  getBundleYAML: utils.makeStubFunction()
+                  getBundleYAML: utils.makeStubFunction(),
+                  downConvertBundleYAML: utils.makeStubFunction('yamlres')
                 });
                 app.set('deployBundle', utils.makeStubFunction());
                 app._deployTargetDispatcher(bundleId);
@@ -648,13 +650,13 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
                 assert.equal(bundleArgs[0], bundleId);
                 // The second param is the callback for the store response. So
                 // we need to manually trigger it to test it.
-                var bundleYAML = 'foo:';
-                bundleArgs[1].call(app, bundleYAML);
+                bundleArgs[1].call(app, 'yaml');
                 var deploy = app.get('deployBundle');
+                assert.equal(charmstore.downConvertBundleYAML.callCount(), 1);
                 assert.equal(deploy.callCount(), 1);
                 assert.deepEqual(
                     deploy.lastArguments(),
-                    [bundleYAML, bundleId]);
+                    ['yamlres', bundleId]);
               });
 
           it('requests charm id from store then deploys', function() {

--- a/test/test_bundle_details_view.js
+++ b/test/test_bundle_details_view.js
@@ -192,8 +192,11 @@ describe('Browser bundle detail view', function() {
           done();
         });
         view.set('charmstore', {
-          _makeRequest: function(url, cb) {
-            cb({target: {responseText: 'bundle: data'}});
+          getBundleYAML: function(id, callback) {
+            callback({target: {responseText: 'bundle: data'}});
+          },
+          downConvertBundleYAML: function() {
+            return 'bundle: data';
           }
         });
         view.set('entity', new models.Bundle(data));

--- a/test/test_charmstore_apiv4.js
+++ b/test/test_charmstore_apiv4.js
@@ -265,7 +265,7 @@ describe('Charmstore API v4', function() {
           location: 'lp:~charmers/charms/bundles/mongodb-cluster/bundle'
         },
         deployerFileUrl: 'local/v4/~charmers/bundle/mongodb-cluster-4/' +
-            'archive/bundles.yaml.orig',
+            'archive/bundle.yaml',
         downloads: 10,
         entityType: 'bundle',
         id: 'cs:~charmers/bundle/mongodb-cluster-4',
@@ -379,6 +379,13 @@ describe('Charmstore API v4', function() {
       assert.equal(success.lastArguments()[0], 'yaml');
       requestArgs[2](); // Should be the failure handler.
       assert.equal(failure.callCount(), 1);
+    });
+  });
+
+  describe('downConvertBundleYAML', function() {
+    it('wraps a supplied bundle yaml', function() {
+      var wrapped = charmstore.downConvertBundleYAML('bundle:\n  test');
+      assert.equal(wrapped, '"bundle-deploy": \n  bundle: test\n');
     });
   });
 });

--- a/test/test_service_module.js
+++ b/test/test_service_module.js
@@ -394,8 +394,11 @@ describe('service module events', function() {
 
     var _charmstore = view.topo.get('charmstore');
     view.topo.set('charmstore', {
-      _makeRequest: function(url, cb) {
-        cb({target: {responseText: 'bundle: BUNDLE DATA'}});
+      getBundleYAML: function(id, callback) {
+        callback({target: {responseText: 'bundle: BUNDLE DATA'}});
+      },
+      downConvertBundleYAML: function() {
+        return 'bundle: BUNDLE DATA';
       }
     });
     // mock out the Y.BundleHelpers call.


### PR DESCRIPTION
Some apiv3 baskets still have multiple bundles in them. To combat this we are switching to using the apiv4 bundle yaml instead of the apiv3 bundle yaml and then wrapping it to make it appear to be the apiv3 format.