### PR TITLE
Add units to subordinate services

### DIFF
--- a/development.ini
+++ b/development.ini
@@ -11,7 +11,7 @@ pyramid.default_locale_name = en
 
 jujugui.sandbox = true
 jujugui.raw = true
-jujugui.combine = true
+jujugui.combine = false
 
 # JEM/IdM connections
 jujugui.interactive_login = false

--- a/development.ini
+++ b/development.ini
@@ -11,7 +11,7 @@ pyramid.default_locale_name = en
 
 jujugui.sandbox = true
 jujugui.raw = true
-jujugui.combine = false
+jujugui.combine = true
 
 # JEM/IdM connections
 jujugui.interactive_login = false

--- a/jujugui/static/gui/src/app/components/inspector/inspector.js
+++ b/jujugui/static/gui/src/app/components/inspector/inspector.js
@@ -143,7 +143,7 @@ YUI.add('inspector-component', function() {
               sectionA: {
                 component: 'inspector',
                 metadata: {
-                  id: serviceId,
+                  id: previousMetadata.id || serviceId,
                   activeComponent: previousComponent || 'units',
                   unit: null,
                   unitStatus: unitStatus

--- a/jujugui/static/gui/src/app/components/inspector/inspector.js
+++ b/jujugui/static/gui/src/app/components/inspector/inspector.js
@@ -121,12 +121,16 @@ YUI.add('inspector-component', function() {
               serviceId + '/' + unitId);
           var unitStatus = null;
           var previousComponent;
+          var id;
           if (previousMetadata) {
             var units = previousMetadata.units;
             previousComponent = previousMetadata.activeComponent;
             // A unit status of 'true' is provided when there is no status, but
             // we don't want to pass that on as the status value.
             unitStatus = units === true ? null : units;
+            id = previousMetadata.id;
+          } else {
+            id = serviceId;
           }
           state.activeChild = {
             title: unit.displayName,
@@ -143,7 +147,7 @@ YUI.add('inspector-component', function() {
               sectionA: {
                 component: 'inspector',
                 metadata: {
-                  id: previousMetadata.id || serviceId,
+                  id: id,
                   activeComponent: previousComponent || 'units',
                   unit: null,
                   unitStatus: unitStatus

--- a/jujugui/static/gui/src/app/components/inspector/test-inspector.js
+++ b/jujugui/static/gui/src/app/components/inspector/test-inspector.js
@@ -189,7 +189,8 @@ describe('Inspector', function() {
       sectionA: {
         metadata: {
           activeComponent: 'units',
-          units: 'error'
+          units: 'error',
+          id: 'demo'
         }}};
     var output = jsTestUtils.shallowRender(
         <juju.components.Inspector

--- a/jujugui/static/gui/src/app/components/inspector/test-inspector.js
+++ b/jujugui/static/gui/src/app/components/inspector/test-inspector.js
@@ -251,6 +251,54 @@ describe('Inspector', function() {
           }}});
   });
 
+  it('goes back to the previous service from unit details', function() {
+    // Subordinates show the services unit that it's placed on so viewing
+    // that unit will take you to another services inspector. This test
+    // makes sure that if the previous service was different then 'back'
+    // takes to you to that service.
+    var destroyUnits = sinon.stub();
+    var changeState = sinon.stub();
+    var getStub = sinon.stub();
+    getStub.withArgs('id').returns('demo');
+    getStub.withArgs('units').returns({getById: function() {
+      return 'unit';
+    }});
+    var service = {
+      get: getStub
+    };
+    var appState = {
+      sectionA: {
+        metadata: {
+          activeComponent: 'unit',
+          unit: '5'
+        }}};
+    var appPreviousState = {
+      sectionA: {
+        metadata: {
+          id: 'previousService',
+          units: true
+        }}};
+    var output = jsTestUtils.shallowRender(
+        <juju.components.Inspector
+          service={service}
+          destroyUnits={destroyUnits}
+          changeState={changeState}
+          appPreviousState={appPreviousState}
+          appState={appState}>
+        </juju.components.Inspector>);
+    output.props.children[0].props.backCallback();
+    assert.equal(changeState.callCount, 1);
+    assert.deepEqual(changeState.args[0][0], {
+        sectionA: {
+          component: 'inspector',
+          metadata: {
+            id: 'previousService',
+            activeComponent: 'units',
+            unit: null,
+            unitStatus: null
+          }}});
+  });
+
   it('displays the Scale Service when the app state calls for it', function() {
     var appPreviousState = sinon.stub();
     var getStub = sinon.stub();

--- a/jujugui/static/gui/src/app/components/unit-list/test-unit-list.js
+++ b/jujugui/static/gui/src/app/components/unit-list/test-unit-list.js
@@ -231,6 +231,39 @@ describe('UnitList', () => {
     });
   });
 
+  it('navigates to the remote service unit when a list item is clicked', () => {
+    // A subordinate shows the remote service unit.
+    var units = [{
+      displayName: 'wordpress/5',
+      id: 'wordpress/5'
+    }];
+    var changeState = sinon.stub();
+    var output = jsTestUtils.shallowRender(
+        <juju.components.UnitList
+          changeState={changeState}
+          serviceId="nrpe"
+          unitStatus={null}
+          units={units} />);
+    output.props.children[1].props.children[1].props.action({
+      currentTarget: {
+        getAttribute: function() {
+          return 'wordpress/5';
+        }
+      }
+    });
+    assert.equal(changeState.callCount, 1);
+    assert.deepEqual(changeState.args[0][0], {
+      sectionA: {
+        component: 'inspector',
+        metadata: {
+          id: 'wordpress',
+          unit: '5',
+          activeComponent: 'unit'
+        }
+      }
+    });
+  });
+
   it('displays a remove button', function() {
     var output = jsTestUtils.shallowRender(
         <juju.components.UnitList

--- a/jujugui/static/gui/src/app/components/unit-list/unit-list.js
+++ b/jujugui/static/gui/src/app/components/unit-list/unit-list.js
@@ -83,13 +83,15 @@ YUI.add('unit-list', function() {
     */
     _unitItemAction: function(e) {
       var unitStatus = this.props.unitStatus;
-      var unitId = e.currentTarget.getAttribute('data-id').split('/')[1];
+      var unitParts = e.currentTarget.getAttribute('data-id').split('/');
       this.props.changeState({
         sectionA: {
           component: 'inspector',
           metadata: {
-            id: this.props.serviceId,
-            unit: unitId,
+            // This is done in parts like this because subordinate units show
+            // the service unit that it's placed on, not the subordinate itself.
+            id: unitParts[0], // Service Id
+            unit: unitParts[1], // Unit Id
             activeComponent: 'unit'
           }
         }

--- a/jujugui/static/gui/src/app/models/models.js
+++ b/jujugui/static/gui/src/app/models/models.js
@@ -274,7 +274,7 @@ YUI.add('juju-models', function(Y) {
       @method removeRelations
       @param {String} relationId The id of the relation to remove.
     */
-    removeRelations: function(relationId) {
+    removeRelations: function(relationId, db) {
       var relations = this.get('relations');
       relations.some(function(rel) {
         if (rel.get('relation_id') === relationId) {
@@ -284,33 +284,61 @@ YUI.add('juju-models', function(Y) {
       });
     },
 
-    getOtherServiceFromRelation: function(relation) {
+    /**
+    Given a relation between two services (this one and one other), return the
+    service on the other end of the relation.
+
+    @method getOtherServiceFromRelation
+    @param relation The relation to check
+    @param db The database of services and relations
+    @return The other service in the relation
+    */
+    getOtherServiceFromRelation: function(relation, db) {
       var endpoints = relation.get('endpoints');
+      if (!endpoints || endpoints.length !== 2) {
+        return;
+      }
       if (endpoints[0][0] === this.get('id')) {
         return db.services.getById(endpoints[1][0]);
       }
       return db.services.getById(endpoints[0][0]);
     },
 
-    updateSubordinateUnits: function(action, data) {
+    /**
+    Update the unit list for subordinate services with the units that they are
+    installed on.
+
+    @method updateSubordinateUnits
+    @param db The database of services, relations, and units
+    @param halt If true, do not continue on to update related services
+    */
+    updateSubordinateUnits: function(db, halt) {
       var relations = db.relations.get_relations_for_service(this);
-      debugger;
       if (this.get('subordinate')) {
-        // Update units on this
-        var units = [];
+        var units = new models.ServiceUnitList();
         relations.forEach(function(relation) {
-          var farService = this.getOtherServiceFromRelation(relation);
-          if (!farService.get('subordinate')) {
-            units.push(farService.get('units').toArray());
+          // Only count subordinate relations.
+          if (relation.get('scope') !== 'container') {
+            return;
           }
-        });
+          var farService = this.getOtherServiceFromRelation(relation, db);
+          if (farService && !farService.get('subordinate')) {
+            // As subordinate services' unit lists are only lists of other units
+            // services, we call add directly here, contrary to the note in the
+            // add method.  This remains dangerous in other instances.
+            units.add(farService.get('units').toArray(), true);
+          }
+        }.bind(this));
+        this.set('units', units);
       } else {
         relations.forEach(function(relation) {
-          var farService = this.getOtherServiceFromRelation(relation);
-          if (!farService.get('subordinate')) {
-            units.push(farService.get('units').toArray());
+          var farService = this.getOtherServiceFromRelation(relation, db);
+          if (farService && farService.get('subordinate') && !halt) {
+            // Run on the far service, but don't follow relations from that
+            // service to prevent infinite loops.
+            farService.updateSubordinateUnits(db, true);
           }
-        });
+        }.bind(this));
       }
     },
 
@@ -750,7 +778,7 @@ YUI.add('juju-models', function(Y) {
     */
     process_delta: function(action, data) {
       _process_delta(this, action, data, {exposed: false});
-    },
+    }
   });
 
   models.ServiceList = ServiceList;
@@ -908,7 +936,7 @@ YUI.add('juju-models', function(Y) {
       // Include the new change in the service own units model list.
       _process_delta(service.get('units'), action, data, {});
       // Also do for subordinates
-      service.updateSubordinateUnits(action, data);
+      service.updateSubordinateUnits(db);
     },
 
     _setDefaultsAndCalculatedValues: function(obj) {
@@ -1713,6 +1741,7 @@ YUI.add('juju-models', function(Y) {
             // first before trying to remove them
             if (service) {
               service.removeRelations(data);
+              service.updateSubordinateUnits(db);
             } else {
               // fixTests
               console.error('Relation added without matching service');
@@ -1728,7 +1757,8 @@ YUI.add('juju-models', function(Y) {
           // Because some of the tests add relations without services
           // it's possible that a service will be null
           if (service) {
-            _process_delta(service.get('relations'), action, data, {});
+            _process_delta(service.get('relations'), action, data, db);
+            service.updateSubordinateUnits(db);
           } else {
             // fixTests
             console.error('Relation added without matching service');
@@ -2132,7 +2162,10 @@ YUI.add('juju-models', function(Y) {
       var units = this.units;
       this.services.each(function(service) {
         units.update_service_unit_aggregates(service);
-      });
+        if (service.get('subordinate')) {
+          service.updateSubordinateUnits(this);
+        }
+      }.bind(this));
       this.fire('update');
     },
 
@@ -2655,11 +2688,14 @@ YUI.add('juju-models', function(Y) {
           unit.set(flag, value);
           dbUnit.set(flag, value);
         });
+        if (service.get('subordinate')) {
+          service.updateSubordinateUnits(this);
+        }
       }
       if (serviceOrServiceList instanceof models.ServiceList) {
-        serviceOrServiceList.each(updateOneService);
+        serviceOrServiceList.each(updateOneService.bind(this));
       } else {
-        updateOneService(serviceOrServiceList);
+        updateOneService.call(this, serviceOrServiceList);
       }
     },
 

--- a/jujugui/static/gui/src/app/models/models.js
+++ b/jujugui/static/gui/src/app/models/models.js
@@ -274,7 +274,7 @@ YUI.add('juju-models', function(Y) {
       @method removeRelations
       @param {String} relationId The id of the relation to remove.
     */
-    removeRelations: function(relationId, db) {
+    removeRelations: function(relationId) {
       var relations = this.get('relations');
       relations.some(function(rel) {
         if (rel.get('relation_id') === relationId) {
@@ -298,6 +298,9 @@ YUI.add('juju-models', function(Y) {
       if (!endpoints || endpoints.length !== 2) {
         return;
       }
+      // Endpoints do not differentiate which end which service is connected to,
+      // this returns the service at the oppostite end from the end that we
+      // check.
       if (endpoints[0][0] === this.get('id')) {
         return db.services.getById(endpoints[1][0]);
       }
@@ -1117,7 +1120,6 @@ YUI.add('juju-models', function(Y) {
      * delta, ensuring that they're up to date.
      */
     update_service_unit_aggregates: function(service) {
-      // TODO add units to subordinates
       var aggregate = this.get_informative_states_for_service(service);
       var sum = Y.Array.reduce(
           Y.Object.values(aggregate[0]), 0, function(a, b) {return a + b;});

--- a/jujugui/static/gui/src/test/test_env_change_set.js
+++ b/jujugui/static/gui/src/test/test_env_change_set.js
@@ -19,7 +19,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 'use strict';
 
 describe('Environment Change Set', function() {
-  var Y, ECS, ecs, envObj, dbObj, testUtils;
+  var Y, ECS, ecs, envObj, dbObj, models, testUtils;
 
   before(function(done) {
     var modules = [
@@ -30,13 +30,14 @@ describe('Environment Change Set', function() {
     Y = YUI(GlobalConfig).use(modules, function(Y) {
       ECS = Y.namespace('juju').EnvironmentChangeSet;
       testUtils = Y.namespace('juju-tests').utils;
+      models = Y.namespace('juju.models');
       done();
     });
     window.flags = { mv: true };
   });
 
   beforeEach(function() {
-    dbObj = {};
+    dbObj = new models.Database();
     ecs = new ECS({
       db: dbObj
     });
@@ -842,6 +843,7 @@ describe('Environment Change Set', function() {
       it('destroys create records for undeployed services', function() {
         var stubRemove = testUtils.makeStubFunction();
         var stubDestroy = testUtils.makeStubFunction();
+        var stubUpdateSubordinates = testUtils.makeStubFunction();
         var db = ecs.get('db');
         var fakeUnits = new Y.LazyModelList();
         fakeUnits.add({});
@@ -852,7 +854,8 @@ describe('Environment Change Set', function() {
               destroy: stubDestroy,
               get: function(key) {
                 if (key === 'units') { return fakeUnits; }
-              }
+              },
+              updateSubordinateUnits: stubUpdateSubordinates
             };
           }
         };
@@ -870,6 +873,8 @@ describe('Environment Change Set', function() {
             stubRemoveUnits.calledOnce(), true, 'remove units not called');
         assert.equal(db.relations.remove.calledOnce(), true,
             'remove relations not called');
+        assert.equal(stubUpdateSubordinates.calledOnce(), true,
+            'subordinate units not updated');
         assert.deepEqual(ecs.changeSet, {});
       });
 
@@ -1044,7 +1049,7 @@ describe('Environment Change Set', function() {
             '_translateKeysToIds');
         this._cleanups.push(translateStub.reset);
         var args = [[{}], done];
-        var key = ecs.lazyAddMachines(args);
+        var key = ecs.lazyAddMachines(args, {modelId: ''});
         var record = ecs.changeSet[key];
         assert.isObject(record);
         assert.isObject(record.command);
@@ -1091,6 +1096,17 @@ describe('Environment Change Set', function() {
     });
 
     describe('lazyAddUnits', function() {
+      var stubUpdateSubordinates;
+
+      beforeEach(function() {
+        stubUpdateSubordinates = testUtils.makeStubFunction();
+        ecs.get('db').services.getServiceByName = function() {
+          return {
+            updateSubordinateUnits: stubUpdateSubordinates
+          };
+        };
+      });
+
       it('creates a new `addUnits` record', function(done) {
         var args = ['mysql', 1, null, done];
         var key = ecs.lazyAddUnits(args);
@@ -1102,6 +1118,7 @@ describe('Environment Change Set', function() {
         var cb = record.command.args.pop();
         args.pop();
         assert.deepEqual(record.command.args, args);
+        assert.equal(stubUpdateSubordinates.calledOnce(), true);
         cb();
       });
 
@@ -1119,6 +1136,7 @@ describe('Environment Change Set', function() {
         var key = ecs.lazyAddUnits(args);
         var record = ecs.changeSet[key];
         assert.equal(record.parents[0], 'service-1');
+        assert.equal(stubUpdateSubordinates.calledOnce(), true);
       });
 
       it('creates a record with a queued machine', function() {
@@ -1134,6 +1152,7 @@ describe('Environment Change Set', function() {
         var key = ecs.lazyAddUnits(args);
         var record = ecs.changeSet[key];
         assert.equal(record.parents[0], 'addMachines-1');
+        assert.equal(stubUpdateSubordinates.calledOnce(), true);
       });
 
       it('updates the machine where to deploy on parent results', function() {
@@ -1145,6 +1164,7 @@ describe('Environment Change Set', function() {
         command.onParentResults(parentRecord, parentResults);
         // The unit will be added to the real machine.
         assert.strictEqual(command.args[2], '42');
+        assert.equal(stubUpdateSubordinates.calledOnce(), true);
       });
 
       it('updates the service and unit on parent results', function() {
@@ -1182,6 +1202,11 @@ describe('Environment Change Set', function() {
                            'service name not set properly');
         assert.equal(command.options.modelId, 'my-service/3',
                      'options model id not updated');
+        assert.equal(stubFinder.calledOnce(), true,
+                     'did not query DB for unit');
+        assert.equal(unit.service, 'my-service',
+                     'service name not updated on unit');
+       assert.equal(stubUpdateSubordinates.calledOnce(), true);
       });
 
     });
@@ -1286,6 +1311,12 @@ describe('Environment Change Set', function() {
             }
           }
         };
+        var stubUpdateSubordinates = testUtils.makeStubFunction();
+        ecs.get('db').services.getServiceByName = function() {
+          return {
+            updateSubordinateUnits: stubUpdateSubordinates
+          };
+        };
         var args = [['serviceId1$', ['db', 'client']],
               ['serviceId2$', ['db', 'server']]];
         var key = ecs._lazyAddRelation(args);
@@ -1306,6 +1337,7 @@ describe('Environment Change Set', function() {
         assert.equal(Y.Object.size(ecs.changeSet), 3);
         // Perform this last, as it will mutate ecs.changeSet.
         assert.equal(ecs._buildHierarchy(ecs.changeSet).length, 2);
+        assert.equal(stubUpdateSubordinates.calledOnce(), true);
       });
     });
 
@@ -1367,7 +1399,17 @@ describe('Environment Change Set', function() {
       it('can remove a ghost unit from the changeset', function() {
         ecs.get('db').removeUnits = testUtils.makeStubFunction();
         ecs.get('db').units = {
-          getById: testUtils.makeStubFunction()
+          getById: function() {
+            return {
+              service: 'foo'
+            };
+          }
+        };
+        var stubUpdateSubordinates = testUtils.makeStubFunction();
+        ecs.get('db').services.getServiceByName = function() {
+          return {
+            updateSubordinateUnits: stubUpdateSubordinates
+          };
         };
         ecs.changeSet['addUnit-982'] = {
           command: {
@@ -1379,6 +1421,7 @@ describe('Environment Change Set', function() {
         assert.strictEqual(record, undefined);
         assert.strictEqual(ecs.changeSet['addUnit-982'], undefined);
         assert.equal(remove.calledOnce(), true);
+        assert.equal(stubUpdateSubordinates.calledOnce(), true);
       });
 
       it('can add a remove unit record into the changeset', function() {

--- a/jujugui/static/gui/src/test/test_env_change_set.js
+++ b/jujugui/static/gui/src/test/test_env_change_set.js
@@ -60,6 +60,8 @@ describe('Environment Change Set', function() {
 
   after(function() {
     window.flags = {};
+    dbObj.reset();
+    dbObj.destroy();
   });
 
   describe('ECS methods', function() {
@@ -1174,9 +1176,7 @@ describe('Environment Change Set', function() {
           _idMap: {},
           fire: testUtils.makeStubFunction()
         };
-        db.services = {
-          getById: testUtils.makeStubFunction()
-        };
+        db.services.getById = testUtils.makeStubFunction();
         var unit = {
           id: '756482$/3',
           number: '3'
@@ -1202,10 +1202,6 @@ describe('Environment Change Set', function() {
                            'service name not set properly');
         assert.equal(command.options.modelId, 'my-service/3',
                      'options model id not updated');
-        assert.equal(stubFinder.calledOnce(), true,
-                     'did not query DB for unit');
-        assert.equal(unit.service, 'my-service',
-                     'service name not updated on unit');
        assert.equal(stubUpdateSubordinates.calledOnce(), true);
       });
 

--- a/jujugui/static/gui/src/test/test_model.js
+++ b/jujugui/static/gui/src/test/test_model.js
@@ -2293,6 +2293,63 @@ describe('test_model.js', function() {
         assert.deepEqual(django.get('environmentConfig'), {debug: 'bar'});
       });
     });
+
+    describe('updateSubordinateUnits', function() {
+      var db;
+      beforeEach(function() {
+        db = new models.Database();
+        db.services = list;
+        rails.set('subordinate', true);
+        db.addUnits({
+          id: 'mysql/0'
+        });
+        db.addUnits({
+          id: 'django/0'
+        });
+
+        db.relations.add([
+          {
+            id: 'rails:db mysql:db',
+            endpoints: [
+              ['mysql', {name: 'db', role: 'provider'}],
+              ['rails', {name: 'db', role: 'requirer'}]
+            ],
+            interface: 'mysql',
+            scope: 'container'
+          },
+          {
+            id: 'rails:sub django:sub',
+            endpoints: [
+              ['django', {name: 'sub', role: 'provider'}],
+              ['rails', {name: 'sub', role: 'requirer'}]
+            ],
+            interface: 'django',
+            scope: 'container'
+          },
+          {
+            id: 'rails:nonsub django:nonsub',
+            endpoints: [
+              ['django', {name: 'nonsub', role: 'provider'}],
+              ['rails', {name: 'nonsub', role: 'requirer'}]
+            ],
+            interface: 'django',
+            scope: 'global'
+          }
+        ]);
+      });
+
+      it('updates subordinate unit lists', function() {
+        assert.equal(rails.get('units').size(), 0);
+        rails.updateSubordinateUnits(db);
+        assert.equal(rails.get('units').size(), 2);
+      });
+
+      it('attempts to update opposite units if not subordinate', function() {
+        assert.equal(rails.get('units').size(), 0);
+        mysql.updateSubordinateUnits(db);
+        assert.equal(rails.get('units').size(), 2);
+      });
+    });
   });
 
   describe('db.charms.addFromCharmData', function() {


### PR DESCRIPTION
This branch ensures that subordinate services' unit lists contain lists of all of the units to which the subordinate has been deployed.

Note that, due to the nature of the ECS, this only applies to deployed units, not uncommitted, until we can figure out how to mark uncommitted relations as scoped to container.