### PR TITLE
Avoid sending the bundle name to the GUI server.

### DIFF
--- a/app/assets/javascripts/bundle-import-helpers.js
+++ b/app/assets/javascripts/bundle-import-helpers.js
@@ -66,25 +66,19 @@ YUI.add('bundle-import-helpers', function(Y) {
       };
 
       if (Y.Lang.isFunction(env.deployerImport)) {
-        // XXX For now, the deployer is expecting the original bundle basket
-        // format, and requires the bundle name to be the top level YAML
-        // element, so grab that naively.  Future deployer work will allow the
-        // new bundle format.  Makyo - 2012-12-19
-        var bundleName = bundle.split(':', 1)[0];
-        var bundleData = {
-          name: bundleName,
-          id: bundleId
-        };
-
         notifications.add({
           title: 'Bundle deployment requested',
           message: 'Waiting for bundle deployment request confirmation.',
           level: 'important'
         });
 
+        // Note that sending the bundle name to the GUI server is not required
+        // since we always send YAML encoded contents including only one
+        // bundle. See
+        // https://api.jujucharms.com/v4/juju-gui/archive/server/guiserver/bundles/__init__.py.
         env.deployerImport(
             bundle,
-            bundleData,
+            {id: bundleId},
             customCallback ? customCallback : defaultCallback
         );
       } else {

--- a/test/test_bundle_import_helpers.js
+++ b/test/test_bundle_import_helpers.js
@@ -99,9 +99,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       env.deployerImport = function(bundle, bundleData, callback) {
         assert.equal(bundle, 'test: bundle');
         assert.equal(bundleData.id, '~jorge/wiki/wiki');
-        assert.equal(
-            bundleData.name, 'test',
-            'The name was not pulled from the bundle.');
+        assert.isUndefined(bundleData.name);
         // This is the default callback from the deployBundle method.
         callback({
           err: undefined,


### PR DESCRIPTION
There is no need to send the bundle name when the YAML only includes one bundle.
Also, the name previously sent was incorrectly decoded from the YAML.