### PR TITLE
Fix inspector layout

### DIFF
--- a/app/assets/css/inspector/_juju-inspector.scss
+++ b/app/assets/css/inspector/_juju-inspector.scss
@@ -596,10 +596,10 @@
             .header-slot,
             .viewlet-manager-navigation,
             .viewlet-manager-footer {
-                @include flex-basis(auto);
+                flex: 0 0 auto;
             }
             .viewlet-container {
-                @include flex(1);
+                flex: 1 1 auto;
                 max-height: none;
             }
         }


### PR DESCRIPTION
Explicitly define the flex properties to fix the inspector. Chrome was having issues guessing the flex properties.