### PR TITLE
Remove bundle confirm step

### DIFF
--- a/app/subapps/browser/views/bundle.js
+++ b/app/subapps/browser/views/bundle.js
@@ -33,15 +33,8 @@ YUI.add('subapp-browser-bundleview', function(Y) {
     views.utils.apiFailingView
   ], {
 
-    // XXX Commented out events are not yet handled for this view
     events: {
-      // '.token': {
-      //   click: '_handleCharmSelection'
-      // },
       '.bundle .add.deploy': {
-        click: '_confirmDeploy'
-      },
-      '.bundle .add.confirm': {
         click: '_deployBundle'
       },
       // Following handlers are provided by entity-base.js
@@ -55,29 +48,9 @@ YUI.add('subapp-browser-bundleview', function(Y) {
       '.bundle .back': {
         click: '_handleBack'
       }
-      // '#sharing a': {
-      //   click: '_openShareLink'
-      // }
     },
 
     template: views.Templates.bundle,
-
-    /**
-      Changes the deploy button to be a confirmation
-
-      @method _confirmDeploy
-      @param {Object} e Click event object.
-    */
-    _confirmDeploy: function(e) {
-      // This is required to stop the following event handlers from triggering.
-      e.stopImmediatePropagation();
-      e.preventDefault();
-      var button = e.currentTarget;
-      button.setHTML('Yes, I\'m sure');
-      button.removeClass('deploy');
-      button.addClass('confirm');
-      this.get('container').one('.notifier-box').removeClass('hidden');
-    },
 
     /**
       Deploys the bundle to the environment via the provided deploy method.

--- a/app/templates/bundle.handlebars
+++ b/app/templates/bundle.handlebars
@@ -15,11 +15,6 @@
                 </div>
                 <div class="details">
                     <h1>{{ name }}</h1>
-                    <div class="notifier-box hidden bundle">
-                        <div class="yui3-notifier-content bottom-arrow">
-                            This bundle will be deployed to your provider immediately
-                        </div>
-                    </div>
                     <div class="add-reviewed">
                         <a href="" class="add deploy">Deploy this bundle</a>
                     </div>

--- a/test/test_bundle_details_view.js
+++ b/test/test_bundle_details_view.js
@@ -156,22 +156,7 @@ describe('Browser bundle detail view', function() {
         container.one('.header .details .charms').all('img').size(), 5);
   });
 
-  it('shows a confirmation when trying to deploy a bundle', function() {
-    view.set('entity', new models.Bundle(data));
-    view.render();
-    var button = container.one('.bundle .add.deploy');
-    button.simulate('click');
-    assert.isFalse(button.hasClass('deploy'),
-        'add button should not have deploy class');
-    assert.isTrue(button.hasClass('confirm'),
-        'add button is missing confirm class');
-    assert.equal(button.getHTML(), 'Yes, I\'m sure');
-    assert.isFalse(
-        container.one('.notifier-box.bundle').hasClass('hidden'),
-        'notification should not have hidden class');
-  });
-
-  it('deploys a bundle when \'add\' and confirmation button is clicked',
+  it('deploys a bundle when deploy button is clicked',
       function(done) {
         var changeStateFired = false;
         var handler = view.on('changeState', function(state) {
@@ -203,7 +188,6 @@ describe('Browser bundle detail view', function() {
         view.set('entity', new models.Bundle(data));
         view.render();
         container.one('.bundle .add.deploy').simulate('click');
-        container.one('.bundle .add.confirm').simulate('click');
       });
 
   it('generates positions if services don\'t provide xy annotations',


### PR DESCRIPTION
Now that bundles no longer auto-deploy we don't need to confirm that they want to add it to their canvas. 