### PR TITLE
Fix service icon bounceback when dragging on canvas

### DIFF
--- a/app/views/topology/service.js
+++ b/app/views/topology/service.js
@@ -1248,7 +1248,7 @@ YUI.add('juju-topology-service', function(Y) {
             var existing = box.model.get('annotations') || {};
             if (!existing || !existing['gui-x']) {
               vertices.push([box.x || 0, box.y || 0]);
-              topo.annotateBoxPosition(box, false);
+              topo.annotateBoxPosition(box);
             } else {
               if (vertices.length > 0) {
                 vertices.push([

--- a/app/views/topology/topology.js
+++ b/app/views/topology/topology.js
@@ -211,33 +211,16 @@ YUI.add('juju-topology', function(Y) {
 
     /**
      Record a new box position on the backend. This maintains the proper drag
-     state. This method also transitions the viewModel to a DRAG_ENDING state
-     with a timeout. During this window the box will behave as if its in a drag
-     state refusing annotation updates. This masks certain classes of races.
+     state. This method also transitions the viewModel to a DRAG_ENDING state.
 
      @method annotateBoxPosition
      @param {Object} box.
-     @param {ms} timeout.
     */
-    annotateBoxPosition: function(box, timeout) {
+    annotateBoxPosition: function(box) {
       if (box.pending) { return; }
-      timeout = timeout || 1000;
-
-      // This can happen in some tests.
       this.get('env').update_annotations(
-          box.id, 'service', {'gui-x': box.x, 'gui-y': box.y},
-          function() {
-            if (timeout) {
-              box.inDrag = views.DRAG_ENDING;
-              Y.later(timeout, box, function() {
-                // Provide (t) ms of protection from sending additional
-                // annotations or applying them locally.
-                box.inDrag = false;
-              });
-            } else {
-              box.inDrag = false;
-            }
-          });
+          box.id, 'service', {'gui-x': box.x, 'gui-y': box.y});
+      box.inDrag = views.DRAG_ENDING;
     }
 
   }, {


### PR DESCRIPTION
This fixes an issue where the service icons would bounce back to their original positions while the user was dragging them around.