### PR TITLE
Fix bug #1428751: prevent incorrect lowercasing.

### DIFF
--- a/app/store/charmstore-api.js
+++ b/app/store/charmstore-api.js
@@ -143,25 +143,37 @@ YUI.add('charmstore-api', function(Y) {
       @method lowerCaseKeys
       @param {Object} obj The source object with the uppercase keys.
       @param {Object} host The host object in which the keys will be assigned.
+      @param {Object} exclude Exclude a particular level from lowercasing when
+        recursing.
       @return {Undefined} Does not return a value, modifies the supplied host
         object in place.
     */
-    _lowerCaseKeys: function(obj, host) {
+    _lowerCaseKeys: function(obj, host, exclude) {
       if (!obj) {
         return;
       }
       Object.keys(obj).forEach(function(key) {
-        host[key.toLowerCase()] =
+        // An exclude of 0 means "don't lowercase this level".
+        var newKey = key;
+        if (exclude !== 0) {
+          newKey = key.toLowerCase();
+        }
+        host[newKey] =
             (typeof obj[key] === 'object' && obj[key] !== null) ?
                 Y.merge(obj[key]) : obj[key];
         if (typeof obj[key] === 'object' && obj[key] !== null) {
-          this._lowerCaseKeys(host[key.toLowerCase()], host[key.toLowerCase()]);
+          // Decrement exclude by one if it exists.
+          var newExclude = exclude;
+          if (newExclude !== undefined) {
+            newExclude = exclude - 1;
+          }
+          this._lowerCaseKeys(host[newKey], host[newKey], newExclude);
         }
         // This technique will create a version with a capitalized key so we
         // need to delete it from the host object. To protect against keys
         // which are already lower case then we test to make sure we don't
         // delete those.
-        if (key.toLowerCase() !== key) {
+        if (newKey !== key) {
           delete host[key];
         }
       }, this);
@@ -198,7 +210,7 @@ YUI.add('charmstore-api', function(Y) {
       };
       // Convert the options keys to lowercase.
       if (charmConfig && typeof charmConfig.Options === 'object') {
-        this._lowerCaseKeys(charmConfig.Options, charmConfig.Options);
+        this._lowerCaseKeys(charmConfig.Options, charmConfig.Options, 0);
         processed.options = charmConfig.Options;
       }
       // An entity will only have one or the other.

--- a/app/store/charmstore-api.js
+++ b/app/store/charmstore-api.js
@@ -144,7 +144,9 @@ YUI.add('charmstore-api', function(Y) {
       @param {Object} obj The source object with the uppercase keys.
       @param {Object} host The host object in which the keys will be assigned.
       @param {Object} exclude Exclude a particular level from lowercasing when
-        recursing.
+        recursing; uses a 0-based index, so if 0 is specified, the keys at the
+        first level of recursion will not be lowercased. If 3 is specified, the
+        keys at the fourth level of recursion will not be lowercased.
       @return {Undefined} Does not return a value, modifies the supplied host
         object in place.
     */

--- a/test/test_charmstore_apiv4.js
+++ b/test/test_charmstore_apiv4.js
@@ -166,6 +166,13 @@ describe('Charmstore API v4', function() {
       charmstore._lowerCaseKeys(uppercase, host);
       assert.deepEqual(host, { baz: '1', foo: { bar: { baz: '1'}}});
     });
+
+    it('can skip one level of keys in an object', function() {
+      var uppercase = { Baz: '1', Foo: { Bar: { Baz: '1' }}, Fee: '2'};
+      var host = {};
+      charmstore._lowerCaseKeys(uppercase, host, 0);
+      assert.deepEqual(host, { Baz: '1', Foo: { bar: { baz: '1'}}, Fee: '2'});
+    });
   });
 
   describe('_processEntityQueryData', function() {
@@ -197,6 +204,11 @@ describe('Charmstore API v4', function() {
               'foo-optn': {
                 Default: 'foo',
                 Description: 'foo is awesome',
+                Type: 'String'
+              },
+              'barOptn': {
+                Default: 'bar',
+                Description: 'bar is less awesome',
                 Type: 'String'
               }
             }
@@ -236,6 +248,11 @@ describe('Charmstore API v4', function() {
           'foo-optn': {
             'default': 'foo',
             description: 'foo is awesome',
+            type: 'String'
+          },
+          'barOptn': {
+            'default': 'bar',
+            description: 'bar is less awesome',
             type: 'String'
           }
         }


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/juju-gui/+bug/1428751, which was caused by overzealous recursive lowercasing of all keys returned by the API. Some keys, such as the charm author-provided ones in the charm config, should not be lowercased. Adds a way to exclude (i.e., no lowercasing) certain levels when recursing through an object.