### PR TITLE
Correct asset routing.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,6 +21,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.provider :virtualbox do |vb|
     vb.memory = 1024
-    vb.name = "Juju GUI Vagrant (Release)"
+    vb.name = "Juju GUI Vagrant"
   end
+
+  config.ssh.forward_agent = true
 end

--- a/jujugui/__init__.py
+++ b/jujugui/__init__.py
@@ -15,6 +15,9 @@ def make_application(config):
     # We use two separate included app/routes so that we can
     # have the gui parts behind a separate route from the
     # assets when we embed it in e.g. the storefront.
-    config.include('jujugui.gui')
+    # NOTE: kadams54, 2015-08-04: It's very important that assets be listed
+    # first; if it isn't, then the jujugui.gui routes override those specified
+    # in assets and any asset requests will go to the main app.
     config.include('jujugui.assets')
+    config.include('jujugui.gui')
     return config.make_wsgi_app()

--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -1059,7 +1059,6 @@ YUI.add('juju-gui', function(Y) {
      * @method on_database_changed
      */
     on_database_changed: function(evt) {
-      Y.log(evt, 'debug', 'App: Database changed');
       // Database changed event is fired when the user logs-in but we deal with
       // that case manually so we don't need to dispatch the whole application.
       // This whole handler can be removed once we go to model bound views.


### PR DESCRIPTION
Asset routing was getting swallowed up by the more generalized app routing, because the app routing came first. Switch them around to correctly handle assets.