### PR TITLE
Update mocha to 2.2.5

### DIFF
--- a/jujugui/static/gui/src/test/index.html
+++ b/jujugui/static/gui/src/test/index.html
@@ -252,7 +252,10 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
           mochaPhantomJS.run();
       } else {
           // The global variable testRunner is required by browser tests.
-          testRunner = mocha.run();
+          testRunner = mocha.run().globals(['testRunner', 'jsyaml',
+            'consoleManager', 'zip', 'spinner', 'yui', '_yuid', 'juju', '_gaq',
+            'PR_SHOULD_USE_CONTINUATION', 'prettyPrintOne', 'prettyPrint', 'PR',
+            'console', 'juju_config', 'lastpass_iter', 'lastpass_f', 'saveAs']);
       }
   });
   </script>

--- a/jujugui/static/gui/src/test/index.html
+++ b/jujugui/static/gui/src/test/index.html
@@ -247,15 +247,16 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
   // tabview needs to be here since it doesn't auto load it for some reason.
   YUI().use(['node', 'event', 'tabview'], function(Y) {
+    var globals = ['testRunner', 'jsyaml',
+      'consoleManager', 'zip', 'spinner', 'yui', '_yuid', 'juju', '_gaq',
+      'PR_SHOULD_USE_CONTINUATION', 'prettyPrintOne', 'prettyPrint', 'PR',
+      'console', 'juju_config', 'lastpass_iter', 'lastpass_f', 'saveAs'];
       // Run the tests.
       if (window.mochaPhantomJS) {
-          mochaPhantomJS.run();
+          mochaPhantomJS.run().globals(globals);
       } else {
           // The global variable testRunner is required by browser tests.
-          testRunner = mocha.run().globals(['testRunner', 'jsyaml',
-            'consoleManager', 'zip', 'spinner', 'yui', '_yuid', 'juju', '_gaq',
-            'PR_SHOULD_USE_CONTINUATION', 'prettyPrintOne', 'prettyPrint', 'PR',
-            'console', 'juju_config', 'lastpass_iter', 'lastpass_f', 'saveAs']);
+          testRunner = mocha.run().globals(globals);
       }
   });
   </script>

--- a/jujugui/static/gui/src/test/test_bundle_module.js
+++ b/jujugui/static/gui/src/test/test_bundle_module.js
@@ -41,6 +41,9 @@ describe('topology bundle module', function() {
     });
   });
 
+  // Required so that the cleanups instance can be attached.
+  beforeEach(function() {});
+
   afterEach(function() {
     if (bundle) { bundle.destroy(); }
   });
@@ -140,4 +143,3 @@ describe('topology bundle module', function() {
 
 
 });
-

--- a/jujugui/static/gui/src/test/test_d3_status.js
+++ b/jujugui/static/gui/src/test/test_d3_status.js
@@ -37,6 +37,9 @@ describe('D3 StatusBar', function() {
     container = utils.makeContainer(this);
   });
 
+  // Required so that the cleanups instance can be attached.
+  afterEach(function() {});
+
   it('should properly parse data', function() {
     var bar = new views.StatusBar({width: 300});
     var result = bar.mapData({'running': 4, 'pending': 4, 'error': 2 });

--- a/jujugui/static/gui/src/test/test_databinding.js
+++ b/jujugui/static/gui/src/test/test_databinding.js
@@ -55,6 +55,9 @@ describe('data binding library', function() {
     });
   });
 
+  // Required so that the cleanups instance can be attached.
+  beforeEach(function() {});
+
   describe('supports declarative bindings', function() {
     var model;
 

--- a/jujugui/static/gui/src/test/test_help_dropdown.js
+++ b/jujugui/static/gui/src/test/test_help_dropdown.js
@@ -62,7 +62,7 @@ describe('help dropdown view', function() {
     // Landscape url should be hidden
     var container = helpView.get('container');
     assert.equal(
-        container.one('.landscape-url').getStyle('display'), 'none');
+        container.one('.landscape-url').hasClass('hidden'), true);
     assert.equal(container.all('li').size(), 4);
   });
 

--- a/jujugui/static/gui/src/test/test_inspector_base.js
+++ b/jujugui/static/gui/src/test/test_inspector_base.js
@@ -32,6 +32,9 @@ describe('Inspector Base', function() {
     });
   });
 
+  // Required so that the cleanups instance can be attached.
+  beforeEach(function() {});
+
   afterEach(function() {});
 
   it('can be instantiated', function() {

--- a/jujugui/static/gui/src/test/test_inspector_relations.js
+++ b/jujugui/static/gui/src/test/test_inspector_relations.js
@@ -43,6 +43,9 @@ describe('Inspector Relations Tab', function() {
     });
   });
 
+  // Required so that the cleanups instance can be attached.
+  beforeEach(function() {});
+
   function ViewletGenerator(config) {
     // Ignore possible strict violation
     /* jshint -W040 */

--- a/jujugui/static/gui/src/test/test_local_charm_import_helpers.js
+++ b/jujugui/static/gui/src/test/test_local_charm_import_helpers.js
@@ -418,6 +418,9 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
             '<div id="bws-sidebar"><div class="bws-content"></div></div>');
       });
 
+      // Required or else the cleanups won't be called.
+      afterEach(function() {});
+
       it('deployLocalCharm: can be stopped when asking for series', function() {
         testUtils.makeContainer(this, 'content');
         var destroyVM = testUtils.makeStubMethod(

--- a/jujugui/static/gui/src/test/test_viewlet_manager.js
+++ b/jujugui/static/gui/src/test/test_viewlet_manager.js
@@ -100,6 +100,9 @@ describe('Viewlet Manager', function() {
     });
   });
 
+  // Required so that the cleanups instance can be attached.
+  beforeEach(function() {});
+
   afterEach(function(done) {
     // destroy is async
     viewletManager.after('destroy', function() {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1236,93 +1236,93 @@
     },
     "eslint": {
       "version": "1.2.0",
-      "from": "eslint@",
+      "from": "https://registry.npmjs.org/eslint/-/eslint-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-1.2.0.tgz",
       "dependencies": {
         "chalk": {
           "version": "1.1.1",
-          "from": "chalk@^1.0.0",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "2.1.0",
-              "from": "ansi-styles@^2.1.0",
+              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "has-ansi@^2.0.0",
+              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@^2.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "3.0.0",
-              "from": "strip-ansi@^3.0.0",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@^2.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "2.0.0",
-              "from": "supports-color@^2.0.0",
+              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             }
           }
         },
         "concat-stream": {
           "version": "1.5.0",
-          "from": "concat-stream@^1.4.6",
+          "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
           "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@~2.0.1",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "typedarray": {
               "version": "0.0.6",
-              "from": "typedarray@~0.0.5",
+              "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
               "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
             },
             "readable-stream": {
               "version": "2.0.2",
-              "from": "readable-stream@~2.0.0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@~1.0.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "process-nextick-args": {
                   "version": "1.0.2",
-                  "from": "process-nextick-args@~1.0.0",
+                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@~0.10.x",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "util-deprecate": {
                   "version": "1.0.1",
-                  "from": "util-deprecate@~1.0.1",
+                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
                 }
               }
@@ -1331,196 +1331,196 @@
         },
         "debug": {
           "version": "2.2.0",
-          "from": "debug@^2.1.1",
+          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "dependencies": {
             "ms": {
               "version": "0.7.1",
-              "from": "ms@0.7.1",
+              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
             }
           }
         },
         "doctrine": {
           "version": "0.6.4",
-          "from": "doctrine@^0.6.2",
+          "from": "https://registry.npmjs.org/doctrine/-/doctrine-0.6.4.tgz",
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.6.4.tgz",
           "dependencies": {
             "esutils": {
               "version": "1.1.6",
-              "from": "esutils@^1.1.6",
+              "from": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
               "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
             },
             "isarray": {
               "version": "0.0.1",
-              "from": "isarray@0.0.1",
+              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
             }
           }
         },
         "escape-string-regexp": {
           "version": "1.0.3",
-          "from": "escape-string-regexp@^1.0.2",
+          "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
         },
         "escope": {
           "version": "3.2.0",
-          "from": "escope@^3.2.0",
+          "from": "https://registry.npmjs.org/escope/-/escope-3.2.0.tgz",
           "resolved": "https://registry.npmjs.org/escope/-/escope-3.2.0.tgz",
           "dependencies": {
             "es6-map": {
               "version": "0.1.1",
-              "from": "es6-map@^0.1.1",
+              "from": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.1.tgz",
               "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.1.tgz",
               "dependencies": {
                 "d": {
                   "version": "0.1.1",
-                  "from": "d@~0.1.1",
+                  "from": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
                 },
                 "es5-ext": {
                   "version": "0.10.7",
-                  "from": "es5-ext@~0.10.6",
+                  "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz",
                   "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz",
                   "dependencies": {
                     "es6-symbol": {
                       "version": "2.0.1",
-                      "from": "es6-symbol@~2.0.1",
+                      "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
                     }
                   }
                 },
                 "es6-iterator": {
                   "version": "0.1.3",
-                  "from": "es6-iterator@~0.1.1",
+                  "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
                   "dependencies": {
                     "es6-symbol": {
                       "version": "2.0.1",
-                      "from": "es6-symbol@~2.0.1",
+                      "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
                     }
                   }
                 },
                 "es6-set": {
                   "version": "0.1.1",
-                  "from": "es6-set@~0.1.1",
+                  "from": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.1.tgz"
                 },
                 "es6-symbol": {
                   "version": "0.1.1",
-                  "from": "es6-symbol@~0.1.1",
+                  "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz"
                 },
                 "event-emitter": {
                   "version": "0.3.3",
-                  "from": "event-emitter@~0.3.1",
+                  "from": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz",
                   "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz"
                 }
               }
             },
             "es6-weak-map": {
               "version": "0.1.4",
-              "from": "es6-weak-map@^0.1.2",
+              "from": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
               "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
               "dependencies": {
                 "d": {
                   "version": "0.1.1",
-                  "from": "d@~0.1.1",
+                  "from": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
                 },
                 "es5-ext": {
                   "version": "0.10.7",
-                  "from": "es5-ext@~0.10.6",
+                  "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz",
                   "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz"
                 },
                 "es6-iterator": {
                   "version": "0.1.3",
-                  "from": "es6-iterator@~0.1.1",
+                  "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
                 },
                 "es6-symbol": {
                   "version": "2.0.1",
-                  "from": "es6-symbol@~2.0.1",
+                  "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
                 }
               }
             },
             "esrecurse": {
               "version": "3.1.1",
-              "from": "esrecurse@^3.1.1",
+              "from": "https://registry.npmjs.org/esrecurse/-/esrecurse-3.1.1.tgz",
               "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-3.1.1.tgz"
             },
             "estraverse": {
               "version": "3.1.0",
-              "from": "estraverse@^3.1.0",
+              "from": "https://registry.npmjs.org/estraverse/-/estraverse-3.1.0.tgz",
               "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-3.1.0.tgz"
             }
           }
         },
         "espree": {
           "version": "2.2.4",
-          "from": "espree@^2.2.4",
+          "from": "https://registry.npmjs.org/espree/-/espree-2.2.4.tgz",
           "resolved": "https://registry.npmjs.org/espree/-/espree-2.2.4.tgz"
         },
         "estraverse": {
           "version": "4.1.0",
-          "from": "estraverse@^4.1.0",
+          "from": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.0.tgz",
           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.0.tgz"
         },
         "estraverse-fb": {
           "version": "1.3.1",
-          "from": "estraverse-fb@^1.3.1",
+          "from": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.1.tgz",
           "resolved": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.1.tgz"
         },
         "globals": {
           "version": "8.5.0",
-          "from": "globals@^8.3.0",
+          "from": "https://registry.npmjs.org/globals/-/globals-8.5.0.tgz",
           "resolved": "https://registry.npmjs.org/globals/-/globals-8.5.0.tgz"
         },
         "inquirer": {
           "version": "0.9.0",
-          "from": "inquirer@^0.9.0",
+          "from": "https://registry.npmjs.org/inquirer/-/inquirer-0.9.0.tgz",
           "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.9.0.tgz",
           "dependencies": {
             "ansi-regex": {
               "version": "2.0.0",
-              "from": "ansi-regex@^2.0.0",
+              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
             },
             "cli-width": {
               "version": "1.0.1",
-              "from": "cli-width@^1.0.1",
+              "from": "https://registry.npmjs.org/cli-width/-/cli-width-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.0.1.tgz"
             },
             "figures": {
               "version": "1.3.5",
-              "from": "figures@^1.3.5",
+              "from": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz",
               "resolved": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz"
             },
             "lodash": {
               "version": "3.10.1",
-              "from": "lodash@>= 3.2.0 < 4.0.0",
+              "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
             },
             "readline2": {
               "version": "0.1.1",
-              "from": "readline2@^0.1.1",
+              "from": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
               "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
               "dependencies": {
                 "mute-stream": {
                   "version": "0.0.4",
-                  "from": "mute-stream@0.0.4",
+                  "from": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
                 },
                 "strip-ansi": {
                   "version": "2.0.1",
-                  "from": "strip-ansi@^2.0.1",
+                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "1.1.1",
-                      "from": "ansi-regex@^1.0.0",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                     }
                   }
@@ -1529,17 +1529,17 @@
             },
             "run-async": {
               "version": "0.1.0",
-              "from": "run-async@^0.1.0",
+              "from": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
               "dependencies": {
                 "once": {
                   "version": "1.3.2",
-                  "from": "once@^1.3.0",
+                  "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@1",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
@@ -1548,151 +1548,151 @@
             },
             "rx-lite": {
               "version": "2.5.2",
-              "from": "rx-lite@^2.5.2",
+              "from": "https://registry.npmjs.org/rx-lite/-/rx-lite-2.5.2.tgz",
               "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-2.5.2.tgz"
             },
             "strip-ansi": {
               "version": "3.0.0",
-              "from": "strip-ansi@^3.0.0",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
             },
             "through": {
               "version": "2.3.8",
-              "from": "through@^2.3.6",
+              "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
               "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
             }
           }
         },
         "is-my-json-valid": {
           "version": "2.12.1",
-          "from": "is-my-json-valid@^2.10.0",
+          "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.1.tgz",
           "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.1.tgz",
           "dependencies": {
             "generate-function": {
               "version": "2.0.0",
-              "from": "generate-function@^2.0.0",
+              "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
             },
             "generate-object-property": {
               "version": "1.2.0",
-              "from": "generate-object-property@^1.1.0",
+              "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
               "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
               "dependencies": {
                 "is-property": {
                   "version": "1.0.2",
-                  "from": "is-property@^1.0.0",
+                  "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                 }
               }
             },
             "jsonpointer": {
               "version": "1.1.0",
-              "from": "jsonpointer@^1.1.0",
+              "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz"
             },
             "xtend": {
               "version": "4.0.0",
-              "from": "xtend@^4.0.0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
             }
           }
         },
         "is-resolvable": {
           "version": "1.0.0",
-          "from": "is-resolvable@^1.0.0",
+          "from": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
           "dependencies": {
             "tryit": {
               "version": "1.0.1",
-              "from": "tryit@^1.0.1",
+              "from": "https://registry.npmjs.org/tryit/-/tryit-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.1.tgz"
             }
           }
         },
         "js-yaml": {
           "version": "3.3.1",
-          "from": "js-yaml@^3.2.5",
+          "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.3.1.tgz",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.3.1.tgz",
           "dependencies": {
             "argparse": {
               "version": "1.0.2",
-              "from": "argparse@~1.0.2",
+              "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
               "dependencies": {
                 "lodash": {
                   "version": "3.10.1",
-                  "from": "lodash@>= 3.2.0 < 4.0.0",
+                  "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                 },
                 "sprintf-js": {
                   "version": "1.0.3",
-                  "from": "sprintf-js@~1.0.2",
+                  "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
                 }
               }
             },
             "esprima": {
               "version": "2.2.0",
-              "from": "esprima@~2.2.0",
+              "from": "https://registry.npmjs.org/esprima/-/esprima-2.2.0.tgz",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.2.0.tgz"
             }
           }
         },
         "lodash.clonedeep": {
           "version": "3.0.2",
-          "from": "lodash.clonedeep@^3.0.1",
+          "from": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
           "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
           "dependencies": {
             "lodash._baseclone": {
               "version": "3.3.0",
-              "from": "lodash._baseclone@^3.0.0",
+              "from": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
               "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
               "dependencies": {
                 "lodash._arraycopy": {
                   "version": "3.0.0",
-                  "from": "lodash._arraycopy@^3.0.0",
+                  "from": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz"
                 },
                 "lodash._arrayeach": {
                   "version": "3.0.0",
-                  "from": "lodash._arrayeach@^3.0.0",
+                  "from": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz"
                 },
                 "lodash._baseassign": {
                   "version": "3.2.0",
-                  "from": "lodash._baseassign@^3.0.0",
+                  "from": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
                   "dependencies": {
                     "lodash._basecopy": {
                       "version": "3.0.1",
-                      "from": "lodash._basecopy@^3.0.0",
+                      "from": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
                     }
                   }
                 },
                 "lodash._basefor": {
                   "version": "3.0.2",
-                  "from": "lodash._basefor@^3.0.0",
+                  "from": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.2.tgz"
                 },
                 "lodash.isarray": {
                   "version": "3.0.4",
-                  "from": "lodash.isarray@^3.0.0",
+                  "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
                 },
                 "lodash.keys": {
                   "version": "3.1.2",
-                  "from": "lodash.keys@^3.0.0",
+                  "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
                   "dependencies": {
                     "lodash._getnative": {
                       "version": "3.9.1",
-                      "from": "lodash._getnative@^3.0.0",
+                      "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
                       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
                     },
                     "lodash.isarguments": {
                       "version": "3.0.4",
-                      "from": "lodash.isarguments@^3.0.0",
+                      "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
                     }
                   }
@@ -1701,98 +1701,98 @@
             },
             "lodash._bindcallback": {
               "version": "3.0.1",
-              "from": "lodash._bindcallback@^3.0.0",
+              "from": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
             }
           }
         },
         "lodash.merge": {
           "version": "3.3.2",
-          "from": "lodash.merge@^3.3.2",
+          "from": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-3.3.2.tgz",
           "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-3.3.2.tgz",
           "dependencies": {
             "lodash._arraycopy": {
               "version": "3.0.0",
-              "from": "lodash._arraycopy@^3.0.0",
+              "from": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz"
             },
             "lodash._arrayeach": {
               "version": "3.0.0",
-              "from": "lodash._arrayeach@^3.0.0",
+              "from": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz"
             },
             "lodash._createassigner": {
               "version": "3.1.1",
-              "from": "lodash._createassigner@^3.0.0",
+              "from": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
               "dependencies": {
                 "lodash._bindcallback": {
                   "version": "3.0.1",
-                  "from": "lodash._bindcallback@^3.0.0",
+                  "from": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
                 },
                 "lodash._isiterateecall": {
                   "version": "3.0.9",
-                  "from": "lodash._isiterateecall@^3.0.0",
+                  "from": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
                   "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
                 },
                 "lodash.restparam": {
                   "version": "3.6.1",
-                  "from": "lodash.restparam@^3.0.0",
+                  "from": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
                 }
               }
             },
             "lodash._getnative": {
               "version": "3.9.1",
-              "from": "lodash._getnative@^3.0.0",
+              "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
             },
             "lodash.isarguments": {
               "version": "3.0.4",
-              "from": "lodash.isarguments@^3.0.0",
+              "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz",
               "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
             },
             "lodash.isarray": {
               "version": "3.0.4",
-              "from": "lodash.isarray@^3.0.0",
+              "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
               "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
             },
             "lodash.isplainobject": {
               "version": "3.2.0",
-              "from": "lodash.isplainobject@^3.0.0",
+              "from": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
               "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
               "dependencies": {
                 "lodash._basefor": {
                   "version": "3.0.2",
-                  "from": "lodash._basefor@^3.0.0",
+                  "from": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.2.tgz"
                 }
               }
             },
             "lodash.istypedarray": {
               "version": "3.0.2",
-              "from": "lodash.istypedarray@^3.0.0",
+              "from": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.2.tgz",
               "resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.2.tgz"
             },
             "lodash.keys": {
               "version": "3.1.2",
-              "from": "lodash.keys@^3.0.0",
+              "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
               "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
             },
             "lodash.keysin": {
               "version": "3.0.8",
-              "from": "lodash.keysin@^3.0.0",
+              "from": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
               "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz"
             },
             "lodash.toplainobject": {
               "version": "3.0.0",
-              "from": "lodash.toplainobject@^3.0.0",
+              "from": "https://registry.npmjs.org/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz",
               "dependencies": {
                 "lodash._basecopy": {
                   "version": "3.0.1",
-                  "from": "lodash._basecopy@^3.0.0",
+                  "from": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
                 }
               }
@@ -1801,37 +1801,37 @@
         },
         "lodash.omit": {
           "version": "3.1.0",
-          "from": "lodash.omit@^3.1.0",
+          "from": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-3.1.0.tgz",
           "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-3.1.0.tgz",
           "dependencies": {
             "lodash._arraymap": {
               "version": "3.0.0",
-              "from": "lodash._arraymap@^3.0.0",
+              "from": "https://registry.npmjs.org/lodash._arraymap/-/lodash._arraymap-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/lodash._arraymap/-/lodash._arraymap-3.0.0.tgz"
             },
             "lodash._basedifference": {
               "version": "3.0.3",
-              "from": "lodash._basedifference@^3.0.0",
+              "from": "https://registry.npmjs.org/lodash._basedifference/-/lodash._basedifference-3.0.3.tgz",
               "resolved": "https://registry.npmjs.org/lodash._basedifference/-/lodash._basedifference-3.0.3.tgz",
               "dependencies": {
                 "lodash._baseindexof": {
                   "version": "3.1.0",
-                  "from": "lodash._baseindexof@^3.0.0",
+                  "from": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz"
                 },
                 "lodash._cacheindexof": {
                   "version": "3.0.2",
-                  "from": "lodash._cacheindexof@^3.0.0",
+                  "from": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz"
                 },
                 "lodash._createcache": {
                   "version": "3.1.2",
-                  "from": "lodash._createcache@^3.0.0",
+                  "from": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
                   "dependencies": {
                     "lodash._getnative": {
                       "version": "3.9.1",
-                      "from": "lodash._getnative@^3.0.0",
+                      "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
                       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
                     }
                   }
@@ -1840,85 +1840,85 @@
             },
             "lodash._baseflatten": {
               "version": "3.1.4",
-              "from": "lodash._baseflatten@^3.0.0",
+              "from": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
               "resolved": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
               "dependencies": {
                 "lodash.isarguments": {
                   "version": "3.0.4",
-                  "from": "lodash.isarguments@^3.0.0",
+                  "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
                 },
                 "lodash.isarray": {
                   "version": "3.0.4",
-                  "from": "lodash.isarray@^3.0.0",
+                  "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
                 }
               }
             },
             "lodash._bindcallback": {
               "version": "3.0.1",
-              "from": "lodash._bindcallback@^3.0.0",
+              "from": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
             },
             "lodash._pickbyarray": {
               "version": "3.0.2",
-              "from": "lodash._pickbyarray@^3.0.0",
+              "from": "https://registry.npmjs.org/lodash._pickbyarray/-/lodash._pickbyarray-3.0.2.tgz",
               "resolved": "https://registry.npmjs.org/lodash._pickbyarray/-/lodash._pickbyarray-3.0.2.tgz"
             },
             "lodash._pickbycallback": {
               "version": "3.0.0",
-              "from": "lodash._pickbycallback@^3.0.0",
+              "from": "https://registry.npmjs.org/lodash._pickbycallback/-/lodash._pickbycallback-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/lodash._pickbycallback/-/lodash._pickbycallback-3.0.0.tgz",
               "dependencies": {
                 "lodash._basefor": {
                   "version": "3.0.2",
-                  "from": "lodash._basefor@^3.0.0",
+                  "from": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.2.tgz"
                 }
               }
             },
             "lodash.keysin": {
               "version": "3.0.8",
-              "from": "lodash.keysin@^3.0.0",
+              "from": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
               "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
               "dependencies": {
                 "lodash.isarguments": {
                   "version": "3.0.4",
-                  "from": "lodash.isarguments@^3.0.0",
+                  "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
                 },
                 "lodash.isarray": {
                   "version": "3.0.4",
-                  "from": "lodash.isarray@^3.0.0",
+                  "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
                 }
               }
             },
             "lodash.restparam": {
               "version": "3.6.1",
-              "from": "lodash.restparam@^3.0.0",
+              "from": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
             }
           }
         },
         "minimatch": {
           "version": "2.0.10",
-          "from": "minimatch@^2.0.1",
+          "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "dependencies": {
             "brace-expansion": {
               "version": "1.1.0",
-              "from": "brace-expansion@^1.0.0",
+              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
               "dependencies": {
                 "balanced-match": {
                   "version": "0.2.0",
-                  "from": "balanced-match@^0.2.0",
+                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                 },
                 "concat-map": {
                   "version": "0.0.1",
-                  "from": "concat-map@0.0.1",
+                  "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                 }
               }
@@ -1927,86 +1927,86 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "from": "mkdirp@^0.5.0",
+          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "from": "minimist@0.0.8",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
         },
         "object-assign": {
           "version": "2.1.1",
-          "from": "object-assign@^2.0.0",
+          "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
         },
         "optionator": {
           "version": "0.5.0",
-          "from": "optionator@^0.5.0",
+          "from": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
           "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
           "dependencies": {
             "prelude-ls": {
               "version": "1.1.2",
-              "from": "prelude-ls@~1.1.1",
+              "from": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
             },
             "deep-is": {
               "version": "0.1.3",
-              "from": "deep-is@~0.1.2",
+              "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
               "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
             },
             "wordwrap": {
               "version": "0.0.3",
-              "from": "wordwrap@~0.0.2",
+              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
             },
             "type-check": {
               "version": "0.3.1",
-              "from": "type-check@~0.3.1",
+              "from": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz",
               "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
             },
             "levn": {
               "version": "0.2.5",
-              "from": "levn@~0.2.5",
+              "from": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
               "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
             },
             "fast-levenshtein": {
               "version": "1.0.7",
-              "from": "fast-levenshtein@~1.0.0",
+              "from": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz",
               "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz"
             }
           }
         },
         "path-is-absolute": {
           "version": "1.0.0",
-          "from": "path-is-absolute@^1.0.0",
+          "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
         },
         "path-is-inside": {
           "version": "1.0.1",
-          "from": "path-is-inside@^1.0.1",
+          "from": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz"
         },
         "strip-json-comments": {
           "version": "1.0.4",
-          "from": "strip-json-comments@~1.0.1",
+          "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
         },
         "text-table": {
           "version": "0.2.0",
-          "from": "text-table@~0.2.0",
+          "from": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
           "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
         },
         "user-home": {
           "version": "1.1.1",
-          "from": "user-home@^1.0.0",
+          "from": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
         },
         "xml-escape": {
           "version": "1.0.0",
-          "from": "xml-escape@~1.0.0",
+          "from": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.0.0.tgz"
         }
       }
@@ -2626,51 +2626,92 @@
       }
     },
     "mocha": {
-      "version": "1.8.2",
-      "from": "https://registry.npmjs.org/mocha/-/mocha-1.8.2.tgz",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-1.8.2.tgz",
+      "version": "2.2.5",
+      "from": "mocha@2.2.5",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.2.5.tgz",
       "dependencies": {
         "commander": {
-          "version": "0.6.1",
-          "from": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
+          "version": "2.3.0",
+          "from": "commander@2.3.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz"
         },
-        "growl": {
-          "version": "1.7.0",
-          "from": "https://registry.npmjs.org/growl/-/growl-1.7.0.tgz",
-          "resolved": "https://registry.npmjs.org/growl/-/growl-1.7.0.tgz"
-        },
-        "jade": {
-          "version": "0.26.3",
-          "from": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
-          "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+        "debug": {
+          "version": "2.0.0",
+          "from": "debug@2.0.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
           "dependencies": {
-            "mkdirp": {
-              "version": "0.3.0",
-              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
+            "ms": {
+              "version": "0.6.2",
+              "from": "ms@0.6.2",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
             }
           }
         },
         "diff": {
-          "version": "1.0.2",
-          "from": "https://registry.npmjs.org/diff/-/diff-1.0.2.tgz",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.2.tgz"
+          "version": "1.4.0",
+          "from": "diff@1.4.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz"
         },
-        "debug": {
-          "version": "0.7.4",
-          "from": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+        "escape-string-regexp": {
+          "version": "1.0.2",
+          "from": "escape-string-regexp@1.0.2",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
+        },
+        "glob": {
+          "version": "3.2.3",
+          "from": "glob@3.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "2.0.3",
+              "from": "graceful-fs@~2.0.0",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@2",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            }
+          }
+        },
+        "growl": {
+          "version": "1.8.1",
+          "from": "growl@1.8.1",
+          "resolved": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz"
+        },
+        "jade": {
+          "version": "0.26.3",
+          "from": "jade@0.26.3",
+          "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+          "dependencies": {
+            "commander": {
+              "version": "0.6.1",
+              "from": "commander@0.6.1",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
+            },
+            "mkdirp": {
+              "version": "0.3.0",
+              "from": "mkdirp@0.3.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
+            }
+          }
         },
         "mkdirp": {
-          "version": "0.3.3",
-          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.3.tgz",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.3.tgz"
+          "version": "0.5.0",
+          "from": "mkdirp@0.5.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "from": "minimist@0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            }
+          }
         },
-        "ms": {
-          "version": "0.3.0",
-          "from": "https://registry.npmjs.org/ms/-/ms-0.3.0.tgz",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.3.0.tgz"
+        "supports-color": {
+          "version": "1.2.1",
+          "from": "supports-color@~1.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.1.tgz"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "graceful-fs": "1.1.x",
     "grunt": "0.3.17",
     "jshint": "2.1.9",
-    "mocha": "1.8.2",
+    "mocha": "^2.2.5",
     "mocha-phantomjs": "^3.6.0",
     "node-markdown": "0.1.x",
     "node-minify": "0.7.x",

--- a/test.ini
+++ b/test.ini
@@ -10,6 +10,8 @@ pyramid.reload_templates = true
 pyramid.default_locale_name = en
 
 jujugui.sandbox = true
+jujugui.raw = true
+jujugui.combine = false
 
 ###
 # wsgi server configuration


### PR DESCRIPTION
The up to date version of mocha is considerably faster and less buggy than the very old version that we were still using. 