### PR TITLE
Create new target to speed up babel builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,10 +107,13 @@ $(MODULESMIN): $(NODE_MODULES) $(PYRAMID) $(BUILT_RAWJSFILES) $(MIN_JS_FILES) $(
 .PHONY: modules-js
 modules-js: $(MODULESMIN)
 
-# The build-js target is used to build and minify only the js files that have
-# changed since the last time they were built.
-.PHONY: build-js
-build-js: $(BUILT_RAWJSFILES) $(MIN_JS_FILES)
+# fast-babel is simply passed an input and output folder which dramatically
+# speeds up the build time because it doesn't need to spin up a new instance
+# for every file.
+.PHONE: fast-babel
+fast-babel:
+	$(NODE_MODULES)/.bin/babel $(GUISRC)/app --out-dir $(GUIBUILD)/app \
+		--ignore /assets/javascripts/
 
 $(GUIBUILD)/app/%-min.js: $(GUIBUILD)/app/%.js $(NODE_MODULES)
 	$(NODE_MODULES)/.bin/uglifyjs --screw-ie8 $(GUIBUILD)/app/$*.js -o $@
@@ -289,7 +292,7 @@ check: clean-pyc lint lint-js test test-js-phantom test-js-karma
 
 # ci-check is the target run by CI.
 .PHONY: ci-check
-ci-check: clean-downloadcache deps check test-selenium
+ci-check: clean-downloadcache deps fast-babel check test-selenium
 
 ###########
 # Packaging

--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ modules-js: $(MODULESMIN)
 # speeds up the build time because it doesn't need to spin up a new instance
 # for every file.
 .PHONE: fast-babel
-fast-babel:
+fast-babel: $(NODE_MODULES)
 	$(NODE_MODULES)/.bin/babel $(GUISRC)/app --out-dir $(GUIBUILD)/app \
 		--ignore /assets/javascripts/
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3,252 +3,228 @@
   "version": "0.1.0",
   "dependencies": {
     "babel": {
-      "version": "5.8.21",
-      "from": "https://registry.npmjs.org/babel/-/babel-5.8.21.tgz",
-      "resolved": "https://registry.npmjs.org/babel/-/babel-5.8.21.tgz",
+      "version": "5.8.23",
+      "from": "babel@5.8.23",
+      "resolved": "https://registry.npmjs.org/babel/-/babel-5.8.23.tgz",
       "dependencies": {
         "babel-core": {
-          "version": "5.8.22",
-          "from": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.22.tgz",
-          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.22.tgz",
+          "version": "5.8.25",
+          "from": "babel-core@^5.6.21",
+          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.25.tgz",
           "dependencies": {
             "babel-plugin-constant-folding": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz",
+              "from": "babel-plugin-constant-folding@^1.0.1",
               "resolved": "https://registry.npmjs.org/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz"
             },
             "babel-plugin-dead-code-elimination": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz",
+              "from": "babel-plugin-dead-code-elimination@^1.0.2",
               "resolved": "https://registry.npmjs.org/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz"
             },
             "babel-plugin-eval": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz",
+              "from": "babel-plugin-eval@^1.0.1",
               "resolved": "https://registry.npmjs.org/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz"
             },
             "babel-plugin-inline-environment-variables": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/babel-plugin-inline-environment-variables/-/babel-plugin-inline-environment-variables-1.0.1.tgz",
+              "from": "babel-plugin-inline-environment-variables@^1.0.1",
               "resolved": "https://registry.npmjs.org/babel-plugin-inline-environment-variables/-/babel-plugin-inline-environment-variables-1.0.1.tgz"
             },
             "babel-plugin-jscript": {
               "version": "1.0.4",
-              "from": "https://registry.npmjs.org/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz",
+              "from": "babel-plugin-jscript@^1.0.4",
               "resolved": "https://registry.npmjs.org/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz"
             },
             "babel-plugin-member-expression-literals": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/babel-plugin-member-expression-literals/-/babel-plugin-member-expression-literals-1.0.1.tgz",
+              "from": "babel-plugin-member-expression-literals@^1.0.1",
               "resolved": "https://registry.npmjs.org/babel-plugin-member-expression-literals/-/babel-plugin-member-expression-literals-1.0.1.tgz"
             },
             "babel-plugin-property-literals": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/babel-plugin-property-literals/-/babel-plugin-property-literals-1.0.1.tgz",
+              "from": "babel-plugin-property-literals@^1.0.1",
               "resolved": "https://registry.npmjs.org/babel-plugin-property-literals/-/babel-plugin-property-literals-1.0.1.tgz"
             },
             "babel-plugin-proto-to-assign": {
               "version": "1.0.4",
-              "from": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz",
+              "from": "babel-plugin-proto-to-assign@^1.0.3",
               "resolved": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz"
             },
             "babel-plugin-react-constant-elements": {
               "version": "1.0.3",
-              "from": "https://registry.npmjs.org/babel-plugin-react-constant-elements/-/babel-plugin-react-constant-elements-1.0.3.tgz",
+              "from": "babel-plugin-react-constant-elements@^1.0.3",
               "resolved": "https://registry.npmjs.org/babel-plugin-react-constant-elements/-/babel-plugin-react-constant-elements-1.0.3.tgz"
             },
             "babel-plugin-react-display-name": {
               "version": "1.0.3",
-              "from": "https://registry.npmjs.org/babel-plugin-react-display-name/-/babel-plugin-react-display-name-1.0.3.tgz",
+              "from": "babel-plugin-react-display-name@^1.0.3",
               "resolved": "https://registry.npmjs.org/babel-plugin-react-display-name/-/babel-plugin-react-display-name-1.0.3.tgz"
             },
             "babel-plugin-remove-console": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/babel-plugin-remove-console/-/babel-plugin-remove-console-1.0.1.tgz",
+              "from": "babel-plugin-remove-console@^1.0.1",
               "resolved": "https://registry.npmjs.org/babel-plugin-remove-console/-/babel-plugin-remove-console-1.0.1.tgz"
             },
             "babel-plugin-remove-debugger": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/babel-plugin-remove-debugger/-/babel-plugin-remove-debugger-1.0.1.tgz",
+              "from": "babel-plugin-remove-debugger@^1.0.1",
               "resolved": "https://registry.npmjs.org/babel-plugin-remove-debugger/-/babel-plugin-remove-debugger-1.0.1.tgz"
             },
             "babel-plugin-runtime": {
               "version": "1.0.7",
-              "from": "https://registry.npmjs.org/babel-plugin-runtime/-/babel-plugin-runtime-1.0.7.tgz",
+              "from": "babel-plugin-runtime@^1.0.7",
               "resolved": "https://registry.npmjs.org/babel-plugin-runtime/-/babel-plugin-runtime-1.0.7.tgz"
             },
             "babel-plugin-undeclared-variables-check": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz",
+              "from": "babel-plugin-undeclared-variables-check@^1.0.2",
               "resolved": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz",
               "dependencies": {
                 "leven": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz",
+                  "from": "leven@^1.0.2",
                   "resolved": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz"
                 }
               }
             },
             "babel-plugin-undefined-to-void": {
               "version": "1.1.6",
-              "from": "https://registry.npmjs.org/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz",
+              "from": "babel-plugin-undefined-to-void@^1.1.6",
               "resolved": "https://registry.npmjs.org/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz"
             },
             "babylon": {
-              "version": "5.8.22",
-              "from": "https://registry.npmjs.org/babylon/-/babylon-5.8.22.tgz",
-              "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.22.tgz"
+              "version": "5.8.23",
+              "from": "babylon@^5.8.23",
+              "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.23.tgz"
             },
             "bluebird": {
-              "version": "2.9.34",
-              "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.34.tgz",
-              "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.34.tgz"
+              "version": "2.10.2",
+              "from": "bluebird@^2.9.33",
+              "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
             },
             "chalk": {
               "version": "1.1.1",
-              "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+              "from": "chalk@^1.0.0",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.1.0",
-                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+                  "from": "ansi-styles@^2.1.0",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.3",
-                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+                  "from": "escape-string-regexp@^1.0.2",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                 },
                 "has-ansi": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                  "from": "has-ansi@^2.0.0",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                      "from": "ansi-regex@^2.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "3.0.0",
-                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                  "from": "strip-ansi@^3.0.0",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                      "from": "ansi-regex@^2.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                  "from": "supports-color@^2.0.0",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                 }
               }
             },
             "core-js": {
-              "version": "1.1.0",
-              "from": "https://registry.npmjs.org/core-js/-/core-js-1.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.1.0.tgz"
+              "version": "1.2.3",
+              "from": "core-js@^1.0.0",
+              "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.3.tgz"
             },
             "debug": {
               "version": "2.2.0",
-              "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "from": "debug@^2.1.1",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.7.1",
-                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                  "from": "ms@0.7.1",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                 }
               }
             },
             "detect-indent": {
               "version": "3.0.1",
-              "from": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
+              "from": "detect-indent@^3.0.0",
               "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
               "dependencies": {
                 "get-stdin": {
                   "version": "4.0.1",
-                  "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+                  "from": "get-stdin@^4.0.1",
                   "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                 },
                 "minimist": {
-                  "version": "1.1.3",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz"
+                  "version": "1.2.0",
+                  "from": "minimist@^1.1.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                 }
               }
             },
             "esutils": {
               "version": "2.0.2",
-              "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+              "from": "esutils@^2.0.0",
               "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
             },
             "globals": {
               "version": "6.4.1",
-              "from": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
+              "from": "globals@^6.4.0",
               "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz"
             },
             "home-or-tmp": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
+              "from": "home-or-tmp@^1.0.0",
               "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
               "dependencies": {
                 "os-tmpdir": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
+                  "from": "os-tmpdir@^1.0.1",
                   "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
                 },
                 "user-home": {
                   "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+                  "from": "user-home@^1.1.1",
                   "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
                 }
               }
             },
             "is-integer": {
-              "version": "1.0.4",
-              "from": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.4.tgz",
-              "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.4.tgz",
+              "version": "1.0.6",
+              "from": "is-integer@^1.0.4",
+              "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.6.tgz",
               "dependencies": {
                 "is-finite": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                  "from": "is-finite@^1.0.0",
                   "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                      "from": "number-is-nan@^1.0.0",
                       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                    }
-                  }
-                },
-                "is-nan": {
-                  "version": "1.2.1",
-                  "from": "https://registry.npmjs.org/is-nan/-/is-nan-1.2.1.tgz",
-                  "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.2.1.tgz",
-                  "dependencies": {
-                    "define-properties": {
-                      "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.1.tgz",
-                      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.1.tgz",
-                      "dependencies": {
-                        "foreach": {
-                          "version": "2.0.5",
-                          "from": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-                          "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
-                        },
-                        "object-keys": {
-                          "version": "1.0.7",
-                          "from": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.7.tgz",
-                          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.7.tgz"
-                        }
-                      }
                     }
                   }
                 }
@@ -256,44 +232,44 @@
             },
             "js-tokens": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz",
+              "from": "js-tokens@1.0.1",
               "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz"
             },
             "json5": {
               "version": "0.4.0",
-              "from": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
+              "from": "json5@^0.4.0",
               "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
             },
             "line-numbers": {
               "version": "0.2.0",
-              "from": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+              "from": "line-numbers@0.2.0",
               "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
               "dependencies": {
                 "left-pad": {
                   "version": "0.0.3",
-                  "from": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz",
+                  "from": "left-pad@0.0.3",
                   "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
                 }
               }
             },
             "minimatch": {
               "version": "2.0.10",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+              "from": "minimatch@^2.0.10",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
               "dependencies": {
                 "brace-expansion": {
-                  "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                  "version": "1.1.1",
+                  "from": "brace-expansion@^1.0.0",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
                   "dependencies": {
                     "balanced-match": {
-                      "version": "0.2.0",
-                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                      "version": "0.2.1",
+                      "from": "balanced-match@^0.2.0",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "from": "concat-map@0.0.1",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
@@ -302,81 +278,81 @@
             },
             "private": {
               "version": "0.1.6",
-              "from": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
+              "from": "private@^0.1.6",
               "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
             },
             "regenerator": {
               "version": "0.8.35",
-              "from": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.35.tgz",
+              "from": "regenerator@0.8.35",
               "resolved": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.35.tgz",
               "dependencies": {
                 "commoner": {
                   "version": "0.10.3",
-                  "from": "https://registry.npmjs.org/commoner/-/commoner-0.10.3.tgz",
+                  "from": "commoner@~0.10.0",
                   "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.3.tgz",
                   "dependencies": {
                     "q": {
                       "version": "1.1.2",
-                      "from": "https://registry.npmjs.org/q/-/q-1.1.2.tgz",
+                      "from": "q@~1.1.2",
                       "resolved": "https://registry.npmjs.org/q/-/q-1.1.2.tgz"
                     },
                     "commander": {
                       "version": "2.5.1",
-                      "from": "https://registry.npmjs.org/commander/-/commander-2.5.1.tgz",
+                      "from": "commander@~2.5.0",
                       "resolved": "https://registry.npmjs.org/commander/-/commander-2.5.1.tgz"
                     },
                     "graceful-fs": {
                       "version": "3.0.8",
-                      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
+                      "from": "graceful-fs@~3.0.4",
                       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
                     },
                     "glob": {
                       "version": "4.2.2",
-                      "from": "https://registry.npmjs.org/glob/-/glob-4.2.2.tgz",
+                      "from": "glob@~4.2.1",
                       "resolved": "https://registry.npmjs.org/glob/-/glob-4.2.2.tgz",
                       "dependencies": {
                         "inflight": {
                           "version": "1.0.4",
-                          "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                          "from": "inflight@^1.0.4",
                           "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                           "dependencies": {
                             "wrappy": {
                               "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                              "from": "wrappy@1",
                               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                             }
                           }
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "from": "inherits@2",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         },
                         "minimatch": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+                          "from": "minimatch@^1.0.0",
                           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
                           "dependencies": {
                             "lru-cache": {
-                              "version": "2.6.5",
-                              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
-                              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
+                              "version": "2.7.0",
+                              "from": "lru-cache@2",
+                              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
                             },
                             "sigmund": {
                               "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                              "from": "sigmund@~1.0.0",
                               "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                             }
                           }
                         },
                         "once": {
                           "version": "1.3.2",
-                          "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                          "from": "once@^1.3.0",
                           "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                           "dependencies": {
                             "wrappy": {
                               "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                              "from": "wrappy@1",
                               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                             }
                           }
@@ -385,156 +361,291 @@
                     },
                     "mkdirp": {
                       "version": "0.5.1",
-                      "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                      "from": "mkdirp@~0.5.0",
                       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                       "dependencies": {
                         "minimist": {
                           "version": "0.0.8",
-                          "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                          "from": "minimist@0.0.8",
                           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                         }
                       }
                     },
                     "install": {
                       "version": "0.1.8",
-                      "from": "https://registry.npmjs.org/install/-/install-0.1.8.tgz",
+                      "from": "install@~0.1.7",
                       "resolved": "https://registry.npmjs.org/install/-/install-0.1.8.tgz"
                     },
                     "iconv-lite": {
-                      "version": "0.4.11",
-                      "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.11.tgz",
-                      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.11.tgz"
+                      "version": "0.4.13",
+                      "from": "iconv-lite@~0.4.5",
+                      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
                     }
                   }
                 },
                 "defs": {
-                  "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/defs/-/defs-1.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/defs/-/defs-1.1.0.tgz",
+                  "version": "1.1.1",
+                  "from": "defs@~1.1.0",
+                  "resolved": "https://registry.npmjs.org/defs/-/defs-1.1.1.tgz",
                   "dependencies": {
                     "alter": {
                       "version": "0.2.0",
-                      "from": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
+                      "from": "alter@~0.2.0",
                       "resolved": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
                       "dependencies": {
                         "stable": {
                           "version": "0.1.5",
-                          "from": "https://registry.npmjs.org/stable/-/stable-0.1.5.tgz",
+                          "from": "stable@~0.1.3",
                           "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.5.tgz"
                         }
                       }
                     },
                     "ast-traverse": {
                       "version": "0.1.1",
-                      "from": "https://registry.npmjs.org/ast-traverse/-/ast-traverse-0.1.1.tgz",
+                      "from": "ast-traverse@~0.1.1",
                       "resolved": "https://registry.npmjs.org/ast-traverse/-/ast-traverse-0.1.1.tgz"
                     },
                     "breakable": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz",
+                      "from": "breakable@~1.0.0",
                       "resolved": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz"
                     },
                     "esprima-fb": {
-                      "version": "8001.1001.0-dev-harmony-fb",
-                      "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-8001.1001.0-dev-harmony-fb.tgz",
-                      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-8001.1001.0-dev-harmony-fb.tgz"
+                      "version": "15001.1001.0-dev-harmony-fb",
+                      "from": "esprima-fb@~15001.1001.0-dev-harmony-fb",
+                      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
                     },
                     "simple-fmt": {
                       "version": "0.1.0",
-                      "from": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz",
+                      "from": "simple-fmt@~0.1.0",
                       "resolved": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz"
                     },
                     "simple-is": {
                       "version": "0.2.0",
-                      "from": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz",
+                      "from": "simple-is@~0.2.0",
                       "resolved": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz"
                     },
                     "stringmap": {
                       "version": "0.2.2",
-                      "from": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz",
+                      "from": "stringmap@~0.2.2",
                       "resolved": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz"
                     },
                     "stringset": {
                       "version": "0.2.1",
-                      "from": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz",
+                      "from": "stringset@~0.2.1",
                       "resolved": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz"
                     },
                     "tryor": {
                       "version": "0.1.2",
-                      "from": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz",
+                      "from": "tryor@~0.1.2",
                       "resolved": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz"
                     },
                     "yargs": {
-                      "version": "1.3.3",
-                      "from": "https://registry.npmjs.org/yargs/-/yargs-1.3.3.tgz",
-                      "resolved": "https://registry.npmjs.org/yargs/-/yargs-1.3.3.tgz"
+                      "version": "3.27.0",
+                      "from": "yargs@~3.27.0",
+                      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz",
+                      "dependencies": {
+                        "camelcase": {
+                          "version": "1.2.1",
+                          "from": "camelcase@^1.2.1",
+                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                        },
+                        "cliui": {
+                          "version": "2.1.0",
+                          "from": "cliui@^2.1.0",
+                          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                          "dependencies": {
+                            "center-align": {
+                              "version": "0.1.1",
+                              "from": "center-align@^0.1.1",
+                              "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.1.tgz",
+                              "dependencies": {
+                                "align-text": {
+                                  "version": "0.1.3",
+                                  "from": "align-text@^0.1.0",
+                                  "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
+                                  "dependencies": {
+                                    "kind-of": {
+                                      "version": "2.0.1",
+                                      "from": "kind-of@^2.0.0",
+                                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+                                      "dependencies": {
+                                        "is-buffer": {
+                                          "version": "1.1.0",
+                                          "from": "is-buffer@^1.0.2",
+                                          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
+                                        }
+                                      }
+                                    },
+                                    "longest": {
+                                      "version": "1.0.1",
+                                      "from": "longest@^1.0.1",
+                                      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                    },
+                                    "repeat-string": {
+                                      "version": "1.5.2",
+                                      "from": "repeat-string@^1.5.2",
+                                      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "right-align": {
+                              "version": "0.1.3",
+                              "from": "right-align@^0.1.1",
+                              "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                              "dependencies": {
+                                "align-text": {
+                                  "version": "0.1.3",
+                                  "from": "align-text@^0.1.0",
+                                  "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
+                                  "dependencies": {
+                                    "kind-of": {
+                                      "version": "2.0.1",
+                                      "from": "kind-of@^2.0.0",
+                                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+                                      "dependencies": {
+                                        "is-buffer": {
+                                          "version": "1.1.0",
+                                          "from": "is-buffer@^1.0.2",
+                                          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
+                                        }
+                                      }
+                                    },
+                                    "longest": {
+                                      "version": "1.0.1",
+                                      "from": "longest@^1.0.1",
+                                      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                    },
+                                    "repeat-string": {
+                                      "version": "1.5.2",
+                                      "from": "repeat-string@^1.5.2",
+                                      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "wordwrap": {
+                              "version": "0.0.2",
+                              "from": "wordwrap@0.0.2",
+                              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                            }
+                          }
+                        },
+                        "decamelize": {
+                          "version": "1.0.0",
+                          "from": "decamelize@^1.0.0",
+                          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
+                        },
+                        "os-locale": {
+                          "version": "1.4.0",
+                          "from": "os-locale@^1.4.0",
+                          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+                          "dependencies": {
+                            "lcid": {
+                              "version": "1.0.0",
+                              "from": "lcid@^1.0.0",
+                              "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+                              "dependencies": {
+                                "invert-kv": {
+                                  "version": "1.0.0",
+                                  "from": "invert-kv@^1.0.0",
+                                  "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "window-size": {
+                          "version": "0.1.2",
+                          "from": "window-size@^0.1.2",
+                          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.2.tgz"
+                        },
+                        "y18n": {
+                          "version": "3.2.0",
+                          "from": "y18n@^3.2.0",
+                          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.0.tgz"
+                        }
+                      }
                     }
                   }
                 },
                 "esprima-fb": {
                   "version": "15001.1.0-dev-harmony-fb",
-                  "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz",
+                  "from": "esprima-fb@~15001.1.0-dev-harmony-fb",
                   "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz"
                 },
                 "recast": {
                   "version": "0.10.24",
-                  "from": "https://registry.npmjs.org/recast/-/recast-0.10.24.tgz",
+                  "from": "recast@0.10.24",
                   "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.24.tgz",
                   "dependencies": {
                     "ast-types": {
                       "version": "0.8.5",
-                      "from": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.5.tgz",
+                      "from": "ast-types@0.8.5",
                       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.5.tgz"
                     }
                   }
                 },
                 "through": {
                   "version": "2.3.8",
-                  "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+                  "from": "through@~2.3.6",
                   "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                 }
               }
             },
             "regexpu": {
-              "version": "1.2.0",
-              "from": "https://registry.npmjs.org/regexpu/-/regexpu-1.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.2.0.tgz",
+              "version": "1.3.0",
+              "from": "regexpu@^1.1.2",
+              "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
               "dependencies": {
+                "esprima": {
+                  "version": "2.7.0",
+                  "from": "esprima@^2.6.0",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.0.tgz"
+                },
                 "recast": {
-                  "version": "0.10.31",
-                  "from": "https://registry.npmjs.org/recast/-/recast-0.10.31.tgz",
-                  "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.31.tgz",
+                  "version": "0.10.34",
+                  "from": "recast@^0.10.10",
+                  "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.34.tgz",
                   "dependencies": {
                     "esprima-fb": {
                       "version": "15001.1001.0-dev-harmony-fb",
-                      "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
+                      "from": "esprima-fb@~15001.1001.0-dev-harmony-fb",
                       "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
                     },
+                    "source-map": {
+                      "version": "0.5.3",
+                      "from": "source-map@~0.5.0",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+                    },
                     "ast-types": {
-                      "version": "0.8.9",
-                      "from": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.9.tgz",
-                      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.9.tgz"
+                      "version": "0.8.12",
+                      "from": "ast-types@0.8.12",
+                      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz"
                     }
                   }
                 },
                 "regenerate": {
                   "version": "1.2.1",
-                  "from": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz",
+                  "from": "regenerate@^1.2.1",
                   "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz"
                 },
                 "regjsgen": {
                   "version": "0.2.0",
-                  "from": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+                  "from": "regjsgen@^0.2.0",
                   "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
                 },
                 "regjsparser": {
                   "version": "0.1.5",
-                  "from": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+                  "from": "regjsparser@^0.1.4",
                   "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
                   "dependencies": {
                     "jsesc": {
                       "version": "0.5.0",
-                      "from": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+                      "from": "jsesc@~0.5.0",
                       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
                     }
                   }
@@ -543,17 +654,17 @@
             },
             "repeating": {
               "version": "1.1.3",
-              "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+              "from": "repeating@^1.1.2",
               "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
               "dependencies": {
                 "is-finite": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                  "from": "is-finite@^1.0.0",
                   "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                      "from": "number-is-nan@^1.0.0",
                       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                     }
                   }
@@ -562,27 +673,27 @@
             },
             "resolve": {
               "version": "1.1.6",
-              "from": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz",
+              "from": "resolve@^1.1.6",
               "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
             },
             "shebang-regex": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+              "from": "shebang-regex@^1.0.0",
               "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
             },
             "source-map-support": {
               "version": "0.2.10",
-              "from": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
+              "from": "source-map-support@^0.2.10",
               "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
               "dependencies": {
                 "source-map": {
                   "version": "0.1.32",
-                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+                  "from": "source-map@0.1.32",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
                   "dependencies": {
                     "amdefine": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                      "from": "amdefine@>=0.0.4",
                       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                     }
                   }
@@ -591,214 +702,227 @@
             },
             "to-fast-properties": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz",
+              "from": "to-fast-properties@^1.0.0",
               "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
             },
             "trim-right": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+              "from": "trim-right@^1.0.0",
               "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
             },
             "try-resolve": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz",
+              "from": "try-resolve@^1.0.0",
               "resolved": "https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz"
             }
           }
         },
         "chokidar": {
-          "version": "1.0.5",
-          "from": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.5.tgz",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.5.tgz",
+          "version": "1.2.0",
+          "from": "chokidar@^1.0.0",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.2.0.tgz",
           "dependencies": {
             "anymatch": {
               "version": "1.3.0",
-              "from": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
+              "from": "anymatch@^1.1.0",
               "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
               "dependencies": {
                 "micromatch": {
                   "version": "2.2.0",
-                  "from": "https://registry.npmjs.org/micromatch/-/micromatch-2.2.0.tgz",
+                  "from": "micromatch@^2.1.5",
                   "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.2.0.tgz",
                   "dependencies": {
                     "arr-diff": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.0.1.tgz",
+                      "version": "1.1.0",
+                      "from": "arr-diff@^1.0.1",
+                      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
                       "dependencies": {
+                        "arr-flatten": {
+                          "version": "1.0.1",
+                          "from": "arr-flatten@^1.0.1",
+                          "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz"
+                        },
                         "array-slice": {
                           "version": "0.2.3",
-                          "from": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
+                          "from": "array-slice@^0.2.3",
                           "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz"
                         }
                       }
                     },
                     "array-unique": {
                       "version": "0.2.1",
-                      "from": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+                      "from": "array-unique@^0.2.1",
                       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
                     },
                     "braces": {
-                      "version": "1.8.0",
-                      "from": "https://registry.npmjs.org/braces/-/braces-1.8.0.tgz",
-                      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.0.tgz",
+                      "version": "1.8.2",
+                      "from": "braces@^1.8.0",
+                      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.2.tgz",
                       "dependencies": {
                         "expand-range": {
                           "version": "1.8.1",
-                          "from": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
+                          "from": "expand-range@^1.8.1",
                           "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
                           "dependencies": {
                             "fill-range": {
                               "version": "2.2.2",
-                              "from": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.2.tgz",
+                              "from": "fill-range@^2.1.0",
                               "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.2.tgz",
                               "dependencies": {
                                 "is-number": {
                                   "version": "1.1.2",
-                                  "from": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz",
+                                  "from": "is-number@^1.1.2",
                                   "resolved": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz"
                                 },
                                 "isobject": {
                                   "version": "1.0.2",
-                                  "from": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz",
+                                  "from": "isobject@^1.0.0",
                                   "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz"
                                 },
                                 "randomatic": {
                                   "version": "1.1.0",
-                                  "from": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.0.tgz",
+                                  "from": "randomatic@^1.1.0",
                                   "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.0.tgz"
                                 },
                                 "repeat-string": {
                                   "version": "1.5.2",
-                                  "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
+                                  "from": "repeat-string@^1.5.2",
                                   "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
                                 }
                               }
                             }
                           }
                         },
+                        "lazy-cache": {
+                          "version": "0.2.3",
+                          "from": "lazy-cache@^0.2.3",
+                          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.3.tgz"
+                        },
                         "preserve": {
                           "version": "0.2.0",
-                          "from": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+                          "from": "preserve@^0.2.0",
                           "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
                         },
                         "repeat-element": {
                           "version": "1.1.2",
-                          "from": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+                          "from": "repeat-element@^1.1.2",
                           "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
                         }
                       }
                     },
                     "expand-brackets": {
-                      "version": "0.1.3",
-                      "from": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.3.tgz",
-                      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.3.tgz",
-                      "dependencies": {
-                        "is-posix-bracket": {
-                          "version": "0.1.0",
-                          "from": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.0.tgz",
-                          "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.0.tgz"
-                        }
-                      }
+                      "version": "0.1.4",
+                      "from": "expand-brackets@^0.1.1",
+                      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.4.tgz"
                     },
                     "extglob": {
                       "version": "0.3.1",
-                      "from": "https://registry.npmjs.org/extglob/-/extglob-0.3.1.tgz",
+                      "from": "extglob@^0.3.0",
                       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.1.tgz",
                       "dependencies": {
                         "ansi-green": {
                           "version": "0.1.1",
-                          "from": "https://registry.npmjs.org/ansi-green/-/ansi-green-0.1.1.tgz",
+                          "from": "ansi-green@^0.1.1",
                           "resolved": "https://registry.npmjs.org/ansi-green/-/ansi-green-0.1.1.tgz",
                           "dependencies": {
                             "ansi-wrap": {
                               "version": "0.1.0",
-                              "from": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+                              "from": "ansi-wrap@0.1.0",
                               "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz"
                             }
                           }
                         },
                         "is-extglob": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                          "from": "is-extglob@^1.0.0",
                           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
                         },
                         "success-symbol": {
                           "version": "0.1.0",
-                          "from": "https://registry.npmjs.org/success-symbol/-/success-symbol-0.1.0.tgz",
+                          "from": "success-symbol@^0.1.0",
                           "resolved": "https://registry.npmjs.org/success-symbol/-/success-symbol-0.1.0.tgz"
                         }
                       }
                     },
                     "filename-regex": {
                       "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
+                      "from": "filename-regex@^2.0.0",
                       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
+                    },
+                    "is-glob": {
+                      "version": "1.1.3",
+                      "from": "is-glob@^1.1.3",
+                      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz"
                     },
                     "kind-of": {
                       "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+                      "from": "kind-of@^1.1.0",
                       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz"
                     },
                     "object.omit": {
                       "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/object.omit/-/object.omit-1.1.0.tgz",
+                      "from": "object.omit@^1.1.0",
                       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-1.1.0.tgz",
                       "dependencies": {
                         "for-own": {
                           "version": "0.1.3",
-                          "from": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
+                          "from": "for-own@^0.1.3",
                           "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
                           "dependencies": {
                             "for-in": {
                               "version": "0.1.4",
-                              "from": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz",
+                              "from": "for-in@^0.1.4",
                               "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
                             }
                           }
                         },
                         "isobject": {
                           "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz",
+                          "from": "isobject@^1.0.0",
                           "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz"
                         }
                       }
                     },
                     "parse-glob": {
-                      "version": "3.0.2",
-                      "from": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.2.tgz",
+                      "version": "3.0.4",
+                      "from": "parse-glob@^3.0.1",
+                      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
                       "dependencies": {
                         "glob-base": {
-                          "version": "0.2.0",
-                          "from": "https://registry.npmjs.org/glob-base/-/glob-base-0.2.0.tgz",
-                          "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.2.0.tgz"
+                          "version": "0.3.0",
+                          "from": "glob-base@^0.3.0",
+                          "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
                         },
                         "is-dotfile": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.1.tgz"
+                          "version": "1.0.2",
+                          "from": "is-dotfile@^1.0.0",
+                          "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz"
                         },
                         "is-extglob": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                          "from": "is-extglob@^1.0.0",
                           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                        },
+                        "is-glob": {
+                          "version": "2.0.1",
+                          "from": "is-glob@^2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
                         }
                       }
                     },
                     "regex-cache": {
                       "version": "0.4.2",
-                      "from": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
+                      "from": "regex-cache@^0.4.2",
                       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
                       "dependencies": {
                         "is-equal-shallow": {
                           "version": "0.1.3",
-                          "from": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+                          "from": "is-equal-shallow@^0.1.1",
                           "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
                         },
                         "is-primitive": {
                           "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+                          "from": "is-primitive@^2.0.0",
                           "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
                         }
                       }
@@ -809,70 +933,140 @@
             },
             "arrify": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz",
+              "from": "arrify@^1.0.0",
               "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz"
             },
             "async-each": {
               "version": "0.1.6",
-              "from": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz",
+              "from": "async-each@^0.1.5",
               "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
             },
             "glob-parent": {
-              "version": "1.2.0",
-              "from": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.2.0.tgz"
+              "version": "2.0.0",
+              "from": "glob-parent@^2.0.0",
+              "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
             },
             "is-binary-path": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+              "from": "is-binary-path@^1.0.0",
               "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
               "dependencies": {
                 "binary-extensions": {
                   "version": "1.3.1",
-                  "from": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.3.1.tgz",
+                  "from": "binary-extensions@^1.0.0",
                   "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.3.1.tgz"
                 }
               }
             },
             "is-glob": {
-              "version": "1.1.3",
-              "from": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz",
-              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz"
+              "version": "2.0.1",
+              "from": "is-glob@^2.0.0",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+              "dependencies": {
+                "is-extglob": {
+                  "version": "1.0.0",
+                  "from": "is-extglob@^1.0.0",
+                  "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                }
+              }
+            },
+            "lodash.flatten": {
+              "version": "3.0.2",
+              "from": "lodash.flatten@^3.0.2",
+              "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-3.0.2.tgz",
+              "dependencies": {
+                "lodash._baseflatten": {
+                  "version": "3.1.4",
+                  "from": "lodash._baseflatten@^3.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
+                  "dependencies": {
+                    "lodash.isarguments": {
+                      "version": "3.0.4",
+                      "from": "lodash.isarguments@^3.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.4",
+                      "from": "lodash.isarray@^3.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                    }
+                  }
+                },
+                "lodash._isiterateecall": {
+                  "version": "3.0.9",
+                  "from": "lodash._isiterateecall@^3.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+                }
+              }
             },
             "readdirp": {
-              "version": "1.4.0",
-              "from": "https://registry.npmjs.org/readdirp/-/readdirp-1.4.0.tgz",
-              "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-1.4.0.tgz",
+              "version": "2.0.0",
+              "from": "readdirp@^2.0.0",
+              "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.0.0.tgz",
               "dependencies": {
                 "graceful-fs": {
                   "version": "4.1.2",
-                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
+                  "from": "graceful-fs@^4.1.2",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
                 },
+                "minimatch": {
+                  "version": "2.0.10",
+                  "from": "minimatch@^2.0.10",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.1",
+                      "from": "brace-expansion@^1.0.0",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.1",
+                          "from": "balanced-match@^0.2.0",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
                 "readable-stream": {
-                  "version": "1.0.33",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "version": "2.0.3",
+                  "from": "readable-stream@^2.0.2",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.3.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "from": "core-util-is@~1.0.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@~2.0.1",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.3",
+                      "from": "process-nextick-args@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@~0.10.x",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "from": "util-deprecate@~1.0.1",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                     }
                   }
                 }
@@ -881,67 +1075,67 @@
           }
         },
         "commander": {
-          "version": "2.8.1",
-          "from": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+          "version": "2.9.0",
+          "from": "commander@^2.6.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
           "dependencies": {
             "graceful-readlink": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+              "from": "graceful-readlink@>= 1.0.0",
               "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
             }
           }
         },
         "convert-source-map": {
           "version": "1.1.1",
-          "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.1.tgz",
+          "from": "convert-source-map@^1.1.0",
           "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.1.tgz"
         },
         "fs-readdir-recursive": {
           "version": "0.1.2",
-          "from": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz",
+          "from": "fs-readdir-recursive@^0.1.0",
           "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz"
         },
         "glob": {
-          "version": "5.0.14",
-          "from": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
+          "version": "5.0.15",
+          "from": "glob@^5.0.5",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "dependencies": {
             "inflight": {
               "version": "1.0.4",
-              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+              "from": "inflight@^1.0.4",
               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                  "from": "wrappy@1",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "from": "inherits@2",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "minimatch": {
-              "version": "2.0.10",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+              "version": "3.0.0",
+              "from": "minimatch@2 || 3",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
               "dependencies": {
                 "brace-expansion": {
-                  "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                  "version": "1.1.1",
+                  "from": "brace-expansion@^1.0.0",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
                   "dependencies": {
                     "balanced-match": {
-                      "version": "0.2.0",
-                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                      "version": "0.2.1",
+                      "from": "balanced-match@^0.2.0",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "from": "concat-map@0.0.1",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
@@ -950,12 +1144,12 @@
             },
             "once": {
               "version": "1.3.2",
-              "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+              "from": "once@^1.3.0",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                  "from": "wrappy@1",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
@@ -964,58 +1158,58 @@
         },
         "lodash": {
           "version": "3.10.1",
-          "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "from": "lodash@^3.2.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         },
         "output-file-sync": {
           "version": "1.1.1",
-          "from": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.1.tgz",
+          "from": "output-file-sync@^1.1.0",
           "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.1.tgz",
           "dependencies": {
             "mkdirp": {
               "version": "0.5.1",
-              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "from": "mkdirp@^0.5.1",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "from": "minimist@0.0.8",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                 }
               }
             },
             "xtend": {
               "version": "4.0.0",
-              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
+              "from": "xtend@^4.0.0",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
             }
           }
         },
         "path-exists": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
+          "from": "path-exists@^1.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz"
         },
         "path-is-absolute": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+          "from": "path-is-absolute@^1.0.0",
           "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
         },
         "source-map": {
           "version": "0.4.4",
-          "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "from": "source-map@^0.4.0",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "dependencies": {
             "amdefine": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+              "from": "amdefine@>=0.0.4",
               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
             }
           }
         },
         "slash": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+          "from": "slash@^1.0.0",
           "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
         }
       }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/juju/juju-gui.git"
   },
   "dependencies": {
-    "babel": "^5.8.21",
+    "babel": "^5.8.23",
     "chai": "^3.2.0",
     "classnames": "^2.1.3",
     "cryptojs": ">= 2.5.3",


### PR DESCRIPTION
To stop babel from starting a new instance for every file it's building on a fresh build use the new `fast-babel` target.