### PR TITLE
Move unit status parsing to utils.

### DIFF
--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -757,6 +757,7 @@ YUI.add('juju-gui', function(Y) {
       @param {Array} services Array of service models.
     */
     _renderAddedServices: function(services) {
+      var utils = views.utils;
       var services = this.db.services.toArray();
       React.render(
         <components.Panel
@@ -764,6 +765,7 @@ YUI.add('juju-gui', function(Y) {
           visible={services.length > 0}>
           <components.AddedServicesList
             services={services}
+            getUnitStatusCounts={utils.getUnitStatusCounts.bind(this)}
             changeState={this.changeState.bind(this)} />
         </components.Panel>,
         document.getElementById('inspector-container'));
@@ -810,6 +812,7 @@ YUI.add('juju-gui', function(Y) {
             clearState={utils.clearState.bind(
                 this, this.views.environment.instance.topo)}
             changeState={this.changeState.bind(this)}
+            getUnitStatusCounts={utils.getUnitStatusCounts.bind(this)}
             appState={state.get('current')}
             appPreviousState={state.get('previous')} />
         </components.Panel>,

--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -765,7 +765,7 @@ YUI.add('juju-gui', function(Y) {
           visible={services.length > 0}>
           <components.AddedServicesList
             services={services}
-            getUnitStatusCounts={utils.getUnitStatusCounts.bind(this)}
+            getUnitStatusCounts={utils.getUnitStatusCounts}
             changeState={this.changeState.bind(this)} />
         </components.Panel>,
         document.getElementById('inspector-container'));
@@ -812,7 +812,7 @@ YUI.add('juju-gui', function(Y) {
             clearState={utils.clearState.bind(
                 this, this.views.environment.instance.topo)}
             changeState={this.changeState.bind(this)}
-            getUnitStatusCounts={utils.getUnitStatusCounts.bind(this)}
+            getUnitStatusCounts={utils.getUnitStatusCounts}
             appState={state.get('current')}
             appPreviousState={state.get('previous')} />
         </components.Panel>,

--- a/jujugui/static/gui/src/app/components/added-services-list-item/added-services-list-item.js
+++ b/jujugui/static/gui/src/app/components/added-services-list-item/added-services-list-item.js
@@ -26,27 +26,11 @@ YUI.add('added-services-list-item', function() {
       Parses the supplied unit data to return the status color and number
       to display.
 
-      @method _parseStatusData
+      @method _getPriorityUnits
       @param {Array} units An array of units.
     */
-    _parseStatusData: function(units) {
-      var unitStatuses = {
-        uncommitted: { priority: 3, size: 0 },
-        started: { priority: 2, size: 0 },
-        pending: { priority: 1, size: 0 },
-        error: { priority: 0, size: 0 },
-      };
-      var agentState;
-      units.forEach(function(unit) {
-        agentState = unit.agent_state || 'uncommitted';
-        // If we don't have it in our status list then add it to the end
-        // with a very low priority.
-        if (!unitStatuses[agentState]) {
-          unitStatuses[agentState] = { priority: 99, size: 0 };
-        }
-        unitStatuses[agentState].size += 1;
-      });
-
+    _getPriorityUnits: function(units) {
+      var unitStatuses = this.props.getUnitStatusCounts(units);
       var top = { priority: 99, key: '', size: 0 };
       var status;
       for (var key in unitStatuses) {
@@ -101,7 +85,7 @@ YUI.add('added-services-list-item', function() {
 
     render: function() {
       var service = this.props.service.getAttrs();
-      var statusData = this._parseStatusData(service.units.toArray());
+      var statusData = this._getPriorityUnits(service.units.toArray());
       var statusIndicator = this._renderStatusIndicator(statusData);
       return (
         <li className="inspector-view__list-item"

--- a/jujugui/static/gui/src/app/components/added-services-list-item/test-added-services-list-item.js
+++ b/jujugui/static/gui/src/app/components/added-services-list-item/test-added-services-list-item.js
@@ -32,6 +32,15 @@ describe('AddedServicesListItem', function() {
     YUI().use('added-services-list-item', function() { done(); });
   });
 
+  function getUnitStatusCounts(error=0, pending=0, uncommitted=0, started=0) {
+    return sinon.stub().returns({
+      error: {size: error, priority: 0},
+      pending: {size: pending, priority: 1},
+      uncommitted: {size: uncommitted, priority: 3},
+      started: {size: started, priority: 2}
+    });
+  }
+
   it('renders the icon, count and display name', function() {
     var service = {
       getAttrs: function() {
@@ -46,6 +55,7 @@ describe('AddedServicesListItem', function() {
     var shallowRenderer = testUtils.createRenderer();
     shallowRenderer.render(
         <juju.components.AddedServicesListItem
+          getUnitStatusCounts={getUnitStatusCounts()}
           service={service} />);
 
     var output = shallowRenderer.getRenderOutput();
@@ -58,13 +68,13 @@ describe('AddedServicesListItem', function() {
 
   it('only shows the status icon for pending, uncommitted, error', function() {
     var statuses = [{
-      name: 'started', icon: false
+      name: 'started', icon: false, statusCounts: getUnitStatusCounts(0, 0, 0, 1)
     }, {
-      name: 'uncommitted', icon: true
+      name: 'uncommitted', icon: true, statusCounts: getUnitStatusCounts(0, 0, 1)
     }, {
-      name: 'pending', icon: true
+      name: 'pending', icon: true, statusCounts: getUnitStatusCounts(0, 1)
     }, {
-      name: 'error', icon: true
+      name: 'error', icon: true, statusCounts: getUnitStatusCounts(1)
     }];
 
     // Generate what the icon should look like depending on the value in
@@ -91,6 +101,7 @@ describe('AddedServicesListItem', function() {
       var shallowRenderer = testUtils.createRenderer();
       shallowRenderer.render(
           <juju.components.AddedServicesListItem
+            getUnitStatusCounts={status.statusCounts}
             service={service} />);
 
       var output = shallowRenderer.getRenderOutput();
@@ -116,6 +127,7 @@ describe('AddedServicesListItem', function() {
     var shallowRenderer = testUtils.createRenderer();
     shallowRenderer.render(
         <juju.components.AddedServicesListItem
+          getUnitStatusCounts={getUnitStatusCounts()}
           service={service} />);
 
     var output = shallowRenderer.getRenderOutput();
@@ -140,6 +152,7 @@ describe('AddedServicesListItem', function() {
     var shallowRenderer = testUtils.createRenderer();
     shallowRenderer.render(
         <juju.components.AddedServicesListItem
+          getUnitStatusCounts={getUnitStatusCounts(1, 1, 0)}
           service={service} />);
 
     var output = shallowRenderer.getRenderOutput();
@@ -164,6 +177,7 @@ describe('AddedServicesListItem', function() {
     var shallowRenderer = testUtils.createRenderer();
     shallowRenderer.render(
         <juju.components.AddedServicesListItem
+          getUnitStatusCounts={getUnitStatusCounts(0, 1, 1)}
           service={service} />);
 
     var output = shallowRenderer.getRenderOutput();
@@ -189,6 +203,7 @@ describe('AddedServicesListItem', function() {
     var component = shallowRenderer.render(
         <juju.components.AddedServicesListItem
           changeState={changeStub}
+          getUnitStatusCounts={getUnitStatusCounts()}
           service={service} />);
     var output = shallowRenderer.getRenderOutput();
     output.props.onClick({

--- a/jujugui/static/gui/src/app/components/added-services-list-item/test-added-services-list-item.js
+++ b/jujugui/static/gui/src/app/components/added-services-list-item/test-added-services-list-item.js
@@ -68,13 +68,17 @@ describe('AddedServicesListItem', function() {
 
   it('only shows the status icon for pending, uncommitted, error', function() {
     var statuses = [{
-      name: 'started', icon: false, statusCounts: getUnitStatusCounts(0, 0, 0, 1)
+      name: 'started', icon: false,
+      statusCounts: getUnitStatusCounts(0, 0, 0, 1)
     }, {
-      name: 'uncommitted', icon: true, statusCounts: getUnitStatusCounts(0, 0, 1)
+      name: 'uncommitted', icon: true, statusCounts:
+      getUnitStatusCounts(0, 0, 1)
     }, {
-      name: 'pending', icon: true, statusCounts: getUnitStatusCounts(0, 1)
+      name: 'pending', icon: true,
+      statusCounts: getUnitStatusCounts(0, 1)
     }, {
-      name: 'error', icon: true, statusCounts: getUnitStatusCounts(1)
+      name: 'error', icon: true,
+      statusCounts: getUnitStatusCounts(1)
     }];
 
     // Generate what the icon should look like depending on the value in

--- a/jujugui/static/gui/src/app/components/added-services-list/added-services-list.js
+++ b/jujugui/static/gui/src/app/components/added-services-list/added-services-list.js
@@ -34,6 +34,7 @@ YUI.add('added-services-list', function() {
               // when they key changes.
               key={service.get('name')}
               changeState={this.props.changeState}
+              getUnitStatusCounts={this.props.getUnitStatusCounts}
               service={service} />);
       });
       return items;

--- a/jujugui/static/gui/src/app/components/added-services-list/test-added-services-list.js
+++ b/jujugui/static/gui/src/app/components/added-services-list/test-added-services-list.js
@@ -34,9 +34,11 @@ describe('AddedServicesList', function() {
     var changeState = 'changeStateCallable';
 
     var shallowRenderer = testUtils.createRenderer();
+    var getUnitStatusCounts = sinon.stub();
     shallowRenderer.render(
         <juju.components.AddedServicesList
           changeState={changeState}
+          getUnitStatusCounts={getUnitStatusCounts}
           services={services}/>);
 
     var output = shallowRenderer.getRenderOutput();
@@ -45,14 +47,17 @@ describe('AddedServicesList', function() {
         <juju.components.AddedServicesListItem
           key={services[0].get()}
           changeState={changeState}
+          getUnitStatusCounts={getUnitStatusCounts}
           service={services[0]} />
         <juju.components.AddedServicesListItem
           key={services[1].get()}
           changeState={changeState}
+          getUnitStatusCounts={getUnitStatusCounts}
           service={services[1]} />
         <juju.components.AddedServicesListItem
           key={services[2].get()}
           changeState={changeState}
+          getUnitStatusCounts={getUnitStatusCounts}
           service={services[2]} />
       </ul>);
   });

--- a/jujugui/static/gui/src/app/components/inspector/inspector.js
+++ b/jujugui/static/gui/src/app/components/inspector/inspector.js
@@ -63,6 +63,7 @@ YUI.add('inspector-component', function() {
               destroyService={this.props.destroyService}
               clearState={this.props.clearState}
               changeState={this.props.changeState}
+              getUnitStatusCounts={this.props.getUnitStatusCounts}
               service={service} />,
             backState: {
               sectionA: {

--- a/jujugui/static/gui/src/app/components/inspector/test-inspector.js
+++ b/jujugui/static/gui/src/app/components/inspector/test-inspector.js
@@ -43,10 +43,12 @@ describe('Inspector', function() {
     var shallowRenderer = testUtils.createRenderer();
     var clearState = sinon.stub();
     var destroyService = sinon.stub();
+    var getUnitStatusCounts = sinon.stub();
     shallowRenderer.render(
         <juju.components.Inspector
           service={service}
           destroyService={destroyService}
+          getUnitStatusCounts={getUnitStatusCounts}
           clearState={clearState}
           appState={appState}>
         </juju.components.Inspector>);
@@ -56,6 +58,7 @@ describe('Inspector', function() {
         <juju.components.ServiceOverview
           changeState={undefined}
           destroyService={destroyService}
+          getUnitStatusCounts={getUnitStatusCounts}
           clearState={clearState}
           service={service} />);
   });

--- a/jujugui/static/gui/src/app/components/service-overview/service-overview.js
+++ b/jujugui/static/gui/src/app/components/service-overview/service-overview.js
@@ -83,27 +83,6 @@ YUI.add('service-overview', function() {
       return items;
     },
 
-      /**
-        Parses the supplied unit data to return the status number.
-
-        @method _parseStatusData
-        @param {Array} units An array of units.
-      */
-      _parseStatusData: function(units) {
-        var unitStatuses = {
-          all: units.length,
-          uncommitted: 0,
-          pending: 0,
-          error: 0,
-        };
-        var agentState;
-        units.forEach(function(unit) {
-          agentState = unit.agent_state || 'uncommitted';
-          unitStatuses[agentState] += 1;
-        });
-        return unitStatuses;
-      },
-
     /**
       create the actions based on the provded service.
       @method _generateActions
@@ -112,7 +91,9 @@ YUI.add('service-overview', function() {
     */
     _generateActions: function(service) {
       var actions = [];
-      var statusCounts = this._parseStatusData(service.get('units').toArray());
+      var units = service.get('units').toArray();
+      var statusCounts = this.props.getUnitStatusCounts(units);
+      statusCounts.all = {size: units.length};
       var statuses = [{
           title: 'Units',
           key: 'all',
@@ -126,11 +107,10 @@ YUI.add('service-overview', function() {
         }, {
           title: 'Uncommitted',
           key: 'uncommitted'
-        }, {
       }];
       statuses.forEach(function(status) {
         var key = status.key;
-        var count = statusCounts[key];
+        var count = statusCounts[key].size;
         if (count > 0 || key === 'all') {
           actions.push({
             title: status.title,

--- a/jujugui/static/gui/src/app/components/service-overview/test-service-overview.js
+++ b/jujugui/static/gui/src/app/components/service-overview/test-service-overview.js
@@ -107,6 +107,7 @@ describe('ServiceOverview', function() {
 
     var output = jsTestUtils.shallowRender(
           <juju.components.ServiceOverview
+            getUnitStatusCounts={getUnitStatusCounts()}
             service={service}/>);
     assert.deepEqual(output.props.children[0].props.children[0],
       <juju.components.OverviewAction

--- a/jujugui/static/gui/src/app/components/service-overview/test-service-overview.js
+++ b/jujugui/static/gui/src/app/components/service-overview/test-service-overview.js
@@ -61,6 +61,14 @@ describe('ServiceOverview', function() {
     }
   }
 
+  function getUnitStatusCounts(error=0, pending=0, uncommitted=0) {
+    return sinon.stub().returns({
+      error: {size: error},
+      pending: {size: pending},
+      uncommitted: {size: uncommitted}
+    });
+  }
+
   it('shows the all units action', function() {
     var service = {
       get: function() {
@@ -73,6 +81,7 @@ describe('ServiceOverview', function() {
 
     var output = jsTestUtils.shallowRender(
           <juju.components.ServiceOverview
+            getUnitStatusCounts={getUnitStatusCounts()}
             service={service}/>);
     assert.deepEqual(output.props.children[0].props.children[0],
       <juju.components.OverviewAction
@@ -123,6 +132,7 @@ describe('ServiceOverview', function() {
     var changeState = sinon.stub();
     var output = jsTestUtils.shallowRender(
           <juju.components.ServiceOverview
+            getUnitStatusCounts={getUnitStatusCounts()}
             changeState={changeState}
             service={service} />);
     // call the action method which is passed to the child to make sure it
@@ -160,6 +170,7 @@ describe('ServiceOverview', function() {
       }};
     var output = jsTestUtils.shallowRender(
           <juju.components.ServiceOverview
+            getUnitStatusCounts={getUnitStatusCounts(0, 0, 2)}
             service={service}/>);
     assert.deepEqual(output.props.children[0].props.children[1],
       <juju.components.OverviewAction
@@ -184,6 +195,7 @@ describe('ServiceOverview', function() {
       }};
     var output = jsTestUtils.shallowRender(
           <juju.components.ServiceOverview
+            getUnitStatusCounts={getUnitStatusCounts(0, 1, 0)}
             service={service}/>);
     assert.deepEqual(output.props.children[0].props.children[1],
       <juju.components.OverviewAction
@@ -208,6 +220,7 @@ describe('ServiceOverview', function() {
       }};
     var output = jsTestUtils.shallowRender(
           <juju.components.ServiceOverview
+            getUnitStatusCounts={getUnitStatusCounts(1, 0, 0)}
             service={service}/>);
     assert.deepEqual(output.props.children[0].props.children[1],
       <juju.components.OverviewAction
@@ -224,6 +237,7 @@ describe('ServiceOverview', function() {
   it('renders the delete button', function() {
     var output = jsTestUtils.shallowRender(
       <juju.components.ServiceOverview
+        getUnitStatusCounts={getUnitStatusCounts()}
         service={fakeService} />);
     var buttons = [{
       title: 'Destroy',
@@ -237,6 +251,7 @@ describe('ServiceOverview', function() {
   it('renders the delete confirmation', function() {
     var output = jsTestUtils.shallowRender(
       <juju.components.ServiceOverview
+        getUnitStatusCounts={getUnitStatusCounts()}
         service={fakeService} />);
     var buttons = [
         {
@@ -263,6 +278,7 @@ describe('ServiceOverview', function() {
         'This cannot be undone.';
     var shallowRenderer = jsTestUtils.shallowRender(
       <juju.components.ServiceOverview
+        getUnitStatusCounts={getUnitStatusCounts()}
         service={fakeService} />, true);
     var output = shallowRenderer.getRenderOutput();
       var buttons = [
@@ -280,6 +296,7 @@ describe('ServiceOverview', function() {
     output.props.children[1].props.buttons[0].action();
     shallowRenderer.render(
       <juju.components.ServiceOverview
+        getUnitStatusCounts={getUnitStatusCounts()}
         service={fakeService} />);
     output = shallowRenderer.getRenderOutput();
     assert.deepEqual(output.props.children[2],
@@ -294,6 +311,7 @@ describe('ServiceOverview', function() {
         'This cannot be undone.';
     var shallowRenderer = jsTestUtils.shallowRender(
       <juju.components.ServiceOverview
+        getUnitStatusCounts={getUnitStatusCounts()}
         service={fakeService} />, true);
     var output = shallowRenderer.getRenderOutput();
       var buttons = [
@@ -313,6 +331,7 @@ describe('ServiceOverview', function() {
     output.props.children[2].props.buttons[0].action();
     shallowRenderer.render(
       <juju.components.ServiceOverview
+        getUnitStatusCounts={getUnitStatusCounts()}
         service={fakeService} />);
     output = shallowRenderer.getRenderOutput();
     assert.deepEqual(output.props.children[2],
@@ -331,6 +350,7 @@ describe('ServiceOverview', function() {
     var shallowRenderer = jsTestUtils.shallowRender(
       <juju.components.ServiceOverview
         destroyService={destroyService}
+        getUnitStatusCounts={getUnitStatusCounts()}
         clearState={clearState}
         changeState={changeState}
         service={fakeService} />, true);
@@ -355,6 +375,7 @@ describe('ServiceOverview', function() {
         destroyService={destroyService}
         clearState={clearState}
         changeState={changeState}
+        getUnitStatusCounts={getUnitStatusCounts()}
         service={fakeService} />);
     output = shallowRenderer.getRenderOutput();
     assert.deepEqual(output.props.children[2],
@@ -373,6 +394,7 @@ describe('ServiceOverview', function() {
         destroyService={destroyService}
         clearState={clearState}
         changeState={changeState}
+        getUnitStatusCounts={getUnitStatusCounts()}
         service={fakeService} />);
     // Simulate the confirm click.
     output.props.children[2].props.buttons[1].action();
@@ -386,6 +408,7 @@ describe('ServiceOverview', function() {
     var output = jsTestUtils.shallowRender(
       <juju.components.ServiceOverview
         destroyService={destroyService}
+        getUnitStatusCounts={getUnitStatusCounts()}
         clearState={clearState}
         changeState={changeState}
         service={fakeService} />);

--- a/jujugui/static/gui/src/app/views/utils.js
+++ b/jujugui/static/gui/src/app/views/utils.js
@@ -2367,6 +2367,33 @@ YUI.add('juju-view-utils', function(Y) {
       app.deployService(entity[0]);
     });
   };
+  /**
+
+    Calculate the number of units per status.
+
+    @method getUnitStatusCounts
+    @param {Array} units An array of units.
+    @returns {Object} The unit statuses.
+  */
+  utils.getUnitStatusCounts = function(units) {
+    var unitStatuses = {
+      uncommitted: { priority: 3, size: 0 },
+      started: { priority: 2, size: 0 },
+      pending: { priority: 1, size: 0 },
+      error: { priority: 0, size: 0 },
+    };
+    var agentState;
+    units.forEach(function(unit) {
+      agentState = unit.agent_state || 'uncommitted';
+      // If we don't have it in our status list then add it to the end
+      // with a very low priority.
+      if (!unitStatuses[agentState]) {
+        unitStatuses[agentState] = { priority: 99, size: 0 };
+      }
+      unitStatuses[agentState].size += 1;
+    });
+    return unitStatuses;
+  };
 
   /**
     Returns the real service name for the provided service ghost id.

--- a/jujugui/static/gui/src/test/test_utils.js
+++ b/jujugui/static/gui/src/test/test_utils.js
@@ -192,6 +192,26 @@ describe('utilities', function() {
     views.humanizeTimestamp(now + 600000).should.equal('10 minutes ago');
   });
 
+  it('generate a list of status by unit counts', function() {
+    var units = [
+      {id: 1, agent_state: 'started'},
+      {id: 2, agent_state: 'pending'},
+      {id: 3, agent_state: 'error'},
+      {id: 4},
+      {id: 5},
+      {id: 6, agent_state: 'started'},
+      {id: 7, agent_state: 'error'},
+      {id: 8, agent_state: 'error'},
+      {id: 9}
+    ];
+    assert.deepEqual(utils.getUnitStatusCounts(units), {
+      uncommitted: {priority: 3, size: 3},
+      started: {priority: 2, size: 2},
+      pending: {priority: 1, size: 1},
+      error: {priority: 0, size: 3}
+    });
+  });
+
 
   describe('getConstraints', function() {
     var customConstraints, genericConstraints,


### PR DESCRIPTION
Remove duplication of unit status parsing by moving the function to the utils.