### PR TITLE
Removed the ~charmers filtering from the charmstore api

### DIFF
--- a/app/store/charmstore-api.js
+++ b/app/store/charmstore-api.js
@@ -118,14 +118,6 @@ YUI.add('charmstore-api', function(Y) {
       data = data.Results ? data.Results : [data];
       var models = [];
       data.forEach(function(entity) {
-        // XXX The current charmstore api returns duplicate results for
-        // promulgated charms and bundles. This filters those out so we only
-        // get the promulgated version in the results list. This conditional
-        // can be removed once that bug is fixed in the charmstore. Est around
-        // the end of Jan 2015
-        if (entity.Id.match(/~(.)*charmers/g)) {
-          return;
-        }
         var entityData = this._processEntityQueryData(entity);
         if (entityData.entityType === 'charm') {
           models.push(new jujuModels.Charm(entityData));

--- a/test/test_charmstore_apiv4.js
+++ b/test/test_charmstore_apiv4.js
@@ -142,9 +142,7 @@ describe('Charmstore API v4', function() {
           charmstore, '_processEntityQueryData', {});
       this._cleanups.push(process.reset);
       charmstore._transformQueryResults(success, response);
-      // If this is only called twice that means it has correctly skipped the
-      // ~charmers records.
-      assert.equal(process.callCount(), 2);
+      assert.equal(process.callCount(), 4);
     });
 
     it('can generate a charm and bundle model', function() {
@@ -154,7 +152,9 @@ describe('Charmstore API v4', function() {
       charmstore._transformQueryResults(success, response);
       var models = success.lastArguments()[0];
       assert.equal(models[0] instanceof Y.juju.models.Charm, true);
-      assert.equal(models[1] instanceof Y.juju.models.Bundle, true);
+      assert.equal(models[1] instanceof Y.juju.models.Charm, true);
+      assert.equal(models[2] instanceof Y.juju.models.Charm, true);
+      assert.equal(models[3] instanceof Y.juju.models.Bundle, true);
     });
   });
 


### PR DESCRIPTION
Now that the charmstore api no longer has duplicated promulgated charms this filtering is no longer necessary.