### PR TITLE
Do not show started units as uncommitted

### DIFF
--- a/jujugui/static/gui/src/app/components/service-overview/service-overview.js
+++ b/jujugui/static/gui/src/app/components/service-overview/service-overview.js
@@ -99,10 +99,6 @@ YUI.add('service-overview', function() {
         var agentState;
         units.forEach(function(unit) {
           agentState = unit.agent_state || 'uncommitted';
-          // Show started units as uncommitted.
-          if (agentState === 'started') {
-            agentState = 'uncommitted';
-          }
           unitStatuses[agentState] += 1;
         });
         return unitStatuses;

--- a/jujugui/static/gui/src/app/components/service-overview/test-service-overview.js
+++ b/jujugui/static/gui/src/app/components/service-overview/test-service-overview.js
@@ -136,7 +136,7 @@ describe('ServiceOverview', function() {
     var output = jsTestUtils.shallowRender(
           <juju.components.ServiceOverview
             service={service}/>);
-    var value = 3;
+    var value = 2;
     assert.deepEqual(output.props.children[0].props.children[1],
       <juju.components.OverviewAction
         key="Uncommitted"


### PR DESCRIPTION
After a service was deployed it was showing it's started units as uncommitted.