### PR TITLE
Default to most recent charm on bundle deploy

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -449,6 +449,7 @@ YUI.add('juju-gui', function(Y) {
         };
         var webModule = environments.web;
         if (this.get('sandbox')) {
+          envOptions.socket_url = this.get('sandboxSocketURL');
           // The GUI is running in sandbox mode.
           var sandboxModule = environments.sandbox;
           if (envOptions.user && envOptions.password) {

--- a/app/config-debug.js
+++ b/app/config-debug.js
@@ -38,6 +38,7 @@ var juju_config = {
   // property above.
   charmstoreURL: 'https://api.jujucharms.com/charmstore/',
   socket_protocol: 'ws',
+  sandboxSocketURL: 'wss://demo.jujucharms.com/ws',
   user: 'admin',
   password: 'admin',
   sandbox: true,

--- a/app/utils/bundle-importer.js
+++ b/app/utils/bundle-importer.js
@@ -353,6 +353,10 @@ YUI.add('bundle-importer', function(Y) {
           ghostService.set('config', config);
 
           this.env.deploy(
+              // Utilize the charm's id, as bundles may specify charms without
+              // fully qualified charm IDs in the service specification. This
+              // allows bundles to use charms without revisions, effectively
+              // requesting the most recent charm.
               charm.get('id'),
               record.args[1],
               record.args[2],

--- a/app/utils/bundle-importer.js
+++ b/app/utils/bundle-importer.js
@@ -353,7 +353,7 @@ YUI.add('bundle-importer', function(Y) {
           ghostService.set('config', config);
 
           this.env.deploy(
-              record.args[0],
+              charm.get('id'),
               record.args[1],
               record.args[2],
               undefined, // Config file content.

--- a/test/data/wordpress-bundle-recordset.json
+++ b/test/data/wordpress-bundle-recordset.json
@@ -9,7 +9,7 @@
     },
     {
         "args": [
-            "cs:precise/haproxy-35",
+            "cs:precise/haproxy",
             "haproxy",
             {}
         ],

--- a/test/test_app.js
+++ b/test/test_app.js
@@ -1270,17 +1270,17 @@ describe('File drag over notification system', function() {
             user: 'admin',
             password: 'admin',
             jujuCoreVersion: '1.21.1.1-trusty-amd64',
-            charmstorestore: new Y.juju.charmstore.APIv4({})
+            charmstorestore: new Y.juju.charmstore.APIv4({}),
+            sandboxSocketURL: 'ws://host:port/ws/environment/undefined/api'
           });
       app.showView(new Y.View());
       // This simply walks through the hierarchy to show that all the
       // necessary parts are there.
       assert.isObject(app.env.get('conn').get('juju').get('state'));
-      var host = window.location.hostname;
-      var port = window.location.port;
+      // Assert we have a default websocket url.
       assert.equal(
           app.env.get('conn').get('juju').get('socket_url'),
-          'wss://' + host + ':' + port + '/ws/environment/undefined/api');
+          'ws://host:port/ws/environment/undefined/api');
     });
 
     it('passes a fake web handler to the environment', function() {

--- a/test/test_bundle_importer.js
+++ b/test/test_bundle_importer.js
@@ -318,6 +318,9 @@ describe('Bundle Importer', function() {
       assert.equal(db.machines.size(), 4);
       assert.equal(db.relations.size(), 2);
       // Services and units
+      // Note that this service, as specified in the fixture, does not include
+      // a revision number, but a revision number is included here due to
+      // fetching the charm.
       assert.equal(db.services.item(0).get('charm'), 'cs:precise/haproxy-35');
       assert.equal(db.units.item(0).service, db.services.item(0).get('id'));
       assert.equal(db.units.item(0).displayName, 'haproxy/0');


### PR DESCRIPTION
Driveby: `make devel` now uses demo.jujucharms.com for bundle parsing.