### PR TITLE
Allow deployment of basketless bundles in fakebackend

### DIFF
--- a/app/store/env/fakebackend.js
+++ b/app/store/env/fakebackend.js
@@ -1697,13 +1697,20 @@ YUI.add('juju-env-fakebackend', function(Y) {
       if (useGhost === undefined) {
         useGhost = true;
       }
-      if (!targetBundle && Object.keys(data).length > 1) {
-        throw new Error('Import target ambigious, aborting.');
-      }
 
-      // Builds out a object with inherited properties.
-      var source = targetBundle && data[targetBundle] ||
-          data[Object.keys(data)[0]];
+      var source;
+      // Check whether this is a raw bundle or a basket of bundles.
+      if (data.services && !data.services.services) {
+        source = data;
+      } else {
+        if (!targetBundle && Object.keys(data).length > 1) {
+          throw new Error('Import target ambiguous, aborting.');
+        }
+
+        // Builds out a object with inherited properties.
+        source = targetBundle && data[targetBundle] ||
+            data[Object.keys(data)[0]];
+      }
       var ancestors = [];
       var seen = [];
 

--- a/test/data/wp-deployer-nobasket.yaml
+++ b/test/data/wp-deployer-nobasket.yaml
@@ -1,0 +1,39 @@
+series: precise
+services:
+  mysql:
+    charm: "cs:precise/mysql-27"
+    num_units: 1
+    options:
+      "binlog-format": MIXED
+      "block-size": "5"
+      "dataset-size": "80%"
+      flavor: distro
+      "ha-bindiface": eth0
+      "ha-mcastport": "5411"
+      "max-connections": "-1"
+      "preferred-storage-engine": InnoDB
+      "query-cache-size": "-1"
+      "query-cache-type": "OFF"
+      "rbd-name": mysql1
+      "tuning-level": safest
+      vip: ""
+      vip_cidr: "24"
+      vip_iface: eth0
+    annotations:
+      "gui-x": 115
+      "gui-y": 89
+    constraints: 'cpu-power=2 cpu-cores=4'
+  wordpress:
+    charm: "cs:precise/wordpress-19"
+    num_units: 2
+    options:
+      debug: "no"
+      engine: apache
+      "wp-content": ""
+    annotations:
+      "gui-x": 510
+      "gui-y": 184
+    expose: true
+relations:
+  - - "wordpress:db"
+    - "mysql:db"

--- a/test/test_fakebackend.js
+++ b/test/test_fakebackend.js
@@ -1291,6 +1291,18 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       });
     });
 
+    it('should support basketless YAML imports', function(done) {
+      var fakebackend = factory.makeFakeBackend();
+      var db = fakebackend.db;
+      db.environment.set('defaultSeries', 'precise');
+      var YAMLData = utils.loadFixture('data/wp-deployer-nobasket.yaml');
+
+      fakebackend.importDeployer(YAMLData, undefined, function(result) {
+        assert.equal(result.Error, undefined);
+        done();
+      });
+    });
+
     it('should keep both config and options properties', function() {
       var fakebackend = factory.makeFakeBackend();
       var db = fakebackend.db;
@@ -1384,7 +1396,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       fakebackend = factory.makeFakeBackend();
       assert.throws(function() {
         fakebackend.importDeployer({a: {}, b: {}});
-      }, 'Import target ambigious, aborting.');
+      }, 'Import target ambiguous, aborting.');
     });
 
     it('detects service id collisions', function(done) {


### PR DESCRIPTION
This fixes https://bugs.launchpad.net/juju-gui/+bug/1446688 by allowing deployments of basketless bundles in the fakebackend.