### PR TITLE
Clean state for uncommitted bundle importer

### DIFF
--- a/app/utils/bundle-importer.js
+++ b/app/utils/bundle-importer.js
@@ -232,6 +232,7 @@ YUI.add('bundle-importer', function(Y) {
           message: 'ChangeSet import complete.',
           level: 'important'
         });
+        this._dryRunIndex = -1;
         return;
       }
       this._dryRunIndex += 1;

--- a/app/views/topology/service.js
+++ b/app/views/topology/service.js
@@ -1191,6 +1191,9 @@ YUI.add('juju-topology-service', function(Y) {
       // annotations.
       var new_service_boxes = Y.Object.values(topo.service_boxes)
       .filter(function(boundingBox) {
+            // In the case where a model has been removed from the database
+            // and update runs before exit, boundingBox.model will be empty;
+            // these can automatically be ignored.
             if (boundingBox.model) {
               var annotations = boundingBox.model.get('annotations');
               return ((!Y.Lang.isNumber(boundingBox.x) &&

--- a/app/views/topology/service.js
+++ b/app/views/topology/service.js
@@ -1191,9 +1191,12 @@ YUI.add('juju-topology-service', function(Y) {
       // annotations.
       var new_service_boxes = Y.Object.values(topo.service_boxes)
       .filter(function(boundingBox) {
-            var annotations = boundingBox.model.get('annotations');
-            return ((!Y.Lang.isNumber(boundingBox.x) &&
-                !(annotations && annotations['gui-x'])));
+            if (boundingBox.model) {
+              var annotations = boundingBox.model.get('annotations');
+              return ((!Y.Lang.isNumber(boundingBox.x) &&
+                  !(annotations && annotations['gui-x'])));
+            }
+            return false;
           });
 
       if (new_service_boxes.length > 0) {

--- a/test/test_bundle_importer.js
+++ b/test/test_bundle_importer.js
@@ -252,10 +252,15 @@ describe('Bundle Importer', function() {
   });
 
   describe('Changeset execution', function() {
-    it('Sets up the correct environment (Integration)', function() {
+    it.only('Sets up the correct environment (Integration)', function() {
       var data = utils.loadFixture(
           'data/wordpress-bundle-recordset.json', true);
       bundleImporter.importBundleDryRun(data);
+      // Cleans up internals.
+      // Note - although we strive to test public methods only, we do need
+      // to check on some aspects of the bundle importer's state to ensure
+      // that subsequent runs will not encounter problems. Makyo 2015-05-18
+      assert.equal(bundleImporter._dryRunIndex, -1);
       assert.equal(db.services.size(), 3);
       assert.equal(db.machines.size(), 4);
       assert.equal(db.relations.size(), 2);

--- a/test/test_bundle_importer.js
+++ b/test/test_bundle_importer.js
@@ -252,7 +252,7 @@ describe('Bundle Importer', function() {
   });
 
   describe('Changeset execution', function() {
-    it.only('Sets up the correct environment (Integration)', function() {
+    it('Sets up the correct environment (Integration)', function() {
       var data = utils.loadFixture(
           'data/wordpress-bundle-recordset.json', true);
       bundleImporter.importBundleDryRun(data);


### PR DESCRIPTION
A counter was not reset when a changeset was completed executing, so an attempt to deploy another bundle led to nothing happening (if the counter was > the number of records) or a broken bundle (if the number of records > the counter, but the counter was still not reset).

Addresses https://bugs.launchpad.net/juju-gui/+bug/1454750 and https://bugs.launchpad.net/juju-gui/+bug/1455652