### PR TITLE
Prepare app for the inspector component

### DIFF
--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -744,7 +744,6 @@ YUI.add('juju-gui', function(Y) {
       React.render(
         <components.Panel
           instanceName="inspector-panel"
-          instanceType="addedServices"
           visible={services.length > 0}>
           <components.AddedServicesList services={services} />
         </components.Panel>,
@@ -762,7 +761,6 @@ YUI.add('juju-gui', function(Y) {
       React.render(
         <components.Panel
           instanceName="inspector-panel"
-          instanceType="inspector"
           visible={true}
           metadata={metadata}>
           <components.Inspector />

--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -42,6 +42,8 @@ YUI.add('juju-gui', function(Y) {
       widgets = Y.namespace('juju.widgets'),
       bundleNotifications = juju.BundleNotifications;
 
+  var components = window.juju.components;
+
   /**
    * The main app class.
    *
@@ -740,9 +742,31 @@ YUI.add('juju-gui', function(Y) {
     _renderAddedServices: function(services) {
       var services = this.db.services.toArray();
       React.render(
-        <window.juju.components.Panel
+        <components.Panel
           instanceName="inspector-panel"
-          services={services}/>,
+          instanceType="addedServices"
+          visible={services.length > 0}>
+          <components.AddedServicesList services={services} />
+        </components.Panel>,
+        document.getElementById('inspector-container'));
+    },
+
+    /**
+      Renders the Inspector component to the page.
+
+      @method _renderInspector
+      @param {Object} metadata The data to pass to the inspector which tells it
+        how to render.
+    */
+    _renderInspector: function(metadata) {
+      React.render(
+        <components.Panel
+          instanceName="inspector-panel"
+          instanceType="inspector"
+          visible={true}
+          metadata={metadata}>
+          <components.Inspector />
+        </components.Panel>,
         document.getElementById('inspector-container'));
     },
 
@@ -764,7 +788,8 @@ YUI.add('juju-gui', function(Y) {
       if (window.flags && window.flags.react) {
         var dispatchers = this.state.get('dispatchers');
         dispatchers.sectionA = {
-          services: this._renderAddedServices.bind(this)
+          services: this._renderAddedServices.bind(this),
+          inspector: this._renderInspector.bind(this)
         };
         this.state.set('dispatchers', dispatchers);
       }
@@ -1532,7 +1557,9 @@ YUI.add('juju-gui', function(Y) {
           this.db.services.size(),
           this.db.machines.size()
         );
-        this._renderAddedServices();
+        // When we render the components we also want to trigger the rest of
+        // the application to render but only based on the current state.
+        this.state.dispatch();
       }
     },
 
@@ -1784,6 +1811,7 @@ YUI.add('juju-gui', function(Y) {
     'juju-env-web-handler',
     'juju-env-web-sandbox',
     'juju-charm-models',
+    'inspector-component',
     'env-size-display',
     'panel-component',
     // juju-views group

--- a/jujugui/static/gui/src/app/components/inspector/inspector.js
+++ b/jujugui/static/gui/src/app/components/inspector/inspector.js
@@ -23,7 +23,6 @@ YUI.add('inspector-component', function() {
   juju.components.Inspector = React.createClass({
 
     render: function() {
-      console.log('render')
       return (
         <div>
           Inspector

--- a/jujugui/static/gui/src/app/components/inspector/inspector.js
+++ b/jujugui/static/gui/src/app/components/inspector/inspector.js
@@ -1,0 +1,36 @@
+/*
+This file is part of the Juju GUI, which lets users view and manage Juju
+environments within a graphical interface (https://launchpad.net/juju-gui).
+Copyright (C) 2015 Canonical Ltd.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU Affero General Public License version 3, as published by
+the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero
+General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along
+with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+'use strict';
+
+YUI.add('inspector-component', function() {
+
+  juju.components.Inspector = React.createClass({
+
+    render: function() {
+      console.log('render')
+      return (
+        <div>
+          Inspector
+        </div>
+      );
+    }
+
+  });
+
+}, '0.1.0', { requires: []});

--- a/jujugui/static/gui/src/app/components/panel/panel.js
+++ b/jujugui/static/gui/src/app/components/panel/panel.js
@@ -36,7 +36,7 @@ YUI.add('panel-component', function() {
         'panel-component',
         this.props.instanceName,
         {
-          hidden: this.props.services.length === 0
+          hidden: !this.props.visible
         }
       );
     },
@@ -44,8 +44,7 @@ YUI.add('panel-component', function() {
     render: function() {
       return (
         <div className={this._genClasses()}>
-          <juju.components.AddedServicesList
-            services={this.props.services} />
+          {this.props.children}
         </div>
       );
     }

--- a/jujugui/static/gui/src/app/components/panel/test-panel.js
+++ b/jujugui/static/gui/src/app/components/panel/test-panel.js
@@ -31,35 +31,42 @@ describe('PanelComponent', function() {
     YUI().use('panel-component', function() { done(); });
   });
 
-  it('generates a visible panel if services are provided', function() {
+  it('generates a visible panel when visible flag is provided', function() {
     var instanceName = 'custom-instance-name';
-    var services = ['']; // one service.
 
     var shallowRenderer = testUtils.createRenderer();
     shallowRenderer.render(
         <juju.components.Panel
           instanceName={instanceName}
-          services={services}/>);
+          visible={true}/>);
 
     var output = shallowRenderer.getRenderOutput();
     assert.equal(output.props.className, 'panel-component ' + instanceName);
-    assert.deepEqual(output.props.children,
-      <juju.components.AddedServicesList services={services} />);
+    assert.equal(output.props.children, undefined);
   });
 
-  it('generates a hidden panel if no services are provided', function() {
+  it('generates a hidden panel if visible flag is falsey', function() {
     var instanceName = 'custom-instance-name';
-    var services = []; // no services.
 
     var shallowRenderer = testUtils.createRenderer();
     shallowRenderer.render(
         <juju.components.Panel
-          instanceName={instanceName}
-          services={services}/>);
+          instanceName={instanceName}/>);
 
     var output = shallowRenderer.getRenderOutput();
-    assert.equal(output.props.className, 'panel-component ' + instanceName + ' hidden');
-    assert.deepEqual(output.props.children,
-      <juju.components.AddedServicesList services={services} />);
+    assert.equal(
+        output.props.className, 'panel-component ' + instanceName + ' hidden');
+    assert.equal(output.props.children, undefined);
+  });
+
+  it('renders provided children components', function() {
+    var shallowRenderer = testUtils.createRenderer();
+    shallowRenderer.render(
+        <juju.components.Panel instanceName="custom-instance-name">
+          <div>child</div>
+        </juju.components.Panel>);
+
+    var output = shallowRenderer.getRenderOutput();
+    assert.deepEqual(output.props.children, <div>child</div>);
   });
 });

--- a/jujugui/static/gui/src/app/subapps/browser/browser.js
+++ b/jujugui/static/gui/src/app/subapps/browser/browser.js
@@ -277,6 +277,13 @@ YUI.add('subapp-browser', function(Y) {
             }.bind(this),
             failureNotification.bind(this));
       }
+      // Because deploy-target is an action and not a state we need to clear
+      // it out of the state as soon as we are done with it so that we can
+      // continue calling dispatch without the worry of it trying to
+      // deploy multiple times.
+      var currentState = this.state.get('current');
+      delete currentState.app.deployTarget;
+      this.navigate(this.state.generateUrl(currentState));
     },
 
     /**

--- a/jujugui/static/gui/src/test/test_browser_app.js
+++ b/jujugui/static/gui/src/test/test_browser_app.js
@@ -629,6 +629,9 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
         describe('_deployTargetDispatcher', function() {
           it('gets bundle yaml from charmstore then deploys', function(done) {
+            var navStub = utils.makeStubMethod(app, 'navigate');
+            this._cleanups.push(navStub.reset);
+            app.state.set('current', {app: {deployTarget: ''}});
             var bundleId = 'bundle/elasticsearch';
             app.set('charmstore', {
               getBundleYAML: utils.makeStubFunction()
@@ -651,6 +654,9 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
           it('requests bundle id from charmstore then deploys (namespaced)',
               function(done) {
+                var navStub = utils.makeStubMethod(app, 'navigate');
+                this._cleanups.push(navStub.reset);
+                app.state.set('current', {app: {deployTarget: ''}});
                 var bundleId = '~jorge/bundle/elasticsearch';
                 app.set('charmstore', {
                   getBundleYAML: utils.makeStubFunction()
@@ -672,6 +678,9 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
               });
 
           it('requests charm id from store then deploys', function() {
+            var navStub = utils.makeStubMethod(app, 'navigate');
+            this._cleanups.push(navStub.reset);
+            app.state.set('current', {app: {deployTarget: ''}});
             app.setAttrs({
               charmstore: { getEntity: utils.makeStubFunction() },
               env: { deploy: utils.makeStubFunction() }
@@ -702,6 +711,19 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
             assert.equal(deployArgs[4], 1);
             assert.deepEqual(deployArgs[5], {});
             assert.strictEqual(deployArgs[6], null);
+          });
+
+          it('clears the deploy target action from the state', function() {
+            var navStub = utils.makeStubMethod(app, 'navigate');
+            this._cleanups.push(navStub.reset);
+            app.state.set(
+                'current', {app: {deployTarget: 'cs:/precise/wordpress'}});
+            var bundleId = 'bundle/elasticsearch';
+            app.set('charmstore', { getBundleYAML: utils.makeStubFunction() });
+            app.set('bundleImporter', utils.makeStubFunction());
+            app._deployTargetDispatcher(bundleId);
+            assert.equal(navStub.callCount(), 1);
+            assert.equal(navStub.lastArguments()[0], '/');
           });
         });
 


### PR DESCRIPTION
To support the new component rendering cycle and the new inspector/added services views we need `state.dispatch()` to be idempotent so that we can call it whenever there is a database change to update the UI using the existing app state.