### PR TITLE
Introduce the socket_path option.

### DIFF
--- a/jujugui/options.py
+++ b/jujugui/options.py
@@ -15,10 +15,13 @@ def update(settings):
 
     Modify the given settings object in place.
     """
+    _update(settings, 'jujugui.auth', default=None)
+    _update(settings, 'jujugui.baseUrl', default=None)
     _update(settings, 'jujugui.charmstore_url', default=DEFAULT_CHARMSTORE_URL)
     _update(settings, 'jujugui.ga_key', default='')
-    _update(settings, 'jujugui.baseUrl', default=None)
-    _update(settings, 'jujugui.auth', default=None)
+    _update(settings, 'jujugui.password', default=None)
+    _update(settings, 'jujugui.socket_path', default=None)
+    _update(settings, 'jujugui.user', default='')
     _update_bool(settings, 'jujugui.sandbox', default=False)
     _update_bool(settings, 'jujugui.raw', default=False)
     _update_bool(settings, 'jujugui.combine', default=True)

--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -445,9 +445,11 @@ YUI.add('juju-gui', function(Y) {
         });
         // Instantiate the environment specified in the configuration, choosing
         // between the available implementations, currently Go and Python.
+        var socketUrl = this._generateSocketUrl();
+        this.set('socket_url', socketUrl);
         var envOptions = {
           ecs: ecs,
-          socket_url: this._generateSocketUrl(),
+          socket_url: socketUrl,
           user: this.get('user'),
           password: this.get('password'),
           readOnly: this.get('readOnly'),
@@ -832,11 +834,11 @@ YUI.add('juju-gui', function(Y) {
     },
 
     /**
-      Composes the various socket paths and protocols and returns the corret
-      url that the GUI should use to communicate with the environment.
+      Composes the various socket paths and protocols and returns the correct
+      URL that the GUI should use to communicate with the environment.
 
       @method _generateSocketUrl
-      @return {String} The fully qualified socket url.
+      @return {String} The fully qualified WebSocket URL.
     */
     _generateSocketUrl: function() {
       var socketProtocol = this.get('socket_protocol');
@@ -847,6 +849,12 @@ YUI.add('juju-gui', function(Y) {
       if (loc.port) {
         socketUrl += ':' + loc.port;
       }
+      // If a WebSocket path is explicitly provided, it gets precedence over
+      // all the other methods to automatically calculate it.
+      var path = this.get('socket_path');
+      if (path) {
+        return socketUrl + path;
+      }
       // If the Juju version is over 1.21 then we need to make requests to the
       // api using the environments uuid.
       var jujuVersion = this.get('jujuCoreVersion').split('.');
@@ -856,9 +864,7 @@ YUI.add('juju-gui', function(Y) {
       if (majorVersion === 1 && minorVersion > 20 || majorVersion > 1) {
         suffix = '/environment/' + this.get('jujuEnvUUID') + '/api';
       }
-      socketUrl = socketUrl + '/ws' + suffix;
-      this.set('socket_url', socketUrl);
-      return socketUrl;
+      return socketUrl + '/ws' + suffix;
     },
 
     /**

--- a/jujugui/static/gui/src/test/test_app.js
+++ b/jujugui/static/gui/src/test/test_app.js
@@ -1354,6 +1354,37 @@ describe('File drag over notification system', function() {
           app.env.get('socket_url'),
           'ws://example.net:71070/ws/environment/1234-1234/api');
     });
+
+    it('uses an explicitly provided socket path', function() {
+      app = new Y.juju.App({
+        container: container,
+        viewContainer: container,
+        socket_path: '/these/are/the/voyages',
+        jujuCoreVersion: '1.21.1.1-trusty-amd64',
+        jujuEnvUUID: '1234-1234',
+        conn: {close: function() {}}
+      });
+      app.showView(new Y.View());
+      assert.equal(
+          app.env.get('socket_url'),
+          'wss://example.net:71070/these/are/the/voyages');
+    });
+
+    it('ignores socket path if empty', function() {
+      app = new Y.juju.App({
+        container: container,
+        viewContainer: container,
+        socket_path: '',
+        jujuCoreVersion: '1.21.1.1-trusty-amd64',
+        jujuEnvUUID: '1234-1234',
+        conn: {close: function() {}}
+      });
+      app.showView(new Y.View());
+      assert.equal(
+          app.env.get('socket_url'),
+          'wss://example.net:71070/ws/environment/1234-1234/api');
+    });
+
   });
 
 })();

--- a/jujugui/tests/test_options.py
+++ b/jujugui/tests/test_options.py
@@ -10,37 +10,48 @@ from jujugui import options
 class TestUpdate(unittest.TestCase):
 
     default_settings = {
+        'jujugui.auth': None,
+        'jujugui.baseUrl': None,
         'jujugui.charmstore_url': options.DEFAULT_CHARMSTORE_URL,
-        'jujugui.ga_key': '',
-        'jujugui.sandbox': False,
-        'jujugui.raw': False,
         'jujugui.combine': True,
+        'jujugui.ga_key': '',
+        'jujugui.password': None,
+        'jujugui.raw': False,
+        'jujugui.sandbox': False,
+        'jujugui.socket_path': None,
+        'jujugui.user': '',
     }
 
     def test_default_values(self):
         settings = {}
         options.update(settings)
         defaults = deepcopy(self.default_settings)
-        defaults['jujugui.baseUrl'] = None
-        defaults['jujugui.auth'] = None
         self.assertEqual(defaults, settings)
 
     def test_customized_values(self):
         expected_settings = {
+            'jujugui.auth': 'blob',
+            'jujugui.baseUrl': '/another/url',
             'jujugui.charmstore_url': 'https://1.2.3.4/api/',
-            'jujugui.ga_key': 'my-key',
-            'jujugui.sandbox': True,
-            'jujugui.raw': False,
             'jujugui.combine': True,
-            'jujugui.baseUrl': None,
-            'jujugui.auth': None,
+            'jujugui.ga_key': 'my-key',
+            'jujugui.password': 'Secret!',
+            'jujugui.raw': False,
+            'jujugui.sandbox': True,
+            'jujugui.socket_path': '1.2.3.4:17070',
+            'jujugui.user': 'who',
         }
         settings = {
+            'jujugui.auth': 'blob',
+            'jujugui.baseUrl': '/another/url',
             'jujugui.charmstore_url': 'https://1.2.3.4/api/',
-            'jujugui.ga_key': 'my-key',
-            'jujugui.sandbox': 'on',
-            'jujugui.raw': 'off',
             'jujugui.combine': 'true',
+            'jujugui.ga_key': 'my-key',
+            'jujugui.password': 'Secret!',
+            'jujugui.raw': 'off',
+            'jujugui.sandbox': 'on',
+            'jujugui.socket_path': '1.2.3.4:17070',
+            'jujugui.user': 'who',
         }
         options.update(settings)
         self.assertEqual(expected_settings, settings)
@@ -49,8 +60,6 @@ class TestUpdate(unittest.TestCase):
         settings = dict((k, '') for k in self.default_settings)
         options.update(settings)
         defaults = deepcopy(self.default_settings)
-        defaults['jujugui.baseUrl'] = None
-        defaults['jujugui.auth'] = None
         self.assertEqual(defaults, settings)
 
     def test_none_returned(self):

--- a/jujugui/views.py
+++ b/jujugui/views.py
@@ -69,8 +69,13 @@ def config(request):
     settings = request.registry.settings
     request.response.content_type = 'application/javascript'
     sandbox_enabled = settings['jujugui.sandbox']
+    # If sandbox is enabled then set the password to "admin" so that the
+    # Juju GUI will automatically log in.
+    user, password = 'user-admin', 'admin'
+    if not sandbox_enabled:
+        user, password = settings['jujugui.user'], settings['jujugui.password']
     env_uuid = request.matchdict.get('uuid', 'sandbox')
-    baseUrl = settings.get('jujugui.baseUrl')
+    baseUrl = settings['jujugui.baseUrl']
     if baseUrl is None:
         if env_uuid == 'sandbox':
             baseUrl = ''
@@ -78,7 +83,7 @@ def config(request):
             baseUrl = '/u/anonymous/{}'.format(env_uuid)
     options = {
         # Base YUI options.
-        'auth': settings.get('jujugui.auth'),
+        'auth': settings['jujugui.auth'],
         'serverRouting': False,
         'html5': True,
         'container': '#main',
@@ -93,10 +98,9 @@ def config(request):
         'charmstoreURL': settings['jujugui.charmstore_url'],
         # WebSocket connection to the Juju API.
         'socket_protocol': 'wss',
-        'user': 'user-admin',
-        # If sandbox is enabled then set the password to "admin" so that the
-        # Juju GUI will automatically log in.
-        'password': 'admin' if sandbox_enabled else None,
+        'socket_path': settings['jujugui.socket_path'],
+        'user': user,
+        'password': password,
         'jujuEnvUUID': request.matchdict.get('uuid', 'sandbox'),
         # Enable/disable sandbox (demonstration) mode.
         'sandbox': sandbox_enabled,

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ requires = [
     ]
 
 setup(name='jujugui',
-      version='0.0.2',
+      version='0.0.3',
       description='jujugui',
       classifiers=[
         "Programming Language :: Python",


### PR DESCRIPTION
The socket_path config option can be used to explicitly set the path to use for the WebSocket connection to the Juju API.

Also allow user and password to be set via the wsgi app ini configuration file.
Bump version up to 0.0.3.
