### PR TITLE
Fix ff failure introduced by d3 not working under 'strict'.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ $(JUJUGUI): $(PYRAMID)
 	$(PY) setup.py develop
 
 $(MODULESMIN): $(NODE_MODULES) $(PYRAMID) $(BUILT_RAWJSFILES) $(MIN_JS_FILES) $(TEMPLATES_FILE) $(BUILT_YUI) $(BUILT_JS_ASSETS) $(BUILT_D3)
-	bin/python scripts/generate_modules.py -n YUI_MODULES -s $(GUIBUILD)/app -o $(MODULES) -x "(-min.js)|(\/yui\/)"
+	bin/python scripts/generate_modules.py -n YUI_MODULES -s $(GUIBUILD)/app -o $(MODULES) -x "(-min.js)|(\/yui\/)|(javascripts\/d3\.js)"
 	$(NODE_MODULES)/.bin/uglifyjs --screw-ie8 $(MODULES) -o $(MODULESMIN)
 
 .PHONY: modules-js

--- a/jujugui/static/gui/src/test/index.html
+++ b/jujugui/static/gui/src/test/index.html
@@ -71,7 +71,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
   <!-- Load up YUI base, app modules, and test utils -->
   <!-- Since only the tests depend on these files and the prod tests disable
        the YUI loader, we have to include them manually here. -->
-  <script src="/combo?app/assets/javascripts/yui/yui/yui.js&app/assets/javascripts/yui/loader/loader.js"></script>
+  <script src="/combo?app/assets/javascripts/yui/yui/yui.js&app/assets/javascripts/yui/loader/loader.js&app/assets/javascripts/d3.js"></script>
   <script src="/combo?modules.js"></script>
   <script>
     var GlobalConfig = {

--- a/jujugui/templates/index.html.mako
+++ b/jujugui/templates/index.html.mako
@@ -376,11 +376,16 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       to download an app the user might not be able to use anyway.
     -->
 
+    <!--
+      d3 must be loaded with the initial yui assets. if loaded by the combo loader
+      it will be combined with our app code and be interpreted under global
+      'use strict' and d3 doesn't work under strict.
+    -->
     % if raw:
-    <script src="${convoy_url}?app/assets/javascripts/yui/yui/yui.js&app/assets/javascripts/yui/loader/loader.js"></script>
+    <script src="${convoy_url}?app/assets/javascripts/yui/yui/yui.js&app/assets/javascripts/yui/loader/loader.js&app/assets/javascripts/d3.js"></script>
     <script src="${convoy_url}?modules.js"></script>
     % else:
-    <script src="${convoy_url}?app/assets/javascripts/yui/yui/yui-min.js&app/assets/javascripts/yui/loader/loader-min.js"></script>
+    <script src="${convoy_url}?app/assets/javascripts/yui/yui/yui-min.js&app/assets/javascripts/yui/loader/loader-min.js&app/assets/javascripts/d3-min.js"></script>
     <script src="${convoy_url}?modules-min.js"></script>
     % endif
 
@@ -453,7 +458,6 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
       };
     </script>
-
     <script async type="text/javascript">
       (function() {
       var ga = document.createElement('script');


### PR DESCRIPTION
* Moves d3 to be loaded with yui outside of the combo loader, so it's not interpreted under 'use strict'.
* test/index.html is similarly updated.