### PR TITLE
Fix name clash on imported bundles

### DIFF
--- a/app/utils/bundle-importer.js
+++ b/app/utils/bundle-importer.js
@@ -338,6 +338,13 @@ YUI.add('bundle-importer', function(Y) {
               config[key] = value['default'];
             });
           }
+          // We have to set the display name and charm name for the services
+          // because some bundles specify multiples of the same charms as
+          // different names.
+          var displayName = record.args[1];
+          ghostService.set('name', displayName);
+          ghostService.set('displayName', displayName);
+
           ghostService.set('config', config);
 
           this.env.deploy(

--- a/test/data/wordpress-bundle-recordset.json
+++ b/test/data/wordpress-bundle-recordset.json
@@ -91,6 +91,18 @@
     },
     {
         "args": [
+            "cs:precise/mysql-51",
+            "mysql-slave",
+            {}
+        ],
+        "requires": [
+            "addCharm-6"
+        ],
+        "id": "addService-99",
+        "method": "deploy"
+    },
+    {
+        "args": [
             "$addService-7",
             "service",
             {

--- a/test/test_bundle_importer.js
+++ b/test/test_bundle_importer.js
@@ -269,7 +269,7 @@ describe('Bundle Importer', function() {
       var order = [
         'addCharm-0', 'addService-1', 'setAnnotations-2',
         'addCharm-3', 'addService-4', 'setAnnotations-5',
-        'addCharm-6', 'addService-7', 'setAnnotations-8',
+        'addCharm-6', 'addService-7', 'addService-99', 'setAnnotations-8',
         'addMachines-9', 'addMachines-10',
         'addRelation-11', 'addRelation-12',
         'addUnit-13', 'addMachines-16',
@@ -308,7 +308,7 @@ describe('Bundle Importer', function() {
       // to check on some aspects of the bundle importer's state to ensure
       // that subsequent runs will not encounter problems. Makyo 2015-05-18
       assert.equal(bundleImporter._dryRunIndex, -1);
-      assert.equal(db.services.size(), 3);
+      assert.equal(db.services.size(), 4);
       assert.equal(db.units.size(), 3);
       assert.equal(db.machines.size(), 4);
       assert.equal(db.relations.size(), 2);
@@ -322,6 +322,12 @@ describe('Bundle Importer', function() {
       assert.equal(db.services.item(2).get('charm'), 'cs:precise/mysql-51');
       assert.equal(db.units.item(2).service, db.services.item(2).get('id'));
       assert.equal(db.units.item(2).displayName, 'mysql/0');
+      // This is an extra service with the same charm as a previous charm.
+      // There was a bug where their names would clash and they would get
+      // combined into a single service on deploy.
+      assert.equal(db.services.item(3).get('charm'), 'cs:precise/mysql-51');
+      assert.equal(db.services.item(3).get('name'), 'mysql-slave');
+      assert.equal(db.services.item(3).get('displayName'), '(mysql-slave)');
       // Machines
       assert.equal(db.machines.item(0).id, 'new0');
       assert.equal(db.machines.item(1).id, 'new1');


### PR DESCRIPTION
Importing bundles with multiple services from the same charm caused name clashes on deploy. This fixes that so that it imports the specified name as well.