### PR TITLE
Close inspector on deployer bar commit

### DIFF
--- a/jujugui/static/gui/src/app/widgets/deployer-bar.js
+++ b/jujugui/static/gui/src/app/widgets/deployer-bar.js
@@ -157,6 +157,10 @@ YUI.add('deployer-bar', function(Y) {
       @param {Object} evt The event object.
     */
     deploy: function(evt) {
+      this.fire('changeState', {
+        sectionA: {
+          component: null,
+          metadata: {id: null}}});
       if (evt && typeof evt.halt === 'function') {
         evt.halt();
       }

--- a/jujugui/static/gui/src/test/test_deployer_bar.js
+++ b/jujugui/static/gui/src/test/test_deployer_bar.js
@@ -19,7 +19,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 'use strict';
 
 
-describe.only('deployer bar view', function() {
+describe('deployer bar view', function() {
   var container, db, ECS, ecs, importBundleFile, mockEvent,
       models, testUtils, utils, view, View, views, Y;
 

--- a/jujugui/static/gui/src/test/test_deployer_bar.js
+++ b/jujugui/static/gui/src/test/test_deployer_bar.js
@@ -19,7 +19,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 'use strict';
 
 
-describe('deployer bar view', function() {
+describe.only('deployer bar view', function() {
   var container, db, ECS, ecs, importBundleFile, mockEvent,
       models, testUtils, utils, view, View, views, Y;
 
@@ -234,6 +234,21 @@ describe('deployer bar view', function() {
                  'ECS commit not called');
     assert.equal(container.hasClass('summary-open'), false,
                  'summary-open class still present');
+  });
+
+  it('closes the inspector on deploy', function() {
+    var stubCommit = utils.makeStubMethod(ecs, 'commit');
+    var fireStub = utils.makeStubMethod(view, 'fire');
+    this._cleanups.push(fireStub.reset);
+    this._cleanups.push(stubCommit.reset);
+    view.deploy(mockEvent);
+    assert.equal(fireStub.callCount(), 1);
+    assert.deepEqual(fireStub.lastArguments(), ['changeState', {
+      sectionA: {
+        component: null,
+        metadata: {id: null}}}]);
+    assert.equal(stubCommit.calledOnce(), true,
+                 'ECS commit not called');
   });
 
   it('updates when the change set is modified', function(done) {

--- a/jujugui/static/gui/src/test/test_environment_view.js
+++ b/jujugui/static/gui/src/test/test_environment_view.js
@@ -1538,7 +1538,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       view.destroy();
     });
 
-    describe.only('onboarding integration with the environment', function() {
+    describe('onboarding integration with the environment', function() {
       // XXX This test does not run in Phantom, but passes in the browser.
       // See https://github.com/ariya/phantomjs/issues/12782 for details.
       // Makyo - 2015-09-21
@@ -1554,7 +1554,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
             var helpText = container.one('.environment-help');
             assert.equal(false, includedPlus.classed('show'));
             assert.equal(false, helpText.hasClass('shrink'));
-            
+
             var service = new models.Service({
               id: 'service-1',
               charm: 'precise/mysql-1'


### PR DESCRIPTION
When deploying commits the inspector needs to be closed and the added-services component shown.