### PR TITLE
Enable support for using Juju to get bundle changes.

### DIFF
--- a/jujugui/static/gui/src/app/store/env/sandbox.js
+++ b/jujugui/static/gui/src/app/store/env/sandbox.js
@@ -1180,7 +1180,7 @@ YUI.add('juju-env-sandbox', function(Y) {
       @param {Object} state An instance of FakeBackend.
     */
     handleChangeSetGetChanges: function(data, client, state) {
-      // The getChangeSet functionality still needs to be possible when
+      // The getBundleChanges functionality still needs to be possible when
       // deployed via charm and in sandbox mode.
       var ws = new Y.ReconnectingWebSocket(this.get('socket_url'));
       ws.onopen = this._changeSetWsOnOpen.bind(this, ws, data);

--- a/jujugui/static/gui/src/app/utils/bundle-importer.js
+++ b/jujugui/static/gui/src/app/utils/bundle-importer.js
@@ -124,7 +124,7 @@ YUI.add('bundle-importer', function(Y) {
       if (bundleYAML) {
         bundleYAML = this._ensureV4Format(bundleYAML);
       }
-      this.env.getChangeSet(
+      this.env.getBundleChanges(
           bundleYAML, changesToken, this._handleFetchDryRun.bind(this));
     },
 
@@ -135,17 +135,16 @@ YUI.add('bundle-importer', function(Y) {
       @param {Object} response The processed response data.
     */
     _handleFetchDryRun: function(response) {
-      if (response.err) {
+      if (response.errors && response.errors.length) {
         this.db.notifications.add({
           title: 'Error generating changeSet',
-          message: 'There was an error generating the changeSet. See browser' +
-              ' console for additional information',
+          message: 'The following errors occurred while retrieving bundle ' +
+              'changes: ' + response.errors.join(', '),
           level: 'error'
         });
-        console.error('Response', response);
         return;
       }
-      this.importBundleDryRun(response.changeSet);
+      this.importBundleDryRun(response.changes);
     },
 
     /**

--- a/jujugui/static/gui/src/test/test_bundle_importer.js
+++ b/jujugui/static/gui/src/test/test_bundle_importer.js
@@ -180,14 +180,14 @@ describe('Bundle Importer', function() {
 
     describe('fetchDryRun', function() {
 
-      it('calls to the env to get a changeset from a YAML', function() {
+      it('calls to the env to get bundle changes from a YAML', function() {
         var yaml = '{"services":{}}';
-        var getChangeSet = utils.makeStubMethod(
-            bundleImporter.env, 'getChangeSet');
-        this._cleanups.push(getChangeSet.reset);
+        var getBundleChanges = utils.makeStubMethod(
+            bundleImporter.env, 'getBundleChanges');
+        this._cleanups.push(getBundleChanges.reset);
         bundleImporter.fetchDryRun(yaml, null);
-        assert.equal(getChangeSet.callCount(), 1);
-        var args = getChangeSet.lastArguments();
+        assert.equal(getBundleChanges.callCount(), 1);
+        var args = getBundleChanges.lastArguments();
         assert.equal(args.length, 3);
         assert.equal(args[0], yaml);
         assert.strictEqual(args[1], null);
@@ -195,42 +195,42 @@ describe('Bundle Importer', function() {
 
       it('ensures v4 format on import', function() {
         var yaml = '{"foo":{"services":{}}}';
-        var getChangeSet = utils.makeStubMethod(
-            bundleImporter.env, 'getChangeSet');
-        this._cleanups.push(getChangeSet.reset);
+        var getBundleChanges = utils.makeStubMethod(
+            bundleImporter.env, 'getBundleChanges');
+        this._cleanups.push(getBundleChanges.reset);
         bundleImporter.fetchDryRun(yaml, null);
-        assert.equal(getChangeSet.callCount(), 1);
-        var args = getChangeSet.lastArguments();
+        assert.equal(getBundleChanges.callCount(), 1);
+        var args = getBundleChanges.lastArguments();
         assert.equal(args.length, 3);
         assert.equal(args[0], '{"services":{}}');
         assert.strictEqual(args[1], null);
       });
 
-      it('calls to the env to get a changeset from a token', function() {
+      it('calls to the env to get bundle changes from a token', function() {
         var token = 'foo';
-        var getChangeSet = utils.makeStubMethod(
-            bundleImporter.env, 'getChangeSet');
-        this._cleanups.push(getChangeSet.reset);
+        var getBundleChanges = utils.makeStubMethod(
+            bundleImporter.env, 'getBundleChanges');
+        this._cleanups.push(getBundleChanges.reset);
         bundleImporter.fetchDryRun(null, token);
-        assert.equal(getChangeSet.callCount(), 1);
-        var args = getChangeSet.lastArguments();
+        assert.equal(getBundleChanges.callCount(), 1);
+        var args = getBundleChanges.lastArguments();
         assert.equal(args.length, 3);
         assert.strictEqual(args[0], null);
         assert.equal(args[1], token);
       });
 
-      it('has a callback which calls to import the dryrun', function() {
+      it('has a callback which calls to import the dry run', function() {
         var yaml = 'foo';
         var dryRun = utils.makeStubMethod(bundleImporter, 'importBundleDryRun');
-        var getChangeSet = utils.makeStubMethod(
-            bundleImporter.env, 'getChangeSet');
-        this._cleanups.concat([dryRun.reset, getChangeSet.reset]);
-        var changeSet = { foo: 'bar' };
+        var getBundleChanges = utils.makeStubMethod(
+            bundleImporter.env, 'getBundleChanges');
+        this._cleanups.concat([dryRun.reset, getBundleChanges.reset]);
+        var changes = [{foo: 'bar'}];
         bundleImporter.fetchDryRun(yaml);
-        var callback = getChangeSet.lastArguments()[2];
-        callback({changeSet: changeSet});
+        var callback = getBundleChanges.lastArguments()[2];
+        callback({changes: changes});
         assert.equal(dryRun.callCount(), 1);
-        assert.deepEqual(dryRun.lastArguments()[0], changeSet);
+        assert.deepEqual(dryRun.lastArguments()[0], changes);
       });
     });
   });

--- a/setup.py
+++ b/setup.py
@@ -2,24 +2,25 @@ import os
 
 from setuptools import setup, find_packages
 
-here = os.path.abspath(os.path.dirname(__file__))
 
+here = os.path.abspath(os.path.dirname(__file__))
 requires = [
     'pyramid',
     'pyramid_mako',
     'waitress',
     'convoy',
-    ]
+]
+
 
 setup(name='jujugui',
-      version='0.0.5',
+      version='0.0.6',
       description='jujugui',
       classifiers=[
-        "Programming Language :: Python",
-        "Framework :: Pyramid",
-        "Topic :: Internet :: WWW/HTTP",
-        "Topic :: Internet :: WWW/HTTP :: WSGI :: Application",
-        ],
+          "Programming Language :: Python",
+          "Framework :: Pyramid",
+          "Topic :: Internet :: WWW/HTTP",
+          "Topic :: Internet :: WWW/HTTP :: WSGI :: Application",
+      ],
       author='Juju UI Engineering Team',
       url='http://github.com/juju/juju-gui',
       packages=find_packages(),


### PR DESCRIPTION
Also fall back to GUI server endpoints if Juju bundle
deployment is not available.