### PR TITLE
Allow the user to change service name after setting config.

### DIFF
--- a/app/utils/environment-change-set.js
+++ b/app/utils/environment-change-set.js
@@ -782,7 +782,6 @@ YUI.add('environment-change-set', function(Y) {
         if (value.command.method === '_deploy') {
           if (value.command.options.modelId === args[0]) {
             parent.push(key);
-            args[0] = value.command.args[1];
           }
         }
       });
@@ -800,12 +799,12 @@ YUI.add('environment-change-set', function(Y) {
         */
         onParentResults: function(record, results) {
           if (record.command.method === '_deploy') {
-            this.args.forEach(function(arg, index) {
-              if (Y.Lang.isArray(arg) &&
-                  record.command.options.modelId === arg[0]) {
-                this.args[index][0] = results[0].service_name;
-              }
-            }, this);
+            // After deploy change the temp id to the real name.
+            var tempId = this.args[0];
+            if (tempId.indexOf('$') > -1 &&
+                record.command.options.modelId === tempId) {
+              this.args[0] = results[0].service_name;
+            }
           }
         }
       };

--- a/app/views/topology/service.js
+++ b/app/views/topology/service.js
@@ -1359,7 +1359,7 @@ YUI.add('juju-topology-service', function(Y) {
       var name = service.displayName;
       if (service.pending) {
         // It will have parens added in the model.
-        name = name.replace(/^\(/, '').replace(/$\)/, '');
+        name = name.match(/^\(?(.{0,}?)\)?$/)[1];
       }
       if (name.length > 10) {
         name = name.substr(0, 9) + '…';

--- a/app/widgets/deployer-bar.js
+++ b/app/widgets/deployer-bar.js
@@ -596,9 +596,10 @@ YUI.add('deployer-bar', function(Y) {
                 ' been destroyed.';
             break;
           case '_set_config':
+            var cfgServ = db.services.getById(change.command.args[0]);
             changeItem.icon = 'changes-config-changed';
             changeItem.description = 'Configuration values changed for ' +
-                change.command.args[0] + '.';
+                cfgServ.get('displayName').match(/^\(?(.{0,}?)\)?$/)[1] + '.';
             break;
           default:
             changeItem.icon = 'changes-service-exposed';
@@ -825,6 +826,10 @@ YUI.add('deployer-bar', function(Y) {
                   return true;
                 }
               });
+            }
+            // If the service is pending then the name will be the temp id.
+            if (service.get('pending')) {
+              name = service.get('displayName').match(/^\(?(.{0,}?)\)?$/)[1];
             }
             changes.setConfigs.push({
               icon: service.get('icon'),

--- a/app/widgets/deployer-bar.js
+++ b/app/widgets/deployer-bar.js
@@ -31,6 +31,8 @@ YUI.add('deployer-bar', function(Y) {
       Templates = views.Templates,
       bundleHelpers = Y.namespace('juju.BundleHelpers');
 
+  var removeBrackets = /^\(?(.{0,}?)\)?$/;
+
   /**
    * The view associated with the deployer bar.
    *
@@ -599,7 +601,7 @@ YUI.add('deployer-bar', function(Y) {
             var cfgServ = db.services.getById(change.command.args[0]);
             changeItem.icon = 'changes-config-changed';
             changeItem.description = 'Configuration values changed for ' +
-                cfgServ.get('displayName').match(/^\(?(.{0,}?)\)?$/)[1] + '.';
+                cfgServ.get('displayName').match(removeBrackets)[1] + '.';
             break;
           default:
             changeItem.icon = 'changes-service-exposed';
@@ -829,7 +831,7 @@ YUI.add('deployer-bar', function(Y) {
             }
             // If the service is pending then the name will be the temp id.
             if (service.get('pending')) {
-              name = service.get('displayName').match(/^\(?(.{0,}?)\)?$/)[1];
+              name = service.get('displayName').match(removeBrackets)[1];
             }
             changes.setConfigs.push({
               icon: service.get('icon'),

--- a/test/test_deployer_bar.js
+++ b/test/test_deployer_bar.js
@@ -364,11 +364,11 @@ describe('deployer bar view', function() {
       }
     }, {
       icon: 'changes-config-changed',
-      msg: 'Configuration values changed for foo.',
+      msg: 'Configuration values changed for django.',
       change: {
         command: {
           method: '_set_config',
-          args: ['foo']
+          args: ['django']
         }
       }
     }, {
@@ -493,9 +493,9 @@ describe('deployer bar view', function() {
 
   it('retrieves all of the _set_config changes', function() {
     db.services.add([
-      { id: 'foo-1', displayName: 'foo', icon: 'foo-icon' },
+      { id: 'foo', displayName: 'foo', icon: 'foo-icon' },
       // To test the ghost config set.
-      { id: '$12345', displayName: '(bar)', icon: 'bar-icon' }
+      { id: '12345$', displayName: '(bar)', icon: 'bar-icon' }
     ]);
     var command1 = {
       method: '_set_config',
@@ -503,7 +503,7 @@ describe('deployer bar view', function() {
     };
     var command2 = {
       method: '_set_config',
-      args: ['bar']
+      args: ['12345$']
     };
     ecs._createNewRecord('setConfig', command1, []);
     ecs._createNewRecord('setConfig', command2, []);
@@ -517,7 +517,7 @@ describe('deployer bar view', function() {
       },
       {
         icon: 'bar-icon',
-        serviceName: 'bar'
+        serviceName: '12345$'
       }
     ]);
   });


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/juju-gui/+bug/1456750

The set config command used the display name of the service at the time the config was set. This caused issues if the user changed the name after setting the service config. This branch makes set config use the id like the rest of the commands.