### PR TITLE
Update change version to use apiv4

### DIFF
--- a/app/models/models.js
+++ b/app/models/models.js
@@ -508,34 +508,15 @@ YUI.add('juju-models', function(Y) {
       aggregateRelationError: {},
 
       /**
-        Whether or not an upgrade is available.
+        A collection of available versions for the charm. This is populated
+        when the user clicks to change their charm version in the inspector.
 
-        @attribute upgrade_available
-        @type {boolean}
-        @default false
+        @attribute available_versions
+        @default undefined
+        @type {Array}
       */
-      upgrade_available: {
-        value: false
-      },
+      available_versions: {},
 
-      /**
-        Whether or not the upgrade availablility has been loaded.
-
-        @attribute upgrade_loaded
-        @type {boolean}
-        @default false
-      */
-      upgrade_loaded: {
-        value: false
-      },
-
-      /**
-        The latest charm URL that the service can be upgraded to.
-
-        @attribute upgrade_to
-        @type {string}
-      */
-      upgrade_to: {},
       aggregated_status: {},
       /**
         The original name from the Charm

--- a/app/store/charmstore-api.js
+++ b/app/store/charmstore-api.js
@@ -407,6 +407,53 @@ YUI.add('charmstore-api', function(Y) {
       var bundle = jsyaml.safeLoad(bundleYAML);
       var wrapped = { 'bundle-deploy': bundle };
       return jsyaml.safeDump(wrapped);
+    },
+
+    /**
+      Gets the list of available versions of the supplied charm id.
+
+      @method getAvailableVersions
+      @param {String} charmId The charm id to fetch all of the versions for.
+      @param {Function} successCallback The success callback.
+      @param {Function} failureCallback The failure callback.
+    */
+    getAvailableVersions: function(charmId, successCallback, failureCallback) {
+      charmId = charmId.replace('cs:', '');
+      var series = charmId.split('/')[0];
+      this._makeRequest(
+          this._generatePath(charmId, null, '/expand-id'),
+          this._processAvailableVersions.bind(
+              this, series, successCallback, failureCallback),
+          failureCallback);
+    },
+
+    /**
+      The structure returned by the api is an array of objects with a single
+      id value. This reduces it to an array of those ids reducing out the
+      ids which are not for the existing series.
+
+      @method _processAvailableVersions
+      @param {String} series The series of the charm requested.
+      @param {Function} success Reference to the success handler.
+      @param {Function} failure Reference to the failure handler.
+      @param {Object} response The response object from the request.
+    */
+    _processAvailableVersions: function(series, success, failure, response) {
+      var list = response.currentTarget.responseText;
+      try {
+        list = JSON.parse(list);
+      } catch (e) {
+        failure(e);
+        return;
+      }
+      var truncatedList = [];
+      list.forEach(function(item) {
+        var id = item.Id;
+        if (id.indexOf(series) > -1) {
+          truncatedList.push(id);
+        }
+      });
+      success(truncatedList);
     }
   };
 

--- a/app/templates/version-list.handlebars
+++ b/app/templates/version-list.handlebars
@@ -2,13 +2,13 @@
   <div class="change-version-close link">
     <i class="sprite close-inspector-click"></i>
   </div>
-  Change {{ name }} version
+  Change version
 </div>
 <ul class="unit-list">
-  {{#each upgrades}}
+  {{#each versions}}
   <li>
-    <a href="{{link}}">{{id}}</a>
-    <a class="upgrade-link right-link" data-upgradeto="{{id}}">Upgrade</a>
+    <a href="{{strip_cs this}}">{{this}}</a>
+    <a class="upgrade-link right-link" data-upgradeto="{{this}}">Upgrade</a>
   </li>
   {{/each}}
 </ul>

--- a/app/views/inspectors/service-inspector-utils-extension.js
+++ b/app/views/inspectors/service-inspector-utils-extension.js
@@ -82,7 +82,7 @@ YUI.add('service-inspector-utils-extension', function(Y) {
             this.showViewlet('changeVersion', model);
           }.bind(this),
           function() {
-            db.notifications.add({
+            this.get('db').notifications.add({
               title: 'Error fetching charm versions',
               message: 'Unable fetch charm versions for: ' + charmId,
               level: 'error'

--- a/app/views/inspectors/service-inspector-utils-extension.js
+++ b/app/views/inspectors/service-inspector-utils-extension.js
@@ -70,31 +70,25 @@ YUI.add('service-inspector-utils-extension', function(Y) {
     */
     _onChangeVersionClick: function(evt) {
       evt.halt();
-      var model = this.get('model');
-      // Check if a newer charm is available for this service so that
-      // we can offer it as an upgrade.
-      if (model.get('charm').substring(0, 2) === 'cs' &&
-          !model.get('upgrade_loaded')) {
-        // XXX show spinner
-        var store = this.get('store');
-        var db = this.get('db');
-        var charm = db.charms.getById(model.get('charm'));
-        store.promiseUpgradeAvailability(charm, db.charms)
-          .then(function(latestId) {
-              model.set('upgrade_loaded', true);
-              model.set('upgrade_available', !!latestId);
-              if (latestId) {
-                model.set('upgrade_to',
-                    charm.get('scheme') + ':' + latestId);
-              }
-              // XXX hide spinner
-              this.showViewlet('changeVersion', this.get('model'));
-            }.bind(this),
-            function() { console.warn('unable to check for upgrades'); }
-            );
-      } else {
-        this.showViewlet('changeVersion', this.get('model'));
-      }
+      var model = this.get('model'),
+          // We use the charm attribute here instead of the id because the id
+          // is a randomly generated number when it's a ghost service.
+          charmId = model.get('charm');
+
+      this.get('charmstore').getAvailableVersions(
+          charmId,
+          function(idList) {
+            model.set('available_versions', idList);
+            this.showViewlet('changeVersion', model);
+          }.bind(this),
+          function() {
+            db.notifications.add({
+              title: 'Error fetching charm versions',
+              message: 'Unable fetch charm versions for: ' + charmId,
+              level: 'error'
+            });
+            this.showViewlet('changeVersion', model);
+          }.bind(this));
     },
 
     /**

--- a/app/views/utils.js
+++ b/app/views/utils.js
@@ -2064,6 +2064,10 @@ YUI.add('juju-view-utils', function(Y) {
                    .replace(/\)$/, '') + ':' + type;
   });
 
+  Y.Handlebars.registerHelper('strip_cs', function(id) {
+    return id.replace('cs:', '/');
+  });
+
   /*
    * Dev tool: dump to debugger in template.
    * Allows you to inspect a variable by passing it to

--- a/app/views/viewlets/change-version.js
+++ b/app/views/viewlets/change-version.js
@@ -47,7 +47,6 @@ YUI.add('change-version-view', function(Y) {
     */
     show: function() {
       var container = this.get('container');
-      var model = this.model;
       container.setHTML(
           this.template({versions: this.model.get('available_versions')}));
       container.show();
@@ -100,10 +99,6 @@ YUI.add('change-version-view', function(Y) {
           }
           // Set the charm on the service.
           service.set('charm', upgradeTo);
-
-          // Force a check for any upgrades that may have happened in the
-          // mean time next time the change version button is clicked.
-          service.set('upgrade_loaded', false);
         });
       });
     }

--- a/app/views/viewlets/change-version.js
+++ b/app/views/viewlets/change-version.js
@@ -48,34 +48,8 @@ YUI.add('change-version-view', function(Y) {
     show: function() {
       var container = this.get('container');
       var model = this.model;
-      var charm = model.get('charm');
-      var upgrades = [];
-      // Find the latest version number - if we have an upgrade, it will be
-      // that charm's version; otherwise it will be the current charm's
-      // version.
-      var currVersion = parseInt(charm.split('-').pop(), 10),
-          maxVersion = model.get('upgrade_available') ?
-              parseInt(model.get('upgrade_to').split('-').pop(), 10) :
-              currVersion;
-      // Remove the version number from the charm so that we can build a
-      // list of downgrades.
-      charm = charm.replace(/-\d+$/, '');
-      // Build a list of available downgrades
-      if (maxVersion > 1) {
-        // XXX Use the list of available versions from Charmworld
-        // Makyo - #1246928 - 2014-06-24
-        for (var version = maxVersion; version > 0; version -= 1) {
-          if (version === currVersion) {
-            continue;
-          }
-          var id = charm + '-' + version;
-          upgrades.push({
-            id: id,
-            link: id.replace('cs:', '/')
-          });
-        }
-      }
-      container.setHTML(this.template({upgrades: upgrades}));
+      container.setHTML(
+          this.template({versions: this.model.get('available_versions')}));
       container.show();
     },
 

--- a/app/views/viewlets/service-overview.js
+++ b/app/views/viewlets/service-overview.js
@@ -405,7 +405,7 @@ YUI.add('inspector-overview-view', function(Y) {
         }
       },
       units: {
-        depends: ['aggregated_status', 'upgrade_to'],
+        depends: ['aggregated_status'],
         'update': function(node, value) {
           // Called under the databinding context.
           // Subordinates may not have a value.

--- a/test/test_change_version_viewlet.js
+++ b/test/test_change_version_viewlet.js
@@ -44,9 +44,7 @@ describe('Change version viewlet', function() {
     serviceAttrs = Y.mix({
       id: 'mediawiki',
       charm: charmId,
-      exposed: false,
-      upgrade_available: true,
-      upgrade_to: 'cs:precise/mediawiki-15'
+      exposed: false
     }, serviceAttrs, true);
     service = new models.Service(serviceAttrs);
     downgrades = (function() {
@@ -128,13 +126,15 @@ describe('Change version viewlet', function() {
   });
 
   it('loads versions on click', function() {
+    var charmstore = inspector.get('charmstore');
+    var versions = utils.makeStubMethod(charmstore, 'getAvailableVersions');
+    this._cleanups.push(versions.reset);
     container.one('.change-version-trigger span').simulate('click');
-    assert.equal(container.all('.upgrade-link').size(), 14);
+    assert.equal(versions.callCount(), 1);
   });
 
   it('closes when clicking the x leaving the inspector open', function() {
     container.one('.change-version-trigger span').simulate('click');
-    assert.equal(container.all('.upgrade-link').size(), 14);
     var showViewlet = utils.makeStubMethod(inspector, 'showViewlet');
     this._cleanups.push(showViewlet.reset);
     container.one('.change-version-close').simulate('click');
@@ -143,6 +143,13 @@ describe('Change version viewlet', function() {
   });
 
   it('attempts to upgrade on click', function(done) {
+    var charmstore = inspector.get('charmstore');
+    charmstore.getAvailableVersions = function(charmId, success, failure) {
+      success([
+        'cs:precise/mediawiki-14',
+        'cs:precise/mediawiki-15'
+      ]);
+    };
     // Ensure that get_charm is called to get the new charm.
     env.setCharm = function(serviceName, upgradeTo, force, callback) {
       callback({});

--- a/test/test_environment_view.js
+++ b/test/test_environment_view.js
@@ -203,9 +203,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       var serviceAttrs = {
         id: 'mediawiki',
         charm: charmId,
-        exposed: false,
-        upgrade_available: true,
-        upgrade_to: 'cs:precise/mediawiki-15'
+        exposed: false
       };
       service = new models.Service(serviceAttrs);
       view.createTopology();

--- a/test/test_fakebackend.js
+++ b/test/test_fakebackend.js
@@ -194,8 +194,6 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
         units: [],
         relations: [],
         unit_count: undefined,
-        upgrade_available: false,
-        upgrade_to: undefined,
         packageName: 'wordpress'
       };
 

--- a/test/test_inspector_overview.js
+++ b/test/test_inspector_overview.js
@@ -91,9 +91,7 @@ describe('Inspector Overview', function() {
     serviceAttrs = Y.mix({
       id: 'mediawiki',
       charm: charmId,
-      exposed: false,
-      upgrade_available: true,
-      upgrade_to: 'cs:precise/mediawiki-15'
+      exposed: false
     }, serviceAttrs, true, null, 0, true);
     service = new models.Service(serviceAttrs);
     downgrades = (function() {


### PR DESCRIPTION
Old change-version generated the version numbers but charmstore apiv4 now has them available.