### PR TITLE
Add baseUrl as a config setting.

### DIFF
--- a/jujugui/options.py
+++ b/jujugui/options.py
@@ -17,6 +17,7 @@ def update(settings):
     """
     _update(settings, 'jujugui.charmstore_url', default=DEFAULT_CHARMSTORE_URL)
     _update(settings, 'jujugui.ga_key', default='')
+    _update(settings, 'jujugui.baseUrl', default=None)
     _update_bool(settings, 'jujugui.sandbox', default=False)
     _update_bool(settings, 'jujugui.raw', default=False)
     _update_bool(settings, 'jujugui.combine', default=True)

--- a/jujugui/tests/test_options.py
+++ b/jujugui/tests/test_options.py
@@ -1,6 +1,7 @@
 # Copyright 2015 Canonical Ltd.  This software is licensed under the
 # GNU Affero General Public License version 3 (see the file LICENSE).
 
+from copy import deepcopy
 import unittest
 
 from jujugui import options
@@ -19,7 +20,9 @@ class TestUpdate(unittest.TestCase):
     def test_default_values(self):
         settings = {}
         options.update(settings)
-        self.assertEqual(self.default_settings, settings)
+        defaults = deepcopy(self.default_settings)
+        defaults['jujugui.baseUrl'] = None
+        self.assertEqual(defaults, settings)
 
     def test_customized_values(self):
         expected_settings = {
@@ -27,14 +30,15 @@ class TestUpdate(unittest.TestCase):
             'jujugui.ga_key': 'my-key',
             'jujugui.sandbox': True,
             'jujugui.raw': False,
-            'jujugui.combine': True
+            'jujugui.combine': True,
+            'jujugui.baseUrl': None,
         }
         settings = {
             'jujugui.charmstore_url': 'https://1.2.3.4/api/',
             'jujugui.ga_key': 'my-key',
             'jujugui.sandbox': 'on',
             'jujugui.raw': 'off',
-            'jujugui.combine': 'true'
+            'jujugui.combine': 'true',
         }
         options.update(settings)
         self.assertEqual(expected_settings, settings)
@@ -42,7 +46,9 @@ class TestUpdate(unittest.TestCase):
     def test_empty_values(self):
         settings = dict((k, '') for k in self.default_settings)
         options.update(settings)
-        self.assertEqual(self.default_settings, settings)
+        defaults = deepcopy(self.default_settings)
+        defaults['jujugui.baseUrl'] = None
+        self.assertEqual(defaults, settings)
 
     def test_none_returned(self):
         self.assertIsNone(options.update({}))

--- a/jujugui/tests/test_views.py
+++ b/jujugui/tests/test_views.py
@@ -122,3 +122,13 @@ class ConfigTests(ViewTestCase):
         config = self.check_response(response)
         self.assertEqual('env-uuid', config['jujuEnvUUID'])
         self.assertEqual('/u/anonymous/env-uuid', config['baseUrl'])
+
+    def test_explicit_baseUrl(self):
+        settings = {'baseUrl': '/ignore/prefix'}
+        self.config = testing.setUp(
+            request=self.request, settings=settings)
+        jujugui.make_application(self.config)
+        response = views.config(self.request)
+        config = self.check_response(response)
+        self.assertEqual('sandbox', config['jujuEnvUUID'])
+        self.assertEqual('/ignore/prefix', config['baseUrl'])

--- a/jujugui/views.py
+++ b/jujugui/views.py
@@ -70,10 +70,12 @@ def config(request):
     request.response.content_type = 'application/javascript'
     sandbox_enabled = settings['jujugui.sandbox']
     env_uuid = request.matchdict.get('uuid', 'sandbox')
-    if env_uuid == 'sandbox':
-        baseUrl = ''
-    else:
-        baseUrl = '/u/anonymous/{}'.format(env_uuid)
+    baseUrl = settings.get('baseUrl')
+    if baseUrl is None:
+        if env_uuid == 'sandbox':
+            baseUrl = ''
+        else:
+            baseUrl = '/u/anonymous/{}'.format(env_uuid)
     options = {
         # Base YUI options.
         'serverRouting': False,


### PR DESCRIPTION
Allow the setting of baseUrl as a config option for use when we are embedded.  If not set, the previous sandbox or jujucharms logic is used.