### PR TITLE
Move UIState instance to app.js

### DIFF
--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -660,6 +660,10 @@ YUI.add('juju-gui', function(Y) {
       cfg.envSeries = this.getEnvDefaultSeries.bind(this);
       cfg.env = this.env;
       cfg.ecs = this.env.ecs;
+
+      this._setupUIState(cfg.sandbox, cfg.baseUrl);
+      cfg.state = this.state;
+
       this.addSubApplications(cfg);
 
       this.on('*:changeState', function(e) {
@@ -681,6 +685,23 @@ YUI.add('juju-gui', function(Y) {
       // XXX (Jeff 19-02-2014) When the inspector mask code is moved into
       // the inspector shortly this can be removed.
       this.on('*:destroyServiceInspector', this.hideDragNotifications, this);
+    },
+
+    /**
+      Sets up the UIState instance on the app
+
+      @method _setupUIState
+      @param {Boolean} sandbox
+      @param {String} baseUrl
+    */
+    _setupUIState: function(sandbox, baseUrl) {
+      this.state = new models.UIState({
+        // Disallow routing to inspectors if we are in sandbox mode; the
+        // model to be inspected will not be available.
+        allowInspector: !sandbox,
+        baseUrl: baseUrl || '',
+        dispatchers: {}
+      });
     },
 
     /**

--- a/jujugui/static/gui/src/app/subapps/browser/browser.js
+++ b/jujugui/static/gui/src/app/subapps/browser/browser.js
@@ -175,29 +175,25 @@ YUI.add('subapp-browser', function(Y) {
       // Hold onto charm data so we can pass model instances to other views when
       // charms are selected.
       this._cache = new Y.juju.BrowserCache();
-      this.state = new models.UIState({
-        // Disallow routing to inspectors if we are in sandbox mode; the
-        // model to be inspected will not be available.
-        allowInspector: !cfg.sandbox,
-        baseUrl: cfg.baseUrl || '',
-        dispatchers: {
-          app: {
-            deployTarget: this._deployTargetDispatcher.bind(this)
-          },
-          sectionA: {
-            charmbrowser: this._charmBrowserDispatcher.bind(this),
-            inspector: this._inspectorDispatcher.bind(this),
-            empty: this.emptySectionA.bind(this),
-            services: this._addedServicesDispatcher.bind(this)
-          },
-          sectionB: {
-            machine: this._machine.bind(this),
-            empty: this.emptySectionB.bind(this)
-          }
-        }
-      });
 
       this._registerSubappHelpers();
+
+      this.state = cfg.state
+      this.state.set('dispatchers', {
+        app: {
+          deployTarget: this._deployTargetDispatcher.bind(this)
+        },
+        sectionA: {
+          charmbrowser: this._charmBrowserDispatcher.bind(this),
+          inspector: this._inspectorDispatcher.bind(this),
+          empty: this.emptySectionA.bind(this),
+          services: this._addedServicesDispatcher.bind(this)
+        },
+        sectionB: {
+          machine: this._machine.bind(this),
+          empty: this.emptySectionB.bind(this)
+        }
+      });
 
       // Setup event handlers.
       // These event handlers come from app/subapps/browser/events-extension.js

--- a/jujugui/static/gui/src/app/subapps/browser/browser.js
+++ b/jujugui/static/gui/src/app/subapps/browser/browser.js
@@ -179,7 +179,7 @@ YUI.add('subapp-browser', function(Y) {
       this._registerSubappHelpers();
 
       this.state = cfg.state
-      this.state.set('dispatchers', {
+      var dispatchers = {
         app: {
           deployTarget: this._deployTargetDispatcher.bind(this)
         },
@@ -193,7 +193,12 @@ YUI.add('subapp-browser', function(Y) {
           machine: this._machine.bind(this),
           empty: this.emptySectionB.bind(this)
         }
-      });
+      };
+      this.state.set(
+        'dispatchers',
+        // If there were any existing dispatchers then merge in ones for
+        // the sub app.
+        Y.merge(dispatchers, this.state.get('dispatchers')));
 
       // Setup event handlers.
       // These event handlers come from app/subapps/browser/events-extension.js

--- a/jujugui/static/gui/src/test/test_browser_app.js
+++ b/jujugui/static/gui/src/test/test_browser_app.js
@@ -72,7 +72,12 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
       beforeEach(function() {
         app = new Y.juju.subapps.Browser({
-          db: new models.Database()
+          db: new models.Database(),
+          state: new models.UIState({
+            allowInspector: true,
+            baseUrl: '',
+            dispatchers: {}
+          })
         });
         app._sidebar = {
           get: function() {
@@ -159,7 +164,14 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
       beforeEach(function() {
         var db = new models.Database();
-        app = new Y.juju.subapps.Browser({db: db});
+        app = new Y.juju.subapps.Browser({
+          db: db,
+          state: new models.UIState({
+            allowInspector: true,
+            baseUrl: '',
+            dispatchers: {}
+          })
+        });
         app._sidebar = {
           get: function() {
             return {
@@ -213,18 +225,20 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
   (function() {
     describe('browser app', function() {
-      var Y, app, browser, container, next, utils;
+      var Y, app, browser, container, next, models, utils;
 
       before(function(done) {
         Y = YUI(GlobalConfig).use(
             'app-subapp-extension',
             'juju-browser',
             'juju-charm-models',
+            'juju-models',
             'juju-tests-utils',
             'juju-views',
             'subapp-browser', function(Y) {
               browser = Y.namespace('juju.subapps');
               utils = Y.namespace('juju-tests.utils');
+              models = Y.namespace('juju.models');
               next = function() {};
               done();
             });
@@ -252,7 +266,13 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
             entityStub, cleanupEntity, metadata, onboarding;
 
         beforeEach(function() {
-          app = new browser.Browser({});
+          app = new browser.Browser({
+            state: new models.UIState({
+              allowInspector: true,
+              baseUrl: '',
+              dispatchers: {}
+            })
+          });
           app._sidebar = {
             destroy: utils.makeStubFunction()
           };
@@ -768,7 +788,13 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       });
 
       it('listens to serviceDeployed events', function(done) {
-        app = new browser.Browser({});
+        app = new browser.Browser({
+          state: new models.UIState({
+            allowInspector: true,
+            baseUrl: '',
+            dispatchers: {}
+          })
+        });
         var generateStub = utils.makeStubMethod(app.state, 'generateUrl');
         this._cleanups.push(generateStub.reset);
         var navigateStub = utils.makeStubMethod(app, 'navigate');
@@ -796,7 +822,13 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       });
 
       it('don\'t render a destroyed inspector on serviceDeployed', function() {
-        app = new browser.Browser({});
+        app = new browser.Browser({
+          state: new models.UIState({
+            allowInspector: true,
+            baseUrl: '',
+            dispatchers: {}
+          })
+        });
         var generateStub = utils.makeStubMethod(app.state, 'generateUrl');
         this._cleanups.push(generateStub.reset);
         var navigateStub = utils.makeStubMethod(app, 'navigate');
@@ -818,7 +850,13 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       });
 
       it('listens to changeState events', function() {
-        app = new browser.Browser({});
+        app = new browser.Browser({
+          state: new models.UIState({
+            allowInspector: true,
+            baseUrl: '',
+            dispatchers: {}
+          })
+        });
         app.state.set('allowInspector', false);
         var generateUrlStub = utils.makeStubMethod(
             app.state, 'generateUrl', 'genUrl');
@@ -832,7 +870,13 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       });
 
       it('verify that route callables exist', function() {
-        app = new browser.Browser({});
+        app = new browser.Browser({
+          state: new models.UIState({
+            allowInspector: true,
+            baseUrl: '',
+            dispatchers: {}
+          })
+        });
         Y.each(app.get('routes'), function(route) {
           assert.isTrue(typeof app[route.callback] === 'function');
         });
@@ -840,7 +884,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     });
 
     describe('browser subapp display tree', function() {
-      var Y, browser, container, hits, minRender, ns,
+      var Y, browser, container, hits, minRender, models, ns,
           resetHits, sidebarRender, utils;
 
       before(function(done) {
@@ -848,10 +892,12 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
             'app-subapp-extension',
             'juju-views',
             'juju-browser',
+            'juju-models',
             'juju-tests-utils',
             'subapp-browser', function(Y) {
               browser = Y.namespace('juju.subapps');
               utils = Y.namespace('juju-tests.utils');
+              models = Y.namespace('juju.models');
               done();
             });
       });
@@ -870,7 +916,14 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       beforeEach(function() {
         container = utils.makeContainer(this, 'container');
         addBrowserContainer(Y, container);
-        browser = new ns.Browser({ sandbox: false });
+        browser = new ns.Browser({
+          sandbox: false,
+          state: new models.UIState({
+            allowInspector: true,
+            baseUrl: '',
+            dispatchers: {}
+          })
+        });
       });
 
       afterEach(function() {
@@ -878,7 +931,14 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       });
 
       it('knows when the search cache should be updated (state)', function() {
-        var charmbrowser = new ns.Browser({ sandbox: false });
+        var charmbrowser = new ns.Browser({
+          sandbox: false,
+          state: new models.UIState({
+            allowInspector: true,
+            baseUrl: '',
+            dispatchers: {}
+          })
+        });
         charmbrowser.state.set('current', {
           sectionA: {
             component: 'charmbrowser',

--- a/jujugui/static/gui/src/test/test_bundle_details_view.js
+++ b/jujugui/static/gui/src/test/test_bundle_details_view.js
@@ -47,7 +47,12 @@ describe('Browser bundle detail view', function() {
           d3 = Y.namespace('d3');
           // Required to register the handlebars helpers
           browser = new Y.juju.subapps.Browser({
-            charmstore: factory.makeFakeCharmstore()
+            charmstore: factory.makeFakeCharmstore(),
+            state: new models.UIState({
+              allowInspector: true,
+              baseUrl: '',
+              dispatchers: {}
+            })
           });
 
           done();


### PR DESCRIPTION
The react components need access to the UIState instance to know how to properly update when the state changes.