### PR TITLE
Get related charms from charmstore apiv4

### DIFF
--- a/app/models/charm.js
+++ b/app/models/charm.js
@@ -257,10 +257,18 @@ YUI.add('juju-charm-models', function(Y) {
       @return {Object} The processed related charms.
     */
     _processRelatedCharms: function(relatedCharms) {
+      var provides, requires;
+      // Not all charms have related charms on both the provides and requires.
+      if (relatedCharms.provides) {
+        provides = this._dedupeRelatedCharms(relatedCharms.provides);
+      }
+      if (relatedCharms.requires) {
+        requires = this._dedupeRelatedCharms(relatedCharms.requires);
+      }
       return {
         all: relatedCharms,
-        provides: this._dedupeRelatedCharms(relatedCharms.provides),
-        requires: this._dedupeRelatedCharms(relatedCharms.requires)
+        provides: provides,
+        requires: requires
       };
     },
 

--- a/app/models/charm.js
+++ b/app/models/charm.js
@@ -119,9 +119,6 @@ YUI.add('juju-charm-models', function(Y) {
    *
    */
   models.Charm = Y.Base.create('browser-charm', Y.Model, [], {
-    // Only care about at most, this number of related charms per interface.
-    maxRelatedCharms: 5,
-
     /**
      * Parse the relations ATTR from the api into specific provides/requires
      * information.
@@ -137,32 +134,6 @@ YUI.add('juju-charm-models', function(Y) {
       } else {
         return null;
       }
-    },
-
-    /**
-      Given the set of data for relatedCharms, make it compatible with the
-      model api to be used in the charm-token widget, for example.
-
-      @method _convertRelatedData
-      @param {Object} data a related charm object.
-
-     */
-    _convertRelatedData: function(data) {
-      return {
-        // Only show the icon if it has one and the charm has been reviewed to
-        // have a safe icon.
-        shouldShowIcon: data.has_icon && data.is_approved,
-        commitCount: parseInt(data.code_source.revision, 10),
-        downloads: data.downloads,
-        is_approved: data.is_approved,
-        name: data.name,
-        owner: data.owner,
-        recent_commit_count: data.commits_in_past_30_days,
-        recent_download_count: data.downloads_in_past_30_days,
-        series: data.distro_series,
-        storeId: data.id,
-        weight: data.weight
-      };
     },
 
     /**
@@ -373,7 +344,7 @@ YUI.add('juju-charm-models', function(Y) {
     */
     _keepLatestRevision: function(charms) {
       var keys = Object.keys(charms);
-      var ids = [];
+      var ids = {};
       keys.forEach(function(key) {
         var keepId = '';
         var keepRevno;
@@ -385,60 +356,9 @@ YUI.add('juju-charm-models', function(Y) {
             keepRevno = revno;
           }
         });
-        ids.push(keepId);
+        ids[key] = keepId;
       });
       return ids;
-    },
-
-    /**
-      Build the relatedCharms attribute from api data
-
-      @method buildRelatedCharms
-      @param {Object} provides the list of provides interfaces/charms.
-      @param {Object} requires the list of requires interfaces/charms.
-
-    */
-    buildRelatedCharms: function(provides, requires) {
-      var charms = {
-        all: {},
-        provides: {},
-        requires: {}
-      };
-
-      var buildWeightedList = function(relationName, relationData, scope) {
-        Y.Object.each(relationData, function(face, key) {
-          // The relations are in the order of score, so we can limit them right
-          // off the bat.
-          charms[relationName][key] = face.slice(0, this.maxRelatedCharms);
-          charms[relationName][key].forEach(function(relation, idx) {
-            // Update the related object with the converted version so that it's
-            // follows the model ATTRS
-            charms[relationName][key][idx] = this._convertRelatedData(relation);
-            // Then track the highest provides charm to be in the running for
-            // overall most weighted related charm.
-            charms.all[relation.id] = charms[relationName][key][idx];
-          }, scope);
-        }, scope);
-      };
-
-      buildWeightedList('provides', provides, this);
-      buildWeightedList('requires', requires, this);
-
-      // Find the highest weight charms, but make sure there are no
-      // duplicates. We build the object to index on key and remove dupes,
-      // then we get a list of results and sort them by weight, grabbing the
-      // top set.
-      var allCharmsList = Y.Object.values(charms.all);
-
-      allCharmsList.sort(function(charm1, charm2) {
-        return charm2.weight - charm1.weight;
-      });
-
-      this.set('relatedCharms', {
-        overall: allCharmsList.slice(0, this.maxRelatedCharms),
-        provides: charms.provides,
-        requires: charms.requires
-      });
     }
   }, {
     /**

--- a/app/store/charmstore-api.js
+++ b/app/store/charmstore-api.js
@@ -143,7 +143,7 @@ YUI.add('charmstore-api', function(Y) {
       @method lowerCaseKeys
       @param {Object} obj The source object with the uppercase keys.
       @param {Object} host The host object in which the keys will be assigned.
-      @param {Object} exclude Exclude a particular level from lowercasing when
+      @param {Integer} exclude Exclude a particular level from lowercasing when
         recursing; uses a 0-based index, so if 0 is specified, the keys at the
         first level of recursion will not be lowercased. If 3 is specified, the
         keys at the fourth level of recursion will not be lowercased.
@@ -210,6 +210,8 @@ YUI.add('charmstore-api', function(Y) {
           location: extraInfo['bzr-url']
         }
       };
+      this._lowerCaseKeys(meta['charm-related'], meta['charm-related']);
+      processed.relatedCharms = meta['charm-related'];
       // Convert the options keys to lowercase.
       if (charmConfig && typeof charmConfig.Options === 'object') {
         this._lowerCaseKeys(charmConfig.Options, charmConfig.Options, 0);
@@ -286,7 +288,8 @@ YUI.add('charmstore-api', function(Y) {
     */
     getEntity: function(entityId, successCallback, failureCallback) {
       var filters = 'include=bundle-metadata&include=charm-metadata' +
-                    '&include=charm-config&include=manifest&include=extra-info';
+                    '&include=charm-config&include=manifest' +
+                    '&include=charm-related&include=extra-info';
       this._makeRequest(
           this._generatePath(entityId, filters, '/meta/any'),
           this._transformQueryResults.bind(this, successCallback),

--- a/app/store/charmstore-api.js
+++ b/app/store/charmstore-api.js
@@ -210,8 +210,10 @@ YUI.add('charmstore-api', function(Y) {
           location: extraInfo['bzr-url']
         }
       };
-      this._lowerCaseKeys(meta['charm-related'], meta['charm-related']);
-      processed.relatedCharms = meta['charm-related'];
+      if (meta['charm-related']) {
+        this._lowerCaseKeys(meta['charm-related'], meta['charm-related']);
+        processed.relatedCharms = meta['charm-related'];
+      }
       // Convert the options keys to lowercase.
       if (charmConfig && typeof charmConfig.Options === 'object') {
         this._lowerCaseKeys(charmConfig.Options, charmConfig.Options, 0);

--- a/app/subapps/browser/views/charm.js
+++ b/app/subapps/browser/views/charm.js
@@ -250,21 +250,19 @@ YUI.add('subapp-browser-charmview', function(Y) {
       if (!this.loadedRelatedInterfaceCharms) {
         this.charmTokens = [];
         Y.Object.each(relatedCharms, function(list, iface) {
-          // we only care about the top three charms in the list.
-          var charms = list.slice(0, 3);
-          charms.forEach(function(charm) {
-            var uiID = [
-              type,
-              iface
-            ].join('-');
-
-            charm.size = 'tiny';
-            // XXX This id assignment is only necessary until we switch the
-            // charm details view over to apiv4.
-            charm.id = charm.storeId;
+          var charms = Object.keys(list);
+          charms.forEach(function(fullCharmName) {
+            var charmName = fullCharmName.split('/')[1];
+            var charm = {
+              size: 'tiny',
+              id: list[fullCharmName],
+              name: charmName
+            };
             var ct = new widgets.browser.Token(charm);
-            var node = Y.one('[data-interface="' + uiID + '"]');
-            ct.render(node);
+            var node = Y.one('[data-interface="' + type + '-' + iface + '"]');
+            if (node) {
+              ct.render(node);
+            }
             this.charmTokens.push(ct);
           }, this);
         }, this);

--- a/app/subapps/browser/views/charm.js
+++ b/app/subapps/browser/views/charm.js
@@ -190,16 +190,9 @@ YUI.add('subapp-browser-charmview', function(Y) {
     _loadInterfacesTabCharms: function() {
       // If we don't have our related-charms data then force it to load.
       var relatedCharms = this.get('entity').get('relatedCharms');
-
-      if (!relatedCharms) {
-        // If we don't have the related charm data, go get and call us back
-        // when it's done loading so we can update the display.
-        this._loadRelatedCharms(this._loadInterfacesTabCharms);
-      } else {
-        this._renderRelatedInterfaceCharms('requires', relatedCharms.requires);
-        this._renderRelatedInterfaceCharms('provides', relatedCharms.provides);
-        this.loadedRelatedInterfaceCharms = true;
-      }
+      this._renderRelatedInterfaceCharms('requires', relatedCharms.requires);
+      this._renderRelatedInterfaceCharms('provides', relatedCharms.provides);
+      this.loadedRelatedInterfaceCharms = true;
     },
 
     /**

--- a/app/subapps/browser/views/entity-base.js
+++ b/app/subapps/browser/views/entity-base.js
@@ -306,29 +306,6 @@ YUI.add('subapp-browser-entitybaseview', function(Y) {
         this.loadedReadme = true;
       }
     },
-    /**
-      Load the related charm data into the model for use.
-
-      @method _loadRelatedCharms
-
-     */
-    _loadRelatedCharms: function(callback) {
-      this.get('store').related(
-          this.get('entity').get('storeId'), {
-            'success': function(data) {
-              this.get('entity').buildRelatedCharms(
-                  data.result.provides, data.result.requires);
-              if (callback) {
-                callback.call(this);
-              }
-            },
-            'failure': function(data, request) {
-              console.log('Error loading related charm data.');
-              console.log(data);
-            }
-          },
-          this);
-    },
 
     /**
      * The readme file in a charm can be upper/lower/etc. This helps find a

--- a/app/views/viewlets/charm-details.js
+++ b/app/views/viewlets/charm-details.js
@@ -41,14 +41,12 @@ YUI.add('charm-details-view', function(Y) {
     */
     render: function(charm, viewletManagerAttrs) {
       var container,
-          store = viewletManagerAttrs.store,
           panel = Y.one('.charmbrowser'),
           activeTab = viewletManagerAttrs.activeTab;
       container = this.get('container');
 
       var cfg = {
         forInspector: true,
-        store: store,
         charmstore: viewletManagerAttrs.charmstore,
         activeTab: activeTab,
         entityId: charm.get('id')

--- a/test/data/browsercharm.json
+++ b/test/data/browsercharm.json
@@ -118,6 +118,13395 @@
   "code_source": {
     "location": "lp:~charmers\/charms\/precise\/apache2\/trunk"
   },
+  "relatedCharms": {
+    "requires": {
+      "http": {
+        "0": {
+          "id": "cs:oneiric\/haproxy-0"
+        },
+        "1": {
+          "id": "cs:precise\/apache2-1"
+        },
+        "2": {
+          "id": "cs:precise\/apache2-10"
+        },
+        "3": {
+          "id": "cs:precise\/apache2-11"
+        },
+        "4": {
+          "id": "cs:precise\/apache2-12"
+        },
+        "5": {
+          "id": "cs:precise\/apache2-13"
+        },
+        "6": {
+          "id": "cs:precise\/apache2-14"
+        },
+        "7": {
+          "id": "cs:precise\/apache2-15"
+        },
+        "8": {
+          "id": "cs:precise\/apache2-16"
+        },
+        "9": {
+          "id": "cs:precise\/apache2-17"
+        },
+        "10": {
+          "id": "cs:precise\/apache2-18"
+        },
+        "11": {
+          "id": "cs:precise\/apache2-19"
+        },
+        "12": {
+          "id": "cs:precise\/apache2-2"
+        },
+        "13": {
+          "id": "cs:precise\/apache2-20"
+        },
+        "14": {
+          "id": "cs:precise\/apache2-21"
+        },
+        "15": {
+          "id": "cs:precise\/apache2-22"
+        },
+        "16": {
+          "id": "cs:precise\/apache2-23"
+        },
+        "17": {
+          "id": "cs:precise\/apache2-24"
+        },
+        "18": {
+          "id": "cs:precise\/apache2-25"
+        },
+        "19": {
+          "id": "cs:precise\/apache2-26"
+        },
+        "20": {
+          "id": "cs:precise\/apache2-27"
+        },
+        "21": {
+          "id": "cs:precise\/apache2-3"
+        },
+        "22": {
+          "id": "cs:precise\/apache2-4"
+        },
+        "23": {
+          "id": "cs:precise\/apache2-5"
+        },
+        "24": {
+          "id": "cs:precise\/apache2-6"
+        },
+        "25": {
+          "id": "cs:precise\/apache2-7"
+        },
+        "26": {
+          "id": "cs:precise\/apache2-8"
+        },
+        "27": {
+          "id": "cs:precise\/apache2-9"
+        },
+        "28": {
+          "id": "cs:precise\/haproxy-0"
+        },
+        "29": {
+          "id": "cs:precise\/haproxy-1"
+        },
+        "30": {
+          "id": "cs:precise\/haproxy-10"
+        },
+        "31": {
+          "id": "cs:precise\/haproxy-11"
+        },
+        "32": {
+          "id": "cs:precise\/haproxy-12"
+        },
+        "33": {
+          "id": "cs:precise\/haproxy-13"
+        },
+        "34": {
+          "id": "cs:precise\/haproxy-14"
+        },
+        "35": {
+          "id": "cs:precise\/haproxy-15"
+        },
+        "36": {
+          "id": "cs:precise\/haproxy-16"
+        },
+        "37": {
+          "id": "cs:precise\/haproxy-17"
+        },
+        "38": {
+          "id": "cs:precise\/haproxy-18"
+        },
+        "39": {
+          "id": "cs:precise\/haproxy-19"
+        },
+        "40": {
+          "id": "cs:precise\/haproxy-2"
+        },
+        "41": {
+          "id": "cs:precise\/haproxy-20"
+        },
+        "42": {
+          "id": "cs:precise\/haproxy-21"
+        },
+        "43": {
+          "id": "cs:precise\/haproxy-22"
+        },
+        "44": {
+          "id": "cs:precise\/haproxy-23"
+        },
+        "45": {
+          "id": "cs:precise\/haproxy-24"
+        },
+        "46": {
+          "id": "cs:precise\/haproxy-25"
+        },
+        "47": {
+          "id": "cs:precise\/haproxy-26"
+        },
+        "48": {
+          "id": "cs:precise\/haproxy-27"
+        },
+        "49": {
+          "id": "cs:precise\/haproxy-28"
+        },
+        "50": {
+          "id": "cs:precise\/haproxy-29"
+        },
+        "51": {
+          "id": "cs:precise\/haproxy-3"
+        },
+        "52": {
+          "id": "cs:precise\/haproxy-30"
+        },
+        "53": {
+          "id": "cs:precise\/haproxy-31"
+        },
+        "54": {
+          "id": "cs:precise\/haproxy-32"
+        },
+        "55": {
+          "id": "cs:precise\/haproxy-33"
+        },
+        "56": {
+          "id": "cs:precise\/haproxy-34"
+        },
+        "57": {
+          "id": "cs:precise\/haproxy-35"
+        },
+        "58": {
+          "id": "cs:precise\/haproxy-4"
+        },
+        "59": {
+          "id": "cs:precise\/haproxy-5"
+        },
+        "60": {
+          "id": "cs:precise\/haproxy-6"
+        },
+        "61": {
+          "id": "cs:precise\/haproxy-7"
+        },
+        "62": {
+          "id": "cs:precise\/haproxy-8"
+        },
+        "63": {
+          "id": "cs:precise\/haproxy-9"
+        },
+        "64": {
+          "id": "cs:precise\/landscape-client-10"
+        },
+        "65": {
+          "id": "cs:precise\/landscape-client-11"
+        },
+        "66": {
+          "id": "cs:precise\/landscape-client-12"
+        },
+        "67": {
+          "id": "cs:precise\/landscape-client-13"
+        },
+        "68": {
+          "id": "cs:precise\/landscape-client-14"
+        },
+        "69": {
+          "id": "cs:precise\/landscape-client-15"
+        },
+        "70": {
+          "id": "cs:precise\/landscape-client-16"
+        },
+        "71": {
+          "id": "cs:precise\/landscape-client-17"
+        },
+        "72": {
+          "id": "cs:precise\/landscape-client-18"
+        },
+        "73": {
+          "id": "cs:precise\/landscape-client-19"
+        },
+        "74": {
+          "id": "cs:precise\/landscape-client-6"
+        },
+        "75": {
+          "id": "cs:precise\/landscape-client-7"
+        },
+        "76": {
+          "id": "cs:precise\/landscape-client-8"
+        },
+        "77": {
+          "id": "cs:precise\/landscape-client-9"
+        },
+        "78": {
+          "id": "cs:precise\/squid-reverseproxy-0"
+        },
+        "79": {
+          "id": "cs:precise\/squid-reverseproxy-1"
+        },
+        "80": {
+          "id": "cs:precise\/squid-reverseproxy-2"
+        },
+        "81": {
+          "id": "cs:precise\/squid-reverseproxy-3"
+        },
+        "82": {
+          "id": "cs:precise\/squid-reverseproxy-4"
+        },
+        "83": {
+          "id": "cs:precise\/squid-reverseproxy-5"
+        },
+        "84": {
+          "id": "cs:precise\/squid-reverseproxy-6"
+        },
+        "85": {
+          "id": "cs:precise\/squid-reverseproxy-7"
+        },
+        "86": {
+          "id": "cs:precise\/squid-reverseproxy-8"
+        },
+        "87": {
+          "id": "cs:precise\/squid-reverseproxy-9"
+        },
+        "88": {
+          "id": "cs:precise\/varnish-0"
+        },
+        "89": {
+          "id": "cs:precise\/varnish-1"
+        },
+        "90": {
+          "id": "cs:precise\/varnish-2"
+        },
+        "91": {
+          "id": "cs:precise\/varnish-3"
+        },
+        "92": {
+          "id": "cs:precise\/varnish-4"
+        },
+        "93": {
+          "id": "cs:precise\/varnish-5"
+        },
+        "94": {
+          "id": "cs:precise\/varnish-6"
+        },
+        "95": {
+          "id": "cs:trusty\/apache2-1"
+        },
+        "96": {
+          "id": "cs:trusty\/apache2-10"
+        },
+        "97": {
+          "id": "cs:trusty\/apache2-11"
+        },
+        "98": {
+          "id": "cs:trusty\/apache2-12"
+        },
+        "99": {
+          "id": "cs:trusty\/apache2-2"
+        },
+        "100": {
+          "id": "cs:trusty\/apache2-3"
+        },
+        "101": {
+          "id": "cs:trusty\/apache2-4"
+        },
+        "102": {
+          "id": "cs:trusty\/apache2-5"
+        },
+        "103": {
+          "id": "cs:trusty\/apache2-6"
+        },
+        "104": {
+          "id": "cs:trusty\/apache2-7"
+        },
+        "105": {
+          "id": "cs:trusty\/apache2-8"
+        },
+        "106": {
+          "id": "cs:trusty\/apache2-9"
+        },
+        "107": {
+          "id": "cs:trusty\/haproxy-1"
+        },
+        "108": {
+          "id": "cs:trusty\/haproxy-2"
+        },
+        "109": {
+          "id": "cs:trusty\/haproxy-3"
+        },
+        "110": {
+          "id": "cs:trusty\/haproxy-4"
+        },
+        "111": {
+          "id": "cs:trusty\/squid-reverseproxy-0"
+        },
+        "112": {
+          "id": "cs:trusty\/squid-reverseproxy-1"
+        },
+        "113": {
+          "id": "cs:trusty\/varnish-1"
+        },
+        "114": {
+          "id": "cs:trusty\/wildfly-ha-master-0"
+        },
+        "115": {
+          "id": "cs:~0atman\/trusty\/wsgi-app-0"
+        },
+        "116": {
+          "id": "cs:~0atman\/trusty\/wsgi-app-1"
+        },
+        "117": {
+          "id": "cs:~0atman\/trusty\/wsgi-app-2"
+        },
+        "118": {
+          "id": "cs:~abentley\/precise\/apache2-reverseproxy-0"
+        },
+        "119": {
+          "id": "cs:~abentley\/precise\/apache2-reverseproxy-1"
+        },
+        "120": {
+          "id": "cs:~abentley\/precise\/apache2-reverseproxy-2"
+        },
+        "121": {
+          "id": "cs:~abentley\/precise\/apache2-reverseproxy-3"
+        },
+        "122": {
+          "id": "cs:~abentley\/precise\/apache2-reverseproxy-4"
+        },
+        "123": {
+          "id": "cs:~abentley\/trusty\/apache2-reverseproxy-0"
+        },
+        "124": {
+          "id": "cs:~abentley\/trusty\/apache2-reverseproxy-1"
+        },
+        "125": {
+          "id": "cs:~abentley\/trusty\/apache2-reverseproxy-2"
+        },
+        "126": {
+          "id": "cs:~abentley\/trusty\/apache2-reverseproxy-3"
+        },
+        "127": {
+          "id": "cs:~abentley\/trusty\/apache2-reverseproxy-4"
+        },
+        "128": {
+          "id": "cs:~alexlist\/precise\/squid-reverseproxy-0"
+        },
+        "129": {
+          "id": "cs:~alexlist\/precise\/squid-reverseproxy-1"
+        },
+        "130": {
+          "id": "cs:~alexlist\/precise\/squid-reverseproxy-2"
+        },
+        "131": {
+          "id": "cs:~alexlist\/precise\/squid-reverseproxy-3"
+        },
+        "132": {
+          "id": "cs:~alexlist\/precise\/squid-reverseproxy-4"
+        },
+        "133": {
+          "id": "cs:~alexlist\/precise\/squid-reverseproxy-5"
+        },
+        "134": {
+          "id": "cs:~alexlist\/precise\/squid-reverseproxy-6"
+        },
+        "135": {
+          "id": "cs:~bac\/precise\/charmworld-0"
+        },
+        "136": {
+          "id": "cs:~bac\/precise\/charmworld-1"
+        },
+        "137": {
+          "id": "cs:~bcsaller\/precise\/restcomm-0"
+        },
+        "138": {
+          "id": "cs:~bigdata-dev\/trusty\/vstorm-vse-0"
+        },
+        "139": {
+          "id": "cs:~bloodearnest\/precise\/squid-reverseproxy-0"
+        },
+        "140": {
+          "id": "cs:~brian-albrecht\/trusty\/haproxy-0"
+        },
+        "141": {
+          "id": "cs:~bzr-sync\/trusty\/wsgi-app-0"
+        },
+        "142": {
+          "id": "cs:~bzr-sync\/trusty\/wsgi-app-1"
+        },
+        "143": {
+          "id": "cs:~bzr-sync\/trusty\/wsgi-app-10"
+        },
+        "144": {
+          "id": "cs:~bzr-sync\/trusty\/wsgi-app-11"
+        },
+        "145": {
+          "id": "cs:~bzr-sync\/trusty\/wsgi-app-12"
+        },
+        "146": {
+          "id": "cs:~bzr-sync\/trusty\/wsgi-app-13"
+        },
+        "147": {
+          "id": "cs:~bzr-sync\/trusty\/wsgi-app-14"
+        },
+        "148": {
+          "id": "cs:~bzr-sync\/trusty\/wsgi-app-15"
+        },
+        "149": {
+          "id": "cs:~bzr-sync\/trusty\/wsgi-app-2"
+        },
+        "150": {
+          "id": "cs:~bzr-sync\/trusty\/wsgi-app-3"
+        },
+        "151": {
+          "id": "cs:~bzr-sync\/trusty\/wsgi-app-4"
+        },
+        "152": {
+          "id": "cs:~bzr-sync\/trusty\/wsgi-app-5"
+        },
+        "153": {
+          "id": "cs:~bzr-sync\/trusty\/wsgi-app-6"
+        },
+        "154": {
+          "id": "cs:~bzr-sync\/trusty\/wsgi-app-7"
+        },
+        "155": {
+          "id": "cs:~bzr-sync\/trusty\/wsgi-app-8"
+        },
+        "156": {
+          "id": "cs:~bzr-sync\/trusty\/wsgi-app-9"
+        },
+        "157": {
+          "id": "cs:~caio1982\/trusty\/system-image-server-0"
+        },
+        "158": {
+          "id": "cs:~caio1982\/trusty\/system-image-server-1"
+        },
+        "159": {
+          "id": "cs:~caio1982\/trusty\/system-image-server-10"
+        },
+        "160": {
+          "id": "cs:~caio1982\/trusty\/system-image-server-11"
+        },
+        "161": {
+          "id": "cs:~caio1982\/trusty\/system-image-server-12"
+        },
+        "162": {
+          "id": "cs:~caio1982\/trusty\/system-image-server-13"
+        },
+        "163": {
+          "id": "cs:~caio1982\/trusty\/system-image-server-14"
+        },
+        "164": {
+          "id": "cs:~caio1982\/trusty\/system-image-server-15"
+        },
+        "165": {
+          "id": "cs:~caio1982\/trusty\/system-image-server-16"
+        },
+        "166": {
+          "id": "cs:~caio1982\/trusty\/system-image-server-17"
+        },
+        "167": {
+          "id": "cs:~caio1982\/trusty\/system-image-server-18"
+        },
+        "168": {
+          "id": "cs:~caio1982\/trusty\/system-image-server-19"
+        },
+        "169": {
+          "id": "cs:~caio1982\/trusty\/system-image-server-2"
+        },
+        "170": {
+          "id": "cs:~caio1982\/trusty\/system-image-server-20"
+        },
+        "171": {
+          "id": "cs:~caio1982\/trusty\/system-image-server-21"
+        },
+        "172": {
+          "id": "cs:~caio1982\/trusty\/system-image-server-22"
+        },
+        "173": {
+          "id": "cs:~caio1982\/trusty\/system-image-server-23"
+        },
+        "174": {
+          "id": "cs:~caio1982\/trusty\/system-image-server-24"
+        },
+        "175": {
+          "id": "cs:~caio1982\/trusty\/system-image-server-25"
+        },
+        "176": {
+          "id": "cs:~caio1982\/trusty\/system-image-server-26"
+        },
+        "177": {
+          "id": "cs:~caio1982\/trusty\/system-image-server-27"
+        },
+        "178": {
+          "id": "cs:~caio1982\/trusty\/system-image-server-3"
+        },
+        "179": {
+          "id": "cs:~caio1982\/trusty\/system-image-server-4"
+        },
+        "180": {
+          "id": "cs:~caio1982\/trusty\/system-image-server-5"
+        },
+        "181": {
+          "id": "cs:~caio1982\/trusty\/system-image-server-6"
+        },
+        "182": {
+          "id": "cs:~caio1982\/trusty\/system-image-server-7"
+        },
+        "183": {
+          "id": "cs:~caio1982\/trusty\/system-image-server-8"
+        },
+        "184": {
+          "id": "cs:~caio1982\/trusty\/system-image-server-9"
+        },
+        "185": {
+          "id": "cs:~canonical-ci-engineering\/precise\/uci-engine-lander-0"
+        },
+        "186": {
+          "id": "cs:~canonical-ci-engineering\/precise\/uci-engine-lander-1"
+        },
+        "187": {
+          "id": "cs:~canonical-ci-engineering\/precise\/uci-engine-system-image-server-0"
+        },
+        "188": {
+          "id": "cs:~canonical-ci-engineering\/precise\/uci-engine-wsgi-app-0"
+        },
+        "189": {
+          "id": "cs:~canonical-ci-engineering\/precise\/uci-engine-wsgi-app-1"
+        },
+        "190": {
+          "id": "cs:~canonical-ci\/precise\/oil-qmaster-0"
+        },
+        "191": {
+          "id": "cs:~cf-charmers\/trusty\/cf-hm9000-1"
+        },
+        "192": {
+          "id": "cs:~cf-charmers\/trusty\/cloud-controller-clock-v1-0"
+        },
+        "193": {
+          "id": "cs:~cf-charmers\/trusty\/cloud-controller-clock-v1-1"
+        },
+        "194": {
+          "id": "cs:~cf-charmers\/trusty\/cloud-controller-clock-v1-2"
+        },
+        "195": {
+          "id": "cs:~cf-charmers\/trusty\/cloud-controller-clock-v2-0"
+        },
+        "196": {
+          "id": "cs:~cf-charmers\/trusty\/cloud-controller-clock-v2-1"
+        },
+        "197": {
+          "id": "cs:~cf-charmers\/trusty\/cloud-controller-clock-v2-2"
+        },
+        "198": {
+          "id": "cs:~cf-charmers\/trusty\/cloud-controller-v1-0"
+        },
+        "199": {
+          "id": "cs:~cf-charmers\/trusty\/cloud-controller-v1-1"
+        },
+        "200": {
+          "id": "cs:~cf-charmers\/trusty\/cloud-controller-v1-2"
+        },
+        "201": {
+          "id": "cs:~cf-charmers\/trusty\/cloud-controller-v2-0"
+        },
+        "202": {
+          "id": "cs:~cf-charmers\/trusty\/cloud-controller-v2-1"
+        },
+        "203": {
+          "id": "cs:~cf-charmers\/trusty\/cloud-controller-v2-2"
+        },
+        "204": {
+          "id": "cs:~cf-charmers\/trusty\/cloud-controller-worker-v1-0"
+        },
+        "205": {
+          "id": "cs:~cf-charmers\/trusty\/cloud-controller-worker-v1-1"
+        },
+        "206": {
+          "id": "cs:~cf-charmers\/trusty\/cloud-controller-worker-v1-2"
+        },
+        "207": {
+          "id": "cs:~cf-charmers\/trusty\/cloud-controller-worker-v2-0"
+        },
+        "208": {
+          "id": "cs:~cf-charmers\/trusty\/cloud-controller-worker-v2-1"
+        },
+        "209": {
+          "id": "cs:~cf-charmers\/trusty\/cloud-controller-worker-v2-2"
+        },
+        "210": {
+          "id": "cs:~cf-charmers\/trusty\/haproxy-v1-0"
+        },
+        "211": {
+          "id": "cs:~cf-charmers\/trusty\/haproxy-v1-1"
+        },
+        "212": {
+          "id": "cs:~cf-charmers\/trusty\/haproxy-v1-2"
+        },
+        "213": {
+          "id": "cs:~cf-charmers\/trusty\/haproxy-v1-3"
+        },
+        "214": {
+          "id": "cs:~cf-charmers\/trusty\/haproxy-v1-4"
+        },
+        "215": {
+          "id": "cs:~cf-charmers\/trusty\/haproxy-v1-5"
+        },
+        "216": {
+          "id": "cs:~cf-charmers\/trusty\/haproxy-v1-6"
+        },
+        "217": {
+          "id": "cs:~cf-charmers\/trusty\/login-v1-0"
+        },
+        "218": {
+          "id": "cs:~cf-charmers\/trusty\/login-v1-1"
+        },
+        "219": {
+          "id": "cs:~cf-charmers\/trusty\/login-v1-2"
+        },
+        "220": {
+          "id": "cs:~charmers\/oneiric\/haproxy-0"
+        },
+        "221": {
+          "id": "cs:~charmers\/precise\/apache2-0"
+        },
+        "222": {
+          "id": "cs:~charmers\/precise\/apache2-1"
+        },
+        "223": {
+          "id": "cs:~charmers\/precise\/apache2-10"
+        },
+        "224": {
+          "id": "cs:~charmers\/precise\/apache2-11"
+        },
+        "225": {
+          "id": "cs:~charmers\/precise\/apache2-12"
+        },
+        "226": {
+          "id": "cs:~charmers\/precise\/apache2-13"
+        },
+        "227": {
+          "id": "cs:~charmers\/precise\/apache2-14"
+        },
+        "228": {
+          "id": "cs:~charmers\/precise\/apache2-15"
+        },
+        "229": {
+          "id": "cs:~charmers\/precise\/apache2-16"
+        },
+        "230": {
+          "id": "cs:~charmers\/precise\/apache2-17"
+        },
+        "231": {
+          "id": "cs:~charmers\/precise\/apache2-18"
+        },
+        "232": {
+          "id": "cs:~charmers\/precise\/apache2-19"
+        },
+        "233": {
+          "id": "cs:~charmers\/precise\/apache2-2"
+        },
+        "234": {
+          "id": "cs:~charmers\/precise\/apache2-20"
+        },
+        "235": {
+          "id": "cs:~charmers\/precise\/apache2-21"
+        },
+        "236": {
+          "id": "cs:~charmers\/precise\/apache2-22"
+        },
+        "237": {
+          "id": "cs:~charmers\/precise\/apache2-23"
+        },
+        "238": {
+          "id": "cs:~charmers\/precise\/apache2-24"
+        },
+        "239": {
+          "id": "cs:~charmers\/precise\/apache2-25"
+        },
+        "240": {
+          "id": "cs:~charmers\/precise\/apache2-26"
+        },
+        "241": {
+          "id": "cs:~charmers\/precise\/apache2-27"
+        },
+        "242": {
+          "id": "cs:~charmers\/precise\/apache2-3"
+        },
+        "243": {
+          "id": "cs:~charmers\/precise\/apache2-4"
+        },
+        "244": {
+          "id": "cs:~charmers\/precise\/apache2-5"
+        },
+        "245": {
+          "id": "cs:~charmers\/precise\/apache2-6"
+        },
+        "246": {
+          "id": "cs:~charmers\/precise\/apache2-7"
+        },
+        "247": {
+          "id": "cs:~charmers\/precise\/apache2-8"
+        },
+        "248": {
+          "id": "cs:~charmers\/precise\/apache2-9"
+        },
+        "249": {
+          "id": "cs:~charmers\/precise\/haproxy-0"
+        },
+        "250": {
+          "id": "cs:~charmers\/precise\/haproxy-1"
+        },
+        "251": {
+          "id": "cs:~charmers\/precise\/haproxy-10"
+        },
+        "252": {
+          "id": "cs:~charmers\/precise\/haproxy-11"
+        },
+        "253": {
+          "id": "cs:~charmers\/precise\/haproxy-12"
+        },
+        "254": {
+          "id": "cs:~charmers\/precise\/haproxy-13"
+        },
+        "255": {
+          "id": "cs:~charmers\/precise\/haproxy-14"
+        },
+        "256": {
+          "id": "cs:~charmers\/precise\/haproxy-15"
+        },
+        "257": {
+          "id": "cs:~charmers\/precise\/haproxy-16"
+        },
+        "258": {
+          "id": "cs:~charmers\/precise\/haproxy-17"
+        },
+        "259": {
+          "id": "cs:~charmers\/precise\/haproxy-18"
+        },
+        "260": {
+          "id": "cs:~charmers\/precise\/haproxy-19"
+        },
+        "261": {
+          "id": "cs:~charmers\/precise\/haproxy-2"
+        },
+        "262": {
+          "id": "cs:~charmers\/precise\/haproxy-20"
+        },
+        "263": {
+          "id": "cs:~charmers\/precise\/haproxy-21"
+        },
+        "264": {
+          "id": "cs:~charmers\/precise\/haproxy-22"
+        },
+        "265": {
+          "id": "cs:~charmers\/precise\/haproxy-23"
+        },
+        "266": {
+          "id": "cs:~charmers\/precise\/haproxy-24"
+        },
+        "267": {
+          "id": "cs:~charmers\/precise\/haproxy-25"
+        },
+        "268": {
+          "id": "cs:~charmers\/precise\/haproxy-26"
+        },
+        "269": {
+          "id": "cs:~charmers\/precise\/haproxy-27"
+        },
+        "270": {
+          "id": "cs:~charmers\/precise\/haproxy-28"
+        },
+        "271": {
+          "id": "cs:~charmers\/precise\/haproxy-29"
+        },
+        "272": {
+          "id": "cs:~charmers\/precise\/haproxy-3"
+        },
+        "273": {
+          "id": "cs:~charmers\/precise\/haproxy-30"
+        },
+        "274": {
+          "id": "cs:~charmers\/precise\/haproxy-31"
+        },
+        "275": {
+          "id": "cs:~charmers\/precise\/haproxy-32"
+        },
+        "276": {
+          "id": "cs:~charmers\/precise\/haproxy-33"
+        },
+        "277": {
+          "id": "cs:~charmers\/precise\/haproxy-34"
+        },
+        "278": {
+          "id": "cs:~charmers\/precise\/haproxy-35"
+        },
+        "279": {
+          "id": "cs:~charmers\/precise\/haproxy-4"
+        },
+        "280": {
+          "id": "cs:~charmers\/precise\/haproxy-5"
+        },
+        "281": {
+          "id": "cs:~charmers\/precise\/haproxy-6"
+        },
+        "282": {
+          "id": "cs:~charmers\/precise\/haproxy-7"
+        },
+        "283": {
+          "id": "cs:~charmers\/precise\/haproxy-8"
+        },
+        "284": {
+          "id": "cs:~charmers\/precise\/haproxy-9"
+        },
+        "285": {
+          "id": "cs:~charmers\/precise\/landscape-client-6"
+        },
+        "286": {
+          "id": "cs:~charmers\/precise\/squid-reverseproxy-0"
+        },
+        "287": {
+          "id": "cs:~charmers\/precise\/squid-reverseproxy-1"
+        },
+        "288": {
+          "id": "cs:~charmers\/precise\/squid-reverseproxy-2"
+        },
+        "289": {
+          "id": "cs:~charmers\/precise\/squid-reverseproxy-3"
+        },
+        "290": {
+          "id": "cs:~charmers\/precise\/squid-reverseproxy-4"
+        },
+        "291": {
+          "id": "cs:~charmers\/precise\/squid-reverseproxy-5"
+        },
+        "292": {
+          "id": "cs:~charmers\/precise\/squid-reverseproxy-6"
+        },
+        "293": {
+          "id": "cs:~charmers\/precise\/squid-reverseproxy-7"
+        },
+        "294": {
+          "id": "cs:~charmers\/precise\/squid-reverseproxy-8"
+        },
+        "295": {
+          "id": "cs:~charmers\/precise\/squid-reverseproxy-9"
+        },
+        "296": {
+          "id": "cs:~charmers\/precise\/varnish-0"
+        },
+        "297": {
+          "id": "cs:~charmers\/precise\/varnish-1"
+        },
+        "298": {
+          "id": "cs:~charmers\/precise\/varnish-2"
+        },
+        "299": {
+          "id": "cs:~charmers\/precise\/varnish-3"
+        },
+        "300": {
+          "id": "cs:~charmers\/precise\/varnish-4"
+        },
+        "301": {
+          "id": "cs:~charmers\/precise\/varnish-5"
+        },
+        "302": {
+          "id": "cs:~charmers\/precise\/varnish-6"
+        },
+        "303": {
+          "id": "cs:~charmers\/trusty\/apache2-0"
+        },
+        "304": {
+          "id": "cs:~charmers\/trusty\/apache2-1"
+        },
+        "305": {
+          "id": "cs:~charmers\/trusty\/apache2-10"
+        },
+        "306": {
+          "id": "cs:~charmers\/trusty\/apache2-11"
+        },
+        "307": {
+          "id": "cs:~charmers\/trusty\/apache2-12"
+        },
+        "308": {
+          "id": "cs:~charmers\/trusty\/apache2-2"
+        },
+        "309": {
+          "id": "cs:~charmers\/trusty\/apache2-3"
+        },
+        "310": {
+          "id": "cs:~charmers\/trusty\/apache2-4"
+        },
+        "311": {
+          "id": "cs:~charmers\/trusty\/apache2-5"
+        },
+        "312": {
+          "id": "cs:~charmers\/trusty\/apache2-6"
+        },
+        "313": {
+          "id": "cs:~charmers\/trusty\/apache2-7"
+        },
+        "314": {
+          "id": "cs:~charmers\/trusty\/apache2-8"
+        },
+        "315": {
+          "id": "cs:~charmers\/trusty\/apache2-9"
+        },
+        "316": {
+          "id": "cs:~charmers\/trusty\/haproxy-0"
+        },
+        "317": {
+          "id": "cs:~charmers\/trusty\/haproxy-1"
+        },
+        "318": {
+          "id": "cs:~charmers\/trusty\/haproxy-2"
+        },
+        "319": {
+          "id": "cs:~charmers\/trusty\/haproxy-3"
+        },
+        "320": {
+          "id": "cs:~charmers\/trusty\/haproxy-4"
+        },
+        "321": {
+          "id": "cs:~charmers\/trusty\/squid-reverseproxy-0"
+        },
+        "322": {
+          "id": "cs:~charmers\/trusty\/squid-reverseproxy-1"
+        },
+        "323": {
+          "id": "cs:~charmers\/trusty\/varnish-0"
+        },
+        "324": {
+          "id": "cs:~charmers\/trusty\/varnish-1"
+        },
+        "325": {
+          "id": "cs:~charmers\/trusty\/wildfly-ha-master-0"
+        },
+        "326": {
+          "id": "cs:~chrisdonati\/precise\/appinventor-0"
+        },
+        "327": {
+          "id": "cs:~chrisdonati\/precise\/appinventor-1"
+        },
+        "328": {
+          "id": "cs:~chrisdonati\/precise\/guestbook-0"
+        },
+        "329": {
+          "id": "cs:~chrisdonati\/precise\/guestbook-1"
+        },
+        "330": {
+          "id": "cs:~chrisdonati\/precise\/guestbook-2"
+        },
+        "331": {
+          "id": "cs:~clint-fewbar\/precise\/haproxy-0"
+        },
+        "332": {
+          "id": "cs:~clint-fewbar\/precise\/haproxy-1"
+        },
+        "333": {
+          "id": "cs:~cmars\/precise\/haproxy-0"
+        },
+        "334": {
+          "id": "cs:~cmars\/precise\/haproxy-1"
+        },
+        "335": {
+          "id": "cs:~cmars\/precise\/haproxy-2"
+        },
+        "336": {
+          "id": "cs:~cmars\/precise\/haproxy-3"
+        },
+        "337": {
+          "id": "cs:~cmars\/precise\/haproxy-4"
+        },
+        "338": {
+          "id": "cs:~cmars\/precise\/haproxy-5"
+        },
+        "339": {
+          "id": "cs:~ctap\/trusty\/hsenidmobile-ctap-doc-0"
+        },
+        "340": {
+          "id": "cs:~ctap\/trusty\/hsenidmobile-ctap-doc-1"
+        },
+        "341": {
+          "id": "cs:~ctap\/trusty\/hsenidmobile-ctap-doc-10"
+        },
+        "342": {
+          "id": "cs:~ctap\/trusty\/hsenidmobile-ctap-doc-2"
+        },
+        "343": {
+          "id": "cs:~ctap\/trusty\/hsenidmobile-ctap-doc-3"
+        },
+        "344": {
+          "id": "cs:~ctap\/trusty\/hsenidmobile-ctap-doc-4"
+        },
+        "345": {
+          "id": "cs:~ctap\/trusty\/hsenidmobile-ctap-doc-5"
+        },
+        "346": {
+          "id": "cs:~ctap\/trusty\/hsenidmobile-ctap-doc-6"
+        },
+        "347": {
+          "id": "cs:~ctap\/trusty\/hsenidmobile-ctap-doc-7"
+        },
+        "348": {
+          "id": "cs:~ctap\/trusty\/hsenidmobile-ctap-doc-8"
+        },
+        "349": {
+          "id": "cs:~ctap\/trusty\/hsenidmobile-ctap-doc-9"
+        },
+        "350": {
+          "id": "cs:~ctap\/trusty\/hsenidmobile-ctap-sampleapp-0"
+        },
+        "351": {
+          "id": "cs:~ctap\/trusty\/hsenidmobile-ctap-sampleapp-1"
+        },
+        "352": {
+          "id": "cs:~ctap\/trusty\/hsenidmobile-ctap-sampleapp-2"
+        },
+        "353": {
+          "id": "cs:~ctap\/trusty\/hsenidmobile-ctap-sampleapp-3"
+        },
+        "354": {
+          "id": "cs:~ctap\/trusty\/hsenidmobile-ctap-sampleapp-4"
+        },
+        "355": {
+          "id": "cs:~ctap\/trusty\/hsenidmobile-ctap-sampleapp-5"
+        },
+        "356": {
+          "id": "cs:~dannf\/precise\/siege-0"
+        },
+        "357": {
+          "id": "cs:~dannf\/precise\/siege-1"
+        },
+        "358": {
+          "id": "cs:~dannf\/precise\/siege-2"
+        },
+        "359": {
+          "id": "cs:~dannf\/precise\/siege-3"
+        },
+        "360": {
+          "id": "cs:~dannf\/precise\/siege-4"
+        },
+        "361": {
+          "id": "cs:~davidpbritton\/precise\/apache2-0"
+        },
+        "362": {
+          "id": "cs:~davidpbritton\/precise\/apache2-1"
+        },
+        "363": {
+          "id": "cs:~davidpbritton\/precise\/apache2-2"
+        },
+        "364": {
+          "id": "cs:~davidpbritton\/precise\/apache2-3"
+        },
+        "365": {
+          "id": "cs:~davidpbritton\/precise\/apache2-4"
+        },
+        "366": {
+          "id": "cs:~davidpbritton\/precise\/haproxy-0"
+        },
+        "367": {
+          "id": "cs:~davidpbritton\/precise\/haproxy-1"
+        },
+        "368": {
+          "id": "cs:~davidpbritton\/precise\/haproxy-2"
+        },
+        "369": {
+          "id": "cs:~davidpbritton\/precise\/haproxy-3"
+        },
+        "370": {
+          "id": "cs:~davidpbritton\/precise\/haproxy-4"
+        },
+        "371": {
+          "id": "cs:~davidpbritton\/precise\/haproxy-5"
+        },
+        "372": {
+          "id": "cs:~davidpbritton\/precise\/landscape-client-1"
+        },
+        "373": {
+          "id": "cs:~ericsnowcurrently\/precise\/reviewboard-oauth-0"
+        },
+        "374": {
+          "id": "cs:~ericsnowcurrently\/precise\/reviewboard-oauth-1"
+        },
+        "375": {
+          "id": "cs:~ericsnowcurrently\/precise\/reviewboard-oauth-2"
+        },
+        "376": {
+          "id": "cs:~ericsnowcurrently\/precise\/reviewboard-oauth-3"
+        },
+        "377": {
+          "id": "cs:~ericsnowcurrently\/precise\/reviewboard-oauth-4"
+        },
+        "378": {
+          "id": "cs:~ericsnowcurrently\/precise\/reviewboard-oauth-5"
+        },
+        "379": {
+          "id": "cs:~ericsnowcurrently\/trusty\/reviewboard-oauth-0"
+        },
+        "380": {
+          "id": "cs:~ericsnowcurrently\/trusty\/reviewboard-oauth-1"
+        },
+        "381": {
+          "id": "cs:~ericsnowcurrently\/trusty\/reviewboard-oauth-2"
+        },
+        "382": {
+          "id": "cs:~ericsnowcurrently\/trusty\/reviewboard-oauth-3"
+        },
+        "383": {
+          "id": "cs:~ericsnowcurrently\/trusty\/reviewboard-oauth-4"
+        },
+        "384": {
+          "id": "cs:~flepied\/precise\/haproxy-0"
+        },
+        "385": {
+          "id": "cs:~flepied\/precise\/naxsi-0"
+        },
+        "386": {
+          "id": "cs:~gnuoy\/precise\/apache2-0"
+        },
+        "387": {
+          "id": "cs:~gnuoy\/precise\/apache2-1"
+        },
+        "388": {
+          "id": "cs:~hazmat\/precise\/aws-elb-0"
+        },
+        "389": {
+          "id": "cs:~hazmat\/precise\/aws-elb-1"
+        },
+        "390": {
+          "id": "cs:~hazmat\/precise\/aws-elb-2"
+        },
+        "391": {
+          "id": "cs:~hazmat\/precise\/aws-elb-3"
+        },
+        "392": {
+          "id": "cs:~hazmat\/precise\/aws-elb-4"
+        },
+        "393": {
+          "id": "cs:~hazmat\/precise\/aws-elb-5"
+        },
+        "394": {
+          "id": "cs:~hloeung\/precise\/apache2-0"
+        },
+        "395": {
+          "id": "cs:~hloeung\/precise\/apache2-1"
+        },
+        "396": {
+          "id": "cs:~hloeung\/precise\/apache2-2"
+        },
+        "397": {
+          "id": "cs:~hloeung\/precise\/varnish-0"
+        },
+        "398": {
+          "id": "cs:~hloeung\/precise\/varnish-1"
+        },
+        "399": {
+          "id": "cs:~hloeung\/precise\/varnish-2"
+        },
+        "400": {
+          "id": "cs:~hloeung\/precise\/varnish-3"
+        },
+        "401": {
+          "id": "cs:~hloeung\/precise\/varnish-4"
+        },
+        "402": {
+          "id": "cs:~hp-discover\/trusty\/nginx-proxy-0"
+        },
+        "403": {
+          "id": "cs:~hp-discover\/trusty\/nginx-proxy-1"
+        },
+        "404": {
+          "id": "cs:~hp-discover\/trusty\/nginx-proxy-2"
+        },
+        "405": {
+          "id": "cs:~hp-discover\/trusty\/nginx-proxy-3"
+        },
+        "406": {
+          "id": "cs:~ibm-demo\/trusty\/apache2-0"
+        },
+        "407": {
+          "id": "cs:~ibm-demo\/trusty\/apache2-1"
+        },
+        "408": {
+          "id": "cs:~ibm-demo\/trusty\/haproxy-0"
+        },
+        "409": {
+          "id": "cs:~ibm-demo\/trusty\/haproxy-1"
+        },
+        "410": {
+          "id": "cs:~ibm-demo\/trusty\/haproxy-2"
+        },
+        "411": {
+          "id": "cs:~ibm-demo\/trusty\/squid-reverseproxy-0"
+        },
+        "412": {
+          "id": "cs:~ibm-demo\/trusty\/varnish-0"
+        },
+        "413": {
+          "id": "cs:~imbrandon\/precise\/newrelic-php-0"
+        },
+        "414": {
+          "id": "cs:~imbrandon\/precise\/nginx-proxy-0"
+        },
+        "415": {
+          "id": "cs:~imbrandon\/precise\/nginx-proxy-1"
+        },
+        "416": {
+          "id": "cs:~imbrandon\/precise\/nginx-proxy-2"
+        },
+        "417": {
+          "id": "cs:~imbrandon\/precise\/nginx-proxy-3"
+        },
+        "418": {
+          "id": "cs:~imbrandon\/precise\/nginx-proxy-4"
+        },
+        "419": {
+          "id": "cs:~james-sapara\/precise\/aws-ec2-elb-0"
+        },
+        "420": {
+          "id": "cs:~james-sapara\/precise\/aws-ec2-elb-1"
+        },
+        "421": {
+          "id": "cs:~jhasaurabh\/trusty\/wildfly-ha-master-1"
+        },
+        "422": {
+          "id": "cs:~jhasaurabh\/trusty\/wildfly-ha-master-2"
+        },
+        "423": {
+          "id": "cs:~jhasaurabh\/trusty\/wildfly-ha-master-3"
+        },
+        "424": {
+          "id": "cs:~jhasaurabh\/trusty\/wildfly-ha-master-4"
+        },
+        "425": {
+          "id": "cs:~jjo\/precise\/httpload-0"
+        },
+        "426": {
+          "id": "cs:~jjo\/precise\/httpload-1"
+        },
+        "427": {
+          "id": "cs:~jjo\/precise\/httpload-2"
+        },
+        "428": {
+          "id": "cs:~jjo\/precise\/httpload-3"
+        },
+        "429": {
+          "id": "cs:~jjo\/precise\/httpload-4"
+        },
+        "430": {
+          "id": "cs:~jjo\/precise\/httpload-5"
+        },
+        "431": {
+          "id": "cs:~jmit\/oneiric\/proxy-0"
+        },
+        "432": {
+          "id": "cs:~johnsca\/trusty\/cloud-controller-clock-v1-0"
+        },
+        "433": {
+          "id": "cs:~johnsca\/trusty\/cloud-controller-clock-v2-0"
+        },
+        "434": {
+          "id": "cs:~johnsca\/trusty\/cloud-controller-v1-0"
+        },
+        "435": {
+          "id": "cs:~johnsca\/trusty\/cloud-controller-v2-0"
+        },
+        "436": {
+          "id": "cs:~johnsca\/trusty\/cloud-controller-worker-v1-0"
+        },
+        "437": {
+          "id": "cs:~johnsca\/trusty\/cloud-controller-worker-v2-0"
+        },
+        "438": {
+          "id": "cs:~johnsca\/trusty\/haproxy-v1-0"
+        },
+        "439": {
+          "id": "cs:~johnsca\/trusty\/login-v1-0"
+        },
+        "440": {
+          "id": "cs:~johnsca\/trusty\/wildfly-ha-master-0"
+        },
+        "441": {
+          "id": "cs:~jseutter\/precise\/haproxy-0"
+        },
+        "442": {
+          "id": "cs:~jseutter\/precise\/haproxy-1"
+        },
+        "443": {
+          "id": "cs:~jseutter\/precise\/haproxy-2"
+        },
+        "444": {
+          "id": "cs:~jseutter\/precise\/haproxy-3"
+        },
+        "445": {
+          "id": "cs:~jseutter\/precise\/haproxy-4"
+        },
+        "446": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-14"
+        },
+        "447": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-15"
+        },
+        "448": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-16"
+        },
+        "449": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-17"
+        },
+        "450": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-18"
+        },
+        "451": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-19"
+        },
+        "452": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-20"
+        },
+        "453": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-21"
+        },
+        "454": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-22"
+        },
+        "455": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-23"
+        },
+        "456": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-24"
+        },
+        "457": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-25"
+        },
+        "458": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-26"
+        },
+        "459": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-27"
+        },
+        "460": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-28"
+        },
+        "461": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-29"
+        },
+        "462": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-30"
+        },
+        "463": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-31"
+        },
+        "464": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-32"
+        },
+        "465": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-33"
+        },
+        "466": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-34"
+        },
+        "467": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-35"
+        },
+        "468": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-36"
+        },
+        "469": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-37"
+        },
+        "470": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-38"
+        },
+        "471": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-39"
+        },
+        "472": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-40"
+        },
+        "473": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-41"
+        },
+        "474": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-42"
+        },
+        "475": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-43"
+        },
+        "476": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-44"
+        },
+        "477": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-45"
+        },
+        "478": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-46"
+        },
+        "479": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-47"
+        },
+        "480": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-48"
+        },
+        "481": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-49"
+        },
+        "482": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-50"
+        },
+        "483": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-51"
+        },
+        "484": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-52"
+        },
+        "485": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-53"
+        },
+        "486": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-54"
+        },
+        "487": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-55"
+        },
+        "488": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-56"
+        },
+        "489": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-57"
+        },
+        "490": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-58"
+        },
+        "491": {
+          "id": "cs:~justin-fathomdb\/trusty\/haproxy-0"
+        },
+        "492": {
+          "id": "cs:~justin-fathomdb\/trusty\/haproxy-1"
+        },
+        "493": {
+          "id": "cs:~justin-fathomdb\/trusty\/haproxy-2"
+        },
+        "494": {
+          "id": "cs:~justin-fathomdb\/trusty\/haproxy-3"
+        },
+        "495": {
+          "id": "cs:~justin-fathomdb\/trusty\/haproxy-4"
+        },
+        "496": {
+          "id": "cs:~justin-fathomdb\/trusty\/haproxy-5"
+        },
+        "497": {
+          "id": "cs:~justin-fathomdb\/trusty\/haproxy-6"
+        },
+        "498": {
+          "id": "cs:~landscape-charmers\/precise\/landscape-client-0"
+        },
+        "499": {
+          "id": "cs:~landscape-charmers\/precise\/landscape-client-10"
+        },
+        "500": {
+          "id": "cs:~landscape-charmers\/precise\/landscape-client-11"
+        },
+        "501": {
+          "id": "cs:~landscape-charmers\/precise\/landscape-client-12"
+        },
+        "502": {
+          "id": "cs:~landscape-charmers\/precise\/landscape-client-13"
+        },
+        "503": {
+          "id": "cs:~landscape-charmers\/precise\/landscape-client-14"
+        },
+        "504": {
+          "id": "cs:~landscape-charmers\/precise\/landscape-client-15"
+        },
+        "505": {
+          "id": "cs:~landscape-charmers\/precise\/landscape-client-16"
+        },
+        "506": {
+          "id": "cs:~landscape-charmers\/precise\/landscape-client-17"
+        },
+        "507": {
+          "id": "cs:~landscape-charmers\/precise\/landscape-client-18"
+        },
+        "508": {
+          "id": "cs:~landscape-charmers\/precise\/landscape-client-19"
+        },
+        "509": {
+          "id": "cs:~landscape-charmers\/precise\/landscape-client-7"
+        },
+        "510": {
+          "id": "cs:~landscape-charmers\/precise\/landscape-client-8"
+        },
+        "511": {
+          "id": "cs:~landscape-charmers\/precise\/landscape-client-9"
+        },
+        "512": {
+          "id": "cs:~landscape\/trusty\/landscape-client-0"
+        },
+        "513": {
+          "id": "cs:~lazypower\/trusty\/haproxy-0"
+        },
+        "514": {
+          "id": "cs:~marcoceppi\/precise\/stingray-0"
+        },
+        "515": {
+          "id": "cs:~marcoceppi\/precise\/stingray-1"
+        },
+        "516": {
+          "id": "cs:~marcoceppi\/precise\/stingray-2"
+        },
+        "517": {
+          "id": "cs:~marcoceppi\/precise\/stingray-3"
+        },
+        "518": {
+          "id": "cs:~marcoceppi\/precise\/stingray-4"
+        },
+        "519": {
+          "id": "cs:~mark-mims\/oneiric\/varnish-0"
+        },
+        "520": {
+          "id": "cs:~mark-mims\/precise\/apache2-0"
+        },
+        "521": {
+          "id": "cs:~mark-mims\/precise\/apache2-1"
+        },
+        "522": {
+          "id": "cs:~mbruzek\/precise\/haproxy-0"
+        },
+        "523": {
+          "id": "cs:~mbruzek\/precise\/haproxy-1"
+        },
+        "524": {
+          "id": "cs:~mew\/precise\/squid-1"
+        },
+        "525": {
+          "id": "cs:~mew\/precise\/squid-2"
+        },
+        "526": {
+          "id": "cs:~mew\/precise\/squid-3"
+        },
+        "527": {
+          "id": "cs:~mew\/precise\/squid-4"
+        },
+        "528": {
+          "id": "cs:~mew\/precise\/squid-5"
+        },
+        "529": {
+          "id": "cs:~mew\/precise\/squid-6"
+        },
+        "530": {
+          "id": "cs:~mew\/precise\/squid-7"
+        },
+        "531": {
+          "id": "cs:~mew\/precise\/squid-8"
+        },
+        "532": {
+          "id": "cs:~mew\/precise\/squid-9"
+        },
+        "533": {
+          "id": "cs:~mreed8855\/precise\/apachebench-0"
+        },
+        "534": {
+          "id": "cs:~mreed8855\/precise\/apachebench-1"
+        },
+        "535": {
+          "id": "cs:~mreed8855\/precise\/apachebench-2"
+        },
+        "536": {
+          "id": "cs:~mreed8855\/precise\/apachebench-3"
+        },
+        "537": {
+          "id": "cs:~mreed8855\/precise\/apachebench-4"
+        },
+        "538": {
+          "id": "cs:~mreed8855\/precise\/apachebench-5"
+        },
+        "539": {
+          "id": "cs:~narindergupta\/trusty\/haproxy-0"
+        },
+        "540": {
+          "id": "cs:~nathwill-deactivatedaccount\/precise\/varnish-0"
+        },
+        "541": {
+          "id": "cs:~nottrobin\/trusty\/apache2-wsgi-0"
+        },
+        "542": {
+          "id": "cs:~nottrobin\/trusty\/apache2-wsgi-1"
+        },
+        "543": {
+          "id": "cs:~nottrobin\/trusty\/apache2-wsgi-10"
+        },
+        "544": {
+          "id": "cs:~nottrobin\/trusty\/apache2-wsgi-11"
+        },
+        "545": {
+          "id": "cs:~nottrobin\/trusty\/apache2-wsgi-12"
+        },
+        "546": {
+          "id": "cs:~nottrobin\/trusty\/apache2-wsgi-13"
+        },
+        "547": {
+          "id": "cs:~nottrobin\/trusty\/apache2-wsgi-14"
+        },
+        "548": {
+          "id": "cs:~nottrobin\/trusty\/apache2-wsgi-15"
+        },
+        "549": {
+          "id": "cs:~nottrobin\/trusty\/apache2-wsgi-16"
+        },
+        "550": {
+          "id": "cs:~nottrobin\/trusty\/apache2-wsgi-2"
+        },
+        "551": {
+          "id": "cs:~nottrobin\/trusty\/apache2-wsgi-3"
+        },
+        "552": {
+          "id": "cs:~nottrobin\/trusty\/apache2-wsgi-4"
+        },
+        "553": {
+          "id": "cs:~nottrobin\/trusty\/apache2-wsgi-5"
+        },
+        "554": {
+          "id": "cs:~nottrobin\/trusty\/apache2-wsgi-6"
+        },
+        "555": {
+          "id": "cs:~nottrobin\/trusty\/apache2-wsgi-7"
+        },
+        "556": {
+          "id": "cs:~nottrobin\/trusty\/apache2-wsgi-8"
+        },
+        "557": {
+          "id": "cs:~nottrobin\/trusty\/apache2-wsgi-9"
+        },
+        "558": {
+          "id": "cs:~pmcgarry\/quantal\/haproxy-0"
+        },
+        "559": {
+          "id": "cs:~samuel-cozannet\/trusty\/flight-delay-demo-0"
+        },
+        "560": {
+          "id": "cs:~samuel-cozannet\/trusty\/flight-delay-demo-1"
+        },
+        "561": {
+          "id": "cs:~samuel-cozannet\/trusty\/flight-delay-demo-2"
+        },
+        "562": {
+          "id": "cs:~samuel-cozannet\/trusty\/flight-delay-demo-3"
+        },
+        "563": {
+          "id": "cs:~samuel-cozannet\/trusty\/flight-delay-demo-4"
+        },
+        "564": {
+          "id": "cs:~samuel-cozannet\/trusty\/flight-delay-demo-5"
+        },
+        "565": {
+          "id": "cs:~samuel-cozannet\/trusty\/flight-delay-demo-6"
+        },
+        "566": {
+          "id": "cs:~samuel-cozannet\/trusty\/flight-delay-demo-7"
+        },
+        "567": {
+          "id": "cs:~samuel-cozannet\/trusty\/flight-delay-demo-8"
+        },
+        "568": {
+          "id": "cs:~samuel-cozannet\/trusty\/sentiment-analysis-frontend-0"
+        },
+        "569": {
+          "id": "cs:~samuel-cozannet\/trusty\/sentiment-analysis-frontend-1"
+        },
+        "570": {
+          "id": "cs:~samuel-cozannet\/trusty\/sentiment-analysis-frontend-2"
+        },
+        "571": {
+          "id": "cs:~samuel-cozannet\/trusty\/sentiment-analysis-frontend-3"
+        },
+        "572": {
+          "id": "cs:~samuel-cozannet\/trusty\/sentiment-analysis-frontend-4"
+        },
+        "573": {
+          "id": "cs:~samuel-cozannet\/trusty\/storm-twitter-0"
+        },
+        "574": {
+          "id": "cs:~samuel-cozannet\/trusty\/storm-twitter-1"
+        },
+        "575": {
+          "id": "cs:~samuel-cozannet\/trusty\/storm-twitter-2"
+        },
+        "576": {
+          "id": "cs:~samuel-cozannet\/trusty\/storm-twitter-3"
+        },
+        "577": {
+          "id": "cs:~samuel-cozannet\/trusty\/storm-twitter-4"
+        },
+        "578": {
+          "id": "cs:~samuel-cozannet\/trusty\/storm-twitter-5"
+        },
+        "579": {
+          "id": "cs:~samuel-cozannet\/trusty\/storm-twitter-6"
+        },
+        "580": {
+          "id": "cs:~samuel-cozannet\/trusty\/storm-twitter-7"
+        },
+        "581": {
+          "id": "cs:~sidnei\/precise\/apache2-0"
+        },
+        "582": {
+          "id": "cs:~sidnei\/precise\/apache2-1"
+        },
+        "583": {
+          "id": "cs:~sidnei\/precise\/apache2-10"
+        },
+        "584": {
+          "id": "cs:~sidnei\/precise\/apache2-11"
+        },
+        "585": {
+          "id": "cs:~sidnei\/precise\/apache2-12"
+        },
+        "586": {
+          "id": "cs:~sidnei\/precise\/apache2-13"
+        },
+        "587": {
+          "id": "cs:~sidnei\/precise\/apache2-14"
+        },
+        "588": {
+          "id": "cs:~sidnei\/precise\/apache2-15"
+        },
+        "589": {
+          "id": "cs:~sidnei\/precise\/apache2-16"
+        },
+        "590": {
+          "id": "cs:~sidnei\/precise\/apache2-17"
+        },
+        "591": {
+          "id": "cs:~sidnei\/precise\/apache2-18"
+        },
+        "592": {
+          "id": "cs:~sidnei\/precise\/apache2-19"
+        },
+        "593": {
+          "id": "cs:~sidnei\/precise\/apache2-2"
+        },
+        "594": {
+          "id": "cs:~sidnei\/precise\/apache2-20"
+        },
+        "595": {
+          "id": "cs:~sidnei\/precise\/apache2-21"
+        },
+        "596": {
+          "id": "cs:~sidnei\/precise\/apache2-22"
+        },
+        "597": {
+          "id": "cs:~sidnei\/precise\/apache2-23"
+        },
+        "598": {
+          "id": "cs:~sidnei\/precise\/apache2-24"
+        },
+        "599": {
+          "id": "cs:~sidnei\/precise\/apache2-25"
+        },
+        "600": {
+          "id": "cs:~sidnei\/precise\/apache2-26"
+        },
+        "601": {
+          "id": "cs:~sidnei\/precise\/apache2-27"
+        },
+        "602": {
+          "id": "cs:~sidnei\/precise\/apache2-28"
+        },
+        "603": {
+          "id": "cs:~sidnei\/precise\/apache2-29"
+        },
+        "604": {
+          "id": "cs:~sidnei\/precise\/apache2-3"
+        },
+        "605": {
+          "id": "cs:~sidnei\/precise\/apache2-30"
+        },
+        "606": {
+          "id": "cs:~sidnei\/precise\/apache2-31"
+        },
+        "607": {
+          "id": "cs:~sidnei\/precise\/apache2-4"
+        },
+        "608": {
+          "id": "cs:~sidnei\/precise\/apache2-5"
+        },
+        "609": {
+          "id": "cs:~sidnei\/precise\/apache2-6"
+        },
+        "610": {
+          "id": "cs:~sidnei\/precise\/apache2-7"
+        },
+        "611": {
+          "id": "cs:~sidnei\/precise\/apache2-8"
+        },
+        "612": {
+          "id": "cs:~sidnei\/precise\/apache2-9"
+        },
+        "613": {
+          "id": "cs:~sidnei\/precise\/haproxy-0"
+        },
+        "614": {
+          "id": "cs:~sidnei\/precise\/haproxy-1"
+        },
+        "615": {
+          "id": "cs:~sidnei\/precise\/haproxy-10"
+        },
+        "616": {
+          "id": "cs:~sidnei\/precise\/haproxy-11"
+        },
+        "617": {
+          "id": "cs:~sidnei\/precise\/haproxy-12"
+        },
+        "618": {
+          "id": "cs:~sidnei\/precise\/haproxy-13"
+        },
+        "619": {
+          "id": "cs:~sidnei\/precise\/haproxy-14"
+        },
+        "620": {
+          "id": "cs:~sidnei\/precise\/haproxy-15"
+        },
+        "621": {
+          "id": "cs:~sidnei\/precise\/haproxy-16"
+        },
+        "622": {
+          "id": "cs:~sidnei\/precise\/haproxy-17"
+        },
+        "623": {
+          "id": "cs:~sidnei\/precise\/haproxy-18"
+        },
+        "624": {
+          "id": "cs:~sidnei\/precise\/haproxy-19"
+        },
+        "625": {
+          "id": "cs:~sidnei\/precise\/haproxy-2"
+        },
+        "626": {
+          "id": "cs:~sidnei\/precise\/haproxy-20"
+        },
+        "627": {
+          "id": "cs:~sidnei\/precise\/haproxy-21"
+        },
+        "628": {
+          "id": "cs:~sidnei\/precise\/haproxy-22"
+        },
+        "629": {
+          "id": "cs:~sidnei\/precise\/haproxy-23"
+        },
+        "630": {
+          "id": "cs:~sidnei\/precise\/haproxy-24"
+        },
+        "631": {
+          "id": "cs:~sidnei\/precise\/haproxy-25"
+        },
+        "632": {
+          "id": "cs:~sidnei\/precise\/haproxy-26"
+        },
+        "633": {
+          "id": "cs:~sidnei\/precise\/haproxy-27"
+        },
+        "634": {
+          "id": "cs:~sidnei\/precise\/haproxy-28"
+        },
+        "635": {
+          "id": "cs:~sidnei\/precise\/haproxy-29"
+        },
+        "636": {
+          "id": "cs:~sidnei\/precise\/haproxy-3"
+        },
+        "637": {
+          "id": "cs:~sidnei\/precise\/haproxy-30"
+        },
+        "638": {
+          "id": "cs:~sidnei\/precise\/haproxy-31"
+        },
+        "639": {
+          "id": "cs:~sidnei\/precise\/haproxy-32"
+        },
+        "640": {
+          "id": "cs:~sidnei\/precise\/haproxy-33"
+        },
+        "641": {
+          "id": "cs:~sidnei\/precise\/haproxy-34"
+        },
+        "642": {
+          "id": "cs:~sidnei\/precise\/haproxy-35"
+        },
+        "643": {
+          "id": "cs:~sidnei\/precise\/haproxy-36"
+        },
+        "644": {
+          "id": "cs:~sidnei\/precise\/haproxy-37"
+        },
+        "645": {
+          "id": "cs:~sidnei\/precise\/haproxy-38"
+        },
+        "646": {
+          "id": "cs:~sidnei\/precise\/haproxy-39"
+        },
+        "647": {
+          "id": "cs:~sidnei\/precise\/haproxy-4"
+        },
+        "648": {
+          "id": "cs:~sidnei\/precise\/haproxy-40"
+        },
+        "649": {
+          "id": "cs:~sidnei\/precise\/haproxy-5"
+        },
+        "650": {
+          "id": "cs:~sidnei\/precise\/haproxy-6"
+        },
+        "651": {
+          "id": "cs:~sidnei\/precise\/haproxy-7"
+        },
+        "652": {
+          "id": "cs:~sidnei\/precise\/haproxy-8"
+        },
+        "653": {
+          "id": "cs:~sidnei\/precise\/haproxy-9"
+        },
+        "654": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-0"
+        },
+        "655": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-1"
+        },
+        "656": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-10"
+        },
+        "657": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-11"
+        },
+        "658": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-12"
+        },
+        "659": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-13"
+        },
+        "660": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-14"
+        },
+        "661": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-15"
+        },
+        "662": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-16"
+        },
+        "663": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-17"
+        },
+        "664": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-18"
+        },
+        "665": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-19"
+        },
+        "666": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-2"
+        },
+        "667": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-20"
+        },
+        "668": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-21"
+        },
+        "669": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-22"
+        },
+        "670": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-23"
+        },
+        "671": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-24"
+        },
+        "672": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-25"
+        },
+        "673": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-26"
+        },
+        "674": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-27"
+        },
+        "675": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-28"
+        },
+        "676": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-29"
+        },
+        "677": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-3"
+        },
+        "678": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-30"
+        },
+        "679": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-31"
+        },
+        "680": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-32"
+        },
+        "681": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-4"
+        },
+        "682": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-5"
+        },
+        "683": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-6"
+        },
+        "684": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-7"
+        },
+        "685": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-8"
+        },
+        "686": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-9"
+        },
+        "687": {
+          "id": "cs:~thedac\/precise\/apache2-0"
+        },
+        "688": {
+          "id": "cs:~thedac\/precise\/apache2-1"
+        },
+        "689": {
+          "id": "cs:~thedac\/precise\/apache2-2"
+        },
+        "690": {
+          "id": "cs:~thedac\/precise\/apache2-3"
+        },
+        "691": {
+          "id": "cs:~thedac\/precise\/apache2-4"
+        },
+        "692": {
+          "id": "cs:~webteam-backend\/precise\/apache2-0"
+        },
+        "693": {
+          "id": "cs:~webteam-backend\/trusty\/apache2-wsgi-0"
+        },
+        "694": {
+          "id": "cs:~webteam-backend\/trusty\/apache2-wsgi-1"
+        },
+        "695": {
+          "id": "cs:~webteam-backend\/trusty\/apache2-wsgi-2"
+        },
+        "696": {
+          "id": "cs:~webteam-backend\/trusty\/apache2-wsgi-3"
+        },
+        "697": {
+          "id": "cs:~webteam-backend\/trusty\/apache2-wsgi-4"
+        },
+        "698": {
+          "id": "cs:~webteam-backend\/trusty\/apache2-wsgi-5"
+        },
+        "699": {
+          "id": "cs:~webteam-backend\/trusty\/apache2-wsgi-6"
+        },
+        "700": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-43"
+        },
+        "701": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-44"
+        },
+        "702": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-45"
+        },
+        "703": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-51"
+        },
+        "704": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-52"
+        },
+        "705": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-53"
+        },
+        "706": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-54"
+        },
+        "707": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-55"
+        },
+        "708": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-56"
+        },
+        "709": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-57"
+        },
+        "710": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-58"
+        },
+        "711": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-59"
+        },
+        "712": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-60"
+        },
+        "713": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-61"
+        },
+        "714": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-62"
+        },
+        "715": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-63"
+        },
+        "716": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-64"
+        },
+        "717": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-65"
+        },
+        "718": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-66"
+        },
+        "719": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-67"
+        },
+        "720": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-68"
+        },
+        "721": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-69"
+        },
+        "722": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-70"
+        },
+        "723": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-71"
+        },
+        "724": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-72"
+        },
+        "725": {
+          "id": "cs:~x3v947pl\/trusty\/devicehive-lb-0"
+        }
+      },
+      "local-monitors": {
+        "0": {
+          "id": "cs:precise\/nrpe-1"
+        },
+        "1": {
+          "id": "cs:precise\/nrpe-2"
+        },
+        "2": {
+          "id": "cs:precise\/nrpe-3"
+        },
+        "3": {
+          "id": "cs:precise\/nrpe-4"
+        },
+        "4": {
+          "id": "cs:precise\/nrpe-5"
+        },
+        "5": {
+          "id": "cs:precise\/nrpe-6"
+        },
+        "6": {
+          "id": "cs:precise\/nrpe-7"
+        },
+        "7": {
+          "id": "cs:precise\/nrpe-8"
+        },
+        "8": {
+          "id": "cs:trusty\/nrpe-1"
+        },
+        "9": {
+          "id": "cs:~charm-demo\/trusty\/nrpe-0"
+        },
+        "10": {
+          "id": "cs:~charmers\/precise\/nrpe-0"
+        },
+        "11": {
+          "id": "cs:~charmers\/precise\/nrpe-1"
+        },
+        "12": {
+          "id": "cs:~charmers\/precise\/nrpe-2"
+        },
+        "13": {
+          "id": "cs:~charmers\/precise\/nrpe-3"
+        },
+        "14": {
+          "id": "cs:~charmers\/precise\/nrpe-4"
+        },
+        "15": {
+          "id": "cs:~charmers\/precise\/nrpe-5"
+        },
+        "16": {
+          "id": "cs:~charmers\/precise\/nrpe-6"
+        },
+        "17": {
+          "id": "cs:~charmers\/precise\/nrpe-7"
+        },
+        "18": {
+          "id": "cs:~charmers\/precise\/nrpe-8"
+        },
+        "19": {
+          "id": "cs:~charmers\/trusty\/nrpe-0"
+        },
+        "20": {
+          "id": "cs:~charmers\/trusty\/nrpe-1"
+        },
+        "21": {
+          "id": "cs:~clint-fewbar\/precise\/nrpe-0"
+        },
+        "22": {
+          "id": "cs:~clint-fewbar\/precise\/nrpe-1"
+        },
+        "23": {
+          "id": "cs:~clint-fewbar\/precise\/nrpe-2"
+        },
+        "24": {
+          "id": "cs:~clint-fewbar\/precise\/nrpe-3"
+        },
+        "25": {
+          "id": "cs:~clint-fewbar\/precise\/nrpe-4"
+        },
+        "26": {
+          "id": "cs:~clint-fewbar\/precise\/nrpe-5"
+        },
+        "27": {
+          "id": "cs:~ibm-demo\/trusty\/nrpe-0"
+        },
+        "28": {
+          "id": "cs:~rcj\/precise\/nrpe-0"
+        },
+        "29": {
+          "id": "cs:~rcj\/precise\/nrpe-1"
+        },
+        "30": {
+          "id": "cs:~rcj\/precise\/nrpe-2"
+        },
+        "31": {
+          "id": "cs:~rcj\/trusty\/nrpe-0"
+        },
+        "32": {
+          "id": "cs:~rcj\/trusty\/nrpe-1"
+        },
+        "33": {
+          "id": "cs:~rcj\/trusty\/nrpe-2"
+        },
+        "34": {
+          "id": "cs:~rcj\/trusty\/nrpe-3"
+        },
+        "35": {
+          "id": "cs:~rcj\/trusty\/nrpe-4"
+        },
+        "36": {
+          "id": "cs:~rcj\/trusty\/nrpe-5"
+        },
+        "37": {
+          "id": "cs:~rcj\/trusty\/nrpe-6"
+        },
+        "38": {
+          "id": "cs:~sidnei\/precise\/nrpe-0"
+        }
+      },
+      "nrpe-external-master": {
+        "0": {
+          "id": "cs:precise\/nova-compute-13"
+        },
+        "1": {
+          "id": "cs:precise\/nova-compute-14"
+        },
+        "2": {
+          "id": "cs:precise\/nova-compute-15"
+        },
+        "3": {
+          "id": "cs:precise\/nova-compute-16"
+        },
+        "4": {
+          "id": "cs:precise\/nova-compute-17"
+        },
+        "5": {
+          "id": "cs:precise\/nova-compute-18"
+        },
+        "6": {
+          "id": "cs:precise\/nova-compute-19"
+        },
+        "7": {
+          "id": "cs:precise\/nova-compute-20"
+        },
+        "8": {
+          "id": "cs:precise\/nova-compute-21"
+        },
+        "9": {
+          "id": "cs:precise\/nova-compute-22"
+        },
+        "10": {
+          "id": "cs:precise\/nova-compute-23"
+        },
+        "11": {
+          "id": "cs:precise\/nova-compute-24"
+        },
+        "12": {
+          "id": "cs:precise\/nova-compute-25"
+        },
+        "13": {
+          "id": "cs:precise\/nova-compute-26"
+        },
+        "14": {
+          "id": "cs:precise\/nova-compute-27"
+        },
+        "15": {
+          "id": "cs:precise\/nova-compute-28"
+        },
+        "16": {
+          "id": "cs:precise\/nova-compute-29"
+        },
+        "17": {
+          "id": "cs:precise\/nova-compute-30"
+        },
+        "18": {
+          "id": "cs:precise\/nova-compute-31"
+        },
+        "19": {
+          "id": "cs:precise\/nrpe-external-master-0"
+        },
+        "20": {
+          "id": "cs:precise\/nrpe-external-master-1"
+        },
+        "21": {
+          "id": "cs:precise\/nrpe-external-master-10"
+        },
+        "22": {
+          "id": "cs:precise\/nrpe-external-master-11"
+        },
+        "23": {
+          "id": "cs:precise\/nrpe-external-master-12"
+        },
+        "24": {
+          "id": "cs:precise\/nrpe-external-master-13"
+        },
+        "25": {
+          "id": "cs:precise\/nrpe-external-master-14"
+        },
+        "26": {
+          "id": "cs:precise\/nrpe-external-master-2"
+        },
+        "27": {
+          "id": "cs:precise\/nrpe-external-master-3"
+        },
+        "28": {
+          "id": "cs:precise\/nrpe-external-master-4"
+        },
+        "29": {
+          "id": "cs:precise\/nrpe-external-master-5"
+        },
+        "30": {
+          "id": "cs:precise\/nrpe-external-master-6"
+        },
+        "31": {
+          "id": "cs:precise\/nrpe-external-master-7"
+        },
+        "32": {
+          "id": "cs:precise\/nrpe-external-master-8"
+        },
+        "33": {
+          "id": "cs:precise\/nrpe-external-master-9"
+        },
+        "34": {
+          "id": "cs:precise\/rabbitmq-server-12"
+        },
+        "35": {
+          "id": "cs:precise\/rabbitmq-server-13"
+        },
+        "36": {
+          "id": "cs:precise\/rabbitmq-server-14"
+        },
+        "37": {
+          "id": "cs:precise\/rabbitmq-server-15"
+        },
+        "38": {
+          "id": "cs:trusty\/nova-compute-0"
+        },
+        "39": {
+          "id": "cs:trusty\/nova-compute-1"
+        },
+        "40": {
+          "id": "cs:trusty\/nova-compute-2"
+        },
+        "41": {
+          "id": "cs:trusty\/nova-compute-3"
+        },
+        "42": {
+          "id": "cs:trusty\/nova-compute-4"
+        },
+        "43": {
+          "id": "cs:trusty\/nova-compute-5"
+        },
+        "44": {
+          "id": "cs:~andybavier\/trusty\/nova-compute-0"
+        },
+        "45": {
+          "id": "cs:~andybavier\/trusty\/nova-compute-1"
+        },
+        "46": {
+          "id": "cs:~charmers\/precise\/nova-compute-13"
+        },
+        "47": {
+          "id": "cs:~charmers\/precise\/nova-compute-14"
+        },
+        "48": {
+          "id": "cs:~charmers\/precise\/nova-compute-15"
+        },
+        "49": {
+          "id": "cs:~charmers\/precise\/nova-compute-16"
+        },
+        "50": {
+          "id": "cs:~charmers\/precise\/nova-compute-17"
+        },
+        "51": {
+          "id": "cs:~charmers\/precise\/nova-compute-18"
+        },
+        "52": {
+          "id": "cs:~charmers\/precise\/nova-compute-19"
+        },
+        "53": {
+          "id": "cs:~charmers\/precise\/nova-compute-20"
+        },
+        "54": {
+          "id": "cs:~charmers\/precise\/nrpe-external-master-0"
+        },
+        "55": {
+          "id": "cs:~charmers\/precise\/nrpe-external-master-1"
+        },
+        "56": {
+          "id": "cs:~charmers\/precise\/nrpe-external-master-10"
+        },
+        "57": {
+          "id": "cs:~charmers\/precise\/nrpe-external-master-11"
+        },
+        "58": {
+          "id": "cs:~charmers\/precise\/nrpe-external-master-12"
+        },
+        "59": {
+          "id": "cs:~charmers\/precise\/nrpe-external-master-13"
+        },
+        "60": {
+          "id": "cs:~charmers\/precise\/nrpe-external-master-14"
+        },
+        "61": {
+          "id": "cs:~charmers\/precise\/nrpe-external-master-2"
+        },
+        "62": {
+          "id": "cs:~charmers\/precise\/nrpe-external-master-3"
+        },
+        "63": {
+          "id": "cs:~charmers\/precise\/nrpe-external-master-4"
+        },
+        "64": {
+          "id": "cs:~charmers\/precise\/nrpe-external-master-5"
+        },
+        "65": {
+          "id": "cs:~charmers\/precise\/nrpe-external-master-6"
+        },
+        "66": {
+          "id": "cs:~charmers\/precise\/nrpe-external-master-7"
+        },
+        "67": {
+          "id": "cs:~charmers\/precise\/nrpe-external-master-8"
+        },
+        "68": {
+          "id": "cs:~charmers\/precise\/nrpe-external-master-9"
+        },
+        "69": {
+          "id": "cs:~charmers\/precise\/rabbitmq-server-12"
+        },
+        "70": {
+          "id": "cs:~charmers\/precise\/rabbitmq-server-13"
+        },
+        "71": {
+          "id": "cs:~charmers\/precise\/rabbitmq-server-14"
+        },
+        "72": {
+          "id": "cs:~charmers\/precise\/rabbitmq-server-15"
+        },
+        "73": {
+          "id": "cs:~chris-gondolin\/precise\/nrpe-external-master-0"
+        },
+        "74": {
+          "id": "cs:~chris-gondolin\/precise\/nrpe-external-master-1"
+        },
+        "75": {
+          "id": "cs:~chris-gondolin\/precise\/nrpe-external-master-2"
+        },
+        "76": {
+          "id": "cs:~chris-gondolin\/precise\/nrpe-external-master-3"
+        },
+        "77": {
+          "id": "cs:~chris-gondolin\/precise\/nrpe-external-master-4"
+        },
+        "78": {
+          "id": "cs:~chris-gondolin\/precise\/nrpe-external-master-5"
+        },
+        "79": {
+          "id": "cs:~gnuoy\/trusty\/nrpe-external-master-0"
+        },
+        "80": {
+          "id": "cs:~gnuoy\/trusty\/nrpe-external-master-1"
+        },
+        "81": {
+          "id": "cs:~gnuoy\/trusty\/nrpe-external-master-2"
+        },
+        "82": {
+          "id": "cs:~ibm-charms\/trusty\/nova-compute-power-0"
+        },
+        "83": {
+          "id": "cs:~mmenkhof\/trusty\/nova-compute-0"
+        },
+        "84": {
+          "id": "cs:~mthaddon\/precise\/nrpe-external-master-0"
+        },
+        "85": {
+          "id": "cs:~mthaddon\/precise\/nrpe-external-master-1"
+        },
+        "86": {
+          "id": "cs:~mthaddon\/precise\/nrpe-external-master-2"
+        },
+        "87": {
+          "id": "cs:~nuclearbob\/trusty\/qlbr-10"
+        },
+        "88": {
+          "id": "cs:~nuclearbob\/trusty\/qlbr-11"
+        },
+        "89": {
+          "id": "cs:~nuclearbob\/trusty\/qlbr-12"
+        },
+        "90": {
+          "id": "cs:~nuclearbob\/trusty\/qlbr-13"
+        },
+        "91": {
+          "id": "cs:~nuclearbob\/trusty\/qlbr-2"
+        },
+        "92": {
+          "id": "cs:~nuclearbob\/trusty\/qlbr-3"
+        },
+        "93": {
+          "id": "cs:~nuclearbob\/trusty\/qlbr-4"
+        },
+        "94": {
+          "id": "cs:~nuclearbob\/trusty\/qlbr-5"
+        },
+        "95": {
+          "id": "cs:~nuclearbob\/trusty\/qlbr-6"
+        },
+        "96": {
+          "id": "cs:~nuclearbob\/trusty\/qlbr-7"
+        },
+        "97": {
+          "id": "cs:~nuclearbob\/trusty\/qlbr-8"
+        },
+        "98": {
+          "id": "cs:~nuclearbob\/trusty\/qlbr-9"
+        },
+        "99": {
+          "id": "cs:~openstack-charmers\/precise\/nova-compute-21"
+        },
+        "100": {
+          "id": "cs:~openstack-charmers\/precise\/nova-compute-22"
+        },
+        "101": {
+          "id": "cs:~openstack-charmers\/precise\/nova-compute-23"
+        },
+        "102": {
+          "id": "cs:~openstack-charmers\/precise\/nova-compute-24"
+        },
+        "103": {
+          "id": "cs:~openstack-charmers\/precise\/nova-compute-25"
+        },
+        "104": {
+          "id": "cs:~openstack-charmers\/precise\/nova-compute-26"
+        },
+        "105": {
+          "id": "cs:~openstack-charmers\/precise\/nova-compute-27"
+        },
+        "106": {
+          "id": "cs:~openstack-charmers\/precise\/nova-compute-28"
+        },
+        "107": {
+          "id": "cs:~openstack-charmers\/precise\/nova-compute-29"
+        },
+        "108": {
+          "id": "cs:~openstack-charmers\/precise\/nova-compute-30"
+        },
+        "109": {
+          "id": "cs:~openstack-charmers\/precise\/nova-compute-31"
+        },
+        "110": {
+          "id": "cs:~openstack-charmers\/trusty\/nova-compute-0"
+        },
+        "111": {
+          "id": "cs:~openstack-charmers\/trusty\/nova-compute-1"
+        },
+        "112": {
+          "id": "cs:~openstack-charmers\/trusty\/nova-compute-2"
+        },
+        "113": {
+          "id": "cs:~openstack-charmers\/trusty\/nova-compute-3"
+        },
+        "114": {
+          "id": "cs:~openstack-charmers\/trusty\/nova-compute-4"
+        },
+        "115": {
+          "id": "cs:~openstack-charmers\/trusty\/nova-compute-5"
+        },
+        "116": {
+          "id": "cs:~openstack-charmers\/trusty\/nova-compute-power-0"
+        },
+        "117": {
+          "id": "cs:~openstack-charmers\/trusty\/nova-compute-power-1"
+        },
+        "118": {
+          "id": "cs:~openstack-charmers\/trusty\/nova-compute-power-2"
+        },
+        "119": {
+          "id": "cs:~openstack-ubuntu-testing\/precise\/nova-compute-28"
+        },
+        "120": {
+          "id": "cs:~openstack-ubuntu-testing\/precise\/nova-compute-29"
+        },
+        "121": {
+          "id": "cs:~openstack-ubuntu-testing\/precise\/nova-compute-30"
+        },
+        "122": {
+          "id": "cs:~openstack-ubuntu-testing\/precise\/nova-compute-31"
+        },
+        "123": {
+          "id": "cs:~openstack-ubuntu-testing\/precise\/nova-compute-32"
+        },
+        "124": {
+          "id": "cs:~openstack-ubuntu-testing\/precise\/nova-compute-33"
+        },
+        "125": {
+          "id": "cs:~openstack-ubuntu-testing\/precise\/nova-compute-34"
+        },
+        "126": {
+          "id": "cs:~openstack-ubuntu-testing\/precise\/nova-compute-35"
+        },
+        "127": {
+          "id": "cs:~openstack-ubuntu-testing\/precise\/nova-compute-36"
+        },
+        "128": {
+          "id": "cs:~openstack-ubuntu-testing\/precise\/nova-compute-37"
+        },
+        "129": {
+          "id": "cs:~springfield-team\/precise\/nova-compute-0"
+        },
+        "130": {
+          "id": "cs:~springfield-team\/precise\/nova-compute-1"
+        },
+        "131": {
+          "id": "cs:~springfield-team\/precise\/nova-compute-2"
+        },
+        "132": {
+          "id": "cs:~springfield-team\/precise\/nova-compute-3"
+        },
+        "133": {
+          "id": "cs:~springfield-team\/precise\/nova-compute-4"
+        },
+        "134": {
+          "id": "cs:~springfield-team\/precise\/nova-compute-5"
+        },
+        "135": {
+          "id": "cs:~springfield-team\/precise\/nova-compute-6"
+        },
+        "136": {
+          "id": "cs:~springfield-team\/precise\/nova-compute-7"
+        },
+        "137": {
+          "id": "cs:~springfield-team\/precise\/nova-compute-8"
+        },
+        "138": {
+          "id": "cs:~springfield-team\/precise\/nova-compute-9"
+        },
+        "139": {
+          "id": "cs:~stub\/trusty\/nrpe-external-master-0"
+        },
+        "140": {
+          "id": "cs:~webteam-backend\/trusty\/nrpe-external-master-0"
+        }
+      }
+    },
+    "provides": {
+      "apache-vhost-config": {
+        "0": {
+          "id": "cs:precise\/landscape-server-10"
+        },
+        "1": {
+          "id": "cs:precise\/landscape-server-11"
+        },
+        "2": {
+          "id": "cs:precise\/landscape-server-12"
+        },
+        "3": {
+          "id": "cs:precise\/landscape-server-13"
+        },
+        "4": {
+          "id": "cs:precise\/landscape-server-14"
+        },
+        "5": {
+          "id": "cs:precise\/landscape-server-4"
+        },
+        "6": {
+          "id": "cs:precise\/landscape-server-5"
+        },
+        "7": {
+          "id": "cs:precise\/landscape-server-6"
+        },
+        "8": {
+          "id": "cs:precise\/landscape-server-7"
+        },
+        "9": {
+          "id": "cs:precise\/landscape-server-8"
+        },
+        "10": {
+          "id": "cs:precise\/landscape-server-9"
+        },
+        "11": {
+          "id": "cs:trusty\/landscape-server-1"
+        },
+        "12": {
+          "id": "cs:trusty\/landscape-server-2"
+        },
+        "13": {
+          "id": "cs:trusty\/landscape-server-3"
+        },
+        "14": {
+          "id": "cs:trusty\/landscape-server-4"
+        },
+        "15": {
+          "id": "cs:trusty\/landscape-server-5"
+        },
+        "16": {
+          "id": "cs:trusty\/landscape-server-6"
+        },
+        "17": {
+          "id": "cs:trusty\/landscape-server-7"
+        },
+        "18": {
+          "id": "cs:~landscape-charmers\/precise\/landscape-server-10"
+        },
+        "19": {
+          "id": "cs:~landscape-charmers\/precise\/landscape-server-11"
+        },
+        "20": {
+          "id": "cs:~landscape-charmers\/precise\/landscape-server-12"
+        },
+        "21": {
+          "id": "cs:~landscape-charmers\/precise\/landscape-server-13"
+        },
+        "22": {
+          "id": "cs:~landscape-charmers\/precise\/landscape-server-4"
+        },
+        "23": {
+          "id": "cs:~landscape-charmers\/precise\/landscape-server-5"
+        },
+        "24": {
+          "id": "cs:~landscape-charmers\/precise\/landscape-server-6"
+        },
+        "25": {
+          "id": "cs:~landscape-charmers\/precise\/landscape-server-7"
+        },
+        "26": {
+          "id": "cs:~landscape-charmers\/precise\/landscape-server-8"
+        },
+        "27": {
+          "id": "cs:~landscape-charmers\/precise\/landscape-server-9"
+        },
+        "28": {
+          "id": "cs:~landscape-charmers\/trusty\/landscape-server-0"
+        },
+        "29": {
+          "id": "cs:~landscape-charmers\/trusty\/landscape-server-1"
+        },
+        "30": {
+          "id": "cs:~landscape-charmers\/trusty\/landscape-server-2"
+        },
+        "31": {
+          "id": "cs:~landscape-charmers\/trusty\/landscape-server-3"
+        },
+        "32": {
+          "id": "cs:~landscape-charmers\/trusty\/landscape-server-4"
+        },
+        "33": {
+          "id": "cs:~landscape-charmers\/trusty\/landscape-server-5"
+        },
+        "34": {
+          "id": "cs:~landscape-charmers\/trusty\/landscape-server-6"
+        },
+        "35": {
+          "id": "cs:~ya-bo-ng\/trusty\/landscape-charm-0"
+        },
+        "36": {
+          "id": "cs:~ya-bo-ng\/trusty\/landscape-charm-1"
+        }
+      },
+      "http": {
+        "0": {
+          "id": "cs:oneiric\/appflower-0"
+        },
+        "1": {
+          "id": "cs:oneiric\/appflower-1"
+        },
+        "2": {
+          "id": "cs:oneiric\/etherpad-lite-0"
+        },
+        "3": {
+          "id": "cs:oneiric\/etherpad-lite-1"
+        },
+        "4": {
+          "id": "cs:oneiric\/ganglia-0"
+        },
+        "5": {
+          "id": "cs:oneiric\/haproxy-0"
+        },
+        "6": {
+          "id": "cs:oneiric\/jenkins-0"
+        },
+        "7": {
+          "id": "cs:oneiric\/limesurvey-0"
+        },
+        "8": {
+          "id": "cs:oneiric\/lodgeit-0"
+        },
+        "9": {
+          "id": "cs:oneiric\/mediawiki-0"
+        },
+        "10": {
+          "id": "cs:oneiric\/munin-0"
+        },
+        "11": {
+          "id": "cs:oneiric\/munin-1"
+        },
+        "12": {
+          "id": "cs:oneiric\/musica-0"
+        },
+        "13": {
+          "id": "cs:oneiric\/nagios-0"
+        },
+        "14": {
+          "id": "cs:oneiric\/node-app-0"
+        },
+        "15": {
+          "id": "cs:oneiric\/oops-tools-0"
+        },
+        "16": {
+          "id": "cs:oneiric\/openerp-server-1"
+        },
+        "17": {
+          "id": "cs:oneiric\/openerp-web-1"
+        },
+        "18": {
+          "id": "cs:oneiric\/owncloud-0"
+        },
+        "19": {
+          "id": "cs:oneiric\/owncloud-1"
+        },
+        "20": {
+          "id": "cs:oneiric\/pictor-0"
+        },
+        "21": {
+          "id": "cs:oneiric\/python-moinmoin-0"
+        },
+        "22": {
+          "id": "cs:oneiric\/roundcube-0"
+        },
+        "23": {
+          "id": "cs:oneiric\/stackmobile-0"
+        },
+        "24": {
+          "id": "cs:oneiric\/stackmobile-1"
+        },
+        "25": {
+          "id": "cs:oneiric\/statusnet-0"
+        },
+        "26": {
+          "id": "cs:oneiric\/subway-0"
+        },
+        "27": {
+          "id": "cs:oneiric\/subway-1"
+        },
+        "28": {
+          "id": "cs:oneiric\/thinkup-0"
+        },
+        "29": {
+          "id": "cs:oneiric\/tomcat6-0"
+        },
+        "30": {
+          "id": "cs:oneiric\/tomcat7-0"
+        },
+        "31": {
+          "id": "cs:oneiric\/wordpress-0"
+        },
+        "32": {
+          "id": "cs:precise\/apache2-1"
+        },
+        "33": {
+          "id": "cs:precise\/apache2-10"
+        },
+        "34": {
+          "id": "cs:precise\/apache2-11"
+        },
+        "35": {
+          "id": "cs:precise\/apache2-12"
+        },
+        "36": {
+          "id": "cs:precise\/apache2-13"
+        },
+        "37": {
+          "id": "cs:precise\/apache2-14"
+        },
+        "38": {
+          "id": "cs:precise\/apache2-15"
+        },
+        "39": {
+          "id": "cs:precise\/apache2-16"
+        },
+        "40": {
+          "id": "cs:precise\/apache2-17"
+        },
+        "41": {
+          "id": "cs:precise\/apache2-18"
+        },
+        "42": {
+          "id": "cs:precise\/apache2-19"
+        },
+        "43": {
+          "id": "cs:precise\/apache2-2"
+        },
+        "44": {
+          "id": "cs:precise\/apache2-20"
+        },
+        "45": {
+          "id": "cs:precise\/apache2-21"
+        },
+        "46": {
+          "id": "cs:precise\/apache2-22"
+        },
+        "47": {
+          "id": "cs:precise\/apache2-23"
+        },
+        "48": {
+          "id": "cs:precise\/apache2-24"
+        },
+        "49": {
+          "id": "cs:precise\/apache2-25"
+        },
+        "50": {
+          "id": "cs:precise\/apache2-26"
+        },
+        "51": {
+          "id": "cs:precise\/apache2-27"
+        },
+        "52": {
+          "id": "cs:precise\/apache2-3"
+        },
+        "53": {
+          "id": "cs:precise\/apache2-4"
+        },
+        "54": {
+          "id": "cs:precise\/apache2-5"
+        },
+        "55": {
+          "id": "cs:precise\/apache2-6"
+        },
+        "56": {
+          "id": "cs:precise\/apache2-7"
+        },
+        "57": {
+          "id": "cs:precise\/apache2-8"
+        },
+        "58": {
+          "id": "cs:precise\/apache2-9"
+        },
+        "59": {
+          "id": "cs:precise\/apache2-passenger-1"
+        },
+        "60": {
+          "id": "cs:precise\/apache2-passenger-2"
+        },
+        "61": {
+          "id": "cs:precise\/apache2-passenger-3"
+        },
+        "62": {
+          "id": "cs:precise\/apache2-passenger-4"
+        },
+        "63": {
+          "id": "cs:precise\/apache2-passenger-5"
+        },
+        "64": {
+          "id": "cs:precise\/apache2-passenger-6"
+        },
+        "65": {
+          "id": "cs:precise\/appflower-0"
+        },
+        "66": {
+          "id": "cs:precise\/appflower-1"
+        },
+        "67": {
+          "id": "cs:precise\/appflower-2"
+        },
+        "68": {
+          "id": "cs:precise\/appflower-3"
+        },
+        "69": {
+          "id": "cs:precise\/appflower-4"
+        },
+        "70": {
+          "id": "cs:precise\/cakephp-2"
+        },
+        "71": {
+          "id": "cs:precise\/cakephp-3"
+        },
+        "72": {
+          "id": "cs:precise\/ceph-radosgw-0"
+        },
+        "73": {
+          "id": "cs:precise\/ceph-radosgw-1"
+        },
+        "74": {
+          "id": "cs:precise\/ceph-radosgw-10"
+        },
+        "75": {
+          "id": "cs:precise\/ceph-radosgw-11"
+        },
+        "76": {
+          "id": "cs:precise\/ceph-radosgw-12"
+        },
+        "77": {
+          "id": "cs:precise\/ceph-radosgw-13"
+        },
+        "78": {
+          "id": "cs:precise\/ceph-radosgw-14"
+        },
+        "79": {
+          "id": "cs:precise\/ceph-radosgw-15"
+        },
+        "80": {
+          "id": "cs:precise\/ceph-radosgw-2"
+        },
+        "81": {
+          "id": "cs:precise\/ceph-radosgw-3"
+        },
+        "82": {
+          "id": "cs:precise\/ceph-radosgw-4"
+        },
+        "83": {
+          "id": "cs:precise\/ceph-radosgw-5"
+        },
+        "84": {
+          "id": "cs:precise\/ceph-radosgw-6"
+        },
+        "85": {
+          "id": "cs:precise\/ceph-radosgw-7"
+        },
+        "86": {
+          "id": "cs:precise\/ceph-radosgw-8"
+        },
+        "87": {
+          "id": "cs:precise\/ceph-radosgw-9"
+        },
+        "88": {
+          "id": "cs:precise\/chamilo-0"
+        },
+        "89": {
+          "id": "cs:precise\/chamilo-1"
+        },
+        "90": {
+          "id": "cs:precise\/chef-server-1"
+        },
+        "91": {
+          "id": "cs:precise\/chef-server-2"
+        },
+        "92": {
+          "id": "cs:precise\/chef-server-3"
+        },
+        "93": {
+          "id": "cs:precise\/chef-server-4"
+        },
+        "94": {
+          "id": "cs:precise\/chef-server-5"
+        },
+        "95": {
+          "id": "cs:precise\/cinder-1"
+        },
+        "96": {
+          "id": "cs:precise\/dokuwiki-0"
+        },
+        "97": {
+          "id": "cs:precise\/dokuwiki-1"
+        },
+        "98": {
+          "id": "cs:precise\/dokuwiki-2"
+        },
+        "99": {
+          "id": "cs:precise\/dokuwiki-3"
+        },
+        "100": {
+          "id": "cs:precise\/dokuwiki-4"
+        },
+        "101": {
+          "id": "cs:precise\/drupal6-0"
+        },
+        "102": {
+          "id": "cs:precise\/drupal6-1"
+        },
+        "103": {
+          "id": "cs:precise\/etherpad-lite-0"
+        },
+        "104": {
+          "id": "cs:precise\/etherpad-lite-1"
+        },
+        "105": {
+          "id": "cs:precise\/etherpad-lite-2"
+        },
+        "106": {
+          "id": "cs:precise\/etherpad-lite-3"
+        },
+        "107": {
+          "id": "cs:precise\/etherpad-lite-4"
+        },
+        "108": {
+          "id": "cs:precise\/etherpad-lite-5"
+        },
+        "109": {
+          "id": "cs:precise\/etherpad-lite-6"
+        },
+        "110": {
+          "id": "cs:precise\/etherpad-lite-7"
+        },
+        "111": {
+          "id": "cs:precise\/etherpad-lite-8"
+        },
+        "112": {
+          "id": "cs:precise\/etherpad-lite-9"
+        },
+        "113": {
+          "id": "cs:precise\/firefox-sync-2"
+        },
+        "114": {
+          "id": "cs:precise\/firefox-sync-3"
+        },
+        "115": {
+          "id": "cs:precise\/firefox-sync-4"
+        },
+        "116": {
+          "id": "cs:precise\/ganglia-0"
+        },
+        "117": {
+          "id": "cs:precise\/ganglia-1"
+        },
+        "118": {
+          "id": "cs:precise\/ganglia-2"
+        },
+        "119": {
+          "id": "cs:precise\/ganglia-3"
+        },
+        "120": {
+          "id": "cs:precise\/ganglia-4"
+        },
+        "121": {
+          "id": "cs:precise\/ganglia-5"
+        },
+        "122": {
+          "id": "cs:precise\/ganglia-6"
+        },
+        "123": {
+          "id": "cs:precise\/ganglia-7"
+        },
+        "124": {
+          "id": "cs:precise\/ganglia-8"
+        },
+        "125": {
+          "id": "cs:precise\/ganglia-9"
+        },
+        "126": {
+          "id": "cs:precise\/ghost-0"
+        },
+        "127": {
+          "id": "cs:precise\/ghost-1"
+        },
+        "128": {
+          "id": "cs:precise\/ghost-2"
+        },
+        "129": {
+          "id": "cs:precise\/gitlab-0"
+        },
+        "130": {
+          "id": "cs:precise\/gitlab-1"
+        },
+        "131": {
+          "id": "cs:precise\/gitlab-2"
+        },
+        "132": {
+          "id": "cs:precise\/gitlab-3"
+        },
+        "133": {
+          "id": "cs:precise\/gitlab-4"
+        },
+        "134": {
+          "id": "cs:precise\/gitlab-5"
+        },
+        "135": {
+          "id": "cs:precise\/haproxy-0"
+        },
+        "136": {
+          "id": "cs:precise\/haproxy-1"
+        },
+        "137": {
+          "id": "cs:precise\/haproxy-10"
+        },
+        "138": {
+          "id": "cs:precise\/haproxy-11"
+        },
+        "139": {
+          "id": "cs:precise\/haproxy-12"
+        },
+        "140": {
+          "id": "cs:precise\/haproxy-13"
+        },
+        "141": {
+          "id": "cs:precise\/haproxy-14"
+        },
+        "142": {
+          "id": "cs:precise\/haproxy-15"
+        },
+        "143": {
+          "id": "cs:precise\/haproxy-16"
+        },
+        "144": {
+          "id": "cs:precise\/haproxy-17"
+        },
+        "145": {
+          "id": "cs:precise\/haproxy-18"
+        },
+        "146": {
+          "id": "cs:precise\/haproxy-19"
+        },
+        "147": {
+          "id": "cs:precise\/haproxy-2"
+        },
+        "148": {
+          "id": "cs:precise\/haproxy-20"
+        },
+        "149": {
+          "id": "cs:precise\/haproxy-21"
+        },
+        "150": {
+          "id": "cs:precise\/haproxy-22"
+        },
+        "151": {
+          "id": "cs:precise\/haproxy-23"
+        },
+        "152": {
+          "id": "cs:precise\/haproxy-24"
+        },
+        "153": {
+          "id": "cs:precise\/haproxy-25"
+        },
+        "154": {
+          "id": "cs:precise\/haproxy-26"
+        },
+        "155": {
+          "id": "cs:precise\/haproxy-27"
+        },
+        "156": {
+          "id": "cs:precise\/haproxy-28"
+        },
+        "157": {
+          "id": "cs:precise\/haproxy-29"
+        },
+        "158": {
+          "id": "cs:precise\/haproxy-3"
+        },
+        "159": {
+          "id": "cs:precise\/haproxy-30"
+        },
+        "160": {
+          "id": "cs:precise\/haproxy-31"
+        },
+        "161": {
+          "id": "cs:precise\/haproxy-32"
+        },
+        "162": {
+          "id": "cs:precise\/haproxy-33"
+        },
+        "163": {
+          "id": "cs:precise\/haproxy-34"
+        },
+        "164": {
+          "id": "cs:precise\/haproxy-35"
+        },
+        "165": {
+          "id": "cs:precise\/haproxy-4"
+        },
+        "166": {
+          "id": "cs:precise\/haproxy-5"
+        },
+        "167": {
+          "id": "cs:precise\/haproxy-6"
+        },
+        "168": {
+          "id": "cs:precise\/haproxy-7"
+        },
+        "169": {
+          "id": "cs:precise\/haproxy-8"
+        },
+        "170": {
+          "id": "cs:precise\/haproxy-9"
+        },
+        "171": {
+          "id": "cs:precise\/hbase-2"
+        },
+        "172": {
+          "id": "cs:precise\/hbase-3"
+        },
+        "173": {
+          "id": "cs:precise\/hbase-4"
+        },
+        "174": {
+          "id": "cs:precise\/hbase-5"
+        },
+        "175": {
+          "id": "cs:precise\/hbase-6"
+        },
+        "176": {
+          "id": "cs:precise\/hbase-7"
+        },
+        "177": {
+          "id": "cs:precise\/hbase-8"
+        },
+        "178": {
+          "id": "cs:precise\/jenkins-0"
+        },
+        "179": {
+          "id": "cs:precise\/jenkins-1"
+        },
+        "180": {
+          "id": "cs:precise\/jenkins-10"
+        },
+        "181": {
+          "id": "cs:precise\/jenkins-11"
+        },
+        "182": {
+          "id": "cs:precise\/jenkins-12"
+        },
+        "183": {
+          "id": "cs:precise\/jenkins-2"
+        },
+        "184": {
+          "id": "cs:precise\/jenkins-3"
+        },
+        "185": {
+          "id": "cs:precise\/jenkins-4"
+        },
+        "186": {
+          "id": "cs:precise\/jenkins-5"
+        },
+        "187": {
+          "id": "cs:precise\/jenkins-6"
+        },
+        "188": {
+          "id": "cs:precise\/jenkins-7"
+        },
+        "189": {
+          "id": "cs:precise\/jenkins-8"
+        },
+        "190": {
+          "id": "cs:precise\/jenkins-9"
+        },
+        "191": {
+          "id": "cs:precise\/joomla-1"
+        },
+        "192": {
+          "id": "cs:precise\/joomla-2"
+        },
+        "193": {
+          "id": "cs:precise\/joomla-3"
+        },
+        "194": {
+          "id": "cs:precise\/juju-gui-1"
+        },
+        "195": {
+          "id": "cs:precise\/juju-gui-100"
+        },
+        "196": {
+          "id": "cs:precise\/juju-gui-101"
+        },
+        "197": {
+          "id": "cs:precise\/juju-gui-102"
+        },
+        "198": {
+          "id": "cs:precise\/juju-gui-103"
+        },
+        "199": {
+          "id": "cs:precise\/juju-gui-104"
+        },
+        "200": {
+          "id": "cs:precise\/juju-gui-105"
+        },
+        "201": {
+          "id": "cs:precise\/juju-gui-106"
+        },
+        "202": {
+          "id": "cs:precise\/juju-gui-107"
+        },
+        "203": {
+          "id": "cs:precise\/juju-gui-108"
+        },
+        "204": {
+          "id": "cs:precise\/juju-gui-2"
+        },
+        "205": {
+          "id": "cs:precise\/juju-gui-3"
+        },
+        "206": {
+          "id": "cs:precise\/juju-gui-39"
+        },
+        "207": {
+          "id": "cs:precise\/juju-gui-40"
+        },
+        "208": {
+          "id": "cs:precise\/juju-gui-41"
+        },
+        "209": {
+          "id": "cs:precise\/juju-gui-42"
+        },
+        "210": {
+          "id": "cs:precise\/juju-gui-43"
+        },
+        "211": {
+          "id": "cs:precise\/juju-gui-44"
+        },
+        "212": {
+          "id": "cs:precise\/juju-gui-45"
+        },
+        "213": {
+          "id": "cs:precise\/juju-gui-46"
+        },
+        "214": {
+          "id": "cs:precise\/juju-gui-47"
+        },
+        "215": {
+          "id": "cs:precise\/juju-gui-48"
+        },
+        "216": {
+          "id": "cs:precise\/juju-gui-49"
+        },
+        "217": {
+          "id": "cs:precise\/juju-gui-50"
+        },
+        "218": {
+          "id": "cs:precise\/juju-gui-51"
+        },
+        "219": {
+          "id": "cs:precise\/juju-gui-52"
+        },
+        "220": {
+          "id": "cs:precise\/juju-gui-53"
+        },
+        "221": {
+          "id": "cs:precise\/juju-gui-54"
+        },
+        "222": {
+          "id": "cs:precise\/juju-gui-55"
+        },
+        "223": {
+          "id": "cs:precise\/juju-gui-56"
+        },
+        "224": {
+          "id": "cs:precise\/juju-gui-57"
+        },
+        "225": {
+          "id": "cs:precise\/juju-gui-58"
+        },
+        "226": {
+          "id": "cs:precise\/juju-gui-59"
+        },
+        "227": {
+          "id": "cs:precise\/juju-gui-60"
+        },
+        "228": {
+          "id": "cs:precise\/juju-gui-61"
+        },
+        "229": {
+          "id": "cs:precise\/juju-gui-62"
+        },
+        "230": {
+          "id": "cs:precise\/juju-gui-63"
+        },
+        "231": {
+          "id": "cs:precise\/juju-gui-64"
+        },
+        "232": {
+          "id": "cs:precise\/juju-gui-65"
+        },
+        "233": {
+          "id": "cs:precise\/juju-gui-66"
+        },
+        "234": {
+          "id": "cs:precise\/juju-gui-67"
+        },
+        "235": {
+          "id": "cs:precise\/juju-gui-68"
+        },
+        "236": {
+          "id": "cs:precise\/juju-gui-69"
+        },
+        "237": {
+          "id": "cs:precise\/juju-gui-70"
+        },
+        "238": {
+          "id": "cs:precise\/juju-gui-71"
+        },
+        "239": {
+          "id": "cs:precise\/juju-gui-72"
+        },
+        "240": {
+          "id": "cs:precise\/juju-gui-73"
+        },
+        "241": {
+          "id": "cs:precise\/juju-gui-74"
+        },
+        "242": {
+          "id": "cs:precise\/juju-gui-75"
+        },
+        "243": {
+          "id": "cs:precise\/juju-gui-76"
+        },
+        "244": {
+          "id": "cs:precise\/juju-gui-77"
+        },
+        "245": {
+          "id": "cs:precise\/juju-gui-78"
+        },
+        "246": {
+          "id": "cs:precise\/juju-gui-79"
+        },
+        "247": {
+          "id": "cs:precise\/juju-gui-80"
+        },
+        "248": {
+          "id": "cs:precise\/juju-gui-81"
+        },
+        "249": {
+          "id": "cs:precise\/juju-gui-82"
+        },
+        "250": {
+          "id": "cs:precise\/juju-gui-83"
+        },
+        "251": {
+          "id": "cs:precise\/juju-gui-84"
+        },
+        "252": {
+          "id": "cs:precise\/juju-gui-85"
+        },
+        "253": {
+          "id": "cs:precise\/juju-gui-86"
+        },
+        "254": {
+          "id": "cs:precise\/juju-gui-87"
+        },
+        "255": {
+          "id": "cs:precise\/juju-gui-88"
+        },
+        "256": {
+          "id": "cs:precise\/juju-gui-89"
+        },
+        "257": {
+          "id": "cs:precise\/juju-gui-90"
+        },
+        "258": {
+          "id": "cs:precise\/juju-gui-91"
+        },
+        "259": {
+          "id": "cs:precise\/juju-gui-92"
+        },
+        "260": {
+          "id": "cs:precise\/juju-gui-93"
+        },
+        "261": {
+          "id": "cs:precise\/juju-gui-94"
+        },
+        "262": {
+          "id": "cs:precise\/juju-gui-95"
+        },
+        "263": {
+          "id": "cs:precise\/juju-gui-96"
+        },
+        "264": {
+          "id": "cs:precise\/juju-gui-97"
+        },
+        "265": {
+          "id": "cs:precise\/juju-gui-98"
+        },
+        "266": {
+          "id": "cs:precise\/juju-gui-99"
+        },
+        "267": {
+          "id": "cs:precise\/kusabax-0"
+        },
+        "268": {
+          "id": "cs:precise\/kusabax-1"
+        },
+        "269": {
+          "id": "cs:precise\/kusabax-2"
+        },
+        "270": {
+          "id": "cs:precise\/kusabax-3"
+        },
+        "271": {
+          "id": "cs:precise\/lamp-1"
+        },
+        "272": {
+          "id": "cs:precise\/lamp-2"
+        },
+        "273": {
+          "id": "cs:precise\/lamp-3"
+        },
+        "274": {
+          "id": "cs:precise\/lamp-4"
+        },
+        "275": {
+          "id": "cs:precise\/lamp-5"
+        },
+        "276": {
+          "id": "cs:precise\/lamp-6"
+        },
+        "277": {
+          "id": "cs:precise\/landscape-server-1"
+        },
+        "278": {
+          "id": "cs:precise\/landscape-server-10"
+        },
+        "279": {
+          "id": "cs:precise\/landscape-server-11"
+        },
+        "280": {
+          "id": "cs:precise\/landscape-server-12"
+        },
+        "281": {
+          "id": "cs:precise\/landscape-server-13"
+        },
+        "282": {
+          "id": "cs:precise\/landscape-server-14"
+        },
+        "283": {
+          "id": "cs:precise\/landscape-server-2"
+        },
+        "284": {
+          "id": "cs:precise\/landscape-server-3"
+        },
+        "285": {
+          "id": "cs:precise\/landscape-server-4"
+        },
+        "286": {
+          "id": "cs:precise\/landscape-server-5"
+        },
+        "287": {
+          "id": "cs:precise\/landscape-server-6"
+        },
+        "288": {
+          "id": "cs:precise\/landscape-server-7"
+        },
+        "289": {
+          "id": "cs:precise\/landscape-server-8"
+        },
+        "290": {
+          "id": "cs:precise\/landscape-server-9"
+        },
+        "291": {
+          "id": "cs:precise\/liferay-0"
+        },
+        "292": {
+          "id": "cs:precise\/liferay-1"
+        },
+        "293": {
+          "id": "cs:precise\/liferay-2"
+        },
+        "294": {
+          "id": "cs:precise\/limesurvey-0"
+        },
+        "295": {
+          "id": "cs:precise\/limesurvey-1"
+        },
+        "296": {
+          "id": "cs:precise\/limesurvey-2"
+        },
+        "297": {
+          "id": "cs:precise\/limesurvey-3"
+        },
+        "298": {
+          "id": "cs:precise\/limesurvey-4"
+        },
+        "299": {
+          "id": "cs:precise\/limesurvey-5"
+        },
+        "300": {
+          "id": "cs:precise\/limesurvey-6"
+        },
+        "301": {
+          "id": "cs:precise\/loggerhead-0"
+        },
+        "302": {
+          "id": "cs:precise\/loggerhead-1"
+        },
+        "303": {
+          "id": "cs:precise\/loggerhead-2"
+        },
+        "304": {
+          "id": "cs:precise\/loggerhead-3"
+        },
+        "305": {
+          "id": "cs:precise\/mailman-0"
+        },
+        "306": {
+          "id": "cs:precise\/mailman-1"
+        },
+        "307": {
+          "id": "cs:precise\/mediawiki-0"
+        },
+        "308": {
+          "id": "cs:precise\/mediawiki-1"
+        },
+        "309": {
+          "id": "cs:precise\/mediawiki-10"
+        },
+        "310": {
+          "id": "cs:precise\/mediawiki-11"
+        },
+        "311": {
+          "id": "cs:precise\/mediawiki-12"
+        },
+        "312": {
+          "id": "cs:precise\/mediawiki-13"
+        },
+        "313": {
+          "id": "cs:precise\/mediawiki-14"
+        },
+        "314": {
+          "id": "cs:precise\/mediawiki-15"
+        },
+        "315": {
+          "id": "cs:precise\/mediawiki-16"
+        },
+        "316": {
+          "id": "cs:precise\/mediawiki-17"
+        },
+        "317": {
+          "id": "cs:precise\/mediawiki-18"
+        },
+        "318": {
+          "id": "cs:precise\/mediawiki-2"
+        },
+        "319": {
+          "id": "cs:precise\/mediawiki-3"
+        },
+        "320": {
+          "id": "cs:precise\/mediawiki-4"
+        },
+        "321": {
+          "id": "cs:precise\/mediawiki-5"
+        },
+        "322": {
+          "id": "cs:precise\/mediawiki-6"
+        },
+        "323": {
+          "id": "cs:precise\/mediawiki-7"
+        },
+        "324": {
+          "id": "cs:precise\/mediawiki-8"
+        },
+        "325": {
+          "id": "cs:precise\/mediawiki-9"
+        },
+        "326": {
+          "id": "cs:precise\/meteor-0"
+        },
+        "327": {
+          "id": "cs:precise\/meteor-1"
+        },
+        "328": {
+          "id": "cs:precise\/meteor-2"
+        },
+        "329": {
+          "id": "cs:precise\/munin-0"
+        },
+        "330": {
+          "id": "cs:precise\/munin-1"
+        },
+        "331": {
+          "id": "cs:precise\/munin-2"
+        },
+        "332": {
+          "id": "cs:precise\/munin-3"
+        },
+        "333": {
+          "id": "cs:precise\/munin-4"
+        },
+        "334": {
+          "id": "cs:precise\/munin-5"
+        },
+        "335": {
+          "id": "cs:precise\/musica-0"
+        },
+        "336": {
+          "id": "cs:precise\/musica-1"
+        },
+        "337": {
+          "id": "cs:precise\/musica-2"
+        },
+        "338": {
+          "id": "cs:precise\/musica-3"
+        },
+        "339": {
+          "id": "cs:precise\/nagios-0"
+        },
+        "340": {
+          "id": "cs:precise\/nagios-1"
+        },
+        "341": {
+          "id": "cs:precise\/nagios-10"
+        },
+        "342": {
+          "id": "cs:precise\/nagios-11"
+        },
+        "343": {
+          "id": "cs:precise\/nagios-2"
+        },
+        "344": {
+          "id": "cs:precise\/nagios-3"
+        },
+        "345": {
+          "id": "cs:precise\/nagios-4"
+        },
+        "346": {
+          "id": "cs:precise\/nagios-5"
+        },
+        "347": {
+          "id": "cs:precise\/nagios-6"
+        },
+        "348": {
+          "id": "cs:precise\/nagios-7"
+        },
+        "349": {
+          "id": "cs:precise\/nagios-8"
+        },
+        "350": {
+          "id": "cs:precise\/nagios-9"
+        },
+        "351": {
+          "id": "cs:precise\/nginx-passenger-1"
+        },
+        "352": {
+          "id": "cs:precise\/nginx-passenger-2"
+        },
+        "353": {
+          "id": "cs:precise\/nginx-passenger-3"
+        },
+        "354": {
+          "id": "cs:precise\/node-app-0"
+        },
+        "355": {
+          "id": "cs:precise\/node-app-1"
+        },
+        "356": {
+          "id": "cs:precise\/node-app-10"
+        },
+        "357": {
+          "id": "cs:precise\/node-app-2"
+        },
+        "358": {
+          "id": "cs:precise\/node-app-3"
+        },
+        "359": {
+          "id": "cs:precise\/node-app-4"
+        },
+        "360": {
+          "id": "cs:precise\/node-app-5"
+        },
+        "361": {
+          "id": "cs:precise\/node-app-6"
+        },
+        "362": {
+          "id": "cs:precise\/node-app-7"
+        },
+        "363": {
+          "id": "cs:precise\/node-app-8"
+        },
+        "364": {
+          "id": "cs:precise\/node-app-9"
+        },
+        "365": {
+          "id": "cs:precise\/oops-tools-0"
+        },
+        "366": {
+          "id": "cs:precise\/oops-tools-1"
+        },
+        "367": {
+          "id": "cs:precise\/oops-tools-2"
+        },
+        "368": {
+          "id": "cs:precise\/oops-tools-3"
+        },
+        "369": {
+          "id": "cs:precise\/openerp-server-0"
+        },
+        "370": {
+          "id": "cs:precise\/openerp-server-1"
+        },
+        "371": {
+          "id": "cs:precise\/openerp-server-2"
+        },
+        "372": {
+          "id": "cs:precise\/openerp-web-0"
+        },
+        "373": {
+          "id": "cs:precise\/openerp-web-1"
+        },
+        "374": {
+          "id": "cs:precise\/openerp-web-2"
+        },
+        "375": {
+          "id": "cs:precise\/openerp-web-3"
+        },
+        "376": {
+          "id": "cs:precise\/openerp-web-4"
+        },
+        "377": {
+          "id": "cs:precise\/opengrok-0"
+        },
+        "378": {
+          "id": "cs:precise\/opengrok-1"
+        },
+        "379": {
+          "id": "cs:precise\/opengrok-2"
+        },
+        "380": {
+          "id": "cs:precise\/opengrok-3"
+        },
+        "381": {
+          "id": "cs:precise\/openstack-dashboard-10"
+        },
+        "382": {
+          "id": "cs:precise\/openstack-dashboard-11"
+        },
+        "383": {
+          "id": "cs:precise\/openstack-dashboard-12"
+        },
+        "384": {
+          "id": "cs:precise\/openstack-dashboard-13"
+        },
+        "385": {
+          "id": "cs:precise\/openstack-dashboard-14"
+        },
+        "386": {
+          "id": "cs:precise\/openstack-dashboard-15"
+        },
+        "387": {
+          "id": "cs:precise\/openstack-dashboard-16"
+        },
+        "388": {
+          "id": "cs:precise\/openstack-dashboard-17"
+        },
+        "389": {
+          "id": "cs:precise\/openstack-dashboard-18"
+        },
+        "390": {
+          "id": "cs:precise\/openstack-dashboard-19"
+        },
+        "391": {
+          "id": "cs:precise\/openstack-dashboard-20"
+        },
+        "392": {
+          "id": "cs:precise\/openstack-dashboard-21"
+        },
+        "393": {
+          "id": "cs:precise\/openstack-dashboard-22"
+        },
+        "394": {
+          "id": "cs:precise\/opentsdb-0"
+        },
+        "395": {
+          "id": "cs:precise\/opentsdb-1"
+        },
+        "396": {
+          "id": "cs:precise\/opentsdb-2"
+        },
+        "397": {
+          "id": "cs:precise\/opentsdb-3"
+        },
+        "398": {
+          "id": "cs:precise\/opentsdb-4"
+        },
+        "399": {
+          "id": "cs:precise\/openvpn-as-1"
+        },
+        "400": {
+          "id": "cs:precise\/openvpn-as-2"
+        },
+        "401": {
+          "id": "cs:precise\/openvpn-as-3"
+        },
+        "402": {
+          "id": "cs:precise\/openvpn-as-4"
+        },
+        "403": {
+          "id": "cs:precise\/openvpn-as-5"
+        },
+        "404": {
+          "id": "cs:precise\/openvpn-as-6"
+        },
+        "405": {
+          "id": "cs:precise\/owncloud-0"
+        },
+        "406": {
+          "id": "cs:precise\/owncloud-1"
+        },
+        "407": {
+          "id": "cs:precise\/owncloud-10"
+        },
+        "408": {
+          "id": "cs:precise\/owncloud-11"
+        },
+        "409": {
+          "id": "cs:precise\/owncloud-12"
+        },
+        "410": {
+          "id": "cs:precise\/owncloud-13"
+        },
+        "411": {
+          "id": "cs:precise\/owncloud-14"
+        },
+        "412": {
+          "id": "cs:precise\/owncloud-15"
+        },
+        "413": {
+          "id": "cs:precise\/owncloud-16"
+        },
+        "414": {
+          "id": "cs:precise\/owncloud-17"
+        },
+        "415": {
+          "id": "cs:precise\/owncloud-18"
+        },
+        "416": {
+          "id": "cs:precise\/owncloud-2"
+        },
+        "417": {
+          "id": "cs:precise\/owncloud-3"
+        },
+        "418": {
+          "id": "cs:precise\/owncloud-4"
+        },
+        "419": {
+          "id": "cs:precise\/owncloud-5"
+        },
+        "420": {
+          "id": "cs:precise\/owncloud-6"
+        },
+        "421": {
+          "id": "cs:precise\/owncloud-7"
+        },
+        "422": {
+          "id": "cs:precise\/owncloud-8"
+        },
+        "423": {
+          "id": "cs:precise\/owncloud-9"
+        },
+        "424": {
+          "id": "cs:precise\/pgbadger-1"
+        },
+        "425": {
+          "id": "cs:precise\/pgbadger-2"
+        },
+        "426": {
+          "id": "cs:precise\/phpmyadmin-1"
+        },
+        "427": {
+          "id": "cs:precise\/phpmyadmin-2"
+        },
+        "428": {
+          "id": "cs:precise\/phpmyadmin-3"
+        },
+        "429": {
+          "id": "cs:precise\/phpmyadmin-4"
+        },
+        "430": {
+          "id": "cs:precise\/phpmyadmin-5"
+        },
+        "431": {
+          "id": "cs:precise\/pictor-1"
+        },
+        "432": {
+          "id": "cs:precise\/pictor-2"
+        },
+        "433": {
+          "id": "cs:precise\/pictor-3"
+        },
+        "434": {
+          "id": "cs:precise\/pictor-4"
+        },
+        "435": {
+          "id": "cs:precise\/pictor-5"
+        },
+        "436": {
+          "id": "cs:precise\/pictor-6"
+        },
+        "437": {
+          "id": "cs:precise\/pubphoto-0"
+        },
+        "438": {
+          "id": "cs:precise\/python-django-0"
+        },
+        "439": {
+          "id": "cs:precise\/python-django-1"
+        },
+        "440": {
+          "id": "cs:precise\/python-django-10"
+        },
+        "441": {
+          "id": "cs:precise\/python-django-11"
+        },
+        "442": {
+          "id": "cs:precise\/python-django-12"
+        },
+        "443": {
+          "id": "cs:precise\/python-django-13"
+        },
+        "444": {
+          "id": "cs:precise\/python-django-14"
+        },
+        "445": {
+          "id": "cs:precise\/python-django-2"
+        },
+        "446": {
+          "id": "cs:precise\/python-django-3"
+        },
+        "447": {
+          "id": "cs:precise\/python-django-4"
+        },
+        "448": {
+          "id": "cs:precise\/python-django-5"
+        },
+        "449": {
+          "id": "cs:precise\/python-django-6"
+        },
+        "450": {
+          "id": "cs:precise\/python-django-7"
+        },
+        "451": {
+          "id": "cs:precise\/python-django-8"
+        },
+        "452": {
+          "id": "cs:precise\/python-django-9"
+        },
+        "453": {
+          "id": "cs:precise\/python-moinmoin-0"
+        },
+        "454": {
+          "id": "cs:precise\/python-moinmoin-1"
+        },
+        "455": {
+          "id": "cs:precise\/python-moinmoin-2"
+        },
+        "456": {
+          "id": "cs:precise\/python-moinmoin-3"
+        },
+        "457": {
+          "id": "cs:precise\/python-moinmoin-4"
+        },
+        "458": {
+          "id": "cs:precise\/python-moinmoin-5"
+        },
+        "459": {
+          "id": "cs:precise\/python-moinmoin-6"
+        },
+        "460": {
+          "id": "cs:precise\/rails-0"
+        },
+        "461": {
+          "id": "cs:precise\/rails-1"
+        },
+        "462": {
+          "id": "cs:precise\/rails-2"
+        },
+        "463": {
+          "id": "cs:precise\/rails-3"
+        },
+        "464": {
+          "id": "cs:precise\/reviewboard-0"
+        },
+        "465": {
+          "id": "cs:precise\/reviewboard-1"
+        },
+        "466": {
+          "id": "cs:precise\/reviewboard-2"
+        },
+        "467": {
+          "id": "cs:precise\/reviewboard-3"
+        },
+        "468": {
+          "id": "cs:precise\/roundcube-0"
+        },
+        "469": {
+          "id": "cs:precise\/roundcube-1"
+        },
+        "470": {
+          "id": "cs:precise\/roundcube-2"
+        },
+        "471": {
+          "id": "cs:precise\/seafile-1"
+        },
+        "472": {
+          "id": "cs:precise\/seafile-2"
+        },
+        "473": {
+          "id": "cs:precise\/seafile-3"
+        },
+        "474": {
+          "id": "cs:precise\/seafile-4"
+        },
+        "475": {
+          "id": "cs:precise\/shelrtv-0"
+        },
+        "476": {
+          "id": "cs:precise\/shelrtv-1"
+        },
+        "477": {
+          "id": "cs:precise\/shelrtv-2"
+        },
+        "478": {
+          "id": "cs:precise\/solr-jetty-1"
+        },
+        "479": {
+          "id": "cs:precise\/solr-jetty-2"
+        },
+        "480": {
+          "id": "cs:precise\/solr-jetty-3"
+        },
+        "481": {
+          "id": "cs:precise\/solr-jetty-4"
+        },
+        "482": {
+          "id": "cs:precise\/solr-jetty-5"
+        },
+        "483": {
+          "id": "cs:precise\/solr-jetty-6"
+        },
+        "484": {
+          "id": "cs:precise\/solr-jetty-7"
+        },
+        "485": {
+          "id": "cs:precise\/spip-0"
+        },
+        "486": {
+          "id": "cs:precise\/spip-1"
+        },
+        "487": {
+          "id": "cs:precise\/spip-2"
+        },
+        "488": {
+          "id": "cs:precise\/spip-3"
+        },
+        "489": {
+          "id": "cs:precise\/squid-forwardproxy-0"
+        },
+        "490": {
+          "id": "cs:precise\/squid-forwardproxy-1"
+        },
+        "491": {
+          "id": "cs:precise\/squid-forwardproxy-2"
+        },
+        "492": {
+          "id": "cs:precise\/squid-reverseproxy-0"
+        },
+        "493": {
+          "id": "cs:precise\/squid-reverseproxy-1"
+        },
+        "494": {
+          "id": "cs:precise\/squid-reverseproxy-2"
+        },
+        "495": {
+          "id": "cs:precise\/squid-reverseproxy-3"
+        },
+        "496": {
+          "id": "cs:precise\/squid-reverseproxy-4"
+        },
+        "497": {
+          "id": "cs:precise\/squid-reverseproxy-5"
+        },
+        "498": {
+          "id": "cs:precise\/squid-reverseproxy-6"
+        },
+        "499": {
+          "id": "cs:precise\/squid-reverseproxy-7"
+        },
+        "500": {
+          "id": "cs:precise\/squid-reverseproxy-8"
+        },
+        "501": {
+          "id": "cs:precise\/squid-reverseproxy-9"
+        },
+        "502": {
+          "id": "cs:precise\/stackmobile-0"
+        },
+        "503": {
+          "id": "cs:precise\/stackmobile-1"
+        },
+        "504": {
+          "id": "cs:precise\/stackmobile-2"
+        },
+        "505": {
+          "id": "cs:precise\/stackmobile-3"
+        },
+        "506": {
+          "id": "cs:precise\/statusnet-1"
+        },
+        "507": {
+          "id": "cs:precise\/statusnet-2"
+        },
+        "508": {
+          "id": "cs:precise\/statusnet-3"
+        },
+        "509": {
+          "id": "cs:precise\/statusnet-4"
+        },
+        "510": {
+          "id": "cs:precise\/statusnet-5"
+        },
+        "511": {
+          "id": "cs:precise\/statusnet-6"
+        },
+        "512": {
+          "id": "cs:precise\/subway-0"
+        },
+        "513": {
+          "id": "cs:precise\/subway-1"
+        },
+        "514": {
+          "id": "cs:precise\/subway-2"
+        },
+        "515": {
+          "id": "cs:precise\/subway-3"
+        },
+        "516": {
+          "id": "cs:precise\/subway-4"
+        },
+        "517": {
+          "id": "cs:precise\/subway-5"
+        },
+        "518": {
+          "id": "cs:precise\/syncope-0"
+        },
+        "519": {
+          "id": "cs:precise\/syncope-1"
+        },
+        "520": {
+          "id": "cs:precise\/thinkup-0"
+        },
+        "521": {
+          "id": "cs:precise\/thinkup-1"
+        },
+        "522": {
+          "id": "cs:precise\/thinkup-2"
+        },
+        "523": {
+          "id": "cs:precise\/thinkup-3"
+        },
+        "524": {
+          "id": "cs:precise\/thinkup-4"
+        },
+        "525": {
+          "id": "cs:precise\/thinkup-5"
+        },
+        "526": {
+          "id": "cs:precise\/tomcat-0"
+        },
+        "527": {
+          "id": "cs:precise\/tomcat-1"
+        },
+        "528": {
+          "id": "cs:precise\/tracks-0"
+        },
+        "529": {
+          "id": "cs:precise\/tracks-1"
+        },
+        "530": {
+          "id": "cs:precise\/tracks-2"
+        },
+        "531": {
+          "id": "cs:precise\/tracks-3"
+        },
+        "532": {
+          "id": "cs:precise\/tracks-4"
+        },
+        "533": {
+          "id": "cs:precise\/tracks-5"
+        },
+        "534": {
+          "id": "cs:precise\/transcode-0"
+        },
+        "535": {
+          "id": "cs:precise\/transcode-1"
+        },
+        "536": {
+          "id": "cs:precise\/tt-rss-0"
+        },
+        "537": {
+          "id": "cs:precise\/tt-rss-1"
+        },
+        "538": {
+          "id": "cs:precise\/varnish-0"
+        },
+        "539": {
+          "id": "cs:precise\/varnish-1"
+        },
+        "540": {
+          "id": "cs:precise\/varnish-2"
+        },
+        "541": {
+          "id": "cs:precise\/varnish-3"
+        },
+        "542": {
+          "id": "cs:precise\/varnish-4"
+        },
+        "543": {
+          "id": "cs:precise\/varnish-5"
+        },
+        "544": {
+          "id": "cs:precise\/varnish-6"
+        },
+        "545": {
+          "id": "cs:precise\/vdbench-1"
+        },
+        "546": {
+          "id": "cs:precise\/vdbench-2"
+        },
+        "547": {
+          "id": "cs:precise\/vdbench-3"
+        },
+        "548": {
+          "id": "cs:precise\/vdbench-4"
+        },
+        "549": {
+          "id": "cs:precise\/wildfly-1"
+        },
+        "550": {
+          "id": "cs:precise\/wildfly-2"
+        },
+        "551": {
+          "id": "cs:precise\/wildfly-3"
+        },
+        "552": {
+          "id": "cs:precise\/wildfly-4"
+        },
+        "553": {
+          "id": "cs:precise\/wildfly-5"
+        },
+        "554": {
+          "id": "cs:precise\/wordpress-0"
+        },
+        "555": {
+          "id": "cs:precise\/wordpress-1"
+        },
+        "556": {
+          "id": "cs:precise\/wordpress-10"
+        },
+        "557": {
+          "id": "cs:precise\/wordpress-11"
+        },
+        "558": {
+          "id": "cs:precise\/wordpress-12"
+        },
+        "559": {
+          "id": "cs:precise\/wordpress-13"
+        },
+        "560": {
+          "id": "cs:precise\/wordpress-14"
+        },
+        "561": {
+          "id": "cs:precise\/wordpress-15"
+        },
+        "562": {
+          "id": "cs:precise\/wordpress-16"
+        },
+        "563": {
+          "id": "cs:precise\/wordpress-17"
+        },
+        "564": {
+          "id": "cs:precise\/wordpress-18"
+        },
+        "565": {
+          "id": "cs:precise\/wordpress-19"
+        },
+        "566": {
+          "id": "cs:precise\/wordpress-2"
+        },
+        "567": {
+          "id": "cs:precise\/wordpress-20"
+        },
+        "568": {
+          "id": "cs:precise\/wordpress-21"
+        },
+        "569": {
+          "id": "cs:precise\/wordpress-22"
+        },
+        "570": {
+          "id": "cs:precise\/wordpress-23"
+        },
+        "571": {
+          "id": "cs:precise\/wordpress-24"
+        },
+        "572": {
+          "id": "cs:precise\/wordpress-25"
+        },
+        "573": {
+          "id": "cs:precise\/wordpress-26"
+        },
+        "574": {
+          "id": "cs:precise\/wordpress-27"
+        },
+        "575": {
+          "id": "cs:precise\/wordpress-3"
+        },
+        "576": {
+          "id": "cs:precise\/wordpress-4"
+        },
+        "577": {
+          "id": "cs:precise\/wordpress-5"
+        },
+        "578": {
+          "id": "cs:precise\/wordpress-6"
+        },
+        "579": {
+          "id": "cs:precise\/wordpress-7"
+        },
+        "580": {
+          "id": "cs:precise\/wordpress-8"
+        },
+        "581": {
+          "id": "cs:precise\/wordpress-9"
+        },
+        "582": {
+          "id": "cs:trusty\/apache2-1"
+        },
+        "583": {
+          "id": "cs:trusty\/apache2-10"
+        },
+        "584": {
+          "id": "cs:trusty\/apache2-11"
+        },
+        "585": {
+          "id": "cs:trusty\/apache2-12"
+        },
+        "586": {
+          "id": "cs:trusty\/apache2-2"
+        },
+        "587": {
+          "id": "cs:trusty\/apache2-3"
+        },
+        "588": {
+          "id": "cs:trusty\/apache2-4"
+        },
+        "589": {
+          "id": "cs:trusty\/apache2-5"
+        },
+        "590": {
+          "id": "cs:trusty\/apache2-6"
+        },
+        "591": {
+          "id": "cs:trusty\/apache2-7"
+        },
+        "592": {
+          "id": "cs:trusty\/apache2-8"
+        },
+        "593": {
+          "id": "cs:trusty\/apache2-9"
+        },
+        "594": {
+          "id": "cs:trusty\/ceph-radosgw-1"
+        },
+        "595": {
+          "id": "cs:trusty\/ceph-radosgw-2"
+        },
+        "596": {
+          "id": "cs:trusty\/ceph-radosgw-3"
+        },
+        "597": {
+          "id": "cs:trusty\/ceph-radosgw-4"
+        },
+        "598": {
+          "id": "cs:trusty\/ceph-radosgw-5"
+        },
+        "599": {
+          "id": "cs:trusty\/ceph-radosgw-6"
+        },
+        "600": {
+          "id": "cs:trusty\/ceph-radosgw-7"
+        },
+        "601": {
+          "id": "cs:trusty\/ceph-radosgw-8"
+        },
+        "602": {
+          "id": "cs:trusty\/ceph-radosgw-9"
+        },
+        "603": {
+          "id": "cs:trusty\/dokuwiki-1"
+        },
+        "604": {
+          "id": "cs:trusty\/etherpad-lite-1"
+        },
+        "605": {
+          "id": "cs:trusty\/ganglia-2"
+        },
+        "606": {
+          "id": "cs:trusty\/haproxy-1"
+        },
+        "607": {
+          "id": "cs:trusty\/haproxy-2"
+        },
+        "608": {
+          "id": "cs:trusty\/haproxy-3"
+        },
+        "609": {
+          "id": "cs:trusty\/haproxy-4"
+        },
+        "610": {
+          "id": "cs:trusty\/jenkins-1"
+        },
+        "611": {
+          "id": "cs:trusty\/jenkins-2"
+        },
+        "612": {
+          "id": "cs:trusty\/jenkins-3"
+        },
+        "613": {
+          "id": "cs:trusty\/joomla-0"
+        },
+        "614": {
+          "id": "cs:trusty\/juju-gui-1"
+        },
+        "615": {
+          "id": "cs:trusty\/juju-gui-10"
+        },
+        "616": {
+          "id": "cs:trusty\/juju-gui-11"
+        },
+        "617": {
+          "id": "cs:trusty\/juju-gui-12"
+        },
+        "618": {
+          "id": "cs:trusty\/juju-gui-13"
+        },
+        "619": {
+          "id": "cs:trusty\/juju-gui-14"
+        },
+        "620": {
+          "id": "cs:trusty\/juju-gui-15"
+        },
+        "621": {
+          "id": "cs:trusty\/juju-gui-16"
+        },
+        "622": {
+          "id": "cs:trusty\/juju-gui-17"
+        },
+        "623": {
+          "id": "cs:trusty\/juju-gui-18"
+        },
+        "624": {
+          "id": "cs:trusty\/juju-gui-19"
+        },
+        "625": {
+          "id": "cs:trusty\/juju-gui-2"
+        },
+        "626": {
+          "id": "cs:trusty\/juju-gui-20"
+        },
+        "627": {
+          "id": "cs:trusty\/juju-gui-21"
+        },
+        "628": {
+          "id": "cs:trusty\/juju-gui-3"
+        },
+        "629": {
+          "id": "cs:trusty\/juju-gui-4"
+        },
+        "630": {
+          "id": "cs:trusty\/juju-gui-5"
+        },
+        "631": {
+          "id": "cs:trusty\/juju-gui-6"
+        },
+        "632": {
+          "id": "cs:trusty\/juju-gui-7"
+        },
+        "633": {
+          "id": "cs:trusty\/juju-gui-8"
+        },
+        "634": {
+          "id": "cs:trusty\/juju-gui-9"
+        },
+        "635": {
+          "id": "cs:trusty\/lamp-0"
+        },
+        "636": {
+          "id": "cs:trusty\/landscape-server-1"
+        },
+        "637": {
+          "id": "cs:trusty\/landscape-server-2"
+        },
+        "638": {
+          "id": "cs:trusty\/landscape-server-3"
+        },
+        "639": {
+          "id": "cs:trusty\/landscape-server-4"
+        },
+        "640": {
+          "id": "cs:trusty\/landscape-server-5"
+        },
+        "641": {
+          "id": "cs:trusty\/landscape-server-6"
+        },
+        "642": {
+          "id": "cs:trusty\/landscape-server-7"
+        },
+        "643": {
+          "id": "cs:trusty\/mediawiki-2"
+        },
+        "644": {
+          "id": "cs:trusty\/mediawiki-3"
+        },
+        "645": {
+          "id": "cs:trusty\/meteor-1"
+        },
+        "646": {
+          "id": "cs:trusty\/munin-1"
+        },
+        "647": {
+          "id": "cs:trusty\/nagios-1"
+        },
+        "648": {
+          "id": "cs:trusty\/nagios-2"
+        },
+        "649": {
+          "id": "cs:trusty\/nagios-3"
+        },
+        "650": {
+          "id": "cs:trusty\/nagios-4"
+        },
+        "651": {
+          "id": "cs:trusty\/nagios-5"
+        },
+        "652": {
+          "id": "cs:trusty\/openerp-server-1"
+        },
+        "653": {
+          "id": "cs:trusty\/openstack-dashboard-0"
+        },
+        "654": {
+          "id": "cs:trusty\/openstack-dashboard-1"
+        },
+        "655": {
+          "id": "cs:trusty\/openstack-dashboard-2"
+        },
+        "656": {
+          "id": "cs:trusty\/openstack-dashboard-3"
+        },
+        "657": {
+          "id": "cs:trusty\/openstack-dashboard-4"
+        },
+        "658": {
+          "id": "cs:trusty\/openstack-dashboard-5"
+        },
+        "659": {
+          "id": "cs:trusty\/openstack-dashboard-6"
+        },
+        "660": {
+          "id": "cs:trusty\/openstack-dashboard-7"
+        },
+        "661": {
+          "id": "cs:trusty\/openstack-dashboard-8"
+        },
+        "662": {
+          "id": "cs:trusty\/openstack-dashboard-9"
+        },
+        "663": {
+          "id": "cs:trusty\/owncloud-1"
+        },
+        "664": {
+          "id": "cs:trusty\/owncloud-2"
+        },
+        "665": {
+          "id": "cs:trusty\/owncloud-3"
+        },
+        "666": {
+          "id": "cs:trusty\/owncloud-4"
+        },
+        "667": {
+          "id": "cs:trusty\/pgbadger-0"
+        },
+        "668": {
+          "id": "cs:trusty\/pgbadger-1"
+        },
+        "669": {
+          "id": "cs:trusty\/python-django-12"
+        },
+        "670": {
+          "id": "cs:trusty\/python-django-13"
+        },
+        "671": {
+          "id": "cs:trusty\/python-django-14"
+        },
+        "672": {
+          "id": "cs:trusty\/python-moinmoin-1"
+        },
+        "673": {
+          "id": "cs:trusty\/python-moinmoin-2"
+        },
+        "674": {
+          "id": "cs:trusty\/squid-reverseproxy-0"
+        },
+        "675": {
+          "id": "cs:trusty\/squid-reverseproxy-1"
+        },
+        "676": {
+          "id": "cs:trusty\/statusnet-1"
+        },
+        "677": {
+          "id": "cs:trusty\/sugarcrm-1"
+        },
+        "678": {
+          "id": "cs:trusty\/tomcat-0"
+        },
+        "679": {
+          "id": "cs:trusty\/tomcat-1"
+        },
+        "680": {
+          "id": "cs:trusty\/varnish-1"
+        },
+        "681": {
+          "id": "cs:trusty\/websphere-liberty-0"
+        },
+        "682": {
+          "id": "cs:trusty\/wordpress-1"
+        },
+        "683": {
+          "id": "cs:trusty\/zend-server-0"
+        },
+        "684": {
+          "id": "cs:trusty\/zend-server-1"
+        },
+        "685": {
+          "id": "cs:~0atman\/trusty\/wsgi-app-0"
+        },
+        "686": {
+          "id": "cs:~0atman\/trusty\/wsgi-app-1"
+        },
+        "687": {
+          "id": "cs:~0atman\/trusty\/wsgi-app-2"
+        },
+        "688": {
+          "id": "cs:~4-ja-d\/oneiric\/appflower-0"
+        },
+        "689": {
+          "id": "cs:~a.rosales\/precise\/mediawiki-0"
+        },
+        "690": {
+          "id": "cs:~a.rosales\/trusty\/sugarcrm-0"
+        },
+        "691": {
+          "id": "cs:~abentley\/precise\/charmworld-0"
+        },
+        "692": {
+          "id": "cs:~abentley\/precise\/charmworld-1"
+        },
+        "693": {
+          "id": "cs:~abentley\/precise\/charmworld-2"
+        },
+        "694": {
+          "id": "cs:~abentley\/precise\/charmworld-3"
+        },
+        "695": {
+          "id": "cs:~abentley\/precise\/charmworld-4"
+        },
+        "696": {
+          "id": "cs:~abentley\/precise\/charmworld-5"
+        },
+        "697": {
+          "id": "cs:~abentley\/precise\/charmworld-6"
+        },
+        "698": {
+          "id": "cs:~abentley\/precise\/charmworld-7"
+        },
+        "699": {
+          "id": "cs:~abentley\/precise\/charmworld-8"
+        },
+        "700": {
+          "id": "cs:~adam-collard\/precise\/oops-tools-0"
+        },
+        "701": {
+          "id": "cs:~adam-collard\/precise\/reviewboard-0"
+        },
+        "702": {
+          "id": "cs:~adam-collard\/precise\/reviewboard-1"
+        },
+        "703": {
+          "id": "cs:~adam-collard\/precise\/reviewboard-10"
+        },
+        "704": {
+          "id": "cs:~adam-collard\/precise\/reviewboard-2"
+        },
+        "705": {
+          "id": "cs:~adam-collard\/precise\/reviewboard-3"
+        },
+        "706": {
+          "id": "cs:~adam-collard\/precise\/reviewboard-4"
+        },
+        "707": {
+          "id": "cs:~adam-collard\/precise\/reviewboard-5"
+        },
+        "708": {
+          "id": "cs:~adam-collard\/precise\/reviewboard-6"
+        },
+        "709": {
+          "id": "cs:~adam-collard\/precise\/reviewboard-7"
+        },
+        "710": {
+          "id": "cs:~adam-collard\/precise\/reviewboard-8"
+        },
+        "711": {
+          "id": "cs:~adam-collard\/precise\/reviewboard-9"
+        },
+        "712": {
+          "id": "cs:~adam-collard\/trusty\/ceph-radosgw-0"
+        },
+        "713": {
+          "id": "cs:~ahasenack\/trusty\/openstack-dashboard-0"
+        },
+        "714": {
+          "id": "cs:~aisrael\/trusty\/opengrok-0"
+        },
+        "715": {
+          "id": "cs:~aisrael\/trusty\/roundcube-0"
+        },
+        "716": {
+          "id": "cs:~aisrael\/trusty\/tracks-0"
+        },
+        "717": {
+          "id": "cs:~alesstimec\/precise\/octave-controller-0"
+        },
+        "718": {
+          "id": "cs:~alesstimec\/precise\/octave-controller-1"
+        },
+        "719": {
+          "id": "cs:~alesstimec\/precise\/octave-controller-2"
+        },
+        "720": {
+          "id": "cs:~alesstimec\/precise\/octave-controller-3"
+        },
+        "721": {
+          "id": "cs:~alesstimec\/precise\/openfoam-controller-0"
+        },
+        "722": {
+          "id": "cs:~alesstimec\/precise\/openfoam-controller-1"
+        },
+        "723": {
+          "id": "cs:~alesstimec\/precise\/openfoam-controller-2"
+        },
+        "724": {
+          "id": "cs:~alexey-pustovalov\/precise\/zabbix-frontend-0"
+        },
+        "725": {
+          "id": "cs:~alexey-pustovalov\/trusty\/zabbix-frontend-0"
+        },
+        "726": {
+          "id": "cs:~alexlist\/precise\/squid-forwardproxy-0"
+        },
+        "727": {
+          "id": "cs:~alexlist\/precise\/squid-forwardproxy-1"
+        },
+        "728": {
+          "id": "cs:~alexlist\/precise\/squid-forwardproxy-10"
+        },
+        "729": {
+          "id": "cs:~alexlist\/precise\/squid-forwardproxy-2"
+        },
+        "730": {
+          "id": "cs:~alexlist\/precise\/squid-forwardproxy-3"
+        },
+        "731": {
+          "id": "cs:~alexlist\/precise\/squid-forwardproxy-4"
+        },
+        "732": {
+          "id": "cs:~alexlist\/precise\/squid-forwardproxy-5"
+        },
+        "733": {
+          "id": "cs:~alexlist\/precise\/squid-forwardproxy-6"
+        },
+        "734": {
+          "id": "cs:~alexlist\/precise\/squid-forwardproxy-7"
+        },
+        "735": {
+          "id": "cs:~alexlist\/precise\/squid-forwardproxy-8"
+        },
+        "736": {
+          "id": "cs:~alexlist\/precise\/squid-forwardproxy-9"
+        },
+        "737": {
+          "id": "cs:~alexlist\/precise\/squid-reverseproxy-0"
+        },
+        "738": {
+          "id": "cs:~alexlist\/precise\/squid-reverseproxy-1"
+        },
+        "739": {
+          "id": "cs:~alexlist\/precise\/squid-reverseproxy-2"
+        },
+        "740": {
+          "id": "cs:~alexlist\/precise\/squid-reverseproxy-3"
+        },
+        "741": {
+          "id": "cs:~alexlist\/precise\/squid-reverseproxy-4"
+        },
+        "742": {
+          "id": "cs:~alexlist\/precise\/squid-reverseproxy-5"
+        },
+        "743": {
+          "id": "cs:~alexlist\/precise\/squid-reverseproxy-6"
+        },
+        "744": {
+          "id": "cs:~ameetp\/precise\/vdbench-0"
+        },
+        "745": {
+          "id": "cs:~ameetp\/precise\/vdbench-1"
+        },
+        "746": {
+          "id": "cs:~ameetp\/precise\/vdbench-2"
+        },
+        "747": {
+          "id": "cs:~ameetp\/precise\/vdbench-3"
+        },
+        "748": {
+          "id": "cs:~ameetp\/precise\/vdbench-4"
+        },
+        "749": {
+          "id": "cs:~ameetp\/precise\/vdbench-5"
+        },
+        "750": {
+          "id": "cs:~andrewsomething\/precise\/bzr-and-loggerhead-0"
+        },
+        "751": {
+          "id": "cs:~asanjar\/trusty\/hadoop2-devel-0"
+        },
+        "752": {
+          "id": "cs:~asanjar\/trusty\/hadoop2-devel-1"
+        },
+        "753": {
+          "id": "cs:~aukan\/precise\/scrapyd-0"
+        },
+        "754": {
+          "id": "cs:~ayrton\/trusty\/zabbix-0"
+        },
+        "755": {
+          "id": "cs:~ayrton\/trusty\/zabbix-1"
+        },
+        "756": {
+          "id": "cs:~ayrton\/trusty\/zabbix-2"
+        },
+        "757": {
+          "id": "cs:~ayrton\/trusty\/zabbix-3"
+        },
+        "758": {
+          "id": "cs:~bac\/precise\/charmworld-0"
+        },
+        "759": {
+          "id": "cs:~bac\/precise\/charmworld-1"
+        },
+        "760": {
+          "id": "cs:~bac\/precise\/juju-gui-0"
+        },
+        "761": {
+          "id": "cs:~bac\/precise\/juju-gui-1"
+        },
+        "762": {
+          "id": "cs:~bcsaller\/precise\/juju-gui-0"
+        },
+        "763": {
+          "id": "cs:~bcsaller\/precise\/juju-gui-1"
+        },
+        "764": {
+          "id": "cs:~bcsaller\/precise\/node-app-0"
+        },
+        "765": {
+          "id": "cs:~bcsaller\/precise\/node-app-1"
+        },
+        "766": {
+          "id": "cs:~bcsaller\/precise\/node-app-2"
+        },
+        "767": {
+          "id": "cs:~bcsaller\/precise\/node-app-3"
+        },
+        "768": {
+          "id": "cs:~bcsaller\/precise\/node-app-4"
+        },
+        "769": {
+          "id": "cs:~bcsaller\/precise\/node-app-5"
+        },
+        "770": {
+          "id": "cs:~bcsaller\/precise\/restcomm-0"
+        },
+        "771": {
+          "id": "cs:~bigdata-dev\/trusty\/vstorm-tomcat-0"
+        },
+        "772": {
+          "id": "cs:~bigdata-dev\/trusty\/vstorm-tomcat-1"
+        },
+        "773": {
+          "id": "cs:~bilalakhtar\/precise\/dokuwiki-0"
+        },
+        "774": {
+          "id": "cs:~bilalakhtar\/precise\/dokuwiki-1"
+        },
+        "775": {
+          "id": "cs:~bjornt\/trusty\/ceph-radosgw-0"
+        },
+        "776": {
+          "id": "cs:~bjornt\/trusty\/ceph-radosgw-1"
+        },
+        "777": {
+          "id": "cs:~bkerensa\/oneiric\/openphoto-0"
+        },
+        "778": {
+          "id": "cs:~bkerensa\/oneiric\/openphoto-1"
+        },
+        "779": {
+          "id": "cs:~bkerensa\/oneiric\/subway-0"
+        },
+        "780": {
+          "id": "cs:~bkerensa\/precise\/locker-0"
+        },
+        "781": {
+          "id": "cs:~bkerensa\/precise\/subway-0"
+        },
+        "782": {
+          "id": "cs:~bkerensa\/precise\/subway-1"
+        },
+        "783": {
+          "id": "cs:~bloodearnest\/precise\/python-django-0"
+        },
+        "784": {
+          "id": "cs:~bloodearnest\/precise\/python-django-1"
+        },
+        "785": {
+          "id": "cs:~bloodearnest\/precise\/python-django-2"
+        },
+        "786": {
+          "id": "cs:~bloodearnest\/precise\/python-django-3"
+        },
+        "787": {
+          "id": "cs:~bloodearnest\/precise\/python-django-4"
+        },
+        "788": {
+          "id": "cs:~bloodearnest\/precise\/python-django-5"
+        },
+        "789": {
+          "id": "cs:~bloodearnest\/precise\/squid-reverseproxy-0"
+        },
+        "790": {
+          "id": "cs:~brian-albrecht\/trusty\/haproxy-0"
+        },
+        "791": {
+          "id": "cs:~bwtiffin\/raring\/gnucobol-sample-0"
+        },
+        "792": {
+          "id": "cs:~bzr-sync\/trusty\/wsgi-app-0"
+        },
+        "793": {
+          "id": "cs:~bzr-sync\/trusty\/wsgi-app-1"
+        },
+        "794": {
+          "id": "cs:~bzr-sync\/trusty\/wsgi-app-10"
+        },
+        "795": {
+          "id": "cs:~bzr-sync\/trusty\/wsgi-app-11"
+        },
+        "796": {
+          "id": "cs:~bzr-sync\/trusty\/wsgi-app-12"
+        },
+        "797": {
+          "id": "cs:~bzr-sync\/trusty\/wsgi-app-13"
+        },
+        "798": {
+          "id": "cs:~bzr-sync\/trusty\/wsgi-app-14"
+        },
+        "799": {
+          "id": "cs:~bzr-sync\/trusty\/wsgi-app-15"
+        },
+        "800": {
+          "id": "cs:~bzr-sync\/trusty\/wsgi-app-2"
+        },
+        "801": {
+          "id": "cs:~bzr-sync\/trusty\/wsgi-app-3"
+        },
+        "802": {
+          "id": "cs:~bzr-sync\/trusty\/wsgi-app-4"
+        },
+        "803": {
+          "id": "cs:~bzr-sync\/trusty\/wsgi-app-5"
+        },
+        "804": {
+          "id": "cs:~bzr-sync\/trusty\/wsgi-app-6"
+        },
+        "805": {
+          "id": "cs:~bzr-sync\/trusty\/wsgi-app-7"
+        },
+        "806": {
+          "id": "cs:~bzr-sync\/trusty\/wsgi-app-8"
+        },
+        "807": {
+          "id": "cs:~bzr-sync\/trusty\/wsgi-app-9"
+        },
+        "808": {
+          "id": "cs:~bzr\/precise\/loggerhead-0"
+        },
+        "809": {
+          "id": "cs:~cabs-team\/trusty\/sugarcrm-0"
+        },
+        "810": {
+          "id": "cs:~cabs-team\/trusty\/sugarcrm-1"
+        },
+        "811": {
+          "id": "cs:~cabs-team\/trusty\/sugarcrm-10"
+        },
+        "812": {
+          "id": "cs:~cabs-team\/trusty\/sugarcrm-11"
+        },
+        "813": {
+          "id": "cs:~cabs-team\/trusty\/sugarcrm-12"
+        },
+        "814": {
+          "id": "cs:~cabs-team\/trusty\/sugarcrm-13"
+        },
+        "815": {
+          "id": "cs:~cabs-team\/trusty\/sugarcrm-14"
+        },
+        "816": {
+          "id": "cs:~cabs-team\/trusty\/sugarcrm-15"
+        },
+        "817": {
+          "id": "cs:~cabs-team\/trusty\/sugarcrm-16"
+        },
+        "818": {
+          "id": "cs:~cabs-team\/trusty\/sugarcrm-2"
+        },
+        "819": {
+          "id": "cs:~cabs-team\/trusty\/sugarcrm-3"
+        },
+        "820": {
+          "id": "cs:~cabs-team\/trusty\/sugarcrm-4"
+        },
+        "821": {
+          "id": "cs:~cabs-team\/trusty\/sugarcrm-5"
+        },
+        "822": {
+          "id": "cs:~cabs-team\/trusty\/sugarcrm-6"
+        },
+        "823": {
+          "id": "cs:~cabs-team\/trusty\/sugarcrm-7"
+        },
+        "824": {
+          "id": "cs:~cabs-team\/trusty\/sugarcrm-8"
+        },
+        "825": {
+          "id": "cs:~cabs-team\/trusty\/sugarcrm-9"
+        },
+        "826": {
+          "id": "cs:~caio1982\/trusty\/jenkins-0"
+        },
+        "827": {
+          "id": "cs:~caio1982\/trusty\/jenkins-1"
+        },
+        "828": {
+          "id": "cs:~canonical-ci-engineering\/precise\/uci-engine-wsgi-app-0"
+        },
+        "829": {
+          "id": "cs:~canonical-ci-engineering\/precise\/uci-engine-wsgi-app-1"
+        },
+        "830": {
+          "id": "cs:~canonical-ci\/precise\/openstack-pypi-mirror-0"
+        },
+        "831": {
+          "id": "cs:~canonical-ci\/precise\/test-catalog-10"
+        },
+        "832": {
+          "id": "cs:~canonical-ci\/precise\/test-catalog-11"
+        },
+        "833": {
+          "id": "cs:~canonical-ci\/precise\/test-catalog-12"
+        },
+        "834": {
+          "id": "cs:~canonical-ci\/precise\/test-catalog-13"
+        },
+        "835": {
+          "id": "cs:~canonical-ci\/precise\/test-catalog-14"
+        },
+        "836": {
+          "id": "cs:~canonical-ci\/precise\/test-catalog-15"
+        },
+        "837": {
+          "id": "cs:~canonical-ci\/precise\/test-catalog-16"
+        },
+        "838": {
+          "id": "cs:~canonical-ci\/precise\/test-catalog-17"
+        },
+        "839": {
+          "id": "cs:~canonical-ci\/precise\/test-catalog-18"
+        },
+        "840": {
+          "id": "cs:~canonical-ci\/precise\/test-catalog-19"
+        },
+        "841": {
+          "id": "cs:~canonical-ci\/precise\/test-catalog-2"
+        },
+        "842": {
+          "id": "cs:~canonical-ci\/precise\/test-catalog-20"
+        },
+        "843": {
+          "id": "cs:~canonical-ci\/precise\/test-catalog-3"
+        },
+        "844": {
+          "id": "cs:~canonical-ci\/precise\/test-catalog-4"
+        },
+        "845": {
+          "id": "cs:~canonical-ci\/precise\/test-catalog-5"
+        },
+        "846": {
+          "id": "cs:~canonical-ci\/precise\/test-catalog-6"
+        },
+        "847": {
+          "id": "cs:~canonical-ci\/precise\/test-catalog-7"
+        },
+        "848": {
+          "id": "cs:~canonical-ci\/precise\/test-catalog-8"
+        },
+        "849": {
+          "id": "cs:~canonical-ci\/precise\/test-catalog-9"
+        },
+        "850": {
+          "id": "cs:~canonical-ci\/trusty\/openstack-pypi-mirror-0"
+        },
+        "851": {
+          "id": "cs:~canonical-sysadmins\/trusty\/apache2-subordinate-0"
+        },
+        "852": {
+          "id": "cs:~cf-charmers\/trusty\/cf-hm9000-0"
+        },
+        "853": {
+          "id": "cs:~cf-charmers\/trusty\/cf-hm9000-1"
+        },
+        "854": {
+          "id": "cs:~cf-charmers\/trusty\/cf-webadmin-0"
+        },
+        "855": {
+          "id": "cs:~cf-charmers\/trusty\/cf-webadmin-1"
+        },
+        "856": {
+          "id": "cs:~cf-charmers\/trusty\/cf-webadmin-2"
+        },
+        "857": {
+          "id": "cs:~cf-charmers\/trusty\/cf-webadmin-3"
+        },
+        "858": {
+          "id": "cs:~cf-charmers\/trusty\/cf-webadmin-4"
+        },
+        "859": {
+          "id": "cs:~cf-charmers\/trusty\/etcd-2"
+        },
+        "860": {
+          "id": "cs:~cf-charmers\/trusty\/router-v1-0"
+        },
+        "861": {
+          "id": "cs:~cf-charmers\/trusty\/router-v1-1"
+        },
+        "862": {
+          "id": "cs:~cf-charmers\/trusty\/router-v1-2"
+        },
+        "863": {
+          "id": "cs:~cf-charmers\/trusty\/router-v1-3"
+        },
+        "864": {
+          "id": "cs:~cf-charmers\/trusty\/router-v1-4"
+        },
+        "865": {
+          "id": "cs:~cf-charmers\/trusty\/router-v1-5"
+        },
+        "866": {
+          "id": "cs:~cf-charmers\/trusty\/router-v1-6"
+        },
+        "867": {
+          "id": "cs:~cf-charmers\/trusty\/router-v1-7"
+        },
+        "868": {
+          "id": "cs:~cf-charmers\/trusty\/router-v2-0"
+        },
+        "869": {
+          "id": "cs:~cf-charmers\/trusty\/router-v2-1"
+        },
+        "870": {
+          "id": "cs:~cf-charmers\/trusty\/router-v2-2"
+        },
+        "871": {
+          "id": "cs:~cf-charmers\/trusty\/router-v2-3"
+        },
+        "872": {
+          "id": "cs:~cf-charmers\/trusty\/router-v2-4"
+        },
+        "873": {
+          "id": "cs:~cf-charmers\/trusty\/router-v2-5"
+        },
+        "874": {
+          "id": "cs:~cf-charmers\/trusty\/router-v2-6"
+        },
+        "875": {
+          "id": "cs:~cf-charmers\/trusty\/router-v2-7"
+        },
+        "876": {
+          "id": "cs:~cf-charmers\/trusty\/uaa-v1-0"
+        },
+        "877": {
+          "id": "cs:~cf-charmers\/trusty\/uaa-v1-1"
+        },
+        "878": {
+          "id": "cs:~cf-charmers\/trusty\/uaa-v1-2"
+        },
+        "879": {
+          "id": "cs:~chad.smith\/trusty\/ceph-radosgw-charmhelpers-sync-apt-fix-0"
+        },
+        "880": {
+          "id": "cs:~charm-demo\/trusty\/nagios-0"
+        },
+        "881": {
+          "id": "cs:~charm-demo\/trusty\/nagios-1"
+        },
+        "882": {
+          "id": "cs:~charm-demo\/trusty\/nagios-2"
+        },
+        "883": {
+          "id": "cs:~charm-demo\/trusty\/nagios-3"
+        },
+        "884": {
+          "id": "cs:~charm-demo\/trusty\/nagios-4"
+        },
+        "885": {
+          "id": "cs:~charm-demo\/trusty\/nagios-5"
+        },
+        "886": {
+          "id": "cs:~charm-demo\/trusty\/nagios-6"
+        },
+        "887": {
+          "id": "cs:~charm-demo\/trusty\/nagios-7"
+        },
+        "888": {
+          "id": "cs:~charmers\/oneiric\/appflower-0"
+        },
+        "889": {
+          "id": "cs:~charmers\/oneiric\/appflower-1"
+        },
+        "890": {
+          "id": "cs:~charmers\/oneiric\/etherpad-lite-0"
+        },
+        "891": {
+          "id": "cs:~charmers\/oneiric\/etherpad-lite-1"
+        },
+        "892": {
+          "id": "cs:~charmers\/oneiric\/ganglia-0"
+        },
+        "893": {
+          "id": "cs:~charmers\/oneiric\/haproxy-0"
+        },
+        "894": {
+          "id": "cs:~charmers\/oneiric\/jenkins-0"
+        },
+        "895": {
+          "id": "cs:~charmers\/oneiric\/limesurvey-0"
+        },
+        "896": {
+          "id": "cs:~charmers\/oneiric\/lodgeit-0"
+        },
+        "897": {
+          "id": "cs:~charmers\/oneiric\/mediawiki-0"
+        },
+        "898": {
+          "id": "cs:~charmers\/oneiric\/munin-0"
+        },
+        "899": {
+          "id": "cs:~charmers\/oneiric\/munin-1"
+        },
+        "900": {
+          "id": "cs:~charmers\/oneiric\/musica-0"
+        },
+        "901": {
+          "id": "cs:~charmers\/oneiric\/nagios-0"
+        },
+        "902": {
+          "id": "cs:~charmers\/oneiric\/node-app-0"
+        },
+        "903": {
+          "id": "cs:~charmers\/oneiric\/oops-tools-0"
+        },
+        "904": {
+          "id": "cs:~charmers\/oneiric\/openerp-server-0"
+        },
+        "905": {
+          "id": "cs:~charmers\/oneiric\/openerp-server-1"
+        },
+        "906": {
+          "id": "cs:~charmers\/oneiric\/openerp-web-0"
+        },
+        "907": {
+          "id": "cs:~charmers\/oneiric\/openerp-web-1"
+        },
+        "908": {
+          "id": "cs:~charmers\/oneiric\/owncloud-0"
+        },
+        "909": {
+          "id": "cs:~charmers\/oneiric\/owncloud-1"
+        },
+        "910": {
+          "id": "cs:~charmers\/oneiric\/python-moinmoin-0"
+        },
+        "911": {
+          "id": "cs:~charmers\/oneiric\/roundcube-0"
+        },
+        "912": {
+          "id": "cs:~charmers\/oneiric\/stackmobile-0"
+        },
+        "913": {
+          "id": "cs:~charmers\/oneiric\/stackmobile-1"
+        },
+        "914": {
+          "id": "cs:~charmers\/oneiric\/statusnet-0"
+        },
+        "915": {
+          "id": "cs:~charmers\/oneiric\/subway-0"
+        },
+        "916": {
+          "id": "cs:~charmers\/oneiric\/subway-1"
+        },
+        "917": {
+          "id": "cs:~charmers\/oneiric\/thinkup-0"
+        },
+        "918": {
+          "id": "cs:~charmers\/oneiric\/tomcat7-0"
+        },
+        "919": {
+          "id": "cs:~charmers\/oneiric\/wordpress-0"
+        },
+        "920": {
+          "id": "cs:~charmers\/precise\/apache2-0"
+        },
+        "921": {
+          "id": "cs:~charmers\/precise\/apache2-1"
+        },
+        "922": {
+          "id": "cs:~charmers\/precise\/apache2-10"
+        },
+        "923": {
+          "id": "cs:~charmers\/precise\/apache2-11"
+        },
+        "924": {
+          "id": "cs:~charmers\/precise\/apache2-12"
+        },
+        "925": {
+          "id": "cs:~charmers\/precise\/apache2-13"
+        },
+        "926": {
+          "id": "cs:~charmers\/precise\/apache2-14"
+        },
+        "927": {
+          "id": "cs:~charmers\/precise\/apache2-15"
+        },
+        "928": {
+          "id": "cs:~charmers\/precise\/apache2-16"
+        },
+        "929": {
+          "id": "cs:~charmers\/precise\/apache2-17"
+        },
+        "930": {
+          "id": "cs:~charmers\/precise\/apache2-18"
+        },
+        "931": {
+          "id": "cs:~charmers\/precise\/apache2-19"
+        },
+        "932": {
+          "id": "cs:~charmers\/precise\/apache2-2"
+        },
+        "933": {
+          "id": "cs:~charmers\/precise\/apache2-20"
+        },
+        "934": {
+          "id": "cs:~charmers\/precise\/apache2-21"
+        },
+        "935": {
+          "id": "cs:~charmers\/precise\/apache2-22"
+        },
+        "936": {
+          "id": "cs:~charmers\/precise\/apache2-23"
+        },
+        "937": {
+          "id": "cs:~charmers\/precise\/apache2-24"
+        },
+        "938": {
+          "id": "cs:~charmers\/precise\/apache2-25"
+        },
+        "939": {
+          "id": "cs:~charmers\/precise\/apache2-26"
+        },
+        "940": {
+          "id": "cs:~charmers\/precise\/apache2-27"
+        },
+        "941": {
+          "id": "cs:~charmers\/precise\/apache2-3"
+        },
+        "942": {
+          "id": "cs:~charmers\/precise\/apache2-4"
+        },
+        "943": {
+          "id": "cs:~charmers\/precise\/apache2-5"
+        },
+        "944": {
+          "id": "cs:~charmers\/precise\/apache2-6"
+        },
+        "945": {
+          "id": "cs:~charmers\/precise\/apache2-7"
+        },
+        "946": {
+          "id": "cs:~charmers\/precise\/apache2-8"
+        },
+        "947": {
+          "id": "cs:~charmers\/precise\/apache2-9"
+        },
+        "948": {
+          "id": "cs:~charmers\/precise\/apache2-passenger-0"
+        },
+        "949": {
+          "id": "cs:~charmers\/precise\/apache2-passenger-1"
+        },
+        "950": {
+          "id": "cs:~charmers\/precise\/apache2-passenger-2"
+        },
+        "951": {
+          "id": "cs:~charmers\/precise\/apache2-passenger-3"
+        },
+        "952": {
+          "id": "cs:~charmers\/precise\/apache2-passenger-4"
+        },
+        "953": {
+          "id": "cs:~charmers\/precise\/apache2-passenger-5"
+        },
+        "954": {
+          "id": "cs:~charmers\/precise\/apache2-passenger-6"
+        },
+        "955": {
+          "id": "cs:~charmers\/precise\/appflower-0"
+        },
+        "956": {
+          "id": "cs:~charmers\/precise\/appflower-1"
+        },
+        "957": {
+          "id": "cs:~charmers\/precise\/appflower-2"
+        },
+        "958": {
+          "id": "cs:~charmers\/precise\/appflower-3"
+        },
+        "959": {
+          "id": "cs:~charmers\/precise\/appflower-4"
+        },
+        "960": {
+          "id": "cs:~charmers\/precise\/cakephp-0"
+        },
+        "961": {
+          "id": "cs:~charmers\/precise\/cakephp-1"
+        },
+        "962": {
+          "id": "cs:~charmers\/precise\/cakephp-2"
+        },
+        "963": {
+          "id": "cs:~charmers\/precise\/cakephp-3"
+        },
+        "964": {
+          "id": "cs:~charmers\/precise\/ceph-radosgw-0"
+        },
+        "965": {
+          "id": "cs:~charmers\/precise\/ceph-radosgw-2"
+        },
+        "966": {
+          "id": "cs:~charmers\/precise\/ceph-radosgw-3"
+        },
+        "967": {
+          "id": "cs:~charmers\/precise\/ceph-radosgw-4"
+        },
+        "968": {
+          "id": "cs:~charmers\/precise\/ceph-radosgw-5"
+        },
+        "969": {
+          "id": "cs:~charmers\/precise\/ceph-radosgw-6"
+        },
+        "970": {
+          "id": "cs:~charmers\/precise\/ceph-radosgw-7"
+        },
+        "971": {
+          "id": "cs:~charmers\/precise\/ceph-radosgw-8"
+        },
+        "972": {
+          "id": "cs:~charmers\/precise\/chamilo-0"
+        },
+        "973": {
+          "id": "cs:~charmers\/precise\/chamilo-1"
+        },
+        "974": {
+          "id": "cs:~charmers\/precise\/chef-server-0"
+        },
+        "975": {
+          "id": "cs:~charmers\/precise\/chef-server-1"
+        },
+        "976": {
+          "id": "cs:~charmers\/precise\/chef-server-2"
+        },
+        "977": {
+          "id": "cs:~charmers\/precise\/chef-server-3"
+        },
+        "978": {
+          "id": "cs:~charmers\/precise\/chef-server-4"
+        },
+        "979": {
+          "id": "cs:~charmers\/precise\/chef-server-5"
+        },
+        "980": {
+          "id": "cs:~charmers\/precise\/cinder-0"
+        },
+        "981": {
+          "id": "cs:~charmers\/precise\/cinder-1"
+        },
+        "982": {
+          "id": "cs:~charmers\/precise\/dokuwiki-0"
+        },
+        "983": {
+          "id": "cs:~charmers\/precise\/dokuwiki-1"
+        },
+        "984": {
+          "id": "cs:~charmers\/precise\/dokuwiki-2"
+        },
+        "985": {
+          "id": "cs:~charmers\/precise\/dokuwiki-3"
+        },
+        "986": {
+          "id": "cs:~charmers\/precise\/dokuwiki-4"
+        },
+        "987": {
+          "id": "cs:~charmers\/precise\/drupal6-0"
+        },
+        "988": {
+          "id": "cs:~charmers\/precise\/drupal6-1"
+        },
+        "989": {
+          "id": "cs:~charmers\/precise\/etherpad-lite-0"
+        },
+        "990": {
+          "id": "cs:~charmers\/precise\/etherpad-lite-1"
+        },
+        "991": {
+          "id": "cs:~charmers\/precise\/etherpad-lite-2"
+        },
+        "992": {
+          "id": "cs:~charmers\/precise\/etherpad-lite-3"
+        },
+        "993": {
+          "id": "cs:~charmers\/precise\/etherpad-lite-4"
+        },
+        "994": {
+          "id": "cs:~charmers\/precise\/etherpad-lite-5"
+        },
+        "995": {
+          "id": "cs:~charmers\/precise\/etherpad-lite-6"
+        },
+        "996": {
+          "id": "cs:~charmers\/precise\/etherpad-lite-7"
+        },
+        "997": {
+          "id": "cs:~charmers\/precise\/etherpad-lite-8"
+        },
+        "998": {
+          "id": "cs:~charmers\/precise\/etherpad-lite-9"
+        },
+        "999": {
+          "id": "cs:~charmers\/precise\/firefox-sync-1"
+        },
+        "1000": {
+          "id": "cs:~charmers\/precise\/firefox-sync-2"
+        },
+        "1001": {
+          "id": "cs:~charmers\/precise\/firefox-sync-3"
+        },
+        "1002": {
+          "id": "cs:~charmers\/precise\/firefox-sync-4"
+        },
+        "1003": {
+          "id": "cs:~charmers\/precise\/ganglia-0"
+        },
+        "1004": {
+          "id": "cs:~charmers\/precise\/ganglia-1"
+        },
+        "1005": {
+          "id": "cs:~charmers\/precise\/ganglia-2"
+        },
+        "1006": {
+          "id": "cs:~charmers\/precise\/ganglia-3"
+        },
+        "1007": {
+          "id": "cs:~charmers\/precise\/ganglia-4"
+        },
+        "1008": {
+          "id": "cs:~charmers\/precise\/ganglia-5"
+        },
+        "1009": {
+          "id": "cs:~charmers\/precise\/ganglia-6"
+        },
+        "1010": {
+          "id": "cs:~charmers\/precise\/ganglia-7"
+        },
+        "1011": {
+          "id": "cs:~charmers\/precise\/ganglia-8"
+        },
+        "1012": {
+          "id": "cs:~charmers\/precise\/ganglia-9"
+        },
+        "1013": {
+          "id": "cs:~charmers\/precise\/ghost-0"
+        },
+        "1014": {
+          "id": "cs:~charmers\/precise\/ghost-1"
+        },
+        "1015": {
+          "id": "cs:~charmers\/precise\/ghost-2"
+        },
+        "1016": {
+          "id": "cs:~charmers\/precise\/gitlab-0"
+        },
+        "1017": {
+          "id": "cs:~charmers\/precise\/gitlab-1"
+        },
+        "1018": {
+          "id": "cs:~charmers\/precise\/gitlab-2"
+        },
+        "1019": {
+          "id": "cs:~charmers\/precise\/gitlab-3"
+        },
+        "1020": {
+          "id": "cs:~charmers\/precise\/gitlab-4"
+        },
+        "1021": {
+          "id": "cs:~charmers\/precise\/gitlab-5"
+        },
+        "1022": {
+          "id": "cs:~charmers\/precise\/haproxy-0"
+        },
+        "1023": {
+          "id": "cs:~charmers\/precise\/haproxy-1"
+        },
+        "1024": {
+          "id": "cs:~charmers\/precise\/haproxy-10"
+        },
+        "1025": {
+          "id": "cs:~charmers\/precise\/haproxy-11"
+        },
+        "1026": {
+          "id": "cs:~charmers\/precise\/haproxy-12"
+        },
+        "1027": {
+          "id": "cs:~charmers\/precise\/haproxy-13"
+        },
+        "1028": {
+          "id": "cs:~charmers\/precise\/haproxy-14"
+        },
+        "1029": {
+          "id": "cs:~charmers\/precise\/haproxy-15"
+        },
+        "1030": {
+          "id": "cs:~charmers\/precise\/haproxy-16"
+        },
+        "1031": {
+          "id": "cs:~charmers\/precise\/haproxy-17"
+        },
+        "1032": {
+          "id": "cs:~charmers\/precise\/haproxy-18"
+        },
+        "1033": {
+          "id": "cs:~charmers\/precise\/haproxy-19"
+        },
+        "1034": {
+          "id": "cs:~charmers\/precise\/haproxy-2"
+        },
+        "1035": {
+          "id": "cs:~charmers\/precise\/haproxy-20"
+        },
+        "1036": {
+          "id": "cs:~charmers\/precise\/haproxy-21"
+        },
+        "1037": {
+          "id": "cs:~charmers\/precise\/haproxy-22"
+        },
+        "1038": {
+          "id": "cs:~charmers\/precise\/haproxy-23"
+        },
+        "1039": {
+          "id": "cs:~charmers\/precise\/haproxy-24"
+        },
+        "1040": {
+          "id": "cs:~charmers\/precise\/haproxy-25"
+        },
+        "1041": {
+          "id": "cs:~charmers\/precise\/haproxy-26"
+        },
+        "1042": {
+          "id": "cs:~charmers\/precise\/haproxy-27"
+        },
+        "1043": {
+          "id": "cs:~charmers\/precise\/haproxy-28"
+        },
+        "1044": {
+          "id": "cs:~charmers\/precise\/haproxy-29"
+        },
+        "1045": {
+          "id": "cs:~charmers\/precise\/haproxy-3"
+        },
+        "1046": {
+          "id": "cs:~charmers\/precise\/haproxy-30"
+        },
+        "1047": {
+          "id": "cs:~charmers\/precise\/haproxy-31"
+        },
+        "1048": {
+          "id": "cs:~charmers\/precise\/haproxy-32"
+        },
+        "1049": {
+          "id": "cs:~charmers\/precise\/haproxy-33"
+        },
+        "1050": {
+          "id": "cs:~charmers\/precise\/haproxy-34"
+        },
+        "1051": {
+          "id": "cs:~charmers\/precise\/haproxy-35"
+        },
+        "1052": {
+          "id": "cs:~charmers\/precise\/haproxy-4"
+        },
+        "1053": {
+          "id": "cs:~charmers\/precise\/haproxy-5"
+        },
+        "1054": {
+          "id": "cs:~charmers\/precise\/haproxy-6"
+        },
+        "1055": {
+          "id": "cs:~charmers\/precise\/haproxy-7"
+        },
+        "1056": {
+          "id": "cs:~charmers\/precise\/haproxy-8"
+        },
+        "1057": {
+          "id": "cs:~charmers\/precise\/haproxy-9"
+        },
+        "1058": {
+          "id": "cs:~charmers\/precise\/hbase-0"
+        },
+        "1059": {
+          "id": "cs:~charmers\/precise\/hbase-1"
+        },
+        "1060": {
+          "id": "cs:~charmers\/precise\/hbase-2"
+        },
+        "1061": {
+          "id": "cs:~charmers\/precise\/hbase-3"
+        },
+        "1062": {
+          "id": "cs:~charmers\/precise\/hbase-4"
+        },
+        "1063": {
+          "id": "cs:~charmers\/precise\/hbase-5"
+        },
+        "1064": {
+          "id": "cs:~charmers\/precise\/hbase-6"
+        },
+        "1065": {
+          "id": "cs:~charmers\/precise\/hbase-7"
+        },
+        "1066": {
+          "id": "cs:~charmers\/precise\/hbase-8"
+        },
+        "1067": {
+          "id": "cs:~charmers\/precise\/jenkins-0"
+        },
+        "1068": {
+          "id": "cs:~charmers\/precise\/jenkins-1"
+        },
+        "1069": {
+          "id": "cs:~charmers\/precise\/jenkins-10"
+        },
+        "1070": {
+          "id": "cs:~charmers\/precise\/jenkins-11"
+        },
+        "1071": {
+          "id": "cs:~charmers\/precise\/jenkins-12"
+        },
+        "1072": {
+          "id": "cs:~charmers\/precise\/jenkins-2"
+        },
+        "1073": {
+          "id": "cs:~charmers\/precise\/jenkins-3"
+        },
+        "1074": {
+          "id": "cs:~charmers\/precise\/jenkins-4"
+        },
+        "1075": {
+          "id": "cs:~charmers\/precise\/jenkins-5"
+        },
+        "1076": {
+          "id": "cs:~charmers\/precise\/jenkins-6"
+        },
+        "1077": {
+          "id": "cs:~charmers\/precise\/jenkins-7"
+        },
+        "1078": {
+          "id": "cs:~charmers\/precise\/jenkins-8"
+        },
+        "1079": {
+          "id": "cs:~charmers\/precise\/jenkins-9"
+        },
+        "1080": {
+          "id": "cs:~charmers\/precise\/joomla-0"
+        },
+        "1081": {
+          "id": "cs:~charmers\/precise\/joomla-1"
+        },
+        "1082": {
+          "id": "cs:~charmers\/precise\/joomla-2"
+        },
+        "1083": {
+          "id": "cs:~charmers\/precise\/joomla-3"
+        },
+        "1084": {
+          "id": "cs:~charmers\/precise\/juju-gui-0"
+        },
+        "1085": {
+          "id": "cs:~charmers\/precise\/juju-gui-1"
+        },
+        "1086": {
+          "id": "cs:~charmers\/precise\/juju-gui-10"
+        },
+        "1087": {
+          "id": "cs:~charmers\/precise\/juju-gui-11"
+        },
+        "1088": {
+          "id": "cs:~charmers\/precise\/juju-gui-12"
+        },
+        "1089": {
+          "id": "cs:~charmers\/precise\/juju-gui-13"
+        },
+        "1090": {
+          "id": "cs:~charmers\/precise\/juju-gui-14"
+        },
+        "1091": {
+          "id": "cs:~charmers\/precise\/juju-gui-15"
+        },
+        "1092": {
+          "id": "cs:~charmers\/precise\/juju-gui-16"
+        },
+        "1093": {
+          "id": "cs:~charmers\/precise\/juju-gui-17"
+        },
+        "1094": {
+          "id": "cs:~charmers\/precise\/juju-gui-18"
+        },
+        "1095": {
+          "id": "cs:~charmers\/precise\/juju-gui-19"
+        },
+        "1096": {
+          "id": "cs:~charmers\/precise\/juju-gui-2"
+        },
+        "1097": {
+          "id": "cs:~charmers\/precise\/juju-gui-20"
+        },
+        "1098": {
+          "id": "cs:~charmers\/precise\/juju-gui-21"
+        },
+        "1099": {
+          "id": "cs:~charmers\/precise\/juju-gui-22"
+        },
+        "1100": {
+          "id": "cs:~charmers\/precise\/juju-gui-23"
+        },
+        "1101": {
+          "id": "cs:~charmers\/precise\/juju-gui-24"
+        },
+        "1102": {
+          "id": "cs:~charmers\/precise\/juju-gui-25"
+        },
+        "1103": {
+          "id": "cs:~charmers\/precise\/juju-gui-3"
+        },
+        "1104": {
+          "id": "cs:~charmers\/precise\/juju-gui-4"
+        },
+        "1105": {
+          "id": "cs:~charmers\/precise\/juju-gui-5"
+        },
+        "1106": {
+          "id": "cs:~charmers\/precise\/juju-gui-6"
+        },
+        "1107": {
+          "id": "cs:~charmers\/precise\/juju-gui-7"
+        },
+        "1108": {
+          "id": "cs:~charmers\/precise\/juju-gui-8"
+        },
+        "1109": {
+          "id": "cs:~charmers\/precise\/juju-gui-9"
+        },
+        "1110": {
+          "id": "cs:~charmers\/precise\/kusabax-0"
+        },
+        "1111": {
+          "id": "cs:~charmers\/precise\/kusabax-1"
+        },
+        "1112": {
+          "id": "cs:~charmers\/precise\/kusabax-2"
+        },
+        "1113": {
+          "id": "cs:~charmers\/precise\/kusabax-3"
+        },
+        "1114": {
+          "id": "cs:~charmers\/precise\/lamp-0"
+        },
+        "1115": {
+          "id": "cs:~charmers\/precise\/lamp-1"
+        },
+        "1116": {
+          "id": "cs:~charmers\/precise\/lamp-2"
+        },
+        "1117": {
+          "id": "cs:~charmers\/precise\/lamp-3"
+        },
+        "1118": {
+          "id": "cs:~charmers\/precise\/lamp-4"
+        },
+        "1119": {
+          "id": "cs:~charmers\/precise\/lamp-5"
+        },
+        "1120": {
+          "id": "cs:~charmers\/precise\/lamp-6"
+        },
+        "1121": {
+          "id": "cs:~charmers\/precise\/liferay-0"
+        },
+        "1122": {
+          "id": "cs:~charmers\/precise\/liferay-1"
+        },
+        "1123": {
+          "id": "cs:~charmers\/precise\/liferay-2"
+        },
+        "1124": {
+          "id": "cs:~charmers\/precise\/limesurvey-0"
+        },
+        "1125": {
+          "id": "cs:~charmers\/precise\/limesurvey-1"
+        },
+        "1126": {
+          "id": "cs:~charmers\/precise\/limesurvey-2"
+        },
+        "1127": {
+          "id": "cs:~charmers\/precise\/limesurvey-3"
+        },
+        "1128": {
+          "id": "cs:~charmers\/precise\/limesurvey-4"
+        },
+        "1129": {
+          "id": "cs:~charmers\/precise\/limesurvey-5"
+        },
+        "1130": {
+          "id": "cs:~charmers\/precise\/limesurvey-6"
+        },
+        "1131": {
+          "id": "cs:~charmers\/precise\/lodgeit-0"
+        },
+        "1132": {
+          "id": "cs:~charmers\/precise\/lodgeit-1"
+        },
+        "1133": {
+          "id": "cs:~charmers\/precise\/loggerhead-0"
+        },
+        "1134": {
+          "id": "cs:~charmers\/precise\/loggerhead-1"
+        },
+        "1135": {
+          "id": "cs:~charmers\/precise\/loggerhead-2"
+        },
+        "1136": {
+          "id": "cs:~charmers\/precise\/loggerhead-3"
+        },
+        "1137": {
+          "id": "cs:~charmers\/precise\/mailman-0"
+        },
+        "1138": {
+          "id": "cs:~charmers\/precise\/mailman-1"
+        },
+        "1139": {
+          "id": "cs:~charmers\/precise\/mediawiki-0"
+        },
+        "1140": {
+          "id": "cs:~charmers\/precise\/mediawiki-1"
+        },
+        "1141": {
+          "id": "cs:~charmers\/precise\/mediawiki-10"
+        },
+        "1142": {
+          "id": "cs:~charmers\/precise\/mediawiki-11"
+        },
+        "1143": {
+          "id": "cs:~charmers\/precise\/mediawiki-12"
+        },
+        "1144": {
+          "id": "cs:~charmers\/precise\/mediawiki-13"
+        },
+        "1145": {
+          "id": "cs:~charmers\/precise\/mediawiki-14"
+        },
+        "1146": {
+          "id": "cs:~charmers\/precise\/mediawiki-15"
+        },
+        "1147": {
+          "id": "cs:~charmers\/precise\/mediawiki-16"
+        },
+        "1148": {
+          "id": "cs:~charmers\/precise\/mediawiki-17"
+        },
+        "1149": {
+          "id": "cs:~charmers\/precise\/mediawiki-18"
+        },
+        "1150": {
+          "id": "cs:~charmers\/precise\/mediawiki-2"
+        },
+        "1151": {
+          "id": "cs:~charmers\/precise\/mediawiki-3"
+        },
+        "1152": {
+          "id": "cs:~charmers\/precise\/mediawiki-4"
+        },
+        "1153": {
+          "id": "cs:~charmers\/precise\/mediawiki-5"
+        },
+        "1154": {
+          "id": "cs:~charmers\/precise\/mediawiki-6"
+        },
+        "1155": {
+          "id": "cs:~charmers\/precise\/mediawiki-7"
+        },
+        "1156": {
+          "id": "cs:~charmers\/precise\/mediawiki-8"
+        },
+        "1157": {
+          "id": "cs:~charmers\/precise\/mediawiki-9"
+        },
+        "1158": {
+          "id": "cs:~charmers\/precise\/meteor-0"
+        },
+        "1159": {
+          "id": "cs:~charmers\/precise\/meteor-1"
+        },
+        "1160": {
+          "id": "cs:~charmers\/precise\/meteor-2"
+        },
+        "1161": {
+          "id": "cs:~charmers\/precise\/munin-0"
+        },
+        "1162": {
+          "id": "cs:~charmers\/precise\/munin-1"
+        },
+        "1163": {
+          "id": "cs:~charmers\/precise\/munin-2"
+        },
+        "1164": {
+          "id": "cs:~charmers\/precise\/munin-3"
+        },
+        "1165": {
+          "id": "cs:~charmers\/precise\/munin-4"
+        },
+        "1166": {
+          "id": "cs:~charmers\/precise\/munin-5"
+        },
+        "1167": {
+          "id": "cs:~charmers\/precise\/musica-0"
+        },
+        "1168": {
+          "id": "cs:~charmers\/precise\/musica-1"
+        },
+        "1169": {
+          "id": "cs:~charmers\/precise\/musica-2"
+        },
+        "1170": {
+          "id": "cs:~charmers\/precise\/musica-3"
+        },
+        "1171": {
+          "id": "cs:~charmers\/precise\/nagios-0"
+        },
+        "1172": {
+          "id": "cs:~charmers\/precise\/nagios-1"
+        },
+        "1173": {
+          "id": "cs:~charmers\/precise\/nagios-10"
+        },
+        "1174": {
+          "id": "cs:~charmers\/precise\/nagios-11"
+        },
+        "1175": {
+          "id": "cs:~charmers\/precise\/nagios-2"
+        },
+        "1176": {
+          "id": "cs:~charmers\/precise\/nagios-3"
+        },
+        "1177": {
+          "id": "cs:~charmers\/precise\/nagios-4"
+        },
+        "1178": {
+          "id": "cs:~charmers\/precise\/nagios-5"
+        },
+        "1179": {
+          "id": "cs:~charmers\/precise\/nagios-6"
+        },
+        "1180": {
+          "id": "cs:~charmers\/precise\/nagios-7"
+        },
+        "1181": {
+          "id": "cs:~charmers\/precise\/nagios-8"
+        },
+        "1182": {
+          "id": "cs:~charmers\/precise\/nagios-9"
+        },
+        "1183": {
+          "id": "cs:~charmers\/precise\/nginx-passenger-0"
+        },
+        "1184": {
+          "id": "cs:~charmers\/precise\/nginx-passenger-1"
+        },
+        "1185": {
+          "id": "cs:~charmers\/precise\/nginx-passenger-2"
+        },
+        "1186": {
+          "id": "cs:~charmers\/precise\/nginx-passenger-3"
+        },
+        "1187": {
+          "id": "cs:~charmers\/precise\/node-app-0"
+        },
+        "1188": {
+          "id": "cs:~charmers\/precise\/node-app-1"
+        },
+        "1189": {
+          "id": "cs:~charmers\/precise\/node-app-10"
+        },
+        "1190": {
+          "id": "cs:~charmers\/precise\/node-app-2"
+        },
+        "1191": {
+          "id": "cs:~charmers\/precise\/node-app-3"
+        },
+        "1192": {
+          "id": "cs:~charmers\/precise\/node-app-4"
+        },
+        "1193": {
+          "id": "cs:~charmers\/precise\/node-app-5"
+        },
+        "1194": {
+          "id": "cs:~charmers\/precise\/node-app-6"
+        },
+        "1195": {
+          "id": "cs:~charmers\/precise\/node-app-7"
+        },
+        "1196": {
+          "id": "cs:~charmers\/precise\/node-app-8"
+        },
+        "1197": {
+          "id": "cs:~charmers\/precise\/node-app-9"
+        },
+        "1198": {
+          "id": "cs:~charmers\/precise\/oops-tools-0"
+        },
+        "1199": {
+          "id": "cs:~charmers\/precise\/oops-tools-1"
+        },
+        "1200": {
+          "id": "cs:~charmers\/precise\/oops-tools-2"
+        },
+        "1201": {
+          "id": "cs:~charmers\/precise\/oops-tools-3"
+        },
+        "1202": {
+          "id": "cs:~charmers\/precise\/openerp-server-0"
+        },
+        "1203": {
+          "id": "cs:~charmers\/precise\/openerp-server-1"
+        },
+        "1204": {
+          "id": "cs:~charmers\/precise\/openerp-server-2"
+        },
+        "1205": {
+          "id": "cs:~charmers\/precise\/openerp-web-0"
+        },
+        "1206": {
+          "id": "cs:~charmers\/precise\/openerp-web-1"
+        },
+        "1207": {
+          "id": "cs:~charmers\/precise\/openerp-web-2"
+        },
+        "1208": {
+          "id": "cs:~charmers\/precise\/openerp-web-3"
+        },
+        "1209": {
+          "id": "cs:~charmers\/precise\/openerp-web-4"
+        },
+        "1210": {
+          "id": "cs:~charmers\/precise\/opengrok-0"
+        },
+        "1211": {
+          "id": "cs:~charmers\/precise\/opengrok-1"
+        },
+        "1212": {
+          "id": "cs:~charmers\/precise\/opengrok-2"
+        },
+        "1213": {
+          "id": "cs:~charmers\/precise\/opengrok-3"
+        },
+        "1214": {
+          "id": "cs:~charmers\/precise\/openstack-dashboard-10"
+        },
+        "1215": {
+          "id": "cs:~charmers\/precise\/openstack-dashboard-11"
+        },
+        "1216": {
+          "id": "cs:~charmers\/precise\/openstack-dashboard-12"
+        },
+        "1217": {
+          "id": "cs:~charmers\/precise\/openstack-dashboard-13"
+        },
+        "1218": {
+          "id": "cs:~charmers\/precise\/opentsdb-0"
+        },
+        "1219": {
+          "id": "cs:~charmers\/precise\/opentsdb-1"
+        },
+        "1220": {
+          "id": "cs:~charmers\/precise\/opentsdb-2"
+        },
+        "1221": {
+          "id": "cs:~charmers\/precise\/opentsdb-3"
+        },
+        "1222": {
+          "id": "cs:~charmers\/precise\/opentsdb-4"
+        },
+        "1223": {
+          "id": "cs:~charmers\/precise\/openvpn-as-0"
+        },
+        "1224": {
+          "id": "cs:~charmers\/precise\/openvpn-as-1"
+        },
+        "1225": {
+          "id": "cs:~charmers\/precise\/openvpn-as-2"
+        },
+        "1226": {
+          "id": "cs:~charmers\/precise\/openvpn-as-3"
+        },
+        "1227": {
+          "id": "cs:~charmers\/precise\/openvpn-as-4"
+        },
+        "1228": {
+          "id": "cs:~charmers\/precise\/openvpn-as-5"
+        },
+        "1229": {
+          "id": "cs:~charmers\/precise\/openvpn-as-6"
+        },
+        "1230": {
+          "id": "cs:~charmers\/precise\/owncloud-0"
+        },
+        "1231": {
+          "id": "cs:~charmers\/precise\/owncloud-1"
+        },
+        "1232": {
+          "id": "cs:~charmers\/precise\/owncloud-10"
+        },
+        "1233": {
+          "id": "cs:~charmers\/precise\/owncloud-11"
+        },
+        "1234": {
+          "id": "cs:~charmers\/precise\/owncloud-12"
+        },
+        "1235": {
+          "id": "cs:~charmers\/precise\/owncloud-13"
+        },
+        "1236": {
+          "id": "cs:~charmers\/precise\/owncloud-14"
+        },
+        "1237": {
+          "id": "cs:~charmers\/precise\/owncloud-15"
+        },
+        "1238": {
+          "id": "cs:~charmers\/precise\/owncloud-16"
+        },
+        "1239": {
+          "id": "cs:~charmers\/precise\/owncloud-17"
+        },
+        "1240": {
+          "id": "cs:~charmers\/precise\/owncloud-18"
+        },
+        "1241": {
+          "id": "cs:~charmers\/precise\/owncloud-2"
+        },
+        "1242": {
+          "id": "cs:~charmers\/precise\/owncloud-3"
+        },
+        "1243": {
+          "id": "cs:~charmers\/precise\/owncloud-4"
+        },
+        "1244": {
+          "id": "cs:~charmers\/precise\/owncloud-5"
+        },
+        "1245": {
+          "id": "cs:~charmers\/precise\/owncloud-6"
+        },
+        "1246": {
+          "id": "cs:~charmers\/precise\/owncloud-7"
+        },
+        "1247": {
+          "id": "cs:~charmers\/precise\/owncloud-8"
+        },
+        "1248": {
+          "id": "cs:~charmers\/precise\/owncloud-9"
+        },
+        "1249": {
+          "id": "cs:~charmers\/precise\/pgbadger-0"
+        },
+        "1250": {
+          "id": "cs:~charmers\/precise\/pgbadger-1"
+        },
+        "1251": {
+          "id": "cs:~charmers\/precise\/pgbadger-2"
+        },
+        "1252": {
+          "id": "cs:~charmers\/precise\/phpmyadmin-1"
+        },
+        "1253": {
+          "id": "cs:~charmers\/precise\/phpmyadmin-2"
+        },
+        "1254": {
+          "id": "cs:~charmers\/precise\/phpmyadmin-3"
+        },
+        "1255": {
+          "id": "cs:~charmers\/precise\/phpmyadmin-4"
+        },
+        "1256": {
+          "id": "cs:~charmers\/precise\/phpmyadmin-5"
+        },
+        "1257": {
+          "id": "cs:~charmers\/precise\/pictor-0"
+        },
+        "1258": {
+          "id": "cs:~charmers\/precise\/pictor-1"
+        },
+        "1259": {
+          "id": "cs:~charmers\/precise\/pictor-2"
+        },
+        "1260": {
+          "id": "cs:~charmers\/precise\/pictor-3"
+        },
+        "1261": {
+          "id": "cs:~charmers\/precise\/pictor-4"
+        },
+        "1262": {
+          "id": "cs:~charmers\/precise\/pictor-5"
+        },
+        "1263": {
+          "id": "cs:~charmers\/precise\/pictor-6"
+        },
+        "1264": {
+          "id": "cs:~charmers\/precise\/promultest-0"
+        },
+        "1265": {
+          "id": "cs:~charmers\/precise\/pubphoto-0"
+        },
+        "1266": {
+          "id": "cs:~charmers\/precise\/python-django-0"
+        },
+        "1267": {
+          "id": "cs:~charmers\/precise\/python-django-1"
+        },
+        "1268": {
+          "id": "cs:~charmers\/precise\/python-django-2"
+        },
+        "1269": {
+          "id": "cs:~charmers\/precise\/python-django-3"
+        },
+        "1270": {
+          "id": "cs:~charmers\/precise\/python-django-4"
+        },
+        "1271": {
+          "id": "cs:~charmers\/precise\/python-django-5"
+        },
+        "1272": {
+          "id": "cs:~charmers\/precise\/python-django-6"
+        },
+        "1273": {
+          "id": "cs:~charmers\/precise\/python-django-7"
+        },
+        "1274": {
+          "id": "cs:~charmers\/precise\/python-moinmoin-0"
+        },
+        "1275": {
+          "id": "cs:~charmers\/precise\/python-moinmoin-1"
+        },
+        "1276": {
+          "id": "cs:~charmers\/precise\/python-moinmoin-2"
+        },
+        "1277": {
+          "id": "cs:~charmers\/precise\/python-moinmoin-3"
+        },
+        "1278": {
+          "id": "cs:~charmers\/precise\/python-moinmoin-4"
+        },
+        "1279": {
+          "id": "cs:~charmers\/precise\/python-moinmoin-5"
+        },
+        "1280": {
+          "id": "cs:~charmers\/precise\/python-moinmoin-6"
+        },
+        "1281": {
+          "id": "cs:~charmers\/precise\/rails-0"
+        },
+        "1282": {
+          "id": "cs:~charmers\/precise\/rails-1"
+        },
+        "1283": {
+          "id": "cs:~charmers\/precise\/rails-2"
+        },
+        "1284": {
+          "id": "cs:~charmers\/precise\/rails-3"
+        },
+        "1285": {
+          "id": "cs:~charmers\/precise\/reviewboard-0"
+        },
+        "1286": {
+          "id": "cs:~charmers\/precise\/reviewboard-1"
+        },
+        "1287": {
+          "id": "cs:~charmers\/precise\/reviewboard-2"
+        },
+        "1288": {
+          "id": "cs:~charmers\/precise\/reviewboard-3"
+        },
+        "1289": {
+          "id": "cs:~charmers\/precise\/roundcube-0"
+        },
+        "1290": {
+          "id": "cs:~charmers\/precise\/roundcube-1"
+        },
+        "1291": {
+          "id": "cs:~charmers\/precise\/roundcube-2"
+        },
+        "1292": {
+          "id": "cs:~charmers\/precise\/seafile-0"
+        },
+        "1293": {
+          "id": "cs:~charmers\/precise\/seafile-1"
+        },
+        "1294": {
+          "id": "cs:~charmers\/precise\/seafile-2"
+        },
+        "1295": {
+          "id": "cs:~charmers\/precise\/seafile-3"
+        },
+        "1296": {
+          "id": "cs:~charmers\/precise\/seafile-4"
+        },
+        "1297": {
+          "id": "cs:~charmers\/precise\/shelrtv-0"
+        },
+        "1298": {
+          "id": "cs:~charmers\/precise\/shelrtv-1"
+        },
+        "1299": {
+          "id": "cs:~charmers\/precise\/shelrtv-2"
+        },
+        "1300": {
+          "id": "cs:~charmers\/precise\/solr-jetty-0"
+        },
+        "1301": {
+          "id": "cs:~charmers\/precise\/solr-jetty-1"
+        },
+        "1302": {
+          "id": "cs:~charmers\/precise\/solr-jetty-2"
+        },
+        "1303": {
+          "id": "cs:~charmers\/precise\/solr-jetty-3"
+        },
+        "1304": {
+          "id": "cs:~charmers\/precise\/solr-jetty-4"
+        },
+        "1305": {
+          "id": "cs:~charmers\/precise\/solr-jetty-5"
+        },
+        "1306": {
+          "id": "cs:~charmers\/precise\/solr-jetty-6"
+        },
+        "1307": {
+          "id": "cs:~charmers\/precise\/solr-jetty-7"
+        },
+        "1308": {
+          "id": "cs:~charmers\/precise\/spip-0"
+        },
+        "1309": {
+          "id": "cs:~charmers\/precise\/spip-1"
+        },
+        "1310": {
+          "id": "cs:~charmers\/precise\/spip-2"
+        },
+        "1311": {
+          "id": "cs:~charmers\/precise\/spip-3"
+        },
+        "1312": {
+          "id": "cs:~charmers\/precise\/squid-forwardproxy-0"
+        },
+        "1313": {
+          "id": "cs:~charmers\/precise\/squid-forwardproxy-1"
+        },
+        "1314": {
+          "id": "cs:~charmers\/precise\/squid-forwardproxy-2"
+        },
+        "1315": {
+          "id": "cs:~charmers\/precise\/squid-reverseproxy-0"
+        },
+        "1316": {
+          "id": "cs:~charmers\/precise\/squid-reverseproxy-1"
+        },
+        "1317": {
+          "id": "cs:~charmers\/precise\/squid-reverseproxy-2"
+        },
+        "1318": {
+          "id": "cs:~charmers\/precise\/squid-reverseproxy-3"
+        },
+        "1319": {
+          "id": "cs:~charmers\/precise\/squid-reverseproxy-4"
+        },
+        "1320": {
+          "id": "cs:~charmers\/precise\/squid-reverseproxy-5"
+        },
+        "1321": {
+          "id": "cs:~charmers\/precise\/squid-reverseproxy-6"
+        },
+        "1322": {
+          "id": "cs:~charmers\/precise\/squid-reverseproxy-7"
+        },
+        "1323": {
+          "id": "cs:~charmers\/precise\/squid-reverseproxy-8"
+        },
+        "1324": {
+          "id": "cs:~charmers\/precise\/squid-reverseproxy-9"
+        },
+        "1325": {
+          "id": "cs:~charmers\/precise\/stackmobile-0"
+        },
+        "1326": {
+          "id": "cs:~charmers\/precise\/stackmobile-1"
+        },
+        "1327": {
+          "id": "cs:~charmers\/precise\/stackmobile-2"
+        },
+        "1328": {
+          "id": "cs:~charmers\/precise\/stackmobile-3"
+        },
+        "1329": {
+          "id": "cs:~charmers\/precise\/statusnet-0"
+        },
+        "1330": {
+          "id": "cs:~charmers\/precise\/statusnet-1"
+        },
+        "1331": {
+          "id": "cs:~charmers\/precise\/statusnet-2"
+        },
+        "1332": {
+          "id": "cs:~charmers\/precise\/statusnet-3"
+        },
+        "1333": {
+          "id": "cs:~charmers\/precise\/statusnet-4"
+        },
+        "1334": {
+          "id": "cs:~charmers\/precise\/statusnet-5"
+        },
+        "1335": {
+          "id": "cs:~charmers\/precise\/statusnet-6"
+        },
+        "1336": {
+          "id": "cs:~charmers\/precise\/subway-0"
+        },
+        "1337": {
+          "id": "cs:~charmers\/precise\/subway-1"
+        },
+        "1338": {
+          "id": "cs:~charmers\/precise\/subway-2"
+        },
+        "1339": {
+          "id": "cs:~charmers\/precise\/subway-3"
+        },
+        "1340": {
+          "id": "cs:~charmers\/precise\/subway-4"
+        },
+        "1341": {
+          "id": "cs:~charmers\/precise\/subway-5"
+        },
+        "1342": {
+          "id": "cs:~charmers\/precise\/syncope-0"
+        },
+        "1343": {
+          "id": "cs:~charmers\/precise\/syncope-1"
+        },
+        "1344": {
+          "id": "cs:~charmers\/precise\/thinkup-0"
+        },
+        "1345": {
+          "id": "cs:~charmers\/precise\/thinkup-1"
+        },
+        "1346": {
+          "id": "cs:~charmers\/precise\/thinkup-2"
+        },
+        "1347": {
+          "id": "cs:~charmers\/precise\/thinkup-3"
+        },
+        "1348": {
+          "id": "cs:~charmers\/precise\/thinkup-4"
+        },
+        "1349": {
+          "id": "cs:~charmers\/precise\/thinkup-5"
+        },
+        "1350": {
+          "id": "cs:~charmers\/precise\/tomcat-0"
+        },
+        "1351": {
+          "id": "cs:~charmers\/precise\/tomcat-1"
+        },
+        "1352": {
+          "id": "cs:~charmers\/precise\/tomcat6-0"
+        },
+        "1353": {
+          "id": "cs:~charmers\/precise\/tomcat6-1"
+        },
+        "1354": {
+          "id": "cs:~charmers\/precise\/tomcat6-2"
+        },
+        "1355": {
+          "id": "cs:~charmers\/precise\/tomcat6-3"
+        },
+        "1356": {
+          "id": "cs:~charmers\/precise\/tomcat7-0"
+        },
+        "1357": {
+          "id": "cs:~charmers\/precise\/tomcat7-1"
+        },
+        "1358": {
+          "id": "cs:~charmers\/precise\/tomcat7-2"
+        },
+        "1359": {
+          "id": "cs:~charmers\/precise\/tomcat7-3"
+        },
+        "1360": {
+          "id": "cs:~charmers\/precise\/tomcat7-4"
+        },
+        "1361": {
+          "id": "cs:~charmers\/precise\/tracks-0"
+        },
+        "1362": {
+          "id": "cs:~charmers\/precise\/tracks-1"
+        },
+        "1363": {
+          "id": "cs:~charmers\/precise\/tracks-2"
+        },
+        "1364": {
+          "id": "cs:~charmers\/precise\/tracks-3"
+        },
+        "1365": {
+          "id": "cs:~charmers\/precise\/tracks-4"
+        },
+        "1366": {
+          "id": "cs:~charmers\/precise\/tracks-5"
+        },
+        "1367": {
+          "id": "cs:~charmers\/precise\/transcode-0"
+        },
+        "1368": {
+          "id": "cs:~charmers\/precise\/transcode-1"
+        },
+        "1369": {
+          "id": "cs:~charmers\/precise\/tt-rss-0"
+        },
+        "1370": {
+          "id": "cs:~charmers\/precise\/tt-rss-1"
+        },
+        "1371": {
+          "id": "cs:~charmers\/precise\/varnish-0"
+        },
+        "1372": {
+          "id": "cs:~charmers\/precise\/varnish-1"
+        },
+        "1373": {
+          "id": "cs:~charmers\/precise\/varnish-2"
+        },
+        "1374": {
+          "id": "cs:~charmers\/precise\/varnish-3"
+        },
+        "1375": {
+          "id": "cs:~charmers\/precise\/varnish-4"
+        },
+        "1376": {
+          "id": "cs:~charmers\/precise\/varnish-5"
+        },
+        "1377": {
+          "id": "cs:~charmers\/precise\/varnish-6"
+        },
+        "1378": {
+          "id": "cs:~charmers\/precise\/vdbench-0"
+        },
+        "1379": {
+          "id": "cs:~charmers\/precise\/vdbench-2"
+        },
+        "1380": {
+          "id": "cs:~charmers\/precise\/vdbench-3"
+        },
+        "1381": {
+          "id": "cs:~charmers\/precise\/vdbench-4"
+        },
+        "1382": {
+          "id": "cs:~charmers\/precise\/wildfly-0"
+        },
+        "1383": {
+          "id": "cs:~charmers\/precise\/wildfly-1"
+        },
+        "1384": {
+          "id": "cs:~charmers\/precise\/wildfly-2"
+        },
+        "1385": {
+          "id": "cs:~charmers\/precise\/wildfly-3"
+        },
+        "1386": {
+          "id": "cs:~charmers\/precise\/wildfly-4"
+        },
+        "1387": {
+          "id": "cs:~charmers\/precise\/wildfly-5"
+        },
+        "1388": {
+          "id": "cs:~charmers\/precise\/wordpress-0"
+        },
+        "1389": {
+          "id": "cs:~charmers\/precise\/wordpress-1"
+        },
+        "1390": {
+          "id": "cs:~charmers\/precise\/wordpress-10"
+        },
+        "1391": {
+          "id": "cs:~charmers\/precise\/wordpress-11"
+        },
+        "1392": {
+          "id": "cs:~charmers\/precise\/wordpress-12"
+        },
+        "1393": {
+          "id": "cs:~charmers\/precise\/wordpress-13"
+        },
+        "1394": {
+          "id": "cs:~charmers\/precise\/wordpress-14"
+        },
+        "1395": {
+          "id": "cs:~charmers\/precise\/wordpress-15"
+        },
+        "1396": {
+          "id": "cs:~charmers\/precise\/wordpress-16"
+        },
+        "1397": {
+          "id": "cs:~charmers\/precise\/wordpress-17"
+        },
+        "1398": {
+          "id": "cs:~charmers\/precise\/wordpress-18"
+        },
+        "1399": {
+          "id": "cs:~charmers\/precise\/wordpress-19"
+        },
+        "1400": {
+          "id": "cs:~charmers\/precise\/wordpress-2"
+        },
+        "1401": {
+          "id": "cs:~charmers\/precise\/wordpress-20"
+        },
+        "1402": {
+          "id": "cs:~charmers\/precise\/wordpress-21"
+        },
+        "1403": {
+          "id": "cs:~charmers\/precise\/wordpress-22"
+        },
+        "1404": {
+          "id": "cs:~charmers\/precise\/wordpress-23"
+        },
+        "1405": {
+          "id": "cs:~charmers\/precise\/wordpress-24"
+        },
+        "1406": {
+          "id": "cs:~charmers\/precise\/wordpress-25"
+        },
+        "1407": {
+          "id": "cs:~charmers\/precise\/wordpress-26"
+        },
+        "1408": {
+          "id": "cs:~charmers\/precise\/wordpress-27"
+        },
+        "1409": {
+          "id": "cs:~charmers\/precise\/wordpress-3"
+        },
+        "1410": {
+          "id": "cs:~charmers\/precise\/wordpress-4"
+        },
+        "1411": {
+          "id": "cs:~charmers\/precise\/wordpress-5"
+        },
+        "1412": {
+          "id": "cs:~charmers\/precise\/wordpress-6"
+        },
+        "1413": {
+          "id": "cs:~charmers\/precise\/wordpress-7"
+        },
+        "1414": {
+          "id": "cs:~charmers\/precise\/wordpress-8"
+        },
+        "1415": {
+          "id": "cs:~charmers\/precise\/wordpress-9"
+        },
+        "1416": {
+          "id": "cs:~charmers\/quantal\/ceph-radosgw-0"
+        },
+        "1417": {
+          "id": "cs:~charmers\/quantal\/ceph-radosgw-1"
+        },
+        "1418": {
+          "id": "cs:~charmers\/trusty\/apache2-0"
+        },
+        "1419": {
+          "id": "cs:~charmers\/trusty\/apache2-1"
+        },
+        "1420": {
+          "id": "cs:~charmers\/trusty\/apache2-10"
+        },
+        "1421": {
+          "id": "cs:~charmers\/trusty\/apache2-11"
+        },
+        "1422": {
+          "id": "cs:~charmers\/trusty\/apache2-12"
+        },
+        "1423": {
+          "id": "cs:~charmers\/trusty\/apache2-2"
+        },
+        "1424": {
+          "id": "cs:~charmers\/trusty\/apache2-3"
+        },
+        "1425": {
+          "id": "cs:~charmers\/trusty\/apache2-4"
+        },
+        "1426": {
+          "id": "cs:~charmers\/trusty\/apache2-5"
+        },
+        "1427": {
+          "id": "cs:~charmers\/trusty\/apache2-6"
+        },
+        "1428": {
+          "id": "cs:~charmers\/trusty\/apache2-7"
+        },
+        "1429": {
+          "id": "cs:~charmers\/trusty\/apache2-8"
+        },
+        "1430": {
+          "id": "cs:~charmers\/trusty\/apache2-9"
+        },
+        "1431": {
+          "id": "cs:~charmers\/trusty\/dokuwiki-0"
+        },
+        "1432": {
+          "id": "cs:~charmers\/trusty\/dokuwiki-1"
+        },
+        "1433": {
+          "id": "cs:~charmers\/trusty\/etherpad-lite-0"
+        },
+        "1434": {
+          "id": "cs:~charmers\/trusty\/etherpad-lite-1"
+        },
+        "1435": {
+          "id": "cs:~charmers\/trusty\/ganglia-0"
+        },
+        "1436": {
+          "id": "cs:~charmers\/trusty\/ganglia-1"
+        },
+        "1437": {
+          "id": "cs:~charmers\/trusty\/ganglia-2"
+        },
+        "1438": {
+          "id": "cs:~charmers\/trusty\/haproxy-0"
+        },
+        "1439": {
+          "id": "cs:~charmers\/trusty\/haproxy-1"
+        },
+        "1440": {
+          "id": "cs:~charmers\/trusty\/haproxy-2"
+        },
+        "1441": {
+          "id": "cs:~charmers\/trusty\/haproxy-3"
+        },
+        "1442": {
+          "id": "cs:~charmers\/trusty\/haproxy-4"
+        },
+        "1443": {
+          "id": "cs:~charmers\/trusty\/jenkins-0"
+        },
+        "1444": {
+          "id": "cs:~charmers\/trusty\/jenkins-1"
+        },
+        "1445": {
+          "id": "cs:~charmers\/trusty\/jenkins-2"
+        },
+        "1446": {
+          "id": "cs:~charmers\/trusty\/jenkins-3"
+        },
+        "1447": {
+          "id": "cs:~charmers\/trusty\/joomla-0"
+        },
+        "1448": {
+          "id": "cs:~charmers\/trusty\/lamp-0"
+        },
+        "1449": {
+          "id": "cs:~charmers\/trusty\/mediawiki-0"
+        },
+        "1450": {
+          "id": "cs:~charmers\/trusty\/mediawiki-1"
+        },
+        "1451": {
+          "id": "cs:~charmers\/trusty\/mediawiki-2"
+        },
+        "1452": {
+          "id": "cs:~charmers\/trusty\/mediawiki-3"
+        },
+        "1453": {
+          "id": "cs:~charmers\/trusty\/meteor-0"
+        },
+        "1454": {
+          "id": "cs:~charmers\/trusty\/meteor-1"
+        },
+        "1455": {
+          "id": "cs:~charmers\/trusty\/munin-0"
+        },
+        "1456": {
+          "id": "cs:~charmers\/trusty\/munin-1"
+        },
+        "1457": {
+          "id": "cs:~charmers\/trusty\/nagios-0"
+        },
+        "1458": {
+          "id": "cs:~charmers\/trusty\/nagios-1"
+        },
+        "1459": {
+          "id": "cs:~charmers\/trusty\/nagios-2"
+        },
+        "1460": {
+          "id": "cs:~charmers\/trusty\/nagios-3"
+        },
+        "1461": {
+          "id": "cs:~charmers\/trusty\/nagios-4"
+        },
+        "1462": {
+          "id": "cs:~charmers\/trusty\/nagios-5"
+        },
+        "1463": {
+          "id": "cs:~charmers\/trusty\/openerp-server-0"
+        },
+        "1464": {
+          "id": "cs:~charmers\/trusty\/openerp-server-1"
+        },
+        "1465": {
+          "id": "cs:~charmers\/trusty\/owncloud-0"
+        },
+        "1466": {
+          "id": "cs:~charmers\/trusty\/owncloud-1"
+        },
+        "1467": {
+          "id": "cs:~charmers\/trusty\/owncloud-2"
+        },
+        "1468": {
+          "id": "cs:~charmers\/trusty\/owncloud-3"
+        },
+        "1469": {
+          "id": "cs:~charmers\/trusty\/owncloud-4"
+        },
+        "1470": {
+          "id": "cs:~charmers\/trusty\/pgbadger-0"
+        },
+        "1471": {
+          "id": "cs:~charmers\/trusty\/pgbadger-1"
+        },
+        "1472": {
+          "id": "cs:~charmers\/trusty\/python-django-0"
+        },
+        "1473": {
+          "id": "cs:~charmers\/trusty\/python-django-10"
+        },
+        "1474": {
+          "id": "cs:~charmers\/trusty\/python-django-11"
+        },
+        "1475": {
+          "id": "cs:~charmers\/trusty\/python-django-12"
+        },
+        "1476": {
+          "id": "cs:~charmers\/trusty\/python-django-13"
+        },
+        "1477": {
+          "id": "cs:~charmers\/trusty\/python-django-14"
+        },
+        "1478": {
+          "id": "cs:~charmers\/trusty\/python-django-8"
+        },
+        "1479": {
+          "id": "cs:~charmers\/trusty\/python-django-9"
+        },
+        "1480": {
+          "id": "cs:~charmers\/trusty\/python-moinmoin-0"
+        },
+        "1481": {
+          "id": "cs:~charmers\/trusty\/python-moinmoin-1"
+        },
+        "1482": {
+          "id": "cs:~charmers\/trusty\/python-moinmoin-2"
+        },
+        "1483": {
+          "id": "cs:~charmers\/trusty\/squid-reverseproxy-0"
+        },
+        "1484": {
+          "id": "cs:~charmers\/trusty\/squid-reverseproxy-1"
+        },
+        "1485": {
+          "id": "cs:~charmers\/trusty\/statusnet-0"
+        },
+        "1486": {
+          "id": "cs:~charmers\/trusty\/statusnet-1"
+        },
+        "1487": {
+          "id": "cs:~charmers\/trusty\/sugarcrm-0"
+        },
+        "1488": {
+          "id": "cs:~charmers\/trusty\/sugarcrm-1"
+        },
+        "1489": {
+          "id": "cs:~charmers\/trusty\/tomcat-0"
+        },
+        "1490": {
+          "id": "cs:~charmers\/trusty\/tomcat-1"
+        },
+        "1491": {
+          "id": "cs:~charmers\/trusty\/varnish-0"
+        },
+        "1492": {
+          "id": "cs:~charmers\/trusty\/varnish-1"
+        },
+        "1493": {
+          "id": "cs:~charmers\/trusty\/websphere-liberty-0"
+        },
+        "1494": {
+          "id": "cs:~charmers\/trusty\/wordpress-0"
+        },
+        "1495": {
+          "id": "cs:~charmers\/trusty\/wordpress-1"
+        },
+        "1496": {
+          "id": "cs:~charmers\/trusty\/zend-server-0"
+        },
+        "1497": {
+          "id": "cs:~charmers\/trusty\/zend-server-1"
+        },
+        "1498": {
+          "id": "cs:~chilicuil\/precise\/observium-0"
+        },
+        "1499": {
+          "id": "cs:~chilicuil\/precise\/observium-1"
+        },
+        "1500": {
+          "id": "cs:~chilicuil\/precise\/observium-2"
+        },
+        "1501": {
+          "id": "cs:~chilicuil\/precise\/observium-3"
+        },
+        "1502": {
+          "id": "cs:~chqistian\/precise\/wordpress-0"
+        },
+        "1503": {
+          "id": "cs:~chqistian\/precise\/wordpress-1"
+        },
+        "1504": {
+          "id": "cs:~chqistian\/trusty\/wordpress-0"
+        },
+        "1505": {
+          "id": "cs:~chqistian\/trusty\/wordpress-1"
+        },
+        "1506": {
+          "id": "cs:~chris-gondolin\/trusty\/pypi-mirror-1"
+        },
+        "1507": {
+          "id": "cs:~chrisdonati\/precise\/appinventor-0"
+        },
+        "1508": {
+          "id": "cs:~chrisdonati\/precise\/appinventor-1"
+        },
+        "1509": {
+          "id": "cs:~chrisdonati\/precise\/appscale-0"
+        },
+        "1510": {
+          "id": "cs:~chrisdonati\/precise\/appscale-1"
+        },
+        "1511": {
+          "id": "cs:~chrisdonati\/precise\/guestbook-0"
+        },
+        "1512": {
+          "id": "cs:~chrisdonati\/precise\/guestbook-1"
+        },
+        "1513": {
+          "id": "cs:~chrisdonati\/precise\/guestbook-2"
+        },
+        "1514": {
+          "id": "cs:~cjohnston\/precise\/summit-0"
+        },
+        "1515": {
+          "id": "cs:~cjohnston\/quantal\/workitems-tracker-0"
+        },
+        "1516": {
+          "id": "cs:~clint-fewbar\/oneiric\/mediagoblin-0"
+        },
+        "1517": {
+          "id": "cs:~clint-fewbar\/oneiric\/musica-0"
+        },
+        "1518": {
+          "id": "cs:~clint-fewbar\/oneiric\/omgubuntu-wp-0"
+        },
+        "1519": {
+          "id": "cs:~clint-fewbar\/oneiric\/pictor-0"
+        },
+        "1520": {
+          "id": "cs:~clint-fewbar\/oneiric\/tomcat6-0"
+        },
+        "1521": {
+          "id": "cs:~clint-fewbar\/precise\/haproxy-0"
+        },
+        "1522": {
+          "id": "cs:~clint-fewbar\/precise\/haproxy-1"
+        },
+        "1523": {
+          "id": "cs:~clint-fewbar\/precise\/limesurvey-0"
+        },
+        "1524": {
+          "id": "cs:~clint-fewbar\/precise\/limesurvey-1"
+        },
+        "1525": {
+          "id": "cs:~clint-fewbar\/precise\/limesurvey-2"
+        },
+        "1526": {
+          "id": "cs:~clint-fewbar\/precise\/mediagoblin-0"
+        },
+        "1527": {
+          "id": "cs:~clint-fewbar\/precise\/mediagoblin-1"
+        },
+        "1528": {
+          "id": "cs:~clint-fewbar\/precise\/nagios-0"
+        },
+        "1529": {
+          "id": "cs:~clint-fewbar\/precise\/nagios-1"
+        },
+        "1530": {
+          "id": "cs:~clint-fewbar\/precise\/nagios-10"
+        },
+        "1531": {
+          "id": "cs:~clint-fewbar\/precise\/nagios-11"
+        },
+        "1532": {
+          "id": "cs:~clint-fewbar\/precise\/nagios-2"
+        },
+        "1533": {
+          "id": "cs:~clint-fewbar\/precise\/nagios-3"
+        },
+        "1534": {
+          "id": "cs:~clint-fewbar\/precise\/nagios-4"
+        },
+        "1535": {
+          "id": "cs:~clint-fewbar\/precise\/nagios-5"
+        },
+        "1536": {
+          "id": "cs:~clint-fewbar\/precise\/nagios-6"
+        },
+        "1537": {
+          "id": "cs:~clint-fewbar\/precise\/nagios-7"
+        },
+        "1538": {
+          "id": "cs:~clint-fewbar\/precise\/nagios-8"
+        },
+        "1539": {
+          "id": "cs:~clint-fewbar\/precise\/nagios-9"
+        },
+        "1540": {
+          "id": "cs:~clint-fewbar\/quantal\/workitems-tracker-0"
+        },
+        "1541": {
+          "id": "cs:~clint-fewbar\/quantal\/workitems-tracker-1"
+        },
+        "1542": {
+          "id": "cs:~clint-fewbar\/quantal\/workitems-tracker-10"
+        },
+        "1543": {
+          "id": "cs:~clint-fewbar\/quantal\/workitems-tracker-11"
+        },
+        "1544": {
+          "id": "cs:~clint-fewbar\/quantal\/workitems-tracker-12"
+        },
+        "1545": {
+          "id": "cs:~clint-fewbar\/quantal\/workitems-tracker-13"
+        },
+        "1546": {
+          "id": "cs:~clint-fewbar\/quantal\/workitems-tracker-14"
+        },
+        "1547": {
+          "id": "cs:~clint-fewbar\/quantal\/workitems-tracker-15"
+        },
+        "1548": {
+          "id": "cs:~clint-fewbar\/quantal\/workitems-tracker-16"
+        },
+        "1549": {
+          "id": "cs:~clint-fewbar\/quantal\/workitems-tracker-2"
+        },
+        "1550": {
+          "id": "cs:~clint-fewbar\/quantal\/workitems-tracker-3"
+        },
+        "1551": {
+          "id": "cs:~clint-fewbar\/quantal\/workitems-tracker-4"
+        },
+        "1552": {
+          "id": "cs:~clint-fewbar\/quantal\/workitems-tracker-5"
+        },
+        "1553": {
+          "id": "cs:~clint-fewbar\/quantal\/workitems-tracker-6"
+        },
+        "1554": {
+          "id": "cs:~clint-fewbar\/quantal\/workitems-tracker-7"
+        },
+        "1555": {
+          "id": "cs:~clint-fewbar\/quantal\/workitems-tracker-8"
+        },
+        "1556": {
+          "id": "cs:~clint-fewbar\/quantal\/workitems-tracker-9"
+        },
+        "1557": {
+          "id": "cs:~cloudware\/precise\/squid-rp-mirror-0"
+        },
+        "1558": {
+          "id": "cs:~cmars\/precise\/charmstore-0"
+        },
+        "1559": {
+          "id": "cs:~cmars\/precise\/haproxy-0"
+        },
+        "1560": {
+          "id": "cs:~cmars\/precise\/haproxy-1"
+        },
+        "1561": {
+          "id": "cs:~cmars\/precise\/haproxy-2"
+        },
+        "1562": {
+          "id": "cs:~cmars\/precise\/haproxy-3"
+        },
+        "1563": {
+          "id": "cs:~cmars\/precise\/haproxy-4"
+        },
+        "1564": {
+          "id": "cs:~cmars\/precise\/haproxy-5"
+        },
+        "1565": {
+          "id": "cs:~crhrabal\/precise\/nagios-0"
+        },
+        "1566": {
+          "id": "cs:~crhrabal\/precise\/nagios-1"
+        },
+        "1567": {
+          "id": "cs:~ctap\/trusty\/hsenidmobile-ctap-doc-10"
+        },
+        "1568": {
+          "id": "cs:~ctap\/trusty\/hsenidmobile-ctap-doc-5"
+        },
+        "1569": {
+          "id": "cs:~ctap\/trusty\/hsenidmobile-ctap-doc-6"
+        },
+        "1570": {
+          "id": "cs:~ctap\/trusty\/hsenidmobile-ctap-doc-7"
+        },
+        "1571": {
+          "id": "cs:~ctap\/trusty\/hsenidmobile-ctap-doc-8"
+        },
+        "1572": {
+          "id": "cs:~ctap\/trusty\/hsenidmobile-ctap-doc-9"
+        },
+        "1573": {
+          "id": "cs:~ctap\/trusty\/hsenidmobile-ctap-sampleapp-2"
+        },
+        "1574": {
+          "id": "cs:~ctap\/trusty\/hsenidmobile-ctap-sampleapp-3"
+        },
+        "1575": {
+          "id": "cs:~ctap\/trusty\/hsenidmobile-ctap-sampleapp-4"
+        },
+        "1576": {
+          "id": "cs:~ctap\/trusty\/hsenidmobile-ctap-sampleapp-5"
+        },
+        "1577": {
+          "id": "cs:~ctap\/trusty\/hsenidmobile-ctap-simulator-0"
+        },
+        "1578": {
+          "id": "cs:~ctap\/trusty\/hsenidmobile-ctap-simulator-1"
+        },
+        "1579": {
+          "id": "cs:~ctap\/trusty\/hsenidmobile-ctap-simulator-2"
+        },
+        "1580": {
+          "id": "cs:~ctap\/trusty\/hsenidmobile-ctap-simulator-3"
+        },
+        "1581": {
+          "id": "cs:~ctap\/trusty\/hsenidmobile-ctap-simulator-4"
+        },
+        "1582": {
+          "id": "cs:~ctap\/trusty\/hsenidmobile-ctap-simulator-5"
+        },
+        "1583": {
+          "id": "cs:~ctap\/trusty\/rate-me-charm-0"
+        },
+        "1584": {
+          "id": "cs:~daisy-pluckers\/precise\/daisy-1"
+        },
+        "1585": {
+          "id": "cs:~daisy-pluckers\/precise\/daisy-10"
+        },
+        "1586": {
+          "id": "cs:~daisy-pluckers\/precise\/daisy-11"
+        },
+        "1587": {
+          "id": "cs:~daisy-pluckers\/precise\/daisy-12"
+        },
+        "1588": {
+          "id": "cs:~daisy-pluckers\/precise\/daisy-13"
+        },
+        "1589": {
+          "id": "cs:~daisy-pluckers\/precise\/daisy-14"
+        },
+        "1590": {
+          "id": "cs:~daisy-pluckers\/precise\/daisy-15"
+        },
+        "1591": {
+          "id": "cs:~daisy-pluckers\/precise\/daisy-16"
+        },
+        "1592": {
+          "id": "cs:~daisy-pluckers\/precise\/daisy-17"
+        },
+        "1593": {
+          "id": "cs:~daisy-pluckers\/precise\/daisy-18"
+        },
+        "1594": {
+          "id": "cs:~daisy-pluckers\/precise\/daisy-19"
+        },
+        "1595": {
+          "id": "cs:~daisy-pluckers\/precise\/daisy-2"
+        },
+        "1596": {
+          "id": "cs:~daisy-pluckers\/precise\/daisy-20"
+        },
+        "1597": {
+          "id": "cs:~daisy-pluckers\/precise\/daisy-21"
+        },
+        "1598": {
+          "id": "cs:~daisy-pluckers\/precise\/daisy-22"
+        },
+        "1599": {
+          "id": "cs:~daisy-pluckers\/precise\/daisy-23"
+        },
+        "1600": {
+          "id": "cs:~daisy-pluckers\/precise\/daisy-24"
+        },
+        "1601": {
+          "id": "cs:~daisy-pluckers\/precise\/daisy-25"
+        },
+        "1602": {
+          "id": "cs:~daisy-pluckers\/precise\/daisy-26"
+        },
+        "1603": {
+          "id": "cs:~daisy-pluckers\/precise\/daisy-27"
+        },
+        "1604": {
+          "id": "cs:~daisy-pluckers\/precise\/daisy-28"
+        },
+        "1605": {
+          "id": "cs:~daisy-pluckers\/precise\/daisy-29"
+        },
+        "1606": {
+          "id": "cs:~daisy-pluckers\/precise\/daisy-3"
+        },
+        "1607": {
+          "id": "cs:~daisy-pluckers\/precise\/daisy-30"
+        },
+        "1608": {
+          "id": "cs:~daisy-pluckers\/precise\/daisy-31"
+        },
+        "1609": {
+          "id": "cs:~daisy-pluckers\/precise\/daisy-32"
+        },
+        "1610": {
+          "id": "cs:~daisy-pluckers\/precise\/daisy-33"
+        },
+        "1611": {
+          "id": "cs:~daisy-pluckers\/precise\/daisy-4"
+        },
+        "1612": {
+          "id": "cs:~daisy-pluckers\/precise\/daisy-5"
+        },
+        "1613": {
+          "id": "cs:~daisy-pluckers\/precise\/daisy-6"
+        },
+        "1614": {
+          "id": "cs:~daisy-pluckers\/precise\/daisy-7"
+        },
+        "1615": {
+          "id": "cs:~daisy-pluckers\/precise\/daisy-8"
+        },
+        "1616": {
+          "id": "cs:~daisy-pluckers\/precise\/daisy-9"
+        },
+        "1617": {
+          "id": "cs:~daisy-pluckers\/precise\/errors-10"
+        },
+        "1618": {
+          "id": "cs:~daisy-pluckers\/precise\/errors-11"
+        },
+        "1619": {
+          "id": "cs:~daisy-pluckers\/precise\/errors-12"
+        },
+        "1620": {
+          "id": "cs:~daisy-pluckers\/precise\/errors-13"
+        },
+        "1621": {
+          "id": "cs:~daisy-pluckers\/precise\/errors-14"
+        },
+        "1622": {
+          "id": "cs:~daisy-pluckers\/precise\/errors-15"
+        },
+        "1623": {
+          "id": "cs:~daisy-pluckers\/precise\/errors-16"
+        },
+        "1624": {
+          "id": "cs:~daisy-pluckers\/precise\/errors-17"
+        },
+        "1625": {
+          "id": "cs:~daisy-pluckers\/precise\/errors-18"
+        },
+        "1626": {
+          "id": "cs:~daisy-pluckers\/precise\/errors-19"
+        },
+        "1627": {
+          "id": "cs:~daisy-pluckers\/precise\/errors-2"
+        },
+        "1628": {
+          "id": "cs:~daisy-pluckers\/precise\/errors-20"
+        },
+        "1629": {
+          "id": "cs:~daisy-pluckers\/precise\/errors-21"
+        },
+        "1630": {
+          "id": "cs:~daisy-pluckers\/precise\/errors-22"
+        },
+        "1631": {
+          "id": "cs:~daisy-pluckers\/precise\/errors-23"
+        },
+        "1632": {
+          "id": "cs:~daisy-pluckers\/precise\/errors-24"
+        },
+        "1633": {
+          "id": "cs:~daisy-pluckers\/precise\/errors-25"
+        },
+        "1634": {
+          "id": "cs:~daisy-pluckers\/precise\/errors-26"
+        },
+        "1635": {
+          "id": "cs:~daisy-pluckers\/precise\/errors-27"
+        },
+        "1636": {
+          "id": "cs:~daisy-pluckers\/precise\/errors-28"
+        },
+        "1637": {
+          "id": "cs:~daisy-pluckers\/precise\/errors-29"
+        },
+        "1638": {
+          "id": "cs:~daisy-pluckers\/precise\/errors-3"
+        },
+        "1639": {
+          "id": "cs:~daisy-pluckers\/precise\/errors-30"
+        },
+        "1640": {
+          "id": "cs:~daisy-pluckers\/precise\/errors-31"
+        },
+        "1641": {
+          "id": "cs:~daisy-pluckers\/precise\/errors-32"
+        },
+        "1642": {
+          "id": "cs:~daisy-pluckers\/precise\/errors-33"
+        },
+        "1643": {
+          "id": "cs:~daisy-pluckers\/precise\/errors-34"
+        },
+        "1644": {
+          "id": "cs:~daisy-pluckers\/precise\/errors-35"
+        },
+        "1645": {
+          "id": "cs:~daisy-pluckers\/precise\/errors-36"
+        },
+        "1646": {
+          "id": "cs:~daisy-pluckers\/precise\/errors-37"
+        },
+        "1647": {
+          "id": "cs:~daisy-pluckers\/precise\/errors-38"
+        },
+        "1648": {
+          "id": "cs:~daisy-pluckers\/precise\/errors-39"
+        },
+        "1649": {
+          "id": "cs:~daisy-pluckers\/precise\/errors-4"
+        },
+        "1650": {
+          "id": "cs:~daisy-pluckers\/precise\/errors-40"
+        },
+        "1651": {
+          "id": "cs:~daisy-pluckers\/precise\/errors-5"
+        },
+        "1652": {
+          "id": "cs:~daisy-pluckers\/precise\/errors-6"
+        },
+        "1653": {
+          "id": "cs:~daisy-pluckers\/precise\/errors-7"
+        },
+        "1654": {
+          "id": "cs:~daisy-pluckers\/precise\/errors-8"
+        },
+        "1655": {
+          "id": "cs:~daisy-pluckers\/precise\/errors-9"
+        },
+        "1656": {
+          "id": "cs:~daker\/oneiric\/joomla-0"
+        },
+        "1657": {
+          "id": "cs:~dave-cheney\/precise\/mediawiki-0"
+        },
+        "1658": {
+          "id": "cs:~dave-cheney\/precise\/wordpress-0"
+        },
+        "1659": {
+          "id": "cs:~dave-cheney\/precise\/wordpress-1"
+        },
+        "1660": {
+          "id": "cs:~davidolf\/precise\/haste-server-0"
+        },
+        "1661": {
+          "id": "cs:~davidolf\/precise\/reviewboard-0"
+        },
+        "1662": {
+          "id": "cs:~davidolf\/precise\/reviewboard-1"
+        },
+        "1663": {
+          "id": "cs:~davidolf\/precise\/reviewboard-2"
+        },
+        "1664": {
+          "id": "cs:~davidpbritton\/precise\/apache2-0"
+        },
+        "1665": {
+          "id": "cs:~davidpbritton\/precise\/apache2-1"
+        },
+        "1666": {
+          "id": "cs:~davidpbritton\/precise\/apache2-2"
+        },
+        "1667": {
+          "id": "cs:~davidpbritton\/precise\/apache2-3"
+        },
+        "1668": {
+          "id": "cs:~davidpbritton\/precise\/apache2-4"
+        },
+        "1669": {
+          "id": "cs:~davidpbritton\/precise\/haproxy-0"
+        },
+        "1670": {
+          "id": "cs:~davidpbritton\/precise\/haproxy-1"
+        },
+        "1671": {
+          "id": "cs:~davidpbritton\/precise\/haproxy-2"
+        },
+        "1672": {
+          "id": "cs:~davidpbritton\/precise\/haproxy-3"
+        },
+        "1673": {
+          "id": "cs:~davidpbritton\/precise\/haproxy-4"
+        },
+        "1674": {
+          "id": "cs:~davidpbritton\/precise\/haproxy-5"
+        },
+        "1675": {
+          "id": "cs:~davidpbritton\/precise\/jenkins-0"
+        },
+        "1676": {
+          "id": "cs:~davidpbritton\/precise\/jenkins-1"
+        },
+        "1677": {
+          "id": "cs:~davidpbritton\/precise\/jenkins-10"
+        },
+        "1678": {
+          "id": "cs:~davidpbritton\/precise\/jenkins-11"
+        },
+        "1679": {
+          "id": "cs:~davidpbritton\/precise\/jenkins-12"
+        },
+        "1680": {
+          "id": "cs:~davidpbritton\/precise\/jenkins-13"
+        },
+        "1681": {
+          "id": "cs:~davidpbritton\/precise\/jenkins-14"
+        },
+        "1682": {
+          "id": "cs:~davidpbritton\/precise\/jenkins-15"
+        },
+        "1683": {
+          "id": "cs:~davidpbritton\/precise\/jenkins-16"
+        },
+        "1684": {
+          "id": "cs:~davidpbritton\/precise\/jenkins-17"
+        },
+        "1685": {
+          "id": "cs:~davidpbritton\/precise\/jenkins-18"
+        },
+        "1686": {
+          "id": "cs:~davidpbritton\/precise\/jenkins-19"
+        },
+        "1687": {
+          "id": "cs:~davidpbritton\/precise\/jenkins-2"
+        },
+        "1688": {
+          "id": "cs:~davidpbritton\/precise\/jenkins-20"
+        },
+        "1689": {
+          "id": "cs:~davidpbritton\/precise\/jenkins-21"
+        },
+        "1690": {
+          "id": "cs:~davidpbritton\/precise\/jenkins-22"
+        },
+        "1691": {
+          "id": "cs:~davidpbritton\/precise\/jenkins-23"
+        },
+        "1692": {
+          "id": "cs:~davidpbritton\/precise\/jenkins-24"
+        },
+        "1693": {
+          "id": "cs:~davidpbritton\/precise\/jenkins-25"
+        },
+        "1694": {
+          "id": "cs:~davidpbritton\/precise\/jenkins-26"
+        },
+        "1695": {
+          "id": "cs:~davidpbritton\/precise\/jenkins-27"
+        },
+        "1696": {
+          "id": "cs:~davidpbritton\/precise\/jenkins-28"
+        },
+        "1697": {
+          "id": "cs:~davidpbritton\/precise\/jenkins-29"
+        },
+        "1698": {
+          "id": "cs:~davidpbritton\/precise\/jenkins-3"
+        },
+        "1699": {
+          "id": "cs:~davidpbritton\/precise\/jenkins-30"
+        },
+        "1700": {
+          "id": "cs:~davidpbritton\/precise\/jenkins-31"
+        },
+        "1701": {
+          "id": "cs:~davidpbritton\/precise\/jenkins-32"
+        },
+        "1702": {
+          "id": "cs:~davidpbritton\/precise\/jenkins-33"
+        },
+        "1703": {
+          "id": "cs:~davidpbritton\/precise\/jenkins-34"
+        },
+        "1704": {
+          "id": "cs:~davidpbritton\/precise\/jenkins-35"
+        },
+        "1705": {
+          "id": "cs:~davidpbritton\/precise\/jenkins-36"
+        },
+        "1706": {
+          "id": "cs:~davidpbritton\/precise\/jenkins-37"
+        },
+        "1707": {
+          "id": "cs:~davidpbritton\/precise\/jenkins-38"
+        },
+        "1708": {
+          "id": "cs:~davidpbritton\/precise\/jenkins-39"
+        },
+        "1709": {
+          "id": "cs:~davidpbritton\/precise\/jenkins-4"
+        },
+        "1710": {
+          "id": "cs:~davidpbritton\/precise\/jenkins-40"
+        },
+        "1711": {
+          "id": "cs:~davidpbritton\/precise\/jenkins-41"
+        },
+        "1712": {
+          "id": "cs:~davidpbritton\/precise\/jenkins-42"
+        },
+        "1713": {
+          "id": "cs:~davidpbritton\/precise\/jenkins-43"
+        },
+        "1714": {
+          "id": "cs:~davidpbritton\/precise\/jenkins-44"
+        },
+        "1715": {
+          "id": "cs:~davidpbritton\/precise\/jenkins-45"
+        },
+        "1716": {
+          "id": "cs:~davidpbritton\/precise\/jenkins-46"
+        },
+        "1717": {
+          "id": "cs:~davidpbritton\/precise\/jenkins-47"
+        },
+        "1718": {
+          "id": "cs:~davidpbritton\/precise\/jenkins-48"
+        },
+        "1719": {
+          "id": "cs:~davidpbritton\/precise\/jenkins-5"
+        },
+        "1720": {
+          "id": "cs:~davidpbritton\/precise\/jenkins-6"
+        },
+        "1721": {
+          "id": "cs:~davidpbritton\/precise\/jenkins-7"
+        },
+        "1722": {
+          "id": "cs:~davidpbritton\/precise\/jenkins-8"
+        },
+        "1723": {
+          "id": "cs:~davidpbritton\/precise\/jenkins-9"
+        },
+        "1724": {
+          "id": "cs:~deanproctor\/precise\/riak-0"
+        },
+        "1725": {
+          "id": "cs:~dotted1337\/precise\/sendy-0"
+        },
+        "1726": {
+          "id": "cs:~dotted1337\/precise\/sendy-1"
+        },
+        "1727": {
+          "id": "cs:~dotted1337\/precise\/sendy-10"
+        },
+        "1728": {
+          "id": "cs:~dotted1337\/precise\/sendy-11"
+        },
+        "1729": {
+          "id": "cs:~dotted1337\/precise\/sendy-12"
+        },
+        "1730": {
+          "id": "cs:~dotted1337\/precise\/sendy-2"
+        },
+        "1731": {
+          "id": "cs:~dotted1337\/precise\/sendy-3"
+        },
+        "1732": {
+          "id": "cs:~dotted1337\/precise\/sendy-4"
+        },
+        "1733": {
+          "id": "cs:~dotted1337\/precise\/sendy-5"
+        },
+        "1734": {
+          "id": "cs:~dotted1337\/precise\/sendy-6"
+        },
+        "1735": {
+          "id": "cs:~dotted1337\/precise\/sendy-7"
+        },
+        "1736": {
+          "id": "cs:~dotted1337\/precise\/sendy-8"
+        },
+        "1737": {
+          "id": "cs:~dotted1337\/precise\/sendy-9"
+        },
+        "1738": {
+          "id": "cs:~dweaver\/precise\/drupal-0"
+        },
+        "1739": {
+          "id": "cs:~dweaver\/precise\/drupal-1"
+        },
+        "1740": {
+          "id": "cs:~dweaver\/precise\/drupal-2"
+        },
+        "1741": {
+          "id": "cs:~dweaver\/precise\/drupal-3"
+        },
+        "1742": {
+          "id": "cs:~dweaver\/precise\/drupal-4"
+        },
+        "1743": {
+          "id": "cs:~ericsnowcurrently\/precise\/reviewboard-fixed-0"
+        },
+        "1744": {
+          "id": "cs:~ericsnowcurrently\/trusty\/reviewboard-fixed-0"
+        },
+        "1745": {
+          "id": "cs:~fenris\/oneiric\/symfony-0"
+        },
+        "1746": {
+          "id": "cs:~fenris\/oneiric\/symfony-1"
+        },
+        "1747": {
+          "id": "cs:~fenris\/oneiric\/symfony-2"
+        },
+        "1748": {
+          "id": "cs:~fenris\/oneiric\/symfony-3"
+        },
+        "1749": {
+          "id": "cs:~fenris\/oneiric\/symfony-4"
+        },
+        "1750": {
+          "id": "cs:~fenris\/precise\/symfony-0"
+        },
+        "1751": {
+          "id": "cs:~fgimenez\/precise\/cakephp-0"
+        },
+        "1752": {
+          "id": "cs:~fgimenez\/precise\/cakephp-1"
+        },
+        "1753": {
+          "id": "cs:~fgimenez\/precise\/cakephp-10"
+        },
+        "1754": {
+          "id": "cs:~fgimenez\/precise\/cakephp-11"
+        },
+        "1755": {
+          "id": "cs:~fgimenez\/precise\/cakephp-12"
+        },
+        "1756": {
+          "id": "cs:~fgimenez\/precise\/cakephp-13"
+        },
+        "1757": {
+          "id": "cs:~fgimenez\/precise\/cakephp-14"
+        },
+        "1758": {
+          "id": "cs:~fgimenez\/precise\/cakephp-15"
+        },
+        "1759": {
+          "id": "cs:~fgimenez\/precise\/cakephp-16"
+        },
+        "1760": {
+          "id": "cs:~fgimenez\/precise\/cakephp-17"
+        },
+        "1761": {
+          "id": "cs:~fgimenez\/precise\/cakephp-18"
+        },
+        "1762": {
+          "id": "cs:~fgimenez\/precise\/cakephp-19"
+        },
+        "1763": {
+          "id": "cs:~fgimenez\/precise\/cakephp-2"
+        },
+        "1764": {
+          "id": "cs:~fgimenez\/precise\/cakephp-3"
+        },
+        "1765": {
+          "id": "cs:~fgimenez\/precise\/cakephp-4"
+        },
+        "1766": {
+          "id": "cs:~fgimenez\/precise\/cakephp-5"
+        },
+        "1767": {
+          "id": "cs:~fgimenez\/precise\/cakephp-6"
+        },
+        "1768": {
+          "id": "cs:~fgimenez\/precise\/cakephp-7"
+        },
+        "1769": {
+          "id": "cs:~fgimenez\/precise\/cakephp-8"
+        },
+        "1770": {
+          "id": "cs:~fgimenez\/precise\/cakephp-9"
+        },
+        "1771": {
+          "id": "cs:~flepied\/precise\/haproxy-0"
+        },
+        "1772": {
+          "id": "cs:~flepied\/precise\/naxsi-0"
+        },
+        "1773": {
+          "id": "cs:~francesco-chicchiricco\/precise\/syncope-0"
+        },
+        "1774": {
+          "id": "cs:~francesco-chicchiricco\/precise\/syncope-1"
+        },
+        "1775": {
+          "id": "cs:~francesco-chicchiricco\/precise\/syncope-2"
+        },
+        "1776": {
+          "id": "cs:~francesco-chicchiricco\/precise\/syncope-3"
+        },
+        "1777": {
+          "id": "cs:~gandelman-a\/precise\/cinder-5"
+        },
+        "1778": {
+          "id": "cs:~gandelman-a\/precise\/cinder-6"
+        },
+        "1779": {
+          "id": "cs:~gandelman-a\/precise\/cinder-7"
+        },
+        "1780": {
+          "id": "cs:~gandelman-a\/precise\/cinder-8"
+        },
+        "1781": {
+          "id": "cs:~gandelman-a\/precise\/cinder-9"
+        },
+        "1782": {
+          "id": "cs:~george-edison55\/oneiric\/lodgeit-0"
+        },
+        "1783": {
+          "id": "cs:~george-edison55\/oneiric\/phpbb3-0"
+        },
+        "1784": {
+          "id": "cs:~george-edison55\/oneiric\/stackmobile-0"
+        },
+        "1785": {
+          "id": "cs:~george-edison55\/oneiric\/stackmobile-1"
+        },
+        "1786": {
+          "id": "cs:~george-edison55\/oneiric\/statusnet-0"
+        },
+        "1787": {
+          "id": "cs:~george-edison55\/precise\/discourse-0"
+        },
+        "1788": {
+          "id": "cs:~gnuoy\/precise\/apache2-0"
+        },
+        "1789": {
+          "id": "cs:~gnuoy\/precise\/apache2-1"
+        },
+        "1790": {
+          "id": "cs:~gnuoy\/precise\/solr-jetty-0"
+        },
+        "1791": {
+          "id": "cs:~gnuoy\/precise\/solr-jetty-1"
+        },
+        "1792": {
+          "id": "cs:~gnuoy\/precise\/solr-jetty-2"
+        },
+        "1793": {
+          "id": "cs:~gnuoy\/precise\/solr-jetty-3"
+        },
+        "1794": {
+          "id": "cs:~gnuoy\/precise\/solr-jetty-4"
+        },
+        "1795": {
+          "id": "cs:~gvagenas-g\/trusty\/telscale-load-balancer-0"
+        },
+        "1796": {
+          "id": "cs:~gvagenas-g\/trusty\/telscale-restcomm-0"
+        },
+        "1797": {
+          "id": "cs:~hackedbellini\/precise\/piwik-0"
+        },
+        "1798": {
+          "id": "cs:~hackedbellini\/precise\/piwik-1"
+        },
+        "1799": {
+          "id": "cs:~hackedbellini\/precise\/piwik-10"
+        },
+        "1800": {
+          "id": "cs:~hackedbellini\/precise\/piwik-11"
+        },
+        "1801": {
+          "id": "cs:~hackedbellini\/precise\/piwik-12"
+        },
+        "1802": {
+          "id": "cs:~hackedbellini\/precise\/piwik-2"
+        },
+        "1803": {
+          "id": "cs:~hackedbellini\/precise\/piwik-3"
+        },
+        "1804": {
+          "id": "cs:~hackedbellini\/precise\/piwik-4"
+        },
+        "1805": {
+          "id": "cs:~hackedbellini\/precise\/piwik-5"
+        },
+        "1806": {
+          "id": "cs:~hackedbellini\/precise\/piwik-6"
+        },
+        "1807": {
+          "id": "cs:~hackedbellini\/precise\/piwik-7"
+        },
+        "1808": {
+          "id": "cs:~hackedbellini\/precise\/piwik-8"
+        },
+        "1809": {
+          "id": "cs:~hackedbellini\/precise\/piwik-9"
+        },
+        "1810": {
+          "id": "cs:~hackedbellini\/trusty\/piwik-0"
+        },
+        "1811": {
+          "id": "cs:~hackedbellini\/trusty\/piwik-1"
+        },
+        "1812": {
+          "id": "cs:~hackedbellini\/trusty\/piwik-2"
+        },
+        "1813": {
+          "id": "cs:~hamed-5\/trusty\/wordpress-0"
+        },
+        "1814": {
+          "id": "cs:~hatch\/precise\/ghost-0"
+        },
+        "1815": {
+          "id": "cs:~hatch\/precise\/ghost-1"
+        },
+        "1816": {
+          "id": "cs:~hatch\/precise\/ghost-2"
+        },
+        "1817": {
+          "id": "cs:~hatch\/precise\/juju-gui-0"
+        },
+        "1818": {
+          "id": "cs:~hatch\/precise\/juju-gui-1"
+        },
+        "1819": {
+          "id": "cs:~hatch\/precise\/juju-gui-10"
+        },
+        "1820": {
+          "id": "cs:~hatch\/precise\/juju-gui-11"
+        },
+        "1821": {
+          "id": "cs:~hatch\/precise\/juju-gui-12"
+        },
+        "1822": {
+          "id": "cs:~hatch\/precise\/juju-gui-13"
+        },
+        "1823": {
+          "id": "cs:~hatch\/precise\/juju-gui-14"
+        },
+        "1824": {
+          "id": "cs:~hatch\/precise\/juju-gui-2"
+        },
+        "1825": {
+          "id": "cs:~hatch\/precise\/juju-gui-3"
+        },
+        "1826": {
+          "id": "cs:~hatch\/precise\/juju-gui-4"
+        },
+        "1827": {
+          "id": "cs:~hatch\/precise\/juju-gui-5"
+        },
+        "1828": {
+          "id": "cs:~hatch\/precise\/juju-gui-6"
+        },
+        "1829": {
+          "id": "cs:~hatch\/precise\/juju-gui-7"
+        },
+        "1830": {
+          "id": "cs:~hatch\/precise\/juju-gui-8"
+        },
+        "1831": {
+          "id": "cs:~hatch\/precise\/juju-gui-9"
+        },
+        "1832": {
+          "id": "cs:~hatch\/precise\/juju-gui-conflict-0"
+        },
+        "1833": {
+          "id": "cs:~hazmat\/precise\/aws-elb-0"
+        },
+        "1834": {
+          "id": "cs:~hazmat\/precise\/aws-elb-1"
+        },
+        "1835": {
+          "id": "cs:~hazmat\/precise\/aws-elb-2"
+        },
+        "1836": {
+          "id": "cs:~hazmat\/precise\/aws-elb-3"
+        },
+        "1837": {
+          "id": "cs:~hazmat\/precise\/aws-elb-4"
+        },
+        "1838": {
+          "id": "cs:~hazmat\/precise\/aws-elb-5"
+        },
+        "1839": {
+          "id": "cs:~hazmat\/precise\/drupal7-0"
+        },
+        "1840": {
+          "id": "cs:~hazmat\/precise\/drupal7-1"
+        },
+        "1841": {
+          "id": "cs:~hazmat\/precise\/drupal7-2"
+        },
+        "1842": {
+          "id": "cs:~hazmat\/precise\/drupal7-3"
+        },
+        "1843": {
+          "id": "cs:~hazmat\/precise\/juju-gui-0"
+        },
+        "1844": {
+          "id": "cs:~hazmat\/precise\/juju-gui-1"
+        },
+        "1845": {
+          "id": "cs:~hazmat\/precise\/juju-gui-2"
+        },
+        "1846": {
+          "id": "cs:~hazmat\/precise\/juju-gui-3"
+        },
+        "1847": {
+          "id": "cs:~hazmat\/trusty\/consul-0"
+        },
+        "1848": {
+          "id": "cs:~hazmat\/trusty\/drone-0"
+        },
+        "1849": {
+          "id": "cs:~hazmat\/trusty\/drone-1"
+        },
+        "1850": {
+          "id": "cs:~hazmat\/trusty\/etcd-0"
+        },
+        "1851": {
+          "id": "cs:~hazmat\/trusty\/etcd-1"
+        },
+        "1852": {
+          "id": "cs:~hazmat\/trusty\/etcd-2"
+        },
+        "1853": {
+          "id": "cs:~hazmat\/trusty\/etcd-3"
+        },
+        "1854": {
+          "id": "cs:~hazmat\/trusty\/etcd-4"
+        },
+        "1855": {
+          "id": "cs:~hazmat\/trusty\/influxdb-0"
+        },
+        "1856": {
+          "id": "cs:~hazmat\/trusty\/juju-gui-0"
+        },
+        "1857": {
+          "id": "cs:~hazmat\/trusty\/juju-gui-1"
+        },
+        "1858": {
+          "id": "cs:~hazmat\/trusty\/juju-gui-2"
+        },
+        "1859": {
+          "id": "cs:~helio-mota\/precise\/gitlab-0"
+        },
+        "1860": {
+          "id": "cs:~helio-mota\/precise\/gitlab-1"
+        },
+        "1861": {
+          "id": "cs:~helio-mota\/precise\/gitlab-2"
+        },
+        "1862": {
+          "id": "cs:~helio-mota\/precise\/gitlab-3"
+        },
+        "1863": {
+          "id": "cs:~helio-mota\/precise\/gitlab-4"
+        },
+        "1864": {
+          "id": "cs:~helio-mota\/precise\/joomla-0"
+        },
+        "1865": {
+          "id": "cs:~helio-mota\/precise\/joomla-1"
+        },
+        "1866": {
+          "id": "cs:~helio-mota\/precise\/joomla-2"
+        },
+        "1867": {
+          "id": "cs:~helio-mota\/precise\/joomla-3"
+        },
+        "1868": {
+          "id": "cs:~helio-mota\/precise\/joomla-4"
+        },
+        "1869": {
+          "id": "cs:~helio-mota\/precise\/joomla-5"
+        },
+        "1870": {
+          "id": "cs:~helio-mota\/precise\/joomla-6"
+        },
+        "1871": {
+          "id": "cs:~helio-mota\/precise\/joomla-7"
+        },
+        "1872": {
+          "id": "cs:~helio-mota\/precise\/joomla-8"
+        },
+        "1873": {
+          "id": "cs:~helio-mota\/precise\/joomla-9"
+        },
+        "1874": {
+          "id": "cs:~hloeung\/precise\/apache2-0"
+        },
+        "1875": {
+          "id": "cs:~hloeung\/precise\/apache2-1"
+        },
+        "1876": {
+          "id": "cs:~hloeung\/precise\/apache2-2"
+        },
+        "1877": {
+          "id": "cs:~hloeung\/precise\/varnish-2"
+        },
+        "1878": {
+          "id": "cs:~hloeung\/precise\/varnish-3"
+        },
+        "1879": {
+          "id": "cs:~hloeung\/precise\/varnish-4"
+        },
+        "1880": {
+          "id": "cs:~hopem\/precise\/chef-server-0"
+        },
+        "1881": {
+          "id": "cs:~hopem\/precise\/chef-server-1"
+        },
+        "1882": {
+          "id": "cs:~hopem\/precise\/chef-server-2"
+        },
+        "1883": {
+          "id": "cs:~hopem\/precise\/chef-server-3"
+        },
+        "1884": {
+          "id": "cs:~hopem\/precise\/chef-server-4"
+        },
+        "1885": {
+          "id": "cs:~hopem\/precise\/chef-server-5"
+        },
+        "1886": {
+          "id": "cs:~hopem\/precise\/chef-server-6"
+        },
+        "1887": {
+          "id": "cs:~hopem\/precise\/chef-server-7"
+        },
+        "1888": {
+          "id": "cs:~hopem\/precise\/chef-server-8"
+        },
+        "1889": {
+          "id": "cs:~hopem\/precise\/chef-server-9"
+        },
+        "1890": {
+          "id": "cs:~hopem\/precise\/template-0"
+        },
+        "1891": {
+          "id": "cs:~hopem\/precise\/template-1"
+        },
+        "1892": {
+          "id": "cs:~hopem\/precise\/template-2"
+        },
+        "1893": {
+          "id": "cs:~hopem\/precise\/template-3"
+        },
+        "1894": {
+          "id": "cs:~hopem\/precise\/template-4"
+        },
+        "1895": {
+          "id": "cs:~hopem\/precise\/template-5"
+        },
+        "1896": {
+          "id": "cs:~hp-discover\/trusty\/nginx-proxy-0"
+        },
+        "1897": {
+          "id": "cs:~hp-discover\/trusty\/nginx-proxy-1"
+        },
+        "1898": {
+          "id": "cs:~hp-discover\/trusty\/nginx-proxy-2"
+        },
+        "1899": {
+          "id": "cs:~hp-discover\/trusty\/nginx-proxy-3"
+        },
+        "1900": {
+          "id": "cs:~hp-discover\/trusty\/nginx-site-0"
+        },
+        "1901": {
+          "id": "cs:~hp-discover\/trusty\/nginx-site-1"
+        },
+        "1902": {
+          "id": "cs:~hp-discover\/trusty\/node-app-0"
+        },
+        "1903": {
+          "id": "cs:~hp-discover\/trusty\/node-app-1"
+        },
+        "1904": {
+          "id": "cs:~hp-discover\/trusty\/website-0"
+        },
+        "1905": {
+          "id": "cs:~hp-discover\/trusty\/website-1"
+        },
+        "1906": {
+          "id": "cs:~hp-discover\/trusty\/website-2"
+        },
+        "1907": {
+          "id": "cs:~hp-discover\/trusty\/website-3"
+        },
+        "1908": {
+          "id": "cs:~ibm-demo\/trusty\/apache2-0"
+        },
+        "1909": {
+          "id": "cs:~ibm-demo\/trusty\/apache2-1"
+        },
+        "1910": {
+          "id": "cs:~ibm-demo\/trusty\/dokuwiki-0"
+        },
+        "1911": {
+          "id": "cs:~ibm-demo\/trusty\/dokuwiki-1"
+        },
+        "1912": {
+          "id": "cs:~ibm-demo\/trusty\/dokuwiki-2"
+        },
+        "1913": {
+          "id": "cs:~ibm-demo\/trusty\/haproxy-0"
+        },
+        "1914": {
+          "id": "cs:~ibm-demo\/trusty\/haproxy-1"
+        },
+        "1915": {
+          "id": "cs:~ibm-demo\/trusty\/haproxy-2"
+        },
+        "1916": {
+          "id": "cs:~ibm-demo\/trusty\/joomla-0"
+        },
+        "1917": {
+          "id": "cs:~ibm-demo\/trusty\/juju-gui-0"
+        },
+        "1918": {
+          "id": "cs:~ibm-demo\/trusty\/lamp-0"
+        },
+        "1919": {
+          "id": "cs:~ibm-demo\/trusty\/lamp-1"
+        },
+        "1920": {
+          "id": "cs:~ibm-demo\/trusty\/magento-0"
+        },
+        "1921": {
+          "id": "cs:~ibm-demo\/trusty\/magento-1"
+        },
+        "1922": {
+          "id": "cs:~ibm-demo\/trusty\/magento-2"
+        },
+        "1923": {
+          "id": "cs:~ibm-demo\/trusty\/mediawiki-0"
+        },
+        "1924": {
+          "id": "cs:~ibm-demo\/trusty\/mediawiki-1"
+        },
+        "1925": {
+          "id": "cs:~ibm-demo\/trusty\/mediawiki-2"
+        },
+        "1926": {
+          "id": "cs:~ibm-demo\/trusty\/munin-0"
+        },
+        "1927": {
+          "id": "cs:~ibm-demo\/trusty\/nagios-0"
+        },
+        "1928": {
+          "id": "cs:~ibm-demo\/trusty\/openerp-server-0"
+        },
+        "1929": {
+          "id": "cs:~ibm-demo\/trusty\/openerp-server-1"
+        },
+        "1930": {
+          "id": "cs:~ibm-demo\/trusty\/openvpn-as-0"
+        },
+        "1931": {
+          "id": "cs:~ibm-demo\/trusty\/php-website-0"
+        },
+        "1932": {
+          "id": "cs:~ibm-demo\/trusty\/python-django-0"
+        },
+        "1933": {
+          "id": "cs:~ibm-demo\/trusty\/python-django-1"
+        },
+        "1934": {
+          "id": "cs:~ibm-demo\/trusty\/python-django-2"
+        },
+        "1935": {
+          "id": "cs:~ibm-demo\/trusty\/python-django-3"
+        },
+        "1936": {
+          "id": "cs:~ibm-demo\/trusty\/python-moinmoin-0"
+        },
+        "1937": {
+          "id": "cs:~ibm-demo\/trusty\/squid-reverseproxy-0"
+        },
+        "1938": {
+          "id": "cs:~ibm-demo\/trusty\/statusnet-0"
+        },
+        "1939": {
+          "id": "cs:~ibm-demo\/trusty\/statusnet-1"
+        },
+        "1940": {
+          "id": "cs:~ibm-demo\/trusty\/statusnet-2"
+        },
+        "1941": {
+          "id": "cs:~ibm-demo\/trusty\/subway-0"
+        },
+        "1942": {
+          "id": "cs:~ibm-demo\/trusty\/sugarcrm-0"
+        },
+        "1943": {
+          "id": "cs:~ibm-demo\/trusty\/sugarcrm-1"
+        },
+        "1944": {
+          "id": "cs:~ibm-demo\/trusty\/sugarcrm-2"
+        },
+        "1945": {
+          "id": "cs:~ibm-demo\/trusty\/sugarcrm-3"
+        },
+        "1946": {
+          "id": "cs:~ibm-demo\/trusty\/sugarcrm-4"
+        },
+        "1947": {
+          "id": "cs:~ibm-demo\/trusty\/sugarcrm-5"
+        },
+        "1948": {
+          "id": "cs:~ibm-demo\/trusty\/varnish-0"
+        },
+        "1949": {
+          "id": "cs:~ibm-demo\/trusty\/website-0"
+        },
+        "1950": {
+          "id": "cs:~ibm-demo\/trusty\/websphere-liberty-0"
+        },
+        "1951": {
+          "id": "cs:~ibm-demo\/trusty\/websphere-liberty-1"
+        },
+        "1952": {
+          "id": "cs:~ibm-demo\/trusty\/websphere-liberty-10"
+        },
+        "1953": {
+          "id": "cs:~ibm-demo\/trusty\/websphere-liberty-2"
+        },
+        "1954": {
+          "id": "cs:~ibm-demo\/trusty\/websphere-liberty-3"
+        },
+        "1955": {
+          "id": "cs:~ibm-demo\/trusty\/websphere-liberty-4"
+        },
+        "1956": {
+          "id": "cs:~ibm-demo\/trusty\/websphere-liberty-5"
+        },
+        "1957": {
+          "id": "cs:~ibm-demo\/trusty\/websphere-liberty-6"
+        },
+        "1958": {
+          "id": "cs:~ibm-demo\/trusty\/websphere-liberty-7"
+        },
+        "1959": {
+          "id": "cs:~ibm-demo\/trusty\/websphere-liberty-8"
+        },
+        "1960": {
+          "id": "cs:~ibm-demo\/trusty\/websphere-liberty-9"
+        },
+        "1961": {
+          "id": "cs:~ibm-demo\/trusty\/wordpress-0"
+        },
+        "1962": {
+          "id": "cs:~ibm-demo\/trusty\/wordpress-1"
+        },
+        "1963": {
+          "id": "cs:~ibm-demo\/trusty\/zend-server-0"
+        },
+        "1964": {
+          "id": "cs:~ibmcharmers\/trusty\/xcat-0"
+        },
+        "1965": {
+          "id": "cs:~imbrandon\/oneiric\/drupal-0"
+        },
+        "1966": {
+          "id": "cs:~imbrandon\/oneiric\/drupal-1"
+        },
+        "1967": {
+          "id": "cs:~imbrandon\/oneiric\/drupal-2"
+        },
+        "1968": {
+          "id": "cs:~imbrandon\/oneiric\/drupal-3"
+        },
+        "1969": {
+          "id": "cs:~imbrandon\/oneiric\/drupal-4"
+        },
+        "1970": {
+          "id": "cs:~imbrandon\/oneiric\/drupal-5"
+        },
+        "1971": {
+          "id": "cs:~imbrandon\/oneiric\/drupal-6"
+        },
+        "1972": {
+          "id": "cs:~imbrandon\/oneiric\/drupal-7"
+        },
+        "1973": {
+          "id": "cs:~imbrandon\/oneiric\/drupal-8"
+        },
+        "1974": {
+          "id": "cs:~imbrandon\/oneiric\/drupal-9"
+        },
+        "1975": {
+          "id": "cs:~imbrandon\/precise\/drupal6-0"
+        },
+        "1976": {
+          "id": "cs:~imbrandon\/precise\/drupal6-1"
+        },
+        "1977": {
+          "id": "cs:~james-falkner\/precise\/liferay-0"
+        },
+        "1978": {
+          "id": "cs:~james-falkner\/precise\/liferay-1"
+        },
+        "1979": {
+          "id": "cs:~james-falkner\/precise\/liferay-2"
+        },
+        "1980": {
+          "id": "cs:~james-falkner\/precise\/liferay-3"
+        },
+        "1981": {
+          "id": "cs:~james-falkner\/precise\/liferay-4"
+        },
+        "1982": {
+          "id": "cs:~james-falkner\/precise\/liferay-5"
+        },
+        "1983": {
+          "id": "cs:~james-page\/oneiric\/jenkins-0"
+        },
+        "1984": {
+          "id": "cs:~james-page\/quantal\/ceph-radosgw-0"
+        },
+        "1985": {
+          "id": "cs:~james-page\/quantal\/ceph-radosgw-1"
+        },
+        "1986": {
+          "id": "cs:~james-page\/quantal\/ceph-radosgw-2"
+        },
+        "1987": {
+          "id": "cs:~james-page\/quantal\/ceph-radosgw-3"
+        },
+        "1988": {
+          "id": "cs:~james-page\/quantal\/ceph-radosgw-4"
+        },
+        "1989": {
+          "id": "cs:~james-page\/quantal\/package-builder-0"
+        },
+        "1990": {
+          "id": "cs:~james-page\/quantal\/package-builder-1"
+        },
+        "1991": {
+          "id": "cs:~james-page\/quantal\/package-builder-2"
+        },
+        "1992": {
+          "id": "cs:~james-page\/raring\/ceph-radosgw-0"
+        },
+        "1993": {
+          "id": "cs:~james-page\/raring\/ceph-radosgw-1"
+        },
+        "1994": {
+          "id": "cs:~james-page\/raring\/ceph-radosgw-2"
+        },
+        "1995": {
+          "id": "cs:~james-page\/raring\/ceph-radosgw-3"
+        },
+        "1996": {
+          "id": "cs:~james-sapara\/precise\/aws-ec2-elb-0"
+        },
+        "1997": {
+          "id": "cs:~james-sapara\/precise\/aws-ec2-elb-1"
+        },
+        "1998": {
+          "id": "cs:~jhasaurabh\/precise\/wildfly-0"
+        },
+        "1999": {
+          "id": "cs:~jhasaurabh\/precise\/wildfly-1"
+        },
+        "2000": {
+          "id": "cs:~jhasaurabh\/precise\/wildfly-2"
+        },
+        "2001": {
+          "id": "cs:~jhasaurabh\/precise\/wildfly-3"
+        },
+        "2002": {
+          "id": "cs:~jhasaurabh\/precise\/wildfly-4"
+        },
+        "2003": {
+          "id": "cs:~jhasaurabh\/precise\/wildfly-5"
+        },
+        "2004": {
+          "id": "cs:~jhasaurabh\/precise\/wildfly-6"
+        },
+        "2005": {
+          "id": "cs:~jhasaurabh\/precise\/wildfly-7"
+        },
+        "2006": {
+          "id": "cs:~jhasaurabh\/trusty\/wildfly-ha-slave-0"
+        },
+        "2007": {
+          "id": "cs:~jim2308\/trusty\/m2mlabs-0"
+        },
+        "2008": {
+          "id": "cs:~jim2308\/trusty\/m2mlabs-simple-0"
+        },
+        "2009": {
+          "id": "cs:~jim2308\/trusty\/m2mlabs-simple-1"
+        },
+        "2010": {
+          "id": "cs:~jmac\/precise\/wordpress-multi-0"
+        },
+        "2011": {
+          "id": "cs:~jmit\/oneiric\/apache-0"
+        },
+        "2012": {
+          "id": "cs:~jmit\/oneiric\/proxy-0"
+        },
+        "2013": {
+          "id": "cs:~johnsca\/trusty\/cf-webadmin-0"
+        },
+        "2014": {
+          "id": "cs:~johnsca\/trusty\/cf-webadmin-1"
+        },
+        "2015": {
+          "id": "cs:~johnsca\/trusty\/cf-webadmin-2"
+        },
+        "2016": {
+          "id": "cs:~johnsca\/trusty\/router-v1-0"
+        },
+        "2017": {
+          "id": "cs:~johnsca\/trusty\/router-v2-0"
+        },
+        "2018": {
+          "id": "cs:~johnsca\/trusty\/uaa-v1-0"
+        },
+        "2019": {
+          "id": "cs:~jose\/precise\/chamilo-0"
+        },
+        "2020": {
+          "id": "cs:~jose\/precise\/chamilo-1"
+        },
+        "2021": {
+          "id": "cs:~jose\/precise\/chamilo-2"
+        },
+        "2022": {
+          "id": "cs:~jose\/precise\/chamilo-3"
+        },
+        "2023": {
+          "id": "cs:~jose\/precise\/chamilo-4"
+        },
+        "2024": {
+          "id": "cs:~jose\/precise\/chamilo-5"
+        },
+        "2025": {
+          "id": "cs:~jose\/precise\/chamilo-6"
+        },
+        "2026": {
+          "id": "cs:~jose\/precise\/chamilo-7"
+        },
+        "2027": {
+          "id": "cs:~jose\/precise\/chamilo-8"
+        },
+        "2028": {
+          "id": "cs:~jose\/precise\/icecast2-0"
+        },
+        "2029": {
+          "id": "cs:~jose\/precise\/mailman-18"
+        },
+        "2030": {
+          "id": "cs:~jose\/precise\/mailman-19"
+        },
+        "2031": {
+          "id": "cs:~jose\/precise\/mailman-20"
+        },
+        "2032": {
+          "id": "cs:~jose\/precise\/mailman-21"
+        },
+        "2033": {
+          "id": "cs:~jose\/precise\/mailman-22"
+        },
+        "2034": {
+          "id": "cs:~jose\/precise\/mailman-23"
+        },
+        "2035": {
+          "id": "cs:~jose\/precise\/mailman-24"
+        },
+        "2036": {
+          "id": "cs:~jose\/precise\/mailman-25"
+        },
+        "2037": {
+          "id": "cs:~jose\/precise\/mailman-26"
+        },
+        "2038": {
+          "id": "cs:~jose\/precise\/mailman-27"
+        },
+        "2039": {
+          "id": "cs:~jose\/precise\/mailman-28"
+        },
+        "2040": {
+          "id": "cs:~jose\/precise\/mailman-29"
+        },
+        "2041": {
+          "id": "cs:~jose\/precise\/opencart-0"
+        },
+        "2042": {
+          "id": "cs:~jose\/precise\/opencart-1"
+        },
+        "2043": {
+          "id": "cs:~jose\/precise\/opencart-2"
+        },
+        "2044": {
+          "id": "cs:~jose\/precise\/opencart-3"
+        },
+        "2045": {
+          "id": "cs:~jose\/precise\/phpbb-0"
+        },
+        "2046": {
+          "id": "cs:~jose\/precise\/phpbb-1"
+        },
+        "2047": {
+          "id": "cs:~jose\/precise\/phpbb-2"
+        },
+        "2048": {
+          "id": "cs:~jose\/precise\/phpbb-3"
+        },
+        "2049": {
+          "id": "cs:~jose\/precise\/phpbb-4"
+        },
+        "2050": {
+          "id": "cs:~jose\/precise\/pubphoto-0"
+        },
+        "2051": {
+          "id": "cs:~jose\/precise\/pubphoto-1"
+        },
+        "2052": {
+          "id": "cs:~jose\/precise\/pubphoto-2"
+        },
+        "2053": {
+          "id": "cs:~jose\/precise\/pubphoto-3"
+        },
+        "2054": {
+          "id": "cs:~jose\/precise\/pubphoto-4"
+        },
+        "2055": {
+          "id": "cs:~jose\/precise\/seafile-0"
+        },
+        "2056": {
+          "id": "cs:~jose\/trusty\/owncloud-0"
+        },
+        "2057": {
+          "id": "cs:~jose\/trusty\/owncloud-1"
+        },
+        "2058": {
+          "id": "cs:~jose\/trusty\/owncloud-2"
+        },
+        "2059": {
+          "id": "cs:~jseutter\/precise\/haproxy-0"
+        },
+        "2060": {
+          "id": "cs:~jseutter\/precise\/haproxy-1"
+        },
+        "2061": {
+          "id": "cs:~jseutter\/precise\/haproxy-2"
+        },
+        "2062": {
+          "id": "cs:~jseutter\/precise\/haproxy-3"
+        },
+        "2063": {
+          "id": "cs:~jseutter\/precise\/haproxy-4"
+        },
+        "2064": {
+          "id": "cs:~juju-gui-charmers\/precise\/juju-gui-0"
+        },
+        "2065": {
+          "id": "cs:~juju-gui-charmers\/precise\/juju-gui-100"
+        },
+        "2066": {
+          "id": "cs:~juju-gui-charmers\/precise\/juju-gui-101"
+        },
+        "2067": {
+          "id": "cs:~juju-gui-charmers\/precise\/juju-gui-102"
+        },
+        "2068": {
+          "id": "cs:~juju-gui-charmers\/precise\/juju-gui-103"
+        },
+        "2069": {
+          "id": "cs:~juju-gui-charmers\/precise\/juju-gui-104"
+        },
+        "2070": {
+          "id": "cs:~juju-gui-charmers\/precise\/juju-gui-105"
+        },
+        "2071": {
+          "id": "cs:~juju-gui-charmers\/precise\/juju-gui-106"
+        },
+        "2072": {
+          "id": "cs:~juju-gui-charmers\/precise\/juju-gui-60"
+        },
+        "2073": {
+          "id": "cs:~juju-gui-charmers\/precise\/juju-gui-61"
+        },
+        "2074": {
+          "id": "cs:~juju-gui-charmers\/precise\/juju-gui-62"
+        },
+        "2075": {
+          "id": "cs:~juju-gui-charmers\/precise\/juju-gui-63"
+        },
+        "2076": {
+          "id": "cs:~juju-gui-charmers\/precise\/juju-gui-64"
+        },
+        "2077": {
+          "id": "cs:~juju-gui-charmers\/precise\/juju-gui-65"
+        },
+        "2078": {
+          "id": "cs:~juju-gui-charmers\/precise\/juju-gui-66"
+        },
+        "2079": {
+          "id": "cs:~juju-gui-charmers\/precise\/juju-gui-67"
+        },
+        "2080": {
+          "id": "cs:~juju-gui-charmers\/precise\/juju-gui-68"
+        },
+        "2081": {
+          "id": "cs:~juju-gui-charmers\/precise\/juju-gui-69"
+        },
+        "2082": {
+          "id": "cs:~juju-gui-charmers\/precise\/juju-gui-70"
+        },
+        "2083": {
+          "id": "cs:~juju-gui-charmers\/precise\/juju-gui-71"
+        },
+        "2084": {
+          "id": "cs:~juju-gui-charmers\/precise\/juju-gui-72"
+        },
+        "2085": {
+          "id": "cs:~juju-gui-charmers\/precise\/juju-gui-73"
+        },
+        "2086": {
+          "id": "cs:~juju-gui-charmers\/precise\/juju-gui-74"
+        },
+        "2087": {
+          "id": "cs:~juju-gui-charmers\/precise\/juju-gui-75"
+        },
+        "2088": {
+          "id": "cs:~juju-gui-charmers\/precise\/juju-gui-76"
+        },
+        "2089": {
+          "id": "cs:~juju-gui-charmers\/precise\/juju-gui-77"
+        },
+        "2090": {
+          "id": "cs:~juju-gui-charmers\/precise\/juju-gui-78"
+        },
+        "2091": {
+          "id": "cs:~juju-gui-charmers\/precise\/juju-gui-79"
+        },
+        "2092": {
+          "id": "cs:~juju-gui-charmers\/precise\/juju-gui-80"
+        },
+        "2093": {
+          "id": "cs:~juju-gui-charmers\/precise\/juju-gui-81"
+        },
+        "2094": {
+          "id": "cs:~juju-gui-charmers\/precise\/juju-gui-82"
+        },
+        "2095": {
+          "id": "cs:~juju-gui-charmers\/precise\/juju-gui-83"
+        },
+        "2096": {
+          "id": "cs:~juju-gui-charmers\/precise\/juju-gui-84"
+        },
+        "2097": {
+          "id": "cs:~juju-gui-charmers\/precise\/juju-gui-85"
+        },
+        "2098": {
+          "id": "cs:~juju-gui-charmers\/precise\/juju-gui-86"
+        },
+        "2099": {
+          "id": "cs:~juju-gui-charmers\/precise\/juju-gui-87"
+        },
+        "2100": {
+          "id": "cs:~juju-gui-charmers\/precise\/juju-gui-88"
+        },
+        "2101": {
+          "id": "cs:~juju-gui-charmers\/precise\/juju-gui-89"
+        },
+        "2102": {
+          "id": "cs:~juju-gui-charmers\/precise\/juju-gui-90"
+        },
+        "2103": {
+          "id": "cs:~juju-gui-charmers\/precise\/juju-gui-91"
+        },
+        "2104": {
+          "id": "cs:~juju-gui-charmers\/precise\/juju-gui-92"
+        },
+        "2105": {
+          "id": "cs:~juju-gui-charmers\/precise\/juju-gui-93"
+        },
+        "2106": {
+          "id": "cs:~juju-gui-charmers\/precise\/juju-gui-94"
+        },
+        "2107": {
+          "id": "cs:~juju-gui-charmers\/precise\/juju-gui-95"
+        },
+        "2108": {
+          "id": "cs:~juju-gui-charmers\/precise\/juju-gui-96"
+        },
+        "2109": {
+          "id": "cs:~juju-gui-charmers\/precise\/juju-gui-97"
+        },
+        "2110": {
+          "id": "cs:~juju-gui-charmers\/precise\/juju-gui-98"
+        },
+        "2111": {
+          "id": "cs:~juju-gui-charmers\/precise\/juju-gui-99"
+        },
+        "2112": {
+          "id": "cs:~juju-gui-charmers\/trusty\/juju-gui-0"
+        },
+        "2113": {
+          "id": "cs:~juju-gui-charmers\/trusty\/juju-gui-1"
+        },
+        "2114": {
+          "id": "cs:~juju-gui-charmers\/trusty\/juju-gui-10"
+        },
+        "2115": {
+          "id": "cs:~juju-gui-charmers\/trusty\/juju-gui-11"
+        },
+        "2116": {
+          "id": "cs:~juju-gui-charmers\/trusty\/juju-gui-12"
+        },
+        "2117": {
+          "id": "cs:~juju-gui-charmers\/trusty\/juju-gui-13"
+        },
+        "2118": {
+          "id": "cs:~juju-gui-charmers\/trusty\/juju-gui-14"
+        },
+        "2119": {
+          "id": "cs:~juju-gui-charmers\/trusty\/juju-gui-15"
+        },
+        "2120": {
+          "id": "cs:~juju-gui-charmers\/trusty\/juju-gui-16"
+        },
+        "2121": {
+          "id": "cs:~juju-gui-charmers\/trusty\/juju-gui-17"
+        },
+        "2122": {
+          "id": "cs:~juju-gui-charmers\/trusty\/juju-gui-18"
+        },
+        "2123": {
+          "id": "cs:~juju-gui-charmers\/trusty\/juju-gui-2"
+        },
+        "2124": {
+          "id": "cs:~juju-gui-charmers\/trusty\/juju-gui-3"
+        },
+        "2125": {
+          "id": "cs:~juju-gui-charmers\/trusty\/juju-gui-4"
+        },
+        "2126": {
+          "id": "cs:~juju-gui-charmers\/trusty\/juju-gui-5"
+        },
+        "2127": {
+          "id": "cs:~juju-gui-charmers\/trusty\/juju-gui-6"
+        },
+        "2128": {
+          "id": "cs:~juju-gui-charmers\/trusty\/juju-gui-7"
+        },
+        "2129": {
+          "id": "cs:~juju-gui-charmers\/trusty\/juju-gui-8"
+        },
+        "2130": {
+          "id": "cs:~juju-gui-charmers\/trusty\/juju-gui-9"
+        },
+        "2131": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-0"
+        },
+        "2132": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-1"
+        },
+        "2133": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-10"
+        },
+        "2134": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-100"
+        },
+        "2135": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-101"
+        },
+        "2136": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-102"
+        },
+        "2137": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-103"
+        },
+        "2138": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-104"
+        },
+        "2139": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-105"
+        },
+        "2140": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-106"
+        },
+        "2141": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-107"
+        },
+        "2142": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-108"
+        },
+        "2143": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-109"
+        },
+        "2144": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-11"
+        },
+        "2145": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-110"
+        },
+        "2146": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-111"
+        },
+        "2147": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-112"
+        },
+        "2148": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-113"
+        },
+        "2149": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-114"
+        },
+        "2150": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-115"
+        },
+        "2151": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-116"
+        },
+        "2152": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-117"
+        },
+        "2153": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-118"
+        },
+        "2154": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-119"
+        },
+        "2155": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-12"
+        },
+        "2156": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-120"
+        },
+        "2157": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-121"
+        },
+        "2158": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-122"
+        },
+        "2159": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-123"
+        },
+        "2160": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-124"
+        },
+        "2161": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-125"
+        },
+        "2162": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-126"
+        },
+        "2163": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-127"
+        },
+        "2164": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-128"
+        },
+        "2165": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-129"
+        },
+        "2166": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-13"
+        },
+        "2167": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-130"
+        },
+        "2168": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-131"
+        },
+        "2169": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-132"
+        },
+        "2170": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-133"
+        },
+        "2171": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-134"
+        },
+        "2172": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-135"
+        },
+        "2173": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-136"
+        },
+        "2174": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-137"
+        },
+        "2175": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-138"
+        },
+        "2176": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-139"
+        },
+        "2177": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-14"
+        },
+        "2178": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-140"
+        },
+        "2179": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-141"
+        },
+        "2180": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-142"
+        },
+        "2181": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-143"
+        },
+        "2182": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-144"
+        },
+        "2183": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-145"
+        },
+        "2184": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-146"
+        },
+        "2185": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-147"
+        },
+        "2186": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-148"
+        },
+        "2187": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-149"
+        },
+        "2188": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-15"
+        },
+        "2189": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-150"
+        },
+        "2190": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-151"
+        },
+        "2191": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-152"
+        },
+        "2192": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-153"
+        },
+        "2193": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-154"
+        },
+        "2194": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-155"
+        },
+        "2195": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-156"
+        },
+        "2196": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-157"
+        },
+        "2197": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-158"
+        },
+        "2198": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-159"
+        },
+        "2199": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-16"
+        },
+        "2200": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-160"
+        },
+        "2201": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-161"
+        },
+        "2202": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-162"
+        },
+        "2203": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-163"
+        },
+        "2204": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-164"
+        },
+        "2205": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-165"
+        },
+        "2206": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-166"
+        },
+        "2207": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-167"
+        },
+        "2208": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-168"
+        },
+        "2209": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-169"
+        },
+        "2210": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-17"
+        },
+        "2211": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-18"
+        },
+        "2212": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-19"
+        },
+        "2213": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-2"
+        },
+        "2214": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-20"
+        },
+        "2215": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-21"
+        },
+        "2216": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-22"
+        },
+        "2217": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-23"
+        },
+        "2218": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-24"
+        },
+        "2219": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-25"
+        },
+        "2220": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-26"
+        },
+        "2221": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-27"
+        },
+        "2222": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-28"
+        },
+        "2223": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-29"
+        },
+        "2224": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-3"
+        },
+        "2225": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-30"
+        },
+        "2226": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-31"
+        },
+        "2227": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-32"
+        },
+        "2228": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-33"
+        },
+        "2229": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-34"
+        },
+        "2230": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-35"
+        },
+        "2231": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-36"
+        },
+        "2232": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-37"
+        },
+        "2233": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-38"
+        },
+        "2234": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-39"
+        },
+        "2235": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-4"
+        },
+        "2236": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-40"
+        },
+        "2237": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-41"
+        },
+        "2238": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-42"
+        },
+        "2239": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-43"
+        },
+        "2240": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-44"
+        },
+        "2241": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-45"
+        },
+        "2242": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-46"
+        },
+        "2243": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-47"
+        },
+        "2244": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-48"
+        },
+        "2245": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-49"
+        },
+        "2246": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-5"
+        },
+        "2247": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-50"
+        },
+        "2248": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-51"
+        },
+        "2249": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-52"
+        },
+        "2250": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-53"
+        },
+        "2251": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-54"
+        },
+        "2252": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-55"
+        },
+        "2253": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-56"
+        },
+        "2254": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-57"
+        },
+        "2255": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-58"
+        },
+        "2256": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-59"
+        },
+        "2257": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-6"
+        },
+        "2258": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-60"
+        },
+        "2259": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-61"
+        },
+        "2260": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-62"
+        },
+        "2261": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-63"
+        },
+        "2262": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-64"
+        },
+        "2263": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-65"
+        },
+        "2264": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-66"
+        },
+        "2265": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-67"
+        },
+        "2266": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-68"
+        },
+        "2267": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-69"
+        },
+        "2268": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-7"
+        },
+        "2269": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-70"
+        },
+        "2270": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-71"
+        },
+        "2271": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-72"
+        },
+        "2272": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-73"
+        },
+        "2273": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-74"
+        },
+        "2274": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-75"
+        },
+        "2275": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-76"
+        },
+        "2276": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-77"
+        },
+        "2277": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-78"
+        },
+        "2278": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-79"
+        },
+        "2279": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-8"
+        },
+        "2280": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-80"
+        },
+        "2281": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-81"
+        },
+        "2282": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-82"
+        },
+        "2283": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-83"
+        },
+        "2284": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-84"
+        },
+        "2285": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-85"
+        },
+        "2286": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-86"
+        },
+        "2287": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-87"
+        },
+        "2288": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-88"
+        },
+        "2289": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-89"
+        },
+        "2290": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-9"
+        },
+        "2291": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-90"
+        },
+        "2292": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-91"
+        },
+        "2293": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-92"
+        },
+        "2294": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-93"
+        },
+        "2295": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-94"
+        },
+        "2296": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-95"
+        },
+        "2297": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-96"
+        },
+        "2298": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-97"
+        },
+        "2299": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-98"
+        },
+        "2300": {
+          "id": "cs:~juju-gui\/precise\/juju-gui-99"
+        },
+        "2301": {
+          "id": "cs:~juju-gui\/trusty\/juju-gui-0"
+        },
+        "2302": {
+          "id": "cs:~juju-gui\/trusty\/juju-gui-1"
+        },
+        "2303": {
+          "id": "cs:~juju-gui\/trusty\/juju-gui-10"
+        },
+        "2304": {
+          "id": "cs:~juju-gui\/trusty\/juju-gui-11"
+        },
+        "2305": {
+          "id": "cs:~juju-gui\/trusty\/juju-gui-12"
+        },
+        "2306": {
+          "id": "cs:~juju-gui\/trusty\/juju-gui-13"
+        },
+        "2307": {
+          "id": "cs:~juju-gui\/trusty\/juju-gui-14"
+        },
+        "2308": {
+          "id": "cs:~juju-gui\/trusty\/juju-gui-15"
+        },
+        "2309": {
+          "id": "cs:~juju-gui\/trusty\/juju-gui-16"
+        },
+        "2310": {
+          "id": "cs:~juju-gui\/trusty\/juju-gui-17"
+        },
+        "2311": {
+          "id": "cs:~juju-gui\/trusty\/juju-gui-18"
+        },
+        "2312": {
+          "id": "cs:~juju-gui\/trusty\/juju-gui-19"
+        },
+        "2313": {
+          "id": "cs:~juju-gui\/trusty\/juju-gui-2"
+        },
+        "2314": {
+          "id": "cs:~juju-gui\/trusty\/juju-gui-20"
+        },
+        "2315": {
+          "id": "cs:~juju-gui\/trusty\/juju-gui-21"
+        },
+        "2316": {
+          "id": "cs:~juju-gui\/trusty\/juju-gui-22"
+        },
+        "2317": {
+          "id": "cs:~juju-gui\/trusty\/juju-gui-23"
+        },
+        "2318": {
+          "id": "cs:~juju-gui\/trusty\/juju-gui-24"
+        },
+        "2319": {
+          "id": "cs:~juju-gui\/trusty\/juju-gui-25"
+        },
+        "2320": {
+          "id": "cs:~juju-gui\/trusty\/juju-gui-26"
+        },
+        "2321": {
+          "id": "cs:~juju-gui\/trusty\/juju-gui-27"
+        },
+        "2322": {
+          "id": "cs:~juju-gui\/trusty\/juju-gui-28"
+        },
+        "2323": {
+          "id": "cs:~juju-gui\/trusty\/juju-gui-29"
+        },
+        "2324": {
+          "id": "cs:~juju-gui\/trusty\/juju-gui-3"
+        },
+        "2325": {
+          "id": "cs:~juju-gui\/trusty\/juju-gui-30"
+        },
+        "2326": {
+          "id": "cs:~juju-gui\/trusty\/juju-gui-31"
+        },
+        "2327": {
+          "id": "cs:~juju-gui\/trusty\/juju-gui-32"
+        },
+        "2328": {
+          "id": "cs:~juju-gui\/trusty\/juju-gui-33"
+        },
+        "2329": {
+          "id": "cs:~juju-gui\/trusty\/juju-gui-34"
+        },
+        "2330": {
+          "id": "cs:~juju-gui\/trusty\/juju-gui-35"
+        },
+        "2331": {
+          "id": "cs:~juju-gui\/trusty\/juju-gui-36"
+        },
+        "2332": {
+          "id": "cs:~juju-gui\/trusty\/juju-gui-37"
+        },
+        "2333": {
+          "id": "cs:~juju-gui\/trusty\/juju-gui-38"
+        },
+        "2334": {
+          "id": "cs:~juju-gui\/trusty\/juju-gui-39"
+        },
+        "2335": {
+          "id": "cs:~juju-gui\/trusty\/juju-gui-4"
+        },
+        "2336": {
+          "id": "cs:~juju-gui\/trusty\/juju-gui-40"
+        },
+        "2337": {
+          "id": "cs:~juju-gui\/trusty\/juju-gui-5"
+        },
+        "2338": {
+          "id": "cs:~juju-gui\/trusty\/juju-gui-6"
+        },
+        "2339": {
+          "id": "cs:~juju-gui\/trusty\/juju-gui-7"
+        },
+        "2340": {
+          "id": "cs:~juju-gui\/trusty\/juju-gui-8"
+        },
+        "2341": {
+          "id": "cs:~juju-gui\/trusty\/juju-gui-9"
+        },
+        "2342": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-0"
+        },
+        "2343": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-1"
+        },
+        "2344": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-10"
+        },
+        "2345": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-11"
+        },
+        "2346": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-12"
+        },
+        "2347": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-13"
+        },
+        "2348": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-14"
+        },
+        "2349": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-15"
+        },
+        "2350": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-16"
+        },
+        "2351": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-17"
+        },
+        "2352": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-18"
+        },
+        "2353": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-19"
+        },
+        "2354": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-2"
+        },
+        "2355": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-20"
+        },
+        "2356": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-21"
+        },
+        "2357": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-22"
+        },
+        "2358": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-23"
+        },
+        "2359": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-24"
+        },
+        "2360": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-25"
+        },
+        "2361": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-26"
+        },
+        "2362": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-27"
+        },
+        "2363": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-28"
+        },
+        "2364": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-29"
+        },
+        "2365": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-3"
+        },
+        "2366": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-30"
+        },
+        "2367": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-31"
+        },
+        "2368": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-32"
+        },
+        "2369": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-33"
+        },
+        "2370": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-34"
+        },
+        "2371": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-35"
+        },
+        "2372": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-36"
+        },
+        "2373": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-37"
+        },
+        "2374": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-38"
+        },
+        "2375": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-39"
+        },
+        "2376": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-4"
+        },
+        "2377": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-40"
+        },
+        "2378": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-41"
+        },
+        "2379": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-42"
+        },
+        "2380": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-43"
+        },
+        "2381": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-44"
+        },
+        "2382": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-45"
+        },
+        "2383": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-46"
+        },
+        "2384": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-47"
+        },
+        "2385": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-48"
+        },
+        "2386": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-49"
+        },
+        "2387": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-5"
+        },
+        "2388": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-50"
+        },
+        "2389": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-51"
+        },
+        "2390": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-52"
+        },
+        "2391": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-53"
+        },
+        "2392": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-54"
+        },
+        "2393": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-55"
+        },
+        "2394": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-56"
+        },
+        "2395": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-57"
+        },
+        "2396": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-58"
+        },
+        "2397": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-6"
+        },
+        "2398": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-7"
+        },
+        "2399": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-8"
+        },
+        "2400": {
+          "id": "cs:~juju-jitsu\/precise\/charmworld-9"
+        },
+        "2401": {
+          "id": "cs:~juju-qa\/precise\/juju-reports-0"
+        },
+        "2402": {
+          "id": "cs:~juju-qa\/precise\/juju-reports-1"
+        },
+        "2403": {
+          "id": "cs:~juju-qa\/precise\/juju-reports-10"
+        },
+        "2404": {
+          "id": "cs:~juju-qa\/precise\/juju-reports-11"
+        },
+        "2405": {
+          "id": "cs:~juju-qa\/precise\/juju-reports-12"
+        },
+        "2406": {
+          "id": "cs:~juju-qa\/precise\/juju-reports-13"
+        },
+        "2407": {
+          "id": "cs:~juju-qa\/precise\/juju-reports-14"
+        },
+        "2408": {
+          "id": "cs:~juju-qa\/precise\/juju-reports-15"
+        },
+        "2409": {
+          "id": "cs:~juju-qa\/precise\/juju-reports-16"
+        },
+        "2410": {
+          "id": "cs:~juju-qa\/precise\/juju-reports-17"
+        },
+        "2411": {
+          "id": "cs:~juju-qa\/precise\/juju-reports-18"
+        },
+        "2412": {
+          "id": "cs:~juju-qa\/precise\/juju-reports-19"
+        },
+        "2413": {
+          "id": "cs:~juju-qa\/precise\/juju-reports-2"
+        },
+        "2414": {
+          "id": "cs:~juju-qa\/precise\/juju-reports-20"
+        },
+        "2415": {
+          "id": "cs:~juju-qa\/precise\/juju-reports-21"
+        },
+        "2416": {
+          "id": "cs:~juju-qa\/precise\/juju-reports-22"
+        },
+        "2417": {
+          "id": "cs:~juju-qa\/precise\/juju-reports-23"
+        },
+        "2418": {
+          "id": "cs:~juju-qa\/precise\/juju-reports-24"
+        },
+        "2419": {
+          "id": "cs:~juju-qa\/precise\/juju-reports-25"
+        },
+        "2420": {
+          "id": "cs:~juju-qa\/precise\/juju-reports-26"
+        },
+        "2421": {
+          "id": "cs:~juju-qa\/precise\/juju-reports-27"
+        },
+        "2422": {
+          "id": "cs:~juju-qa\/precise\/juju-reports-28"
+        },
+        "2423": {
+          "id": "cs:~juju-qa\/precise\/juju-reports-29"
+        },
+        "2424": {
+          "id": "cs:~juju-qa\/precise\/juju-reports-3"
+        },
+        "2425": {
+          "id": "cs:~juju-qa\/precise\/juju-reports-30"
+        },
+        "2426": {
+          "id": "cs:~juju-qa\/precise\/juju-reports-31"
+        },
+        "2427": {
+          "id": "cs:~juju-qa\/precise\/juju-reports-32"
+        },
+        "2428": {
+          "id": "cs:~juju-qa\/precise\/juju-reports-33"
+        },
+        "2429": {
+          "id": "cs:~juju-qa\/precise\/juju-reports-34"
+        },
+        "2430": {
+          "id": "cs:~juju-qa\/precise\/juju-reports-35"
+        },
+        "2431": {
+          "id": "cs:~juju-qa\/precise\/juju-reports-36"
+        },
+        "2432": {
+          "id": "cs:~juju-qa\/precise\/juju-reports-37"
+        },
+        "2433": {
+          "id": "cs:~juju-qa\/precise\/juju-reports-4"
+        },
+        "2434": {
+          "id": "cs:~juju-qa\/precise\/juju-reports-5"
+        },
+        "2435": {
+          "id": "cs:~juju-qa\/precise\/juju-reports-6"
+        },
+        "2436": {
+          "id": "cs:~juju-qa\/precise\/juju-reports-7"
+        },
+        "2437": {
+          "id": "cs:~juju-qa\/precise\/juju-reports-8"
+        },
+        "2438": {
+          "id": "cs:~juju-qa\/precise\/juju-reports-9"
+        },
+        "2439": {
+          "id": "cs:~juju-qa\/trusty\/juju-reports-0"
+        },
+        "2440": {
+          "id": "cs:~juju-qa\/trusty\/juju-reports-1"
+        },
+        "2441": {
+          "id": "cs:~juju-qa\/trusty\/juju-reports-10"
+        },
+        "2442": {
+          "id": "cs:~juju-qa\/trusty\/juju-reports-11"
+        },
+        "2443": {
+          "id": "cs:~juju-qa\/trusty\/juju-reports-2"
+        },
+        "2444": {
+          "id": "cs:~juju-qa\/trusty\/juju-reports-3"
+        },
+        "2445": {
+          "id": "cs:~juju-qa\/trusty\/juju-reports-4"
+        },
+        "2446": {
+          "id": "cs:~juju-qa\/trusty\/juju-reports-5"
+        },
+        "2447": {
+          "id": "cs:~juju-qa\/trusty\/juju-reports-6"
+        },
+        "2448": {
+          "id": "cs:~juju-qa\/trusty\/juju-reports-7"
+        },
+        "2449": {
+          "id": "cs:~juju-qa\/trusty\/juju-reports-8"
+        },
+        "2450": {
+          "id": "cs:~juju-qa\/trusty\/juju-reports-9"
+        },
+        "2451": {
+          "id": "cs:~justin-fathomdb\/trusty\/haproxy-0"
+        },
+        "2452": {
+          "id": "cs:~justin-fathomdb\/trusty\/haproxy-1"
+        },
+        "2453": {
+          "id": "cs:~justin-fathomdb\/trusty\/haproxy-2"
+        },
+        "2454": {
+          "id": "cs:~justin-fathomdb\/trusty\/haproxy-3"
+        },
+        "2455": {
+          "id": "cs:~justin-fathomdb\/trusty\/haproxy-4"
+        },
+        "2456": {
+          "id": "cs:~justin-fathomdb\/trusty\/haproxy-5"
+        },
+        "2457": {
+          "id": "cs:~justin-fathomdb\/trusty\/haproxy-6"
+        },
+        "2458": {
+          "id": "cs:~justin-fathomdb\/trusty\/jxaas-0"
+        },
+        "2459": {
+          "id": "cs:~justin-fathomdb\/trusty\/jxaas-1"
+        },
+        "2460": {
+          "id": "cs:~justin-fathomdb\/trusty\/jxaas-10"
+        },
+        "2461": {
+          "id": "cs:~justin-fathomdb\/trusty\/jxaas-11"
+        },
+        "2462": {
+          "id": "cs:~justin-fathomdb\/trusty\/jxaas-12"
+        },
+        "2463": {
+          "id": "cs:~justin-fathomdb\/trusty\/jxaas-13"
+        },
+        "2464": {
+          "id": "cs:~justin-fathomdb\/trusty\/jxaas-2"
+        },
+        "2465": {
+          "id": "cs:~justin-fathomdb\/trusty\/jxaas-3"
+        },
+        "2466": {
+          "id": "cs:~justin-fathomdb\/trusty\/jxaas-4"
+        },
+        "2467": {
+          "id": "cs:~justin-fathomdb\/trusty\/jxaas-5"
+        },
+        "2468": {
+          "id": "cs:~justin-fathomdb\/trusty\/jxaas-6"
+        },
+        "2469": {
+          "id": "cs:~justin-fathomdb\/trusty\/jxaas-7"
+        },
+        "2470": {
+          "id": "cs:~justin-fathomdb\/trusty\/jxaas-8"
+        },
+        "2471": {
+          "id": "cs:~justin-fathomdb\/trusty\/jxaas-9"
+        },
+        "2472": {
+          "id": "cs:~justin-fathomdb\/trusty\/mediawiki-0"
+        },
+        "2473": {
+          "id": "cs:~justin-fathomdb\/trusty\/mediawiki-1"
+        },
+        "2474": {
+          "id": "cs:~justin-fathomdb\/trusty\/mediawiki-2"
+        },
+        "2475": {
+          "id": "cs:~justin-fathomdb\/trusty\/mediawiki-3"
+        },
+        "2476": {
+          "id": "cs:~justin-fathomdb\/trusty\/mediawiki-4"
+        },
+        "2477": {
+          "id": "cs:~justin-fathomdb\/trusty\/mediawiki-5"
+        },
+        "2478": {
+          "id": "cs:~justin-fathomdb\/trusty\/node-app-0"
+        },
+        "2479": {
+          "id": "cs:~justin-fathomdb\/trusty\/python-django-0"
+        },
+        "2480": {
+          "id": "cs:~justin-fathomdb\/trusty\/python-django-1"
+        },
+        "2481": {
+          "id": "cs:~justin-fathomdb\/trusty\/stub-client-10"
+        },
+        "2482": {
+          "id": "cs:~justin-fathomdb\/trusty\/stub-client-11"
+        },
+        "2483": {
+          "id": "cs:~justin-fathomdb\/trusty\/stub-client-12"
+        },
+        "2484": {
+          "id": "cs:~justin-fathomdb\/trusty\/stub-client-13"
+        },
+        "2485": {
+          "id": "cs:~justin-fathomdb\/trusty\/stub-client-14"
+        },
+        "2486": {
+          "id": "cs:~justin-fathomdb\/trusty\/stub-client-15"
+        },
+        "2487": {
+          "id": "cs:~justin-fathomdb\/trusty\/stub-client-7"
+        },
+        "2488": {
+          "id": "cs:~justin-fathomdb\/trusty\/stub-client-8"
+        },
+        "2489": {
+          "id": "cs:~justin-fathomdb\/trusty\/stub-client-9"
+        },
+        "2490": {
+          "id": "cs:~justin-fathomdb\/trusty\/wordpress-0"
+        },
+        "2491": {
+          "id": "cs:~justin-fathomdb\/trusty\/wordpress-1"
+        },
+        "2492": {
+          "id": "cs:~kaaloo\/oneiric\/elb-0"
+        },
+        "2493": {
+          "id": "cs:~kaaloo\/precise\/kibana-0"
+        },
+        "2494": {
+          "id": "cs:~kaaloo\/precise\/kibana-1"
+        },
+        "2495": {
+          "id": "cs:~kirkland\/oneiric\/musica-0"
+        },
+        "2496": {
+          "id": "cs:~kirkland\/oneiric\/pictor-0"
+        },
+        "2497": {
+          "id": "cs:~kirkland\/precise\/transcode-1"
+        },
+        "2498": {
+          "id": "cs:~kirkland\/precise\/transcode-10"
+        },
+        "2499": {
+          "id": "cs:~kirkland\/precise\/transcode-11"
+        },
+        "2500": {
+          "id": "cs:~kirkland\/precise\/transcode-12"
+        },
+        "2501": {
+          "id": "cs:~kirkland\/precise\/transcode-13"
+        },
+        "2502": {
+          "id": "cs:~kirkland\/precise\/transcode-14"
+        },
+        "2503": {
+          "id": "cs:~kirkland\/precise\/transcode-15"
+        },
+        "2504": {
+          "id": "cs:~kirkland\/precise\/transcode-16"
+        },
+        "2505": {
+          "id": "cs:~kirkland\/precise\/transcode-17"
+        },
+        "2506": {
+          "id": "cs:~kirkland\/precise\/transcode-18"
+        },
+        "2507": {
+          "id": "cs:~kirkland\/precise\/transcode-19"
+        },
+        "2508": {
+          "id": "cs:~kirkland\/precise\/transcode-2"
+        },
+        "2509": {
+          "id": "cs:~kirkland\/precise\/transcode-20"
+        },
+        "2510": {
+          "id": "cs:~kirkland\/precise\/transcode-21"
+        },
+        "2511": {
+          "id": "cs:~kirkland\/precise\/transcode-22"
+        },
+        "2512": {
+          "id": "cs:~kirkland\/precise\/transcode-23"
+        },
+        "2513": {
+          "id": "cs:~kirkland\/precise\/transcode-24"
+        },
+        "2514": {
+          "id": "cs:~kirkland\/precise\/transcode-25"
+        },
+        "2515": {
+          "id": "cs:~kirkland\/precise\/transcode-3"
+        },
+        "2516": {
+          "id": "cs:~kirkland\/precise\/transcode-4"
+        },
+        "2517": {
+          "id": "cs:~kirkland\/precise\/transcode-5"
+        },
+        "2518": {
+          "id": "cs:~kirkland\/precise\/transcode-6"
+        },
+        "2519": {
+          "id": "cs:~kirkland\/precise\/transcode-7"
+        },
+        "2520": {
+          "id": "cs:~kirkland\/precise\/transcode-8"
+        },
+        "2521": {
+          "id": "cs:~kirkland\/precise\/transcode-9"
+        },
+        "2522": {
+          "id": "cs:~kirkland\/precise\/yo-0"
+        },
+        "2523": {
+          "id": "cs:~kirkland\/precise\/yo-1"
+        },
+        "2524": {
+          "id": "cs:~kirkland\/precise\/yo-2"
+        },
+        "2525": {
+          "id": "cs:~kirkland\/precise\/yo-3"
+        },
+        "2526": {
+          "id": "cs:~koolhead17\/oneiric\/owncloud2-0"
+        },
+        "2527": {
+          "id": "cs:~lamont\/precise\/errors-0"
+        },
+        "2528": {
+          "id": "cs:~landscape-charmers\/precise\/landscape-server-0"
+        },
+        "2529": {
+          "id": "cs:~landscape-charmers\/precise\/landscape-server-1"
+        },
+        "2530": {
+          "id": "cs:~landscape-charmers\/precise\/landscape-server-10"
+        },
+        "2531": {
+          "id": "cs:~landscape-charmers\/precise\/landscape-server-11"
+        },
+        "2532": {
+          "id": "cs:~landscape-charmers\/precise\/landscape-server-12"
+        },
+        "2533": {
+          "id": "cs:~landscape-charmers\/precise\/landscape-server-13"
+        },
+        "2534": {
+          "id": "cs:~landscape-charmers\/precise\/landscape-server-2"
+        },
+        "2535": {
+          "id": "cs:~landscape-charmers\/precise\/landscape-server-3"
+        },
+        "2536": {
+          "id": "cs:~landscape-charmers\/precise\/landscape-server-4"
+        },
+        "2537": {
+          "id": "cs:~landscape-charmers\/precise\/landscape-server-5"
+        },
+        "2538": {
+          "id": "cs:~landscape-charmers\/precise\/landscape-server-6"
+        },
+        "2539": {
+          "id": "cs:~landscape-charmers\/precise\/landscape-server-7"
+        },
+        "2540": {
+          "id": "cs:~landscape-charmers\/precise\/landscape-server-8"
+        },
+        "2541": {
+          "id": "cs:~landscape-charmers\/precise\/landscape-server-9"
+        },
+        "2542": {
+          "id": "cs:~landscape-charmers\/trusty\/landscape-server-0"
+        },
+        "2543": {
+          "id": "cs:~landscape-charmers\/trusty\/landscape-server-1"
+        },
+        "2544": {
+          "id": "cs:~landscape-charmers\/trusty\/landscape-server-2"
+        },
+        "2545": {
+          "id": "cs:~landscape-charmers\/trusty\/landscape-server-3"
+        },
+        "2546": {
+          "id": "cs:~landscape-charmers\/trusty\/landscape-server-4"
+        },
+        "2547": {
+          "id": "cs:~landscape-charmers\/trusty\/landscape-server-5"
+        },
+        "2548": {
+          "id": "cs:~landscape-charmers\/trusty\/landscape-server-6"
+        },
+        "2549": {
+          "id": "cs:~landscape\/precise\/landscape-server-0"
+        },
+        "2550": {
+          "id": "cs:~landscape\/precise\/landscape-server-1"
+        },
+        "2551": {
+          "id": "cs:~landscape\/precise\/landscape-server-2"
+        },
+        "2552": {
+          "id": "cs:~landscape\/precise\/landscape-server-3"
+        },
+        "2553": {
+          "id": "cs:~landscape\/trusty\/ceph-radosgw-0"
+        },
+        "2554": {
+          "id": "cs:~landscape\/trusty\/ceph-radosgw-1"
+        },
+        "2555": {
+          "id": "cs:~landscape\/trusty\/ceph-radosgw-apt-0"
+        },
+        "2556": {
+          "id": "cs:~landscape\/trusty\/ceph-radosgw-cache-fix-0"
+        },
+        "2557": {
+          "id": "cs:~landscape\/trusty\/ceph-radosgw-cache-fix-1"
+        },
+        "2558": {
+          "id": "cs:~landscape\/trusty\/ceph-radosgw-merged-0"
+        },
+        "2559": {
+          "id": "cs:~landscape\/trusty\/ceph-radosgw-next-0"
+        },
+        "2560": {
+          "id": "cs:~landscape\/trusty\/ceph-radosgw-next-1"
+        },
+        "2561": {
+          "id": "cs:~landscape\/trusty\/ceph-radosgw-next-2"
+        },
+        "2562": {
+          "id": "cs:~landscape\/trusty\/ceph-radosgw-next-3"
+        },
+        "2563": {
+          "id": "cs:~landscape\/trusty\/ceph-radosgw-next-4"
+        },
+        "2564": {
+          "id": "cs:~landscape\/trusty\/ceph-radosgw-next-5"
+        },
+        "2565": {
+          "id": "cs:~landscape\/trusty\/ceph-radosgw-next-6"
+        },
+        "2566": {
+          "id": "cs:~landscape\/trusty\/openstack-dashboard-next-0"
+        },
+        "2567": {
+          "id": "cs:~landscape\/trusty\/openstack-dashboard-next-1"
+        },
+        "2568": {
+          "id": "cs:~landscape\/trusty\/openstack-dashboard-next-2"
+        },
+        "2569": {
+          "id": "cs:~landscape\/trusty\/openstack-dashboard-next-3"
+        },
+        "2570": {
+          "id": "cs:~landscape\/trusty\/openstack-dashboard-next-4"
+        },
+        "2571": {
+          "id": "cs:~landscape\/trusty\/openstack-dashboard-next-5"
+        },
+        "2572": {
+          "id": "cs:~landscape\/trusty\/openstack-dashboard-next-6"
+        },
+        "2573": {
+          "id": "cs:~lazypower\/precise\/airtime-0"
+        },
+        "2574": {
+          "id": "cs:~lazypower\/precise\/errbit-0"
+        },
+        "2575": {
+          "id": "cs:~lazypower\/precise\/errbit-1"
+        },
+        "2576": {
+          "id": "cs:~lazypower\/precise\/errbit-2"
+        },
+        "2577": {
+          "id": "cs:~lazypower\/precise\/genghisapp-0"
+        },
+        "2578": {
+          "id": "cs:~lazypower\/precise\/genghisapp-1"
+        },
+        "2579": {
+          "id": "cs:~lazypower\/precise\/genghisapp-2"
+        },
+        "2580": {
+          "id": "cs:~lazypower\/precise\/genghisapp-3"
+        },
+        "2581": {
+          "id": "cs:~lazypower\/precise\/genghisapp-4"
+        },
+        "2582": {
+          "id": "cs:~lazypower\/precise\/genghisapp-5"
+        },
+        "2583": {
+          "id": "cs:~lazypower\/precise\/genghisapp-6"
+        },
+        "2584": {
+          "id": "cs:~lazypower\/precise\/genghisapp-7"
+        },
+        "2585": {
+          "id": "cs:~lazypower\/precise\/gitlab-ci-0"
+        },
+        "2586": {
+          "id": "cs:~lazypower\/precise\/jenkins-0"
+        },
+        "2587": {
+          "id": "cs:~lazypower\/precise\/jenkins-1"
+        },
+        "2588": {
+          "id": "cs:~lazypower\/precise\/opscenter-0"
+        },
+        "2589": {
+          "id": "cs:~lazypower\/precise\/opscenter-1"
+        },
+        "2590": {
+          "id": "cs:~lazypower\/precise\/opscenter-2"
+        },
+        "2591": {
+          "id": "cs:~lazypower\/precise\/rails-0"
+        },
+        "2592": {
+          "id": "cs:~lazypower\/trusty\/dashing-0"
+        },
+        "2593": {
+          "id": "cs:~lazypower\/trusty\/haproxy-0"
+        },
+        "2594": {
+          "id": "cs:~lazypower\/trusty\/mcmyadmin-0"
+        },
+        "2595": {
+          "id": "cs:~lazypower\/trusty\/rails-0"
+        },
+        "2596": {
+          "id": "cs:~lifeless\/precise\/opentsdb-0"
+        },
+        "2597": {
+          "id": "cs:~lifeless\/precise\/opentsdb-1"
+        },
+        "2598": {
+          "id": "cs:~lifeless\/precise\/opentsdb-2"
+        },
+        "2599": {
+          "id": "cs:~lynxman\/precise\/drupal6-0"
+        },
+        "2600": {
+          "id": "cs:~mahmoh\/trusty\/bigbluebutton-0"
+        },
+        "2601": {
+          "id": "cs:~manjiri\/precise\/contrail-webui-0"
+        },
+        "2602": {
+          "id": "cs:~manjiri\/precise\/contrail-webui-1"
+        },
+        "2603": {
+          "id": "cs:~manjiri\/precise\/contrail-webui-2"
+        },
+        "2604": {
+          "id": "cs:~marcoceppi\/oneiric\/omg-wp-0"
+        },
+        "2605": {
+          "id": "cs:~marcoceppi\/oneiric\/omgubuntu-wp-0"
+        },
+        "2606": {
+          "id": "cs:~marcoceppi\/oneiric\/omgubuntu-wp-1"
+        },
+        "2607": {
+          "id": "cs:~marcoceppi\/oneiric\/omgubuntu-wp-2"
+        },
+        "2608": {
+          "id": "cs:~marcoceppi\/oneiric\/omgubuntu-wp-3"
+        },
+        "2609": {
+          "id": "cs:~marcoceppi\/precise\/charmworld-0"
+        },
+        "2610": {
+          "id": "cs:~marcoceppi\/precise\/charmworld-1"
+        },
+        "2611": {
+          "id": "cs:~marcoceppi\/precise\/charmworld-2"
+        },
+        "2612": {
+          "id": "cs:~marcoceppi\/precise\/charmworld-3"
+        },
+        "2613": {
+          "id": "cs:~marcoceppi\/precise\/charmworld-4"
+        },
+        "2614": {
+          "id": "cs:~marcoceppi\/precise\/charmworld-5"
+        },
+        "2615": {
+          "id": "cs:~marcoceppi\/precise\/charmworld-6"
+        },
+        "2616": {
+          "id": "cs:~marcoceppi\/precise\/charmworld-7"
+        },
+        "2617": {
+          "id": "cs:~marcoceppi\/precise\/discourse-0"
+        },
+        "2618": {
+          "id": "cs:~marcoceppi\/precise\/discourse-1"
+        },
+        "2619": {
+          "id": "cs:~marcoceppi\/precise\/discourse-10"
+        },
+        "2620": {
+          "id": "cs:~marcoceppi\/precise\/discourse-11"
+        },
+        "2621": {
+          "id": "cs:~marcoceppi\/precise\/discourse-12"
+        },
+        "2622": {
+          "id": "cs:~marcoceppi\/precise\/discourse-13"
+        },
+        "2623": {
+          "id": "cs:~marcoceppi\/precise\/discourse-14"
+        },
+        "2624": {
+          "id": "cs:~marcoceppi\/precise\/discourse-15"
+        },
+        "2625": {
+          "id": "cs:~marcoceppi\/precise\/discourse-16"
+        },
+        "2626": {
+          "id": "cs:~marcoceppi\/precise\/discourse-17"
+        },
+        "2627": {
+          "id": "cs:~marcoceppi\/precise\/discourse-18"
+        },
+        "2628": {
+          "id": "cs:~marcoceppi\/precise\/discourse-19"
+        },
+        "2629": {
+          "id": "cs:~marcoceppi\/precise\/discourse-2"
+        },
+        "2630": {
+          "id": "cs:~marcoceppi\/precise\/discourse-20"
+        },
+        "2631": {
+          "id": "cs:~marcoceppi\/precise\/discourse-21"
+        },
+        "2632": {
+          "id": "cs:~marcoceppi\/precise\/discourse-22"
+        },
+        "2633": {
+          "id": "cs:~marcoceppi\/precise\/discourse-23"
+        },
+        "2634": {
+          "id": "cs:~marcoceppi\/precise\/discourse-24"
+        },
+        "2635": {
+          "id": "cs:~marcoceppi\/precise\/discourse-25"
+        },
+        "2636": {
+          "id": "cs:~marcoceppi\/precise\/discourse-26"
+        },
+        "2637": {
+          "id": "cs:~marcoceppi\/precise\/discourse-27"
+        },
+        "2638": {
+          "id": "cs:~marcoceppi\/precise\/discourse-3"
+        },
+        "2639": {
+          "id": "cs:~marcoceppi\/precise\/discourse-4"
+        },
+        "2640": {
+          "id": "cs:~marcoceppi\/precise\/discourse-5"
+        },
+        "2641": {
+          "id": "cs:~marcoceppi\/precise\/discourse-6"
+        },
+        "2642": {
+          "id": "cs:~marcoceppi\/precise\/discourse-7"
+        },
+        "2643": {
+          "id": "cs:~marcoceppi\/precise\/discourse-8"
+        },
+        "2644": {
+          "id": "cs:~marcoceppi\/precise\/discourse-9"
+        },
+        "2645": {
+          "id": "cs:~marcoceppi\/precise\/hue-0"
+        },
+        "2646": {
+          "id": "cs:~marcoceppi\/precise\/jenkins-0"
+        },
+        "2647": {
+          "id": "cs:~marcoceppi\/precise\/magento-0"
+        },
+        "2648": {
+          "id": "cs:~marcoceppi\/precise\/magento-1"
+        },
+        "2649": {
+          "id": "cs:~marcoceppi\/precise\/stingray-0"
+        },
+        "2650": {
+          "id": "cs:~marcoceppi\/precise\/stingray-1"
+        },
+        "2651": {
+          "id": "cs:~marcoceppi\/precise\/stingray-2"
+        },
+        "2652": {
+          "id": "cs:~marcoceppi\/precise\/stingray-3"
+        },
+        "2653": {
+          "id": "cs:~marcoceppi\/precise\/stingray-4"
+        },
+        "2654": {
+          "id": "cs:~marcoceppi\/precise\/vanilla-0"
+        },
+        "2655": {
+          "id": "cs:~marcoceppi\/precise\/wordpress-0"
+        },
+        "2656": {
+          "id": "cs:~marcoceppi\/precise\/wordpress-1"
+        },
+        "2657": {
+          "id": "cs:~marcoceppi\/precise\/wordpress-10"
+        },
+        "2658": {
+          "id": "cs:~marcoceppi\/precise\/wordpress-11"
+        },
+        "2659": {
+          "id": "cs:~marcoceppi\/precise\/wordpress-12"
+        },
+        "2660": {
+          "id": "cs:~marcoceppi\/precise\/wordpress-13"
+        },
+        "2661": {
+          "id": "cs:~marcoceppi\/precise\/wordpress-14"
+        },
+        "2662": {
+          "id": "cs:~marcoceppi\/precise\/wordpress-15"
+        },
+        "2663": {
+          "id": "cs:~marcoceppi\/precise\/wordpress-16"
+        },
+        "2664": {
+          "id": "cs:~marcoceppi\/precise\/wordpress-17"
+        },
+        "2665": {
+          "id": "cs:~marcoceppi\/precise\/wordpress-2"
+        },
+        "2666": {
+          "id": "cs:~marcoceppi\/precise\/wordpress-3"
+        },
+        "2667": {
+          "id": "cs:~marcoceppi\/precise\/wordpress-4"
+        },
+        "2668": {
+          "id": "cs:~marcoceppi\/precise\/wordpress-5"
+        },
+        "2669": {
+          "id": "cs:~marcoceppi\/precise\/wordpress-6"
+        },
+        "2670": {
+          "id": "cs:~marcoceppi\/precise\/wordpress-7"
+        },
+        "2671": {
+          "id": "cs:~marcoceppi\/precise\/wordpress-8"
+        },
+        "2672": {
+          "id": "cs:~marcoceppi\/precise\/wordpress-9"
+        },
+        "2673": {
+          "id": "cs:~marcoceppi\/precise\/zabbix-0"
+        },
+        "2674": {
+          "id": "cs:~marcoceppi\/precise\/zabbix-1"
+        },
+        "2675": {
+          "id": "cs:~marcoceppi\/trusty\/nagios-0"
+        },
+        "2676": {
+          "id": "cs:~marcoceppi\/trusty\/nagios-1"
+        },
+        "2677": {
+          "id": "cs:~marcoceppi\/trusty\/php-website-0"
+        },
+        "2678": {
+          "id": "cs:~marcoceppi\/trusty\/php-website-1"
+        },
+        "2679": {
+          "id": "cs:~mariusko\/precise\/node-app-0"
+        },
+        "2680": {
+          "id": "cs:~mariusko\/precise\/node-app-1"
+        },
+        "2681": {
+          "id": "cs:~mariusko\/precise\/node-app-10"
+        },
+        "2682": {
+          "id": "cs:~mariusko\/precise\/node-app-11"
+        },
+        "2683": {
+          "id": "cs:~mariusko\/precise\/node-app-2"
+        },
+        "2684": {
+          "id": "cs:~mariusko\/precise\/node-app-3"
+        },
+        "2685": {
+          "id": "cs:~mariusko\/precise\/node-app-4"
+        },
+        "2686": {
+          "id": "cs:~mariusko\/precise\/node-app-5"
+        },
+        "2687": {
+          "id": "cs:~mariusko\/precise\/node-app-6"
+        },
+        "2688": {
+          "id": "cs:~mariusko\/precise\/node-app-7"
+        },
+        "2689": {
+          "id": "cs:~mariusko\/precise\/node-app-8"
+        },
+        "2690": {
+          "id": "cs:~mariusko\/precise\/node-app-9"
+        },
+        "2691": {
+          "id": "cs:~mark-mims\/oneiric\/charmtester-0"
+        },
+        "2692": {
+          "id": "cs:~mark-mims\/oneiric\/charmtester-1"
+        },
+        "2693": {
+          "id": "cs:~mark-mims\/oneiric\/charmtester-2"
+        },
+        "2694": {
+          "id": "cs:~mark-mims\/oneiric\/charmtester-3"
+        },
+        "2695": {
+          "id": "cs:~mark-mims\/oneiric\/charmtester-4"
+        },
+        "2696": {
+          "id": "cs:~mark-mims\/oneiric\/drupal-0"
+        },
+        "2697": {
+          "id": "cs:~mark-mims\/oneiric\/juju-classroom-0"
+        },
+        "2698": {
+          "id": "cs:~mark-mims\/oneiric\/node-0"
+        },
+        "2699": {
+          "id": "cs:~mark-mims\/oneiric\/varnish-0"
+        },
+        "2700": {
+          "id": "cs:~mark-mims\/precise\/apache2-0"
+        },
+        "2701": {
+          "id": "cs:~mark-mims\/precise\/apache2-1"
+        },
+        "2702": {
+          "id": "cs:~mark-mims\/precise\/charmrunner-0"
+        },
+        "2703": {
+          "id": "cs:~mark-mims\/precise\/charmrunner-1"
+        },
+        "2704": {
+          "id": "cs:~mark-mims\/precise\/charmrunner-2"
+        },
+        "2705": {
+          "id": "cs:~mark-mims\/precise\/charmrunner-3"
+        },
+        "2706": {
+          "id": "cs:~mark-mims\/precise\/charmrunner-4"
+        },
+        "2707": {
+          "id": "cs:~mark-mims\/precise\/charmtester-0"
+        },
+        "2708": {
+          "id": "cs:~mark-mims\/precise\/charmtester-1"
+        },
+        "2709": {
+          "id": "cs:~mark-mims\/precise\/charmtester-2"
+        },
+        "2710": {
+          "id": "cs:~mark-mims\/precise\/charmtester-3"
+        },
+        "2711": {
+          "id": "cs:~mark-mims\/precise\/charmtester-4"
+        },
+        "2712": {
+          "id": "cs:~mark-mims\/precise\/charmtester-5"
+        },
+        "2713": {
+          "id": "cs:~mark-mims\/precise\/charmtester-6"
+        },
+        "2714": {
+          "id": "cs:~mark-mims\/precise\/juju-gui-0"
+        },
+        "2715": {
+          "id": "cs:~mark-mims\/precise\/liferay-0"
+        },
+        "2716": {
+          "id": "cs:~mark-mims\/precise\/mediawiki-0"
+        },
+        "2717": {
+          "id": "cs:~mark-mims\/precise\/promultest-0"
+        },
+        "2718": {
+          "id": "cs:~mark-mims\/precise\/promultest-1"
+        },
+        "2719": {
+          "id": "cs:~mark-mims\/precise\/rack-0"
+        },
+        "2720": {
+          "id": "cs:~mark-mims\/precise\/rack-1"
+        },
+        "2721": {
+          "id": "cs:~mark-mims\/precise\/rails-0"
+        },
+        "2722": {
+          "id": "cs:~mark-mims\/precise\/rails-1"
+        },
+        "2723": {
+          "id": "cs:~mark-mims\/precise\/rails-2"
+        },
+        "2724": {
+          "id": "cs:~mark-mims\/precise\/rails-3"
+        },
+        "2725": {
+          "id": "cs:~mark-mims\/precise\/rails-4"
+        },
+        "2726": {
+          "id": "cs:~mark-mims\/precise\/ruby-0"
+        },
+        "2727": {
+          "id": "cs:~mark-mims\/precise\/summit-3"
+        },
+        "2728": {
+          "id": "cs:~martin-hilton\/precise\/nagios-0"
+        },
+        "2729": {
+          "id": "cs:~martin-hilton\/precise\/nagios-1"
+        },
+        "2730": {
+          "id": "cs:~matsubara\/precise\/oops-tools-0"
+        },
+        "2731": {
+          "id": "cs:~matsubara\/precise\/oops-tools-1"
+        },
+        "2732": {
+          "id": "cs:~mbruzek\/precise\/etherpad-lite-0"
+        },
+        "2733": {
+          "id": "cs:~mbruzek\/precise\/haproxy-0"
+        },
+        "2734": {
+          "id": "cs:~mbruzek\/precise\/haproxy-1"
+        },
+        "2735": {
+          "id": "cs:~mbruzek\/precise\/lamp-0"
+        },
+        "2736": {
+          "id": "cs:~mbruzek\/precise\/lamp-1"
+        },
+        "2737": {
+          "id": "cs:~mbruzek\/precise\/lamp-2"
+        },
+        "2738": {
+          "id": "cs:~mbruzek\/precise\/lamp-3"
+        },
+        "2739": {
+          "id": "cs:~mbruzek\/precise\/lamp-4"
+        },
+        "2740": {
+          "id": "cs:~mbruzek\/precise\/lamp-5"
+        },
+        "2741": {
+          "id": "cs:~mbruzek\/precise\/pubphoto-0"
+        },
+        "2742": {
+          "id": "cs:~mbruzek\/precise\/tomcat-0"
+        },
+        "2743": {
+          "id": "cs:~mbruzek\/precise\/tomcat-1"
+        },
+        "2744": {
+          "id": "cs:~mbruzek\/precise\/tomcat-2"
+        },
+        "2745": {
+          "id": "cs:~mbruzek\/precise\/tomcat-3"
+        },
+        "2746": {
+          "id": "cs:~mbruzek\/precise\/tomcat-4"
+        },
+        "2747": {
+          "id": "cs:~mbruzek\/trusty\/appflower-0"
+        },
+        "2748": {
+          "id": "cs:~mbruzek\/trusty\/etherpad-lite-0"
+        },
+        "2749": {
+          "id": "cs:~mbruzek\/trusty\/ganglia-0"
+        },
+        "2750": {
+          "id": "cs:~mbruzek\/trusty\/ganglia-1"
+        },
+        "2751": {
+          "id": "cs:~mbruzek\/trusty\/sugarcrm-0"
+        },
+        "2752": {
+          "id": "cs:~med\/precise\/squid-rp-mirror-0"
+        },
+        "2753": {
+          "id": "cs:~menesis\/precise\/schooltool-0"
+        },
+        "2754": {
+          "id": "cs:~menesis\/precise\/schooltool-1"
+        },
+        "2755": {
+          "id": "cs:~menesis\/precise\/schooltool-2"
+        },
+        "2756": {
+          "id": "cs:~mew\/precise\/squid-1"
+        },
+        "2757": {
+          "id": "cs:~mew\/precise\/squid-2"
+        },
+        "2758": {
+          "id": "cs:~mew\/precise\/squid-3"
+        },
+        "2759": {
+          "id": "cs:~mew\/precise\/squid-4"
+        },
+        "2760": {
+          "id": "cs:~mew\/precise\/squid-5"
+        },
+        "2761": {
+          "id": "cs:~mew\/precise\/squid-6"
+        },
+        "2762": {
+          "id": "cs:~mew\/precise\/squid-7"
+        },
+        "2763": {
+          "id": "cs:~mew\/precise\/squid-8"
+        },
+        "2764": {
+          "id": "cs:~mew\/precise\/squid-9"
+        },
+        "2765": {
+          "id": "cs:~mfisch\/precise\/tracks-1"
+        },
+        "2766": {
+          "id": "cs:~mfisch\/precise\/tracks-2"
+        },
+        "2767": {
+          "id": "cs:~mfisch\/precise\/tracks-3"
+        },
+        "2768": {
+          "id": "cs:~mfisch\/precise\/tracks-4"
+        },
+        "2769": {
+          "id": "cs:~michael.nelson\/precise\/elasticsearch-16"
+        },
+        "2770": {
+          "id": "cs:~michael.nelson\/precise\/elasticsearch-17"
+        },
+        "2771": {
+          "id": "cs:~michael.nelson\/precise\/elasticsearch-18"
+        },
+        "2772": {
+          "id": "cs:~michael.nelson\/precise\/elasticsearch-19"
+        },
+        "2773": {
+          "id": "cs:~michael.nelson\/precise\/elasticsearch-20"
+        },
+        "2774": {
+          "id": "cs:~michael.nelson\/precise\/elasticsearch-21"
+        },
+        "2775": {
+          "id": "cs:~michael.nelson\/precise\/elasticsearch-22"
+        },
+        "2776": {
+          "id": "cs:~michael.nelson\/precise\/elasticsearch-23"
+        },
+        "2777": {
+          "id": "cs:~michael.nelson\/precise\/elasticsearch-24"
+        },
+        "2778": {
+          "id": "cs:~michael.nelson\/precise\/elasticsearch-25"
+        },
+        "2779": {
+          "id": "cs:~michael.nelson\/precise\/elasticsearch-26"
+        },
+        "2780": {
+          "id": "cs:~michael.nelson\/precise\/elasticsearch-27"
+        },
+        "2781": {
+          "id": "cs:~michael.nelson\/precise\/elasticsearch-28"
+        },
+        "2782": {
+          "id": "cs:~michael.nelson\/precise\/elasticsearch-29"
+        },
+        "2783": {
+          "id": "cs:~michael.nelson\/precise\/elasticsearch-30"
+        },
+        "2784": {
+          "id": "cs:~michael.nelson\/precise\/elasticsearch-31"
+        },
+        "2785": {
+          "id": "cs:~michael.nelson\/precise\/elasticsearch-32"
+        },
+        "2786": {
+          "id": "cs:~narindergupta\/trusty\/ganglia-0"
+        },
+        "2787": {
+          "id": "cs:~narindergupta\/trusty\/haproxy-0"
+        },
+        "2788": {
+          "id": "cs:~narindergupta\/trusty\/mediawiki-0"
+        },
+        "2789": {
+          "id": "cs:~natefinch\/trusty\/discourse-0"
+        },
+        "2790": {
+          "id": "cs:~natefinch\/trusty\/discourse-1"
+        },
+        "2791": {
+          "id": "cs:~natefinch\/trusty\/discourse-2"
+        },
+        "2792": {
+          "id": "cs:~natefinch\/trusty\/discourse-3"
+        },
+        "2793": {
+          "id": "cs:~natefinch\/trusty\/discourse-4"
+        },
+        "2794": {
+          "id": "cs:~natefinch\/trusty\/discourse-5"
+        },
+        "2795": {
+          "id": "cs:~natefinch\/trusty\/discourse-6"
+        },
+        "2796": {
+          "id": "cs:~natefinch\/trusty\/discourse-7"
+        },
+        "2797": {
+          "id": "cs:~natefinch\/trusty\/discourse-8"
+        },
+        "2798": {
+          "id": "cs:~nathwill-deactivatedaccount\/precise\/owncloud-0"
+        },
+        "2799": {
+          "id": "cs:~nathwill-deactivatedaccount\/precise\/varnish-0"
+        },
+        "2800": {
+          "id": "cs:~negronjl\/oneiric\/tomcat6-0"
+        },
+        "2801": {
+          "id": "cs:~negronjl\/precise\/seafile-0"
+        },
+        "2802": {
+          "id": "cs:~negronjl\/precise\/seafile-1"
+        },
+        "2803": {
+          "id": "cs:~negronjl\/precise\/seafile-2"
+        },
+        "2804": {
+          "id": "cs:~negronjl\/precise\/seafile-3"
+        },
+        "2805": {
+          "id": "cs:~negronjl\/precise\/seafile-4"
+        },
+        "2806": {
+          "id": "cs:~negronjl\/precise\/seafile-5"
+        },
+        "2807": {
+          "id": "cs:~negronjl\/precise\/seafile-6"
+        },
+        "2808": {
+          "id": "cs:~nextrevision\/precise\/openvpn-as-1"
+        },
+        "2809": {
+          "id": "cs:~nextrevision\/precise\/openvpn-as-2"
+        },
+        "2810": {
+          "id": "cs:~nextrevision\/precise\/openvpn-as-3"
+        },
+        "2811": {
+          "id": "cs:~nextrevision\/precise\/openvpn-as-4"
+        },
+        "2812": {
+          "id": "cs:~nextrevision\/precise\/openvpn-as-5"
+        },
+        "2813": {
+          "id": "cs:~nextrevision\/precise\/openvpn-as-6"
+        },
+        "2814": {
+          "id": "cs:~nextrevision\/precise\/openvpn-as-7"
+        },
+        "2815": {
+          "id": "cs:~nextrevision\/precise\/tt-rss-0"
+        },
+        "2816": {
+          "id": "cs:~nextrevision\/precise\/tt-rss-1"
+        },
+        "2817": {
+          "id": "cs:~nextrevision\/precise\/tt-rss-2"
+        },
+        "2818": {
+          "id": "cs:~nextrevision\/precise\/tt-rss-3"
+        },
+        "2819": {
+          "id": "cs:~noise\/trusty\/grafana-0"
+        },
+        "2820": {
+          "id": "cs:~nottrobin\/trusty\/apache2-wsgi-0"
+        },
+        "2821": {
+          "id": "cs:~nottrobin\/trusty\/apache2-wsgi-1"
+        },
+        "2822": {
+          "id": "cs:~nottrobin\/trusty\/apache2-wsgi-10"
+        },
+        "2823": {
+          "id": "cs:~nottrobin\/trusty\/apache2-wsgi-11"
+        },
+        "2824": {
+          "id": "cs:~nottrobin\/trusty\/apache2-wsgi-12"
+        },
+        "2825": {
+          "id": "cs:~nottrobin\/trusty\/apache2-wsgi-13"
+        },
+        "2826": {
+          "id": "cs:~nottrobin\/trusty\/apache2-wsgi-14"
+        },
+        "2827": {
+          "id": "cs:~nottrobin\/trusty\/apache2-wsgi-15"
+        },
+        "2828": {
+          "id": "cs:~nottrobin\/trusty\/apache2-wsgi-16"
+        },
+        "2829": {
+          "id": "cs:~nottrobin\/trusty\/apache2-wsgi-2"
+        },
+        "2830": {
+          "id": "cs:~nottrobin\/trusty\/apache2-wsgi-3"
+        },
+        "2831": {
+          "id": "cs:~nottrobin\/trusty\/apache2-wsgi-4"
+        },
+        "2832": {
+          "id": "cs:~nottrobin\/trusty\/apache2-wsgi-5"
+        },
+        "2833": {
+          "id": "cs:~nottrobin\/trusty\/apache2-wsgi-6"
+        },
+        "2834": {
+          "id": "cs:~nottrobin\/trusty\/apache2-wsgi-7"
+        },
+        "2835": {
+          "id": "cs:~nottrobin\/trusty\/apache2-wsgi-8"
+        },
+        "2836": {
+          "id": "cs:~nottrobin\/trusty\/apache2-wsgi-9"
+        },
+        "2837": {
+          "id": "cs:~nskaggs\/precise\/vivo-1"
+        },
+        "2838": {
+          "id": "cs:~nskaggs\/precise\/vivo-10"
+        },
+        "2839": {
+          "id": "cs:~nskaggs\/precise\/vivo-11"
+        },
+        "2840": {
+          "id": "cs:~nskaggs\/precise\/vivo-2"
+        },
+        "2841": {
+          "id": "cs:~nskaggs\/precise\/vivo-3"
+        },
+        "2842": {
+          "id": "cs:~nskaggs\/precise\/vivo-4"
+        },
+        "2843": {
+          "id": "cs:~nskaggs\/precise\/vivo-5"
+        },
+        "2844": {
+          "id": "cs:~nskaggs\/precise\/vivo-6"
+        },
+        "2845": {
+          "id": "cs:~nskaggs\/precise\/vivo-7"
+        },
+        "2846": {
+          "id": "cs:~nskaggs\/precise\/vivo-8"
+        },
+        "2847": {
+          "id": "cs:~nskaggs\/precise\/vivo-9"
+        },
+        "2848": {
+          "id": "cs:~nuage-canonical\/trusty\/nuage-vsd-10"
+        },
+        "2849": {
+          "id": "cs:~nuage-canonical\/trusty\/nuage-vsd-11"
+        },
+        "2850": {
+          "id": "cs:~nuage-canonical\/trusty\/nuage-vsd-12"
+        },
+        "2851": {
+          "id": "cs:~nuage-canonical\/trusty\/nuage-vsd-13"
+        },
+        "2852": {
+          "id": "cs:~nuage-canonical\/trusty\/nuage-vsd-14"
+        },
+        "2853": {
+          "id": "cs:~nuage-canonical\/trusty\/nuage-vsd-15"
+        },
+        "2854": {
+          "id": "cs:~nuage-canonical\/trusty\/nuage-vsd-16"
+        },
+        "2855": {
+          "id": "cs:~nuage-canonical\/trusty\/nuage-vsd-17"
+        },
+        "2856": {
+          "id": "cs:~nuage-canonical\/trusty\/nuage-vsd-18"
+        },
+        "2857": {
+          "id": "cs:~nuage-canonical\/trusty\/nuage-vsd-19"
+        },
+        "2858": {
+          "id": "cs:~nuage-canonical\/trusty\/nuage-vsd-2"
+        },
+        "2859": {
+          "id": "cs:~nuage-canonical\/trusty\/nuage-vsd-20"
+        },
+        "2860": {
+          "id": "cs:~nuage-canonical\/trusty\/nuage-vsd-21"
+        },
+        "2861": {
+          "id": "cs:~nuage-canonical\/trusty\/nuage-vsd-22"
+        },
+        "2862": {
+          "id": "cs:~nuage-canonical\/trusty\/nuage-vsd-23"
+        },
+        "2863": {
+          "id": "cs:~nuage-canonical\/trusty\/nuage-vsd-24"
+        },
+        "2864": {
+          "id": "cs:~nuage-canonical\/trusty\/nuage-vsd-25"
+        },
+        "2865": {
+          "id": "cs:~nuage-canonical\/trusty\/nuage-vsd-26"
+        },
+        "2866": {
+          "id": "cs:~nuage-canonical\/trusty\/nuage-vsd-27"
+        },
+        "2867": {
+          "id": "cs:~nuage-canonical\/trusty\/nuage-vsd-28"
+        },
+        "2868": {
+          "id": "cs:~nuage-canonical\/trusty\/nuage-vsd-29"
+        },
+        "2869": {
+          "id": "cs:~nuage-canonical\/trusty\/nuage-vsd-3"
+        },
+        "2870": {
+          "id": "cs:~nuage-canonical\/trusty\/nuage-vsd-30"
+        },
+        "2871": {
+          "id": "cs:~nuage-canonical\/trusty\/nuage-vsd-31"
+        },
+        "2872": {
+          "id": "cs:~nuage-canonical\/trusty\/nuage-vsd-32"
+        },
+        "2873": {
+          "id": "cs:~nuage-canonical\/trusty\/nuage-vsd-33"
+        },
+        "2874": {
+          "id": "cs:~nuage-canonical\/trusty\/nuage-vsd-34"
+        },
+        "2875": {
+          "id": "cs:~nuage-canonical\/trusty\/nuage-vsd-35"
+        },
+        "2876": {
+          "id": "cs:~nuage-canonical\/trusty\/nuage-vsd-36"
+        },
+        "2877": {
+          "id": "cs:~nuage-canonical\/trusty\/nuage-vsd-37"
+        },
+        "2878": {
+          "id": "cs:~nuage-canonical\/trusty\/nuage-vsd-38"
+        },
+        "2879": {
+          "id": "cs:~nuage-canonical\/trusty\/nuage-vsd-39"
+        },
+        "2880": {
+          "id": "cs:~nuage-canonical\/trusty\/nuage-vsd-4"
+        },
+        "2881": {
+          "id": "cs:~nuage-canonical\/trusty\/nuage-vsd-40"
+        },
+        "2882": {
+          "id": "cs:~nuage-canonical\/trusty\/nuage-vsd-41"
+        },
+        "2883": {
+          "id": "cs:~nuage-canonical\/trusty\/nuage-vsd-42"
+        },
+        "2884": {
+          "id": "cs:~nuage-canonical\/trusty\/nuage-vsd-43"
+        },
+        "2885": {
+          "id": "cs:~nuage-canonical\/trusty\/nuage-vsd-44"
+        },
+        "2886": {
+          "id": "cs:~nuage-canonical\/trusty\/nuage-vsd-45"
+        },
+        "2887": {
+          "id": "cs:~nuage-canonical\/trusty\/nuage-vsd-46"
+        },
+        "2888": {
+          "id": "cs:~nuage-canonical\/trusty\/nuage-vsd-47"
+        },
+        "2889": {
+          "id": "cs:~nuage-canonical\/trusty\/nuage-vsd-5"
+        },
+        "2890": {
+          "id": "cs:~nuage-canonical\/trusty\/nuage-vsd-6"
+        },
+        "2891": {
+          "id": "cs:~nuage-canonical\/trusty\/nuage-vsd-7"
+        },
+        "2892": {
+          "id": "cs:~nuage-canonical\/trusty\/nuage-vsd-8"
+        },
+        "2893": {
+          "id": "cs:~nuage-canonical\/trusty\/nuage-vsd-9"
+        },
+        "2894": {
+          "id": "cs:~nuclearbob\/trusty\/qlbr-18"
+        },
+        "2895": {
+          "id": "cs:~openstack-charmers\/precise\/ceph-radosgw-0"
+        },
+        "2896": {
+          "id": "cs:~openstack-charmers\/precise\/ceph-radosgw-10"
+        },
+        "2897": {
+          "id": "cs:~openstack-charmers\/precise\/ceph-radosgw-11"
+        },
+        "2898": {
+          "id": "cs:~openstack-charmers\/precise\/ceph-radosgw-12"
+        },
+        "2899": {
+          "id": "cs:~openstack-charmers\/precise\/ceph-radosgw-13"
+        },
+        "2900": {
+          "id": "cs:~openstack-charmers\/precise\/ceph-radosgw-14"
+        },
+        "2901": {
+          "id": "cs:~openstack-charmers\/precise\/ceph-radosgw-15"
+        },
+        "2902": {
+          "id": "cs:~openstack-charmers\/precise\/ceph-radosgw-9"
+        },
+        "2903": {
+          "id": "cs:~openstack-charmers\/precise\/openstack-dashboard-14"
+        },
+        "2904": {
+          "id": "cs:~openstack-charmers\/precise\/openstack-dashboard-15"
+        },
+        "2905": {
+          "id": "cs:~openstack-charmers\/precise\/openstack-dashboard-16"
+        },
+        "2906": {
+          "id": "cs:~openstack-charmers\/precise\/openstack-dashboard-17"
+        },
+        "2907": {
+          "id": "cs:~openstack-charmers\/precise\/openstack-dashboard-18"
+        },
+        "2908": {
+          "id": "cs:~openstack-charmers\/precise\/openstack-dashboard-19"
+        },
+        "2909": {
+          "id": "cs:~openstack-charmers\/precise\/openstack-dashboard-20"
+        },
+        "2910": {
+          "id": "cs:~openstack-charmers\/precise\/openstack-dashboard-21"
+        },
+        "2911": {
+          "id": "cs:~openstack-charmers\/precise\/openstack-dashboard-22"
+        },
+        "2912": {
+          "id": "cs:~openstack-charmers\/trusty\/ceph-radosgw-0"
+        },
+        "2913": {
+          "id": "cs:~openstack-charmers\/trusty\/ceph-radosgw-1"
+        },
+        "2914": {
+          "id": "cs:~openstack-charmers\/trusty\/ceph-radosgw-2"
+        },
+        "2915": {
+          "id": "cs:~openstack-charmers\/trusty\/ceph-radosgw-3"
+        },
+        "2916": {
+          "id": "cs:~openstack-charmers\/trusty\/ceph-radosgw-4"
+        },
+        "2917": {
+          "id": "cs:~openstack-charmers\/trusty\/ceph-radosgw-5"
+        },
+        "2918": {
+          "id": "cs:~openstack-charmers\/trusty\/ceph-radosgw-6"
+        },
+        "2919": {
+          "id": "cs:~openstack-charmers\/trusty\/ceph-radosgw-7"
+        },
+        "2920": {
+          "id": "cs:~openstack-charmers\/trusty\/ceph-radosgw-8"
+        },
+        "2921": {
+          "id": "cs:~openstack-charmers\/trusty\/ceph-radosgw-9"
+        },
+        "2922": {
+          "id": "cs:~openstack-charmers\/trusty\/openstack-dashboard-0"
+        },
+        "2923": {
+          "id": "cs:~openstack-charmers\/trusty\/openstack-dashboard-1"
+        },
+        "2924": {
+          "id": "cs:~openstack-charmers\/trusty\/openstack-dashboard-2"
+        },
+        "2925": {
+          "id": "cs:~openstack-charmers\/trusty\/openstack-dashboard-3"
+        },
+        "2926": {
+          "id": "cs:~openstack-charmers\/trusty\/openstack-dashboard-4"
+        },
+        "2927": {
+          "id": "cs:~openstack-charmers\/trusty\/openstack-dashboard-5"
+        },
+        "2928": {
+          "id": "cs:~openstack-charmers\/trusty\/openstack-dashboard-6"
+        },
+        "2929": {
+          "id": "cs:~openstack-charmers\/trusty\/openstack-dashboard-7"
+        },
+        "2930": {
+          "id": "cs:~openstack-charmers\/trusty\/openstack-dashboard-8"
+        },
+        "2931": {
+          "id": "cs:~openstack-charmers\/trusty\/openstack-dashboard-9"
+        },
+        "2932": {
+          "id": "cs:~openstack-ubuntu-testing\/precise\/cinder-0"
+        },
+        "2933": {
+          "id": "cs:~openstack-ubuntu-testing\/precise\/openstack-dashboard-15"
+        },
+        "2934": {
+          "id": "cs:~openstack-ubuntu-testing\/precise\/openstack-dashboard-16"
+        },
+        "2935": {
+          "id": "cs:~openstack-ubuntu-testing\/precise\/openstack-dashboard-17"
+        },
+        "2936": {
+          "id": "cs:~openstack-ubuntu-testing\/precise\/openstack-dashboard-18"
+        },
+        "2937": {
+          "id": "cs:~openstack-ubuntu-testing\/precise\/openstack-dashboard-19"
+        },
+        "2938": {
+          "id": "cs:~openstack-ubuntu-testing\/precise\/openstack-dashboard-20"
+        },
+        "2939": {
+          "id": "cs:~openstack-ubuntu-testing\/precise\/openstack-dashboard-21"
+        },
+        "2940": {
+          "id": "cs:~openstack-ubuntu-testing\/precise\/openstack-dashboard-22"
+        },
+        "2941": {
+          "id": "cs:~openstack-ubuntu-testing\/precise\/openstack-dashboard-23"
+        },
+        "2942": {
+          "id": "cs:~patrick-hetu\/oneiric\/icecast2-0"
+        },
+        "2943": {
+          "id": "cs:~patrick-hetu\/oneiric\/openerp-server-0"
+        },
+        "2944": {
+          "id": "cs:~patrick-hetu\/oneiric\/openerp-server-1"
+        },
+        "2945": {
+          "id": "cs:~patrick-hetu\/oneiric\/openerp-server-2"
+        },
+        "2946": {
+          "id": "cs:~patrick-hetu\/oneiric\/openerp-server-3"
+        },
+        "2947": {
+          "id": "cs:~patrick-hetu\/oneiric\/openerp-web-0"
+        },
+        "2948": {
+          "id": "cs:~patrick-hetu\/oneiric\/openerp-web-1"
+        },
+        "2949": {
+          "id": "cs:~patrick-hetu\/oneiric\/openerp-web-2"
+        },
+        "2950": {
+          "id": "cs:~patrick-hetu\/oneiric\/python-moinmoin-0"
+        },
+        "2951": {
+          "id": "cs:~patrick-hetu\/oneiric\/python-moinmoin-1"
+        },
+        "2952": {
+          "id": "cs:~patrick-hetu\/oneiric\/python-moinmoin-10"
+        },
+        "2953": {
+          "id": "cs:~patrick-hetu\/oneiric\/python-moinmoin-11"
+        },
+        "2954": {
+          "id": "cs:~patrick-hetu\/oneiric\/python-moinmoin-2"
+        },
+        "2955": {
+          "id": "cs:~patrick-hetu\/oneiric\/python-moinmoin-4"
+        },
+        "2956": {
+          "id": "cs:~patrick-hetu\/oneiric\/python-moinmoin-5"
+        },
+        "2957": {
+          "id": "cs:~patrick-hetu\/oneiric\/python-moinmoin-6"
+        },
+        "2958": {
+          "id": "cs:~patrick-hetu\/oneiric\/python-moinmoin-7"
+        },
+        "2959": {
+          "id": "cs:~patrick-hetu\/oneiric\/python-moinmoin-8"
+        },
+        "2960": {
+          "id": "cs:~patrick-hetu\/oneiric\/python-moinmoin-9"
+        },
+        "2961": {
+          "id": "cs:~patrick-hetu\/precise\/gunicorn-0"
+        },
+        "2962": {
+          "id": "cs:~patrick-hetu\/precise\/gunicorn-1"
+        },
+        "2963": {
+          "id": "cs:~patrick-hetu\/precise\/python-django-0"
+        },
+        "2964": {
+          "id": "cs:~patrick-hetu\/precise\/python-django-1"
+        },
+        "2965": {
+          "id": "cs:~patrick-hetu\/precise\/python-django-2"
+        },
+        "2966": {
+          "id": "cs:~patrick-hetu\/precise\/python-django-3"
+        },
+        "2967": {
+          "id": "cs:~patrick-hetu\/precise\/python-django-4"
+        },
+        "2968": {
+          "id": "cs:~patrick-hetu\/precise\/python-django-5"
+        },
+        "2969": {
+          "id": "cs:~paulcz\/precise\/auth-proxy-0"
+        },
+        "2970": {
+          "id": "cs:~paulcz\/precise\/graphite-0"
+        },
+        "2971": {
+          "id": "cs:~paulcz\/precise\/graphite-1"
+        },
+        "2972": {
+          "id": "cs:~paulcz\/precise\/sensu-server-0"
+        },
+        "2973": {
+          "id": "cs:~paulcz\/precise\/sensu-server-1"
+        },
+        "2974": {
+          "id": "cs:~paulcz\/precise\/sensu-server-2"
+        },
+        "2975": {
+          "id": "cs:~paulgear\/precise\/gerrit-0"
+        },
+        "2976": {
+          "id": "cs:~paulgear\/precise\/gerrit-1"
+        },
+        "2977": {
+          "id": "cs:~paulgear\/precise\/zuul-0"
+        },
+        "2978": {
+          "id": "cs:~paulgear\/precise\/zuul-1"
+        },
+        "2979": {
+          "id": "cs:~pavel-pachkovskij\/precise\/apache2-passenger-0"
+        },
+        "2980": {
+          "id": "cs:~pavel-pachkovskij\/precise\/apache2-passenger-1"
+        },
+        "2981": {
+          "id": "cs:~pavel-pachkovskij\/precise\/apache2-passenger-2"
+        },
+        "2982": {
+          "id": "cs:~pavel-pachkovskij\/precise\/apache2-passenger-3"
+        },
+        "2983": {
+          "id": "cs:~pavel-pachkovskij\/precise\/nginx-passenger-0"
+        },
+        "2984": {
+          "id": "cs:~pavel-pachkovskij\/precise\/nginx-passenger-1"
+        },
+        "2985": {
+          "id": "cs:~pavel-pachkovskij\/precise\/nginx-passenger-2"
+        },
+        "2986": {
+          "id": "cs:~pavel-pachkovskij\/precise\/nginx-passenger-3"
+        },
+        "2987": {
+          "id": "cs:~pavel-pachkovskij\/precise\/rack-5"
+        },
+        "2988": {
+          "id": "cs:~pavel-pachkovskij\/precise\/rack-6"
+        },
+        "2989": {
+          "id": "cs:~pavel-pachkovskij\/precise\/rack-7"
+        },
+        "2990": {
+          "id": "cs:~pavel-pachkovskij\/precise\/rack-8"
+        },
+        "2991": {
+          "id": "cs:~peter-petrakis\/precise\/opengrok-10"
+        },
+        "2992": {
+          "id": "cs:~peter-petrakis\/precise\/opengrok-9"
+        },
+        "2993": {
+          "id": "cs:~peterklein2308\/trusty\/m2mlabs-0"
+        },
+        "2994": {
+          "id": "cs:~pierre-amadio\/precise\/spip-0"
+        },
+        "2995": {
+          "id": "cs:~pierre-amadio\/precise\/spip-1"
+        },
+        "2996": {
+          "id": "cs:~pierre-amadio\/precise\/spip-2"
+        },
+        "2997": {
+          "id": "cs:~pierre-amadio\/precise\/spip-3"
+        },
+        "2998": {
+          "id": "cs:~pierre-amadio\/precise\/spip-4"
+        },
+        "2999": {
+          "id": "cs:~pierre-amadio\/precise\/spip-5"
+        },
+        "3000": {
+          "id": "cs:~pierre-amadio\/precise\/spip-6"
+        },
+        "3001": {
+          "id": "cs:~pierre-amadio\/precise\/spip-7"
+        },
+        "3002": {
+          "id": "cs:~pierre-amadio\/precise\/spip-8"
+        },
+        "3003": {
+          "id": "cs:~pmcgarry\/quantal\/ceph-radosgw-0"
+        },
+        "3004": {
+          "id": "cs:~pmcgarry\/quantal\/ceph-radosgw-1"
+        },
+        "3005": {
+          "id": "cs:~pmcgarry\/quantal\/ceph-radosgw-2"
+        },
+        "3006": {
+          "id": "cs:~pmcgarry\/quantal\/ceph-radosgw-3"
+        },
+        "3007": {
+          "id": "cs:~pmcgarry\/quantal\/haproxy-0"
+        },
+        "3008": {
+          "id": "cs:~pmcgarry\/quantal\/juju-gui-0"
+        },
+        "3009": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-10"
+        },
+        "3010": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-100"
+        },
+        "3011": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-101"
+        },
+        "3012": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-102"
+        },
+        "3013": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-103"
+        },
+        "3014": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-104"
+        },
+        "3015": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-105"
+        },
+        "3016": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-106"
+        },
+        "3017": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-107"
+        },
+        "3018": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-108"
+        },
+        "3019": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-109"
+        },
+        "3020": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-11"
+        },
+        "3021": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-110"
+        },
+        "3022": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-111"
+        },
+        "3023": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-112"
+        },
+        "3024": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-12"
+        },
+        "3025": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-13"
+        },
+        "3026": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-14"
+        },
+        "3027": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-15"
+        },
+        "3028": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-16"
+        },
+        "3029": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-17"
+        },
+        "3030": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-18"
+        },
+        "3031": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-19"
+        },
+        "3032": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-20"
+        },
+        "3033": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-21"
+        },
+        "3034": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-22"
+        },
+        "3035": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-23"
+        },
+        "3036": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-24"
+        },
+        "3037": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-25"
+        },
+        "3038": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-26"
+        },
+        "3039": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-27"
+        },
+        "3040": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-28"
+        },
+        "3041": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-29"
+        },
+        "3042": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-30"
+        },
+        "3043": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-31"
+        },
+        "3044": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-32"
+        },
+        "3045": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-33"
+        },
+        "3046": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-34"
+        },
+        "3047": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-35"
+        },
+        "3048": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-36"
+        },
+        "3049": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-37"
+        },
+        "3050": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-38"
+        },
+        "3051": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-39"
+        },
+        "3052": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-40"
+        },
+        "3053": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-41"
+        },
+        "3054": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-42"
+        },
+        "3055": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-43"
+        },
+        "3056": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-44"
+        },
+        "3057": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-45"
+        },
+        "3058": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-46"
+        },
+        "3059": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-47"
+        },
+        "3060": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-48"
+        },
+        "3061": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-49"
+        },
+        "3062": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-50"
+        },
+        "3063": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-51"
+        },
+        "3064": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-52"
+        },
+        "3065": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-53"
+        },
+        "3066": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-54"
+        },
+        "3067": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-55"
+        },
+        "3068": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-56"
+        },
+        "3069": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-57"
+        },
+        "3070": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-58"
+        },
+        "3071": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-59"
+        },
+        "3072": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-60"
+        },
+        "3073": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-61"
+        },
+        "3074": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-62"
+        },
+        "3075": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-63"
+        },
+        "3076": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-64"
+        },
+        "3077": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-65"
+        },
+        "3078": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-66"
+        },
+        "3079": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-67"
+        },
+        "3080": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-68"
+        },
+        "3081": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-69"
+        },
+        "3082": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-70"
+        },
+        "3083": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-71"
+        },
+        "3084": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-72"
+        },
+        "3085": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-73"
+        },
+        "3086": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-74"
+        },
+        "3087": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-75"
+        },
+        "3088": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-76"
+        },
+        "3089": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-77"
+        },
+        "3090": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-78"
+        },
+        "3091": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-79"
+        },
+        "3092": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-80"
+        },
+        "3093": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-81"
+        },
+        "3094": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-82"
+        },
+        "3095": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-83"
+        },
+        "3096": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-84"
+        },
+        "3097": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-85"
+        },
+        "3098": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-86"
+        },
+        "3099": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-87"
+        },
+        "3100": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-88"
+        },
+        "3101": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-89"
+        },
+        "3102": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-9"
+        },
+        "3103": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-90"
+        },
+        "3104": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-91"
+        },
+        "3105": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-92"
+        },
+        "3106": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-93"
+        },
+        "3107": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-94"
+        },
+        "3108": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-95"
+        },
+        "3109": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-96"
+        },
+        "3110": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-97"
+        },
+        "3111": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-98"
+        },
+        "3112": {
+          "id": "cs:~rcj\/trusty\/ubuntu-repository-cache-99"
+        },
+        "3113": {
+          "id": "cs:~rhanna\/precise\/trac-0"
+        },
+        "3114": {
+          "id": "cs:~rhanna\/precise\/trac-1"
+        },
+        "3115": {
+          "id": "cs:~rhanna\/precise\/trac-2"
+        },
+        "3116": {
+          "id": "cs:~rhanna\/precise\/trac-3"
+        },
+        "3117": {
+          "id": "cs:~ricardokirkner\/trusty\/devpi-0"
+        },
+        "3118": {
+          "id": "cs:~ricardokirkner\/trusty\/devpi-1"
+        },
+        "3119": {
+          "id": "cs:~rkather\/oneiric\/moodle-0"
+        },
+        "3120": {
+          "id": "cs:~rkather\/oneiric\/moodle-1"
+        },
+        "3121": {
+          "id": "cs:~rkather\/oneiric\/moodle-10"
+        },
+        "3122": {
+          "id": "cs:~rkather\/oneiric\/moodle-11"
+        },
+        "3123": {
+          "id": "cs:~rkather\/oneiric\/moodle-2"
+        },
+        "3124": {
+          "id": "cs:~rkather\/oneiric\/moodle-3"
+        },
+        "3125": {
+          "id": "cs:~rkather\/oneiric\/moodle-4"
+        },
+        "3126": {
+          "id": "cs:~rkather\/oneiric\/moodle-5"
+        },
+        "3127": {
+          "id": "cs:~rkather\/oneiric\/moodle-6"
+        },
+        "3128": {
+          "id": "cs:~rkather\/oneiric\/moodle-7"
+        },
+        "3129": {
+          "id": "cs:~rkather\/oneiric\/moodle-8"
+        },
+        "3130": {
+          "id": "cs:~rkather\/oneiric\/moodle-9"
+        },
+        "3131": {
+          "id": "cs:~rkather\/precise\/gitlab-0"
+        },
+        "3132": {
+          "id": "cs:~rkather\/precise\/gitlab-1"
+        },
+        "3133": {
+          "id": "cs:~rkather\/precise\/gitlab-2"
+        },
+        "3134": {
+          "id": "cs:~rkather\/precise\/gitlab-3"
+        },
+        "3135": {
+          "id": "cs:~rkather\/precise\/gitlab-4"
+        },
+        "3136": {
+          "id": "cs:~rkather\/precise\/rstudio-server-0"
+        },
+        "3137": {
+          "id": "cs:~robert-ayres\/precise\/tomcat-0"
+        },
+        "3138": {
+          "id": "cs:~robert-ayres\/precise\/tomcat-1"
+        },
+        "3139": {
+          "id": "cs:~robert-ayres\/precise\/tomcat-2"
+        },
+        "3140": {
+          "id": "cs:~robert-ayres\/precise\/tomcat-3"
+        },
+        "3141": {
+          "id": "cs:~robert-ayres\/precise\/tomcat-4"
+        },
+        "3142": {
+          "id": "cs:~samuel-cozannet\/trusty\/dashing-0"
+        },
+        "3143": {
+          "id": "cs:~samuel-cozannet\/trusty\/dashing-1"
+        },
+        "3144": {
+          "id": "cs:~samuel-cozannet\/trusty\/dashing-2"
+        },
+        "3145": {
+          "id": "cs:~samuel-cozannet\/trusty\/ipython-notebook-0"
+        },
+        "3146": {
+          "id": "cs:~samuel-cozannet\/trusty\/ipython-notebook-1"
+        },
+        "3147": {
+          "id": "cs:~samuel-cozannet\/trusty\/ipython-notebook-2"
+        },
+        "3148": {
+          "id": "cs:~samuel-cozannet\/trusty\/ipython-notebook-3"
+        },
+        "3149": {
+          "id": "cs:~samuel-cozannet\/trusty\/ipython-notebook-4"
+        },
+        "3150": {
+          "id": "cs:~samuel-cozannet\/trusty\/ipython-notebook-5"
+        },
+        "3151": {
+          "id": "cs:~samuel-cozannet\/trusty\/ipython-notebook-6"
+        },
+        "3152": {
+          "id": "cs:~samuel-cozannet\/trusty\/ipython-notebook-7"
+        },
+        "3153": {
+          "id": "cs:~samuel-cozannet\/trusty\/sentiment-analysis-frontend-0"
+        },
+        "3154": {
+          "id": "cs:~samuel-cozannet\/trusty\/sentiment-analysis-frontend-1"
+        },
+        "3155": {
+          "id": "cs:~samuel-cozannet\/trusty\/sentiment-analysis-frontend-2"
+        },
+        "3156": {
+          "id": "cs:~samuel-cozannet\/trusty\/sentiment-analysis-frontend-3"
+        },
+        "3157": {
+          "id": "cs:~samuel-cozannet\/trusty\/sentiment-analysis-frontend-4"
+        },
+        "3158": {
+          "id": "cs:~sebas5384\/precise\/drupal-0"
+        },
+        "3159": {
+          "id": "cs:~sebas5384\/precise\/drupal-1"
+        },
+        "3160": {
+          "id": "cs:~sebas5384\/precise\/drupal-2"
+        },
+        "3161": {
+          "id": "cs:~sebas5384\/precise\/drupal-3"
+        },
+        "3162": {
+          "id": "cs:~sebas5384\/precise\/drupal-4"
+        },
+        "3163": {
+          "id": "cs:~sebas5384\/precise\/drupal-5"
+        },
+        "3164": {
+          "id": "cs:~sebas5384\/precise\/drupal-6"
+        },
+        "3165": {
+          "id": "cs:~serge-hallyn\/oneiric\/jenkins-0"
+        },
+        "3166": {
+          "id": "cs:~shantanu-q\/precise\/alfresco-0"
+        },
+        "3167": {
+          "id": "cs:~shazzner\/oneiric\/gitolite-0"
+        },
+        "3168": {
+          "id": "cs:~shazzner\/oneiric\/gitolite-1"
+        },
+        "3169": {
+          "id": "cs:~shazzner\/precise\/kusabax-0"
+        },
+        "3170": {
+          "id": "cs:~shazzner\/precise\/kusabax-1"
+        },
+        "3171": {
+          "id": "cs:~shazzner\/precise\/kusabax-2"
+        },
+        "3172": {
+          "id": "cs:~shazzner\/precise\/kusabax-3"
+        },
+        "3173": {
+          "id": "cs:~shazzner\/precise\/kusabax-4"
+        },
+        "3174": {
+          "id": "cs:~shazzner\/precise\/kusabax-5"
+        },
+        "3175": {
+          "id": "cs:~shazzner\/precise\/phplist-0"
+        },
+        "3176": {
+          "id": "cs:~shazzner\/precise\/phplist-1"
+        },
+        "3177": {
+          "id": "cs:~shazzner\/precise\/phplist-2"
+        },
+        "3178": {
+          "id": "cs:~sidnei\/precise\/apache2-0"
+        },
+        "3179": {
+          "id": "cs:~sidnei\/precise\/apache2-1"
+        },
+        "3180": {
+          "id": "cs:~sidnei\/precise\/apache2-10"
+        },
+        "3181": {
+          "id": "cs:~sidnei\/precise\/apache2-11"
+        },
+        "3182": {
+          "id": "cs:~sidnei\/precise\/apache2-12"
+        },
+        "3183": {
+          "id": "cs:~sidnei\/precise\/apache2-13"
+        },
+        "3184": {
+          "id": "cs:~sidnei\/precise\/apache2-14"
+        },
+        "3185": {
+          "id": "cs:~sidnei\/precise\/apache2-15"
+        },
+        "3186": {
+          "id": "cs:~sidnei\/precise\/apache2-16"
+        },
+        "3187": {
+          "id": "cs:~sidnei\/precise\/apache2-17"
+        },
+        "3188": {
+          "id": "cs:~sidnei\/precise\/apache2-18"
+        },
+        "3189": {
+          "id": "cs:~sidnei\/precise\/apache2-19"
+        },
+        "3190": {
+          "id": "cs:~sidnei\/precise\/apache2-2"
+        },
+        "3191": {
+          "id": "cs:~sidnei\/precise\/apache2-20"
+        },
+        "3192": {
+          "id": "cs:~sidnei\/precise\/apache2-21"
+        },
+        "3193": {
+          "id": "cs:~sidnei\/precise\/apache2-22"
+        },
+        "3194": {
+          "id": "cs:~sidnei\/precise\/apache2-23"
+        },
+        "3195": {
+          "id": "cs:~sidnei\/precise\/apache2-24"
+        },
+        "3196": {
+          "id": "cs:~sidnei\/precise\/apache2-25"
+        },
+        "3197": {
+          "id": "cs:~sidnei\/precise\/apache2-26"
+        },
+        "3198": {
+          "id": "cs:~sidnei\/precise\/apache2-27"
+        },
+        "3199": {
+          "id": "cs:~sidnei\/precise\/apache2-28"
+        },
+        "3200": {
+          "id": "cs:~sidnei\/precise\/apache2-29"
+        },
+        "3201": {
+          "id": "cs:~sidnei\/precise\/apache2-3"
+        },
+        "3202": {
+          "id": "cs:~sidnei\/precise\/apache2-30"
+        },
+        "3203": {
+          "id": "cs:~sidnei\/precise\/apache2-31"
+        },
+        "3204": {
+          "id": "cs:~sidnei\/precise\/apache2-4"
+        },
+        "3205": {
+          "id": "cs:~sidnei\/precise\/apache2-5"
+        },
+        "3206": {
+          "id": "cs:~sidnei\/precise\/apache2-6"
+        },
+        "3207": {
+          "id": "cs:~sidnei\/precise\/apache2-7"
+        },
+        "3208": {
+          "id": "cs:~sidnei\/precise\/apache2-8"
+        },
+        "3209": {
+          "id": "cs:~sidnei\/precise\/apache2-9"
+        },
+        "3210": {
+          "id": "cs:~sidnei\/precise\/graphite-0"
+        },
+        "3211": {
+          "id": "cs:~sidnei\/precise\/haproxy-0"
+        },
+        "3212": {
+          "id": "cs:~sidnei\/precise\/haproxy-1"
+        },
+        "3213": {
+          "id": "cs:~sidnei\/precise\/haproxy-10"
+        },
+        "3214": {
+          "id": "cs:~sidnei\/precise\/haproxy-11"
+        },
+        "3215": {
+          "id": "cs:~sidnei\/precise\/haproxy-12"
+        },
+        "3216": {
+          "id": "cs:~sidnei\/precise\/haproxy-13"
+        },
+        "3217": {
+          "id": "cs:~sidnei\/precise\/haproxy-14"
+        },
+        "3218": {
+          "id": "cs:~sidnei\/precise\/haproxy-15"
+        },
+        "3219": {
+          "id": "cs:~sidnei\/precise\/haproxy-16"
+        },
+        "3220": {
+          "id": "cs:~sidnei\/precise\/haproxy-17"
+        },
+        "3221": {
+          "id": "cs:~sidnei\/precise\/haproxy-18"
+        },
+        "3222": {
+          "id": "cs:~sidnei\/precise\/haproxy-19"
+        },
+        "3223": {
+          "id": "cs:~sidnei\/precise\/haproxy-2"
+        },
+        "3224": {
+          "id": "cs:~sidnei\/precise\/haproxy-20"
+        },
+        "3225": {
+          "id": "cs:~sidnei\/precise\/haproxy-21"
+        },
+        "3226": {
+          "id": "cs:~sidnei\/precise\/haproxy-22"
+        },
+        "3227": {
+          "id": "cs:~sidnei\/precise\/haproxy-23"
+        },
+        "3228": {
+          "id": "cs:~sidnei\/precise\/haproxy-24"
+        },
+        "3229": {
+          "id": "cs:~sidnei\/precise\/haproxy-25"
+        },
+        "3230": {
+          "id": "cs:~sidnei\/precise\/haproxy-26"
+        },
+        "3231": {
+          "id": "cs:~sidnei\/precise\/haproxy-27"
+        },
+        "3232": {
+          "id": "cs:~sidnei\/precise\/haproxy-28"
+        },
+        "3233": {
+          "id": "cs:~sidnei\/precise\/haproxy-29"
+        },
+        "3234": {
+          "id": "cs:~sidnei\/precise\/haproxy-3"
+        },
+        "3235": {
+          "id": "cs:~sidnei\/precise\/haproxy-30"
+        },
+        "3236": {
+          "id": "cs:~sidnei\/precise\/haproxy-31"
+        },
+        "3237": {
+          "id": "cs:~sidnei\/precise\/haproxy-32"
+        },
+        "3238": {
+          "id": "cs:~sidnei\/precise\/haproxy-33"
+        },
+        "3239": {
+          "id": "cs:~sidnei\/precise\/haproxy-34"
+        },
+        "3240": {
+          "id": "cs:~sidnei\/precise\/haproxy-35"
+        },
+        "3241": {
+          "id": "cs:~sidnei\/precise\/haproxy-36"
+        },
+        "3242": {
+          "id": "cs:~sidnei\/precise\/haproxy-37"
+        },
+        "3243": {
+          "id": "cs:~sidnei\/precise\/haproxy-38"
+        },
+        "3244": {
+          "id": "cs:~sidnei\/precise\/haproxy-39"
+        },
+        "3245": {
+          "id": "cs:~sidnei\/precise\/haproxy-4"
+        },
+        "3246": {
+          "id": "cs:~sidnei\/precise\/haproxy-40"
+        },
+        "3247": {
+          "id": "cs:~sidnei\/precise\/haproxy-5"
+        },
+        "3248": {
+          "id": "cs:~sidnei\/precise\/haproxy-6"
+        },
+        "3249": {
+          "id": "cs:~sidnei\/precise\/haproxy-7"
+        },
+        "3250": {
+          "id": "cs:~sidnei\/precise\/haproxy-8"
+        },
+        "3251": {
+          "id": "cs:~sidnei\/precise\/haproxy-9"
+        },
+        "3252": {
+          "id": "cs:~sidnei\/precise\/moztrap-0"
+        },
+        "3253": {
+          "id": "cs:~sidnei\/precise\/moztrap-1"
+        },
+        "3254": {
+          "id": "cs:~sidnei\/precise\/nagios-0"
+        },
+        "3255": {
+          "id": "cs:~sidnei\/precise\/squid-forwardproxy-0"
+        },
+        "3256": {
+          "id": "cs:~sidnei\/precise\/squid-forwardproxy-1"
+        },
+        "3257": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-0"
+        },
+        "3258": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-1"
+        },
+        "3259": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-10"
+        },
+        "3260": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-11"
+        },
+        "3261": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-12"
+        },
+        "3262": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-13"
+        },
+        "3263": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-14"
+        },
+        "3264": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-15"
+        },
+        "3265": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-16"
+        },
+        "3266": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-17"
+        },
+        "3267": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-18"
+        },
+        "3268": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-19"
+        },
+        "3269": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-2"
+        },
+        "3270": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-20"
+        },
+        "3271": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-21"
+        },
+        "3272": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-22"
+        },
+        "3273": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-23"
+        },
+        "3274": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-24"
+        },
+        "3275": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-25"
+        },
+        "3276": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-26"
+        },
+        "3277": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-27"
+        },
+        "3278": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-28"
+        },
+        "3279": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-29"
+        },
+        "3280": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-3"
+        },
+        "3281": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-30"
+        },
+        "3282": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-31"
+        },
+        "3283": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-32"
+        },
+        "3284": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-4"
+        },
+        "3285": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-5"
+        },
+        "3286": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-6"
+        },
+        "3287": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-7"
+        },
+        "3288": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-8"
+        },
+        "3289": {
+          "id": "cs:~sidnei\/precise\/squid-reverseproxy-9"
+        },
+        "3290": {
+          "id": "cs:~springfield-team\/precise\/openstack-dashboard-0"
+        },
+        "3291": {
+          "id": "cs:~springfield-team\/precise\/openstack-dashboard-1"
+        },
+        "3292": {
+          "id": "cs:~springfield-team\/precise\/openstack-dashboard-2"
+        },
+        "3293": {
+          "id": "cs:~springfield-team\/precise\/openstack-dashboard-3"
+        },
+        "3294": {
+          "id": "cs:~springfield-team\/precise\/openstack-dashboard-4"
+        },
+        "3295": {
+          "id": "cs:~springfield-team\/precise\/openstack-dashboard-5"
+        },
+        "3296": {
+          "id": "cs:~springfield-team\/precise\/openstack-dashboard-6"
+        },
+        "3297": {
+          "id": "cs:~stefan-hartmann\/precise\/chive-1"
+        },
+        "3298": {
+          "id": "cs:~tasdomas\/precise\/drupal-0"
+        },
+        "3299": {
+          "id": "cs:~thedac\/precise\/apache2-0"
+        },
+        "3300": {
+          "id": "cs:~thedac\/precise\/apache2-1"
+        },
+        "3301": {
+          "id": "cs:~thedac\/precise\/apache2-2"
+        },
+        "3302": {
+          "id": "cs:~thedac\/precise\/apache2-3"
+        },
+        "3303": {
+          "id": "cs:~thedac\/precise\/apache2-4"
+        },
+        "3304": {
+          "id": "cs:~therealmarv\/trusty\/pybossa-0"
+        },
+        "3305": {
+          "id": "cs:~therealmarv\/trusty\/pybossa-1"
+        },
+        "3306": {
+          "id": "cs:~thomnico\/trusty\/telscale-load-balancer-0"
+        },
+        "3307": {
+          "id": "cs:~thomnico\/trusty\/telscale-load-balancer-1"
+        },
+        "3308": {
+          "id": "cs:~thomnico\/trusty\/telscale-restcomm-0"
+        },
+        "3309": {
+          "id": "cs:~thomnico\/trusty\/telscale-restcomm-1"
+        },
+        "3310": {
+          "id": "cs:~timrchavez\/precise\/offspring-web-0"
+        },
+        "3311": {
+          "id": "cs:~timrchavez\/precise\/offspring-web-1"
+        },
+        "3312": {
+          "id": "cs:~tribaal\/trusty\/ceph-radosgw-0"
+        },
+        "3313": {
+          "id": "cs:~tribaal\/trusty\/ceph-radosgw-1"
+        },
+        "3314": {
+          "id": "cs:~tribaal\/trusty\/ubuntu-mirror-0"
+        },
+        "3315": {
+          "id": "cs:~tribaal\/trusty\/ubuntu-mirror-1"
+        },
+        "3316": {
+          "id": "cs:~tribaal\/trusty\/ubuntu-mirror-10"
+        },
+        "3317": {
+          "id": "cs:~tribaal\/trusty\/ubuntu-mirror-2"
+        },
+        "3318": {
+          "id": "cs:~tribaal\/trusty\/ubuntu-mirror-3"
+        },
+        "3319": {
+          "id": "cs:~tribaal\/trusty\/ubuntu-mirror-4"
+        },
+        "3320": {
+          "id": "cs:~tribaal\/trusty\/ubuntu-mirror-5"
+        },
+        "3321": {
+          "id": "cs:~tribaal\/trusty\/ubuntu-mirror-6"
+        },
+        "3322": {
+          "id": "cs:~tribaal\/trusty\/ubuntu-mirror-7"
+        },
+        "3323": {
+          "id": "cs:~tribaal\/trusty\/ubuntu-mirror-8"
+        },
+        "3324": {
+          "id": "cs:~tribaal\/trusty\/ubuntu-mirror-9"
+        },
+        "3325": {
+          "id": "cs:~truthfromlies\/precise\/metis-0"
+        },
+        "3326": {
+          "id": "cs:~truthfromlies\/precise\/metis-1"
+        },
+        "3327": {
+          "id": "cs:~truthfromlies\/trusty\/metis-0"
+        },
+        "3328": {
+          "id": "cs:~truthfromlies\/trusty\/metis-1"
+        },
+        "3329": {
+          "id": "cs:~truthfromlies\/trusty\/metis-2"
+        },
+        "3330": {
+          "id": "cs:~truthfromlies\/trusty\/metis-3"
+        },
+        "3331": {
+          "id": "cs:~tvansteenburgh\/precise\/meteor-0"
+        },
+        "3332": {
+          "id": "cs:~tvansteenburgh\/precise\/meteor-1"
+        },
+        "3333": {
+          "id": "cs:~tvansteenburgh\/precise\/meteor-2"
+        },
+        "3334": {
+          "id": "cs:~tvansteenburgh\/precise\/meteor-3"
+        },
+        "3335": {
+          "id": "cs:~tvansteenburgh\/trusty\/meteor-0"
+        },
+        "3336": {
+          "id": "cs:~tvansteenburgh\/trusty\/meteor-1"
+        },
+        "3337": {
+          "id": "cs:~ubuntu-ci-engineering\/precise\/graphite-0"
+        },
+        "3338": {
+          "id": "cs:~ubuntu-ci-engineering\/precise\/graphite-1"
+        },
+        "3339": {
+          "id": "cs:~ubuntu-ci-engineering\/precise\/graphite-2"
+        },
+        "3340": {
+          "id": "cs:~ubuntu-ci-engineering\/trusty\/graphite-0"
+        },
+        "3341": {
+          "id": "cs:~ubuntu-ci-engineering\/trusty\/graphite-1"
+        },
+        "3342": {
+          "id": "cs:~ubuntu-server-dev\/quantal\/package-builder-0"
+        },
+        "3343": {
+          "id": "cs:~ubuntu-server-dev\/quantal\/package-builder-1"
+        },
+        "3344": {
+          "id": "cs:~unmaintained-charms\/precise\/opentsdb-0"
+        },
+        "3345": {
+          "id": "cs:~unmaintained-charms\/precise\/solr-jetty-0"
+        },
+        "3346": {
+          "id": "cs:~unmaintained-charms\/precise\/thinkup-0"
+        },
+        "3347": {
+          "id": "cs:~utlemming\/precise\/fsync-0"
+        },
+        "3348": {
+          "id": "cs:~utlemming\/precise\/fsync-1"
+        },
+        "3349": {
+          "id": "cs:~utlemming\/precise\/fsync-2"
+        },
+        "3350": {
+          "id": "cs:~utlemming\/precise\/fsync-3"
+        },
+        "3351": {
+          "id": "cs:~utlemming\/precise\/fsync-4"
+        },
+        "3352": {
+          "id": "cs:~vtuson\/precise\/lamp-0"
+        },
+        "3353": {
+          "id": "cs:~vtuson\/precise\/lamp-1"
+        },
+        "3354": {
+          "id": "cs:~vtuson\/precise\/lamp-2"
+        },
+        "3355": {
+          "id": "cs:~vtuson\/precise\/lamp-3"
+        },
+        "3356": {
+          "id": "cs:~vtuson\/precise\/your-charms-name-0"
+        },
+        "3357": {
+          "id": "cs:~web-brandon\/precise\/my-site-0"
+        },
+        "3358": {
+          "id": "cs:~web-brandon\/precise\/my-site-1"
+        },
+        "3359": {
+          "id": "cs:~webteam-backend\/precise\/apache2-0"
+        },
+        "3360": {
+          "id": "cs:~webteam-backend\/trusty\/apache2-wsgi-0"
+        },
+        "3361": {
+          "id": "cs:~webteam-backend\/trusty\/apache2-wsgi-1"
+        },
+        "3362": {
+          "id": "cs:~webteam-backend\/trusty\/apache2-wsgi-2"
+        },
+        "3363": {
+          "id": "cs:~webteam-backend\/trusty\/apache2-wsgi-3"
+        },
+        "3364": {
+          "id": "cs:~webteam-backend\/trusty\/apache2-wsgi-4"
+        },
+        "3365": {
+          "id": "cs:~webteam-backend\/trusty\/apache2-wsgi-5"
+        },
+        "3366": {
+          "id": "cs:~webteam-backend\/trusty\/apache2-wsgi-6"
+        },
+        "3367": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-0"
+        },
+        "3368": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-1"
+        },
+        "3369": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-10"
+        },
+        "3370": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-11"
+        },
+        "3371": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-12"
+        },
+        "3372": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-13"
+        },
+        "3373": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-14"
+        },
+        "3374": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-15"
+        },
+        "3375": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-16"
+        },
+        "3376": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-17"
+        },
+        "3377": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-18"
+        },
+        "3378": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-19"
+        },
+        "3379": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-2"
+        },
+        "3380": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-20"
+        },
+        "3381": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-21"
+        },
+        "3382": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-22"
+        },
+        "3383": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-23"
+        },
+        "3384": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-24"
+        },
+        "3385": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-25"
+        },
+        "3386": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-26"
+        },
+        "3387": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-27"
+        },
+        "3388": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-28"
+        },
+        "3389": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-29"
+        },
+        "3390": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-3"
+        },
+        "3391": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-30"
+        },
+        "3392": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-31"
+        },
+        "3393": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-32"
+        },
+        "3394": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-33"
+        },
+        "3395": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-34"
+        },
+        "3396": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-35"
+        },
+        "3397": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-36"
+        },
+        "3398": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-37"
+        },
+        "3399": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-38"
+        },
+        "3400": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-39"
+        },
+        "3401": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-4"
+        },
+        "3402": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-40"
+        },
+        "3403": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-41"
+        },
+        "3404": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-42"
+        },
+        "3405": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-43"
+        },
+        "3406": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-44"
+        },
+        "3407": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-45"
+        },
+        "3408": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-46"
+        },
+        "3409": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-47"
+        },
+        "3410": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-48"
+        },
+        "3411": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-49"
+        },
+        "3412": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-5"
+        },
+        "3413": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-50"
+        },
+        "3414": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-51"
+        },
+        "3415": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-52"
+        },
+        "3416": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-53"
+        },
+        "3417": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-54"
+        },
+        "3418": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-55"
+        },
+        "3419": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-56"
+        },
+        "3420": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-57"
+        },
+        "3421": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-58"
+        },
+        "3422": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-59"
+        },
+        "3423": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-6"
+        },
+        "3424": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-60"
+        },
+        "3425": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-61"
+        },
+        "3426": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-62"
+        },
+        "3427": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-63"
+        },
+        "3428": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-64"
+        },
+        "3429": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-65"
+        },
+        "3430": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-66"
+        },
+        "3431": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-67"
+        },
+        "3432": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-68"
+        },
+        "3433": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-69"
+        },
+        "3434": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-7"
+        },
+        "3435": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-70"
+        },
+        "3436": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-71"
+        },
+        "3437": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-72"
+        },
+        "3438": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-8"
+        },
+        "3439": {
+          "id": "cs:~webteam-backend\/trusty\/wsgi-app-9"
+        },
+        "3440": {
+          "id": "cs:~whitmo\/trusty\/cf-webadmin-0"
+        },
+        "3441": {
+          "id": "cs:~whitmo\/trusty\/cf-webadmin-1"
+        },
+        "3442": {
+          "id": "cs:~whitmo\/trusty\/graphite-heka-0"
+        },
+        "3443": {
+          "id": "cs:~whitmo\/trusty\/graphite-heka-1"
+        },
+        "3444": {
+          "id": "cs:~whitmo\/trusty\/graphite-heka-2"
+        },
+        "3445": {
+          "id": "cs:~whitmo\/trusty\/graphite-heka-3"
+        },
+        "3446": {
+          "id": "cs:~whitmo\/trusty\/graphite-heka-4"
+        },
+        "3447": {
+          "id": "cs:~wiz\/precise\/gitit-0"
+        },
+        "3448": {
+          "id": "cs:~x3v947pl\/trusty\/devicehive-0"
+        },
+        "3449": {
+          "id": "cs:~x3v947pl\/trusty\/devicehive-1"
+        },
+        "3450": {
+          "id": "cs:~x3v947pl\/trusty\/devicehive-dh-ka-ca-0"
+        },
+        "3451": {
+          "id": "cs:~x3v947pl\/trusty\/devicehive-dh-ka-ca-1"
+        },
+        "3452": {
+          "id": "cs:~x3v947pl\/trusty\/devicehive-dh-ka-ca-2"
+        },
+        "3453": {
+          "id": "cs:~x3v947pl\/trusty\/devicehive-lb-0"
+        },
+        "3454": {
+          "id": "cs:~ya-bo-ng\/trusty\/landscape-charm-0"
+        },
+        "3455": {
+          "id": "cs:~ya-bo-ng\/trusty\/landscape-charm-1"
+        },
+        "3456": {
+          "id": "cs:~yolanda.robla\/precise\/ceilometer-0"
+        },
+        "3457": {
+          "id": "cs:~zivley\/oneiric\/cacti-0"
+        },
+        "3458": {
+          "id": "cs:~zulcss\/oneiric\/nagios-0"
+        }
+      },
+      "syslog": {
+        "0": {
+          "id": "cs:precise\/pgbadger-1"
+        },
+        "1": {
+          "id": "cs:precise\/pgbadger-2"
+        },
+        "2": {
+          "id": "cs:precise\/rsyslog-1"
+        },
+        "3": {
+          "id": "cs:precise\/rsyslog-2"
+        },
+        "4": {
+          "id": "cs:precise\/rsyslog-3"
+        },
+        "5": {
+          "id": "cs:precise\/rsyslog-4"
+        },
+        "6": {
+          "id": "cs:precise\/rsyslog-5"
+        },
+        "7": {
+          "id": "cs:precise\/rsyslog-6"
+        },
+        "8": {
+          "id": "cs:trusty\/pgbadger-0"
+        },
+        "9": {
+          "id": "cs:trusty\/pgbadger-1"
+        },
+        "10": {
+          "id": "cs:trusty\/rsyslog-2"
+        },
+        "11": {
+          "id": "cs:trusty\/rsyslog-3"
+        },
+        "12": {
+          "id": "cs:trusty\/rsyslog-4"
+        },
+        "13": {
+          "id": "cs:trusty\/rsyslog-5"
+        },
+        "14": {
+          "id": "cs:trusty\/rsyslog-6"
+        },
+        "15": {
+          "id": "cs:trusty\/rsyslog-7"
+        },
+        "16": {
+          "id": "cs:~charmers\/precise\/pgbadger-0"
+        },
+        "17": {
+          "id": "cs:~charmers\/precise\/pgbadger-1"
+        },
+        "18": {
+          "id": "cs:~charmers\/precise\/pgbadger-2"
+        },
+        "19": {
+          "id": "cs:~charmers\/precise\/rsyslog-0"
+        },
+        "20": {
+          "id": "cs:~charmers\/precise\/rsyslog-1"
+        },
+        "21": {
+          "id": "cs:~charmers\/precise\/rsyslog-2"
+        },
+        "22": {
+          "id": "cs:~charmers\/precise\/rsyslog-3"
+        },
+        "23": {
+          "id": "cs:~charmers\/precise\/rsyslog-4"
+        },
+        "24": {
+          "id": "cs:~charmers\/precise\/rsyslog-5"
+        },
+        "25": {
+          "id": "cs:~charmers\/precise\/rsyslog-6"
+        },
+        "26": {
+          "id": "cs:~charmers\/trusty\/pgbadger-0"
+        },
+        "27": {
+          "id": "cs:~charmers\/trusty\/pgbadger-1"
+        },
+        "28": {
+          "id": "cs:~charmers\/trusty\/rsyslog-0"
+        },
+        "29": {
+          "id": "cs:~charmers\/trusty\/rsyslog-1"
+        },
+        "30": {
+          "id": "cs:~charmers\/trusty\/rsyslog-2"
+        },
+        "31": {
+          "id": "cs:~charmers\/trusty\/rsyslog-3"
+        },
+        "32": {
+          "id": "cs:~charmers\/trusty\/rsyslog-4"
+        },
+        "33": {
+          "id": "cs:~charmers\/trusty\/rsyslog-5"
+        },
+        "34": {
+          "id": "cs:~charmers\/trusty\/rsyslog-6"
+        },
+        "35": {
+          "id": "cs:~charmers\/trusty\/rsyslog-7"
+        },
+        "36": {
+          "id": "cs:~clint-fewbar\/precise\/rsyslog-0"
+        },
+        "37": {
+          "id": "cs:~clint-fewbar\/precise\/rsyslog-1"
+        },
+        "38": {
+          "id": "cs:~clint-fewbar\/precise\/rsyslog-2"
+        },
+        "39": {
+          "id": "cs:~clint-fewbar\/precise\/rsyslog-3"
+        },
+        "40": {
+          "id": "cs:~heckj\/oneiric\/rsyslog-0"
+        },
+        "41": {
+          "id": "cs:~hloeung\/precise\/rsyslog-0"
+        },
+        "42": {
+          "id": "cs:~hloeung\/precise\/rsyslog-1"
+        },
+        "43": {
+          "id": "cs:~hloeung\/precise\/rsyslog-10"
+        },
+        "44": {
+          "id": "cs:~hloeung\/precise\/rsyslog-11"
+        },
+        "45": {
+          "id": "cs:~hloeung\/precise\/rsyslog-2"
+        },
+        "46": {
+          "id": "cs:~hloeung\/precise\/rsyslog-3"
+        },
+        "47": {
+          "id": "cs:~hloeung\/precise\/rsyslog-4"
+        },
+        "48": {
+          "id": "cs:~hloeung\/precise\/rsyslog-5"
+        },
+        "49": {
+          "id": "cs:~hloeung\/precise\/rsyslog-6"
+        },
+        "50": {
+          "id": "cs:~hloeung\/precise\/rsyslog-7"
+        },
+        "51": {
+          "id": "cs:~hloeung\/precise\/rsyslog-8"
+        },
+        "52": {
+          "id": "cs:~hloeung\/precise\/rsyslog-9"
+        },
+        "53": {
+          "id": "cs:~ibm-demo\/trusty\/rsyslog-0"
+        },
+        "54": {
+          "id": "cs:~louis-bouchard\/precise\/rsyslog-0"
+        }
+      }
+    }
+  },
   "options": {
     "config_change_command": {
       "type": "string",

--- a/test/test_browser_charm_details.js
+++ b/test/test_browser_charm_details.js
@@ -875,84 +875,24 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       view.get('container').one('.charm .back').simulate('click');
     });
 
-    it('loads related charms when interface tab selected', function() {
+    it('renders related charms when interface tab selected', function() {
       var data = utils.loadFixture('data/browsercharm.json', true);
       testContainer = utils.makeContainer(this);
       // We don't want any files so we don't have to mock/load them.
       data.files = [];
 
-      var fakeStore = new Y.juju.charmworld.APIv3({});
-      fakeStore.set('datasource', {
-        sendRequest: function(params) {
-          // Stubbing the server callback value
-          params.callback.success({
-            response: {
-              results: [{
-                responseText: utils.loadFixture('data/related.json')
-              }]
-            }
-          });
-        }
-      });
-
       view = new CharmView({
         activeTab: '#related-charms',
         entity: new models.Charm(data),
-        renderTo: testContainer,
-        store: fakeStore
+        renderTo: testContainer
       });
       view.render();
 
       assert.equal(
           testContainer.all('#related-charms .token').size(),
-          9);
+          18);
       assert.equal(view.get('entity').get('id'), 'cs:precise/apache2-27');
       assert.isTrue(view.loadedRelatedInterfaceCharms);
-    });
-
-    it('only loads the interface data once', function() {
-      var data = utils.loadFixture('data/browsercharm.json', true);
-      testContainer = utils.makeContainer(this);
-      // We don't want any files so we don't have to mock/load them.
-      data.files = [];
-
-      var fakeStore = new Y.juju.charmworld.APIv3({});
-      fakeStore.set('datasource', {
-        sendRequest: function(params) {
-          // Stubbing the server callback value
-          params.callback.success({
-            response: {
-              results: [{
-                responseText: utils.loadFixture('data/related.json')
-              }]
-            }
-          });
-        }
-      });
-
-      view = new CharmView({
-        activeTab: '#related-charms',
-        entity: new models.Charm(data),
-        renderTo: testContainer,
-        store: fakeStore
-      });
-
-      var origLoadRelatedCharms = view._loadRelatedCharms;
-      var state = {
-        loadCount: 0,
-        hitTabRender: false
-      };
-      view._loadRelatedCharms = function(callback) {
-        state.loadCount += 1;
-        origLoadRelatedCharms.call(view, callback);
-      };
-      view._renderRelatedInterfaceCharms = function() {
-        state.hitTabRender = true;
-      };
-      view.render();
-
-      assert.equal(state.loadCount, 1);
-      assert.isTrue(state.hitTabRender);
     });
 
     it('ignore invalid tab selections', function() {

--- a/test/test_charmstore_apiv4.js
+++ b/test/test_charmstore_apiv4.js
@@ -199,6 +199,14 @@ describe('Charmstore API v4', function() {
             'bzr-revisions': 5,
             'bzr-url': 'cs:precise/mongodb'
           },
+          'charm-related': {
+            Requires: {
+              'ceph-client': { id: 'cs:foo' }
+            },
+            Provides: {
+              haproxy: { id: 'cs:bar' }
+            }
+          },
           'charm-config': {
             Options: {
               'foo-optn': {
@@ -243,6 +251,14 @@ describe('Charmstore API v4', function() {
             }
           },
           requires: {}
+        },
+        relatedCharms: {
+          requires: {
+            'ceph-client': { id: 'cs:foo' }
+          },
+          provides: {
+            haproxy: { id: 'cs:bar' }
+          }
         },
         options: {
           'foo-optn': {

--- a/test/test_inspector_charm.js
+++ b/test/test_inspector_charm.js
@@ -90,7 +90,7 @@ describe('Inspector Charm', function() {
 
     fakeStore = new Y.juju.charmstore.APIv4({});
     fakeStore.getEntity = function(entityId, callback) {
-      callback()
+      callback();
     };
 
     var viewletAttrs = {

--- a/test/test_model.js
+++ b/test/test_model.js
@@ -1526,45 +1526,6 @@ describe('test_model.js', function() {
           {successes: ['ec2'], failures: ['local', 'openstack']});
     });
 
-    // Testing a private method because if this test fails it'll provide a much
-    // nicer hint as to why something in a View or such doesn't work correctly.
-    // The api data that we get must be converted into what the
-    // CharmMode.getAttrs() would have sent out to the token widget.
-    it('maps related data to the model-ish api', function() {
-      var providesData = relatedData.provides.http[0];
-      instance = new models.Charm(data);
-      var converted = instance._convertRelatedData(providesData);
-      assert.equal(providesData.name, converted.name);
-      assert.equal(providesData.id, converted.storeId);
-      assert.equal(
-          providesData.downloads_in_past_30_days,
-          converted.recent_download_count);
-      assert.equal(
-          providesData.downloads,
-          converted.downloads);
-      assert.equal(providesData.has_icon, converted.shouldShowIcon);
-      assert.equal(converted.is_approved, providesData.is_approved);
-    });
-
-    it('builds proper relatedCharms object', function() {
-      instance = new models.Charm(data);
-      instance.buildRelatedCharms(relatedData.provides, relatedData.requires);
-      var relatedObject = instance.get('relatedCharms');
-
-      // The overall should have the default 5 max charms listed.
-      assert.equal(5, relatedObject.overall.length);
-      // The requires for mysql should be truncated to the max of 5 as well.
-      assert.equal(5, relatedObject.requires.http.length);
-      // There's only one key in the provides section.
-      assert.equal(1, Y.Object.keys(relatedObject.provides).length);
-
-      // The overall should be sorted by their weights.
-      var weights = relatedObject.overall.map(function(charm) {
-        return charm.weight;
-      });
-      assert.equal(weights.sort(), weights);
-    });
-
     it('has an entity type static property', function() {
       instance = new models.Charm(data);
       assert.equal(instance.constructor.entityType, 'charm');


### PR DESCRIPTION
The format of responded data from the charmstore apiv3 and v4 were completely different so the parsing implementation needed to be rewritten.