### PR TITLE
Use the state-server's name for the template when creating environments.

### DIFF
--- a/jujugui/static/gui/src/app/assets/javascripts/jujulib/juju.js
+++ b/jujugui/static/gui/src/app/assets/javascripts/jujulib/juju.js
@@ -6,8 +6,6 @@ XXX jcssackett 2015-09-18: Licensing for juju.js? It's different then the
 licensing for the GUI.
 */
 
-'use strict';
-
 var module = module;
 
 /**
@@ -18,6 +16,7 @@ var module = module;
  * manager (IdM).
  */
 (function (exports) {
+  'use strict';
 
   /**
    * Environment object for jujulib.
@@ -120,6 +119,8 @@ var module = module;
    * @param envName {String} The name of the given environment.
    * @param baseTemplate {String} The name of the config template to be used
    *     for creating the environment.
+   * @param stateServer {String} The entityPath name of the state server to
+   *     create the environment with.
    * @param password {String} The password for the new environment.
    * @param success {function} An optional callback to be called on success.
    *     Should receive a 200 OK response as its only object.
@@ -127,24 +128,16 @@ var module = module;
    *     take an error message as its one parameter.
    */
   environment.prototype.newEnvironment = function (
-      envOwnerName, envName, baseTemplate, password, success, failure) {
+      envOwnerName, envName, baseTemplate, stateServer, password,
+      success, failure) {
     var body = {
       name: envName,
       password: password,
-      templates: [baseTemplate]
+      templates: [baseTemplate],
+      'state-server': stateServer
     };
     var url = [this.jemUrl, 'env', envOwnerName].join('/');
-    var _newEnvironment = function(servers) {
-      var path;
-      if (servers && servers.length > 0 && servers[0].path) {
-        path = servers[0].path;
-      } else {
-        failure('Cannot create a new environment: No state servers found.');
-      }
-      body['state-server'] = path;
-      this._makeRequest(url, 'POST', body, success, failure);
-    };
-    this.listServers(_newEnvironment.bind(this), failure);
+    this._makeRequest(url, 'POST', body, success, failure);
   };
 
   /**

--- a/jujugui/static/gui/src/app/assets/javascripts/jujulib/test-juju.js
+++ b/jujugui/static/gui/src/app/assets/javascripts/jujulib/test-juju.js
@@ -136,44 +136,18 @@ describe('jujulib', function() {
             });
           var xhr = _makeXHRRequest({});
           success(xhr);
-        },
-        sendGetRequest: function(path, success, failure) {
-          var xhr = _makeXHRRequest({"state-servers": [{path: "foo"}]});
-          success(xhr);
         }
       };
 
       env = new window.jujulib.environment('http://example.com', bakery);
-      env.newEnvironment('rose', 'fnord', 'rose/template', 'password', function(data) {
-        done();
-      }, function(error) {
-        assert.fail('Failure callback should not have been called.');
-        done();
-      });
-    });
-
-    it('handles no state servers being available when creating a new environment',
-        function(done) {
-      var err = 'Cannot create a new environment: No state servers found.';
-      var bakery = {
-        sendPostRequest: function(path, data, success, failure) {
-          assert.equal(path, 'http://example.com/v1/env/rose');
-          failure(err);
-        },
-        sendGetRequest: function(path, success, failure) {
-          var xhr = _makeXHRRequest({"state-servers": []});
-          success(xhr);
+      env.newEnvironment('rose', 'fnord', 'rose/template', 'foo', 'password',
+        function(data) {
+          done();
+        }, function(error) {
+          assert.fail('Failure callback should not have been called.');
+          done();
         }
-      };
-
-      env = new window.jujulib.environment('http://example.com', bakery);
-      env.newEnvironment('rose', 'fnord', 'rose/template', 'password', function(data) {
-        done();
-        assert.fail('Success callback should not have been called.');
-      }, function(error) {
-        assert.equal(error, err)
-        done();
-      });
+      );
     });
 
     it('handles errors creating a new environment', function(done) {
@@ -183,20 +157,18 @@ describe('jujulib', function() {
           assert.equal(path, 'http://example.com/v1/env/rose');
           failure(err);
         },
-        sendGetRequest: function(path, success, failure) {
-          var xhr = _makeXHRRequest({"state-servers": [{path: "foo"}]});
-          success(xhr);
-        }
       };
 
       env = new window.jujulib.environment('http://example.com', bakery);
-      env.newEnvironment('rose', 'fnord', 'rose/template', 'password', function(data) {
-        done();
-        assert.fail('Success callback should not have been called.');
-      }, function(error) {
-        assert.equal(error, err)
-        done();
-      });
+      env.newEnvironment('rose', 'fnord', 'rose/template', 'foo', 'password',
+        function(data) {
+          done();
+          assert.fail('Success callback should not have been called.');
+        }, function(error) {
+          assert.equal(error, err)
+          done();
+        }
+      );
     });
   });
 

--- a/jujugui/static/gui/src/app/components/env-switcher/env-switcher.js
+++ b/jujugui/static/gui/src/app/components/env-switcher/env-switcher.js
@@ -137,6 +137,9 @@ YUI.add('env-switcher', function() {
       var randomString = () => Math.random().toString(36).slice(2);
       var password = randomString() + randomString();
 
+      // XXX j.c.sackett 2015-10-28 When we have the UI for template creation
+      // and template selection in the GUI, this code should be updated to not
+      // select template based on state server.
       var srvCb = function(servers) {
         if (servers && servers.length > 0 && servers[0].path) {
           var serverName = servers[0].path;

--- a/jujugui/static/gui/src/app/components/env-switcher/env-switcher.js
+++ b/jujugui/static/gui/src/app/components/env-switcher/env-switcher.js
@@ -133,16 +133,16 @@ YUI.add('env-switcher', function() {
       // number at the end. Users will be able to customize their env names
       // once there is UX for it.
       var envName = 'new-env-' + this.state.envList.length;
-      var baseTemplate = 'admin/gui';
       // Generates an alphanumeric string
       var randomString = () => Math.random().toString(36).slice(2);
       var password = randomString() + randomString();
 
       var srvCb = function(servers) {
         if (servers && servers.length > 0 && servers[0].path) {
-          var path = servers[0].path;
+          var serverName = servers[0].path;
+          var baseTemplate = serverName;
           jem.newEnvironment(
-            envOwnerName, envName, baseTemplate, path, password,
+            envOwnerName, envName, baseTemplate, serverName, password,
             this.createEnvCallback, this.jemFailHandler);
         } else {
           this.jemFailHandler(

--- a/jujugui/static/gui/src/app/components/env-switcher/env-switcher.js
+++ b/jujugui/static/gui/src/app/components/env-switcher/env-switcher.js
@@ -138,10 +138,20 @@ YUI.add('env-switcher', function() {
       var randomString = () => Math.random().toString(36).slice(2);
       var password = randomString() + randomString();
 
+      var srvCb = function(servers) {
+        if (servers && servers.length > 0 && servers[0].path) {
+          var path = servers[0].path;
+          jem.newEnvironment(
+            envOwnerName, envName, baseTemplate, path, password,
+            this.createEnvCallback, this.jemFailHandler);
+        } else {
+          this.jemFailHandler(
+            'Cannot create a new environment: No state servers found.');
+        }
+      };
+
       if (jem) {
-        jem.newEnvironment(
-          envOwnerName, envName, baseTemplate, password,
-          this.createEnvCallback, this.jemFailHandler);
+        jem.listServers(srvCb.bind(this), this.jemFailure);
       } else {
         this.props.env.createEnv(
             envName, 'user-admin', this.createEnvCallback);

--- a/jujugui/static/gui/src/app/components/env-switcher/test-env-switcher.js
+++ b/jujugui/static/gui/src/app/components/env-switcher/test-env-switcher.js
@@ -182,7 +182,7 @@ describe('EnvSwitcher', function() {
     var listSrv = sinon.stub();
     var newEnv = sinon.stub();
 
-    listSrv.callsArgWith(0, [{path: 'stateserver'}]);
+    listSrv.callsArgWith(0, [{path: 'admin/gui'}]);
 
     var jem = {
       listEnvironments: listEnvs,
@@ -206,7 +206,7 @@ describe('EnvSwitcher', function() {
     assert.equal(newEnv.args[0][0], 'admin');
     assert.equal(newEnv.args[0][1], 'new-env-1');
     assert.equal(newEnv.args[0][2], 'admin/gui');
-    assert.equal(newEnv.args[0][3], 'stateserver');
+    assert.equal(newEnv.args[0][3], 'admin/gui');
     assert.closeTo(newEnv.args[0][4].length, 31, 2);
     // Check to make sure that the env creation callback switches envs.
     var createdEnv = {uuid: '123abc'};

--- a/jujugui/static/gui/src/app/components/env-switcher/test-env-switcher.js
+++ b/jujugui/static/gui/src/app/components/env-switcher/test-env-switcher.js
@@ -179,10 +179,15 @@ describe('EnvSwitcher', function() {
       password: 'buffalo'
     }];
     var listEnvs = sinon.stub();
+    var listSrv = sinon.stub();
     var newEnv = sinon.stub();
+
+    listSrv.callsArgWith(0, [{path: 'stateserver'}]);
+
     var jem = {
-      newEnvironment: newEnv,
-      listEnvironments: listEnvs
+      listEnvironments: listEnvs,
+      listServers: listSrv,
+      newEnvironment: newEnv
     };
     var switchEnv = sinon.stub();
     var app = {
@@ -201,10 +206,11 @@ describe('EnvSwitcher', function() {
     assert.equal(newEnv.args[0][0], 'admin');
     assert.equal(newEnv.args[0][1], 'new-env-1');
     assert.equal(newEnv.args[0][2], 'admin/gui');
-    assert.closeTo(newEnv.args[0][3].length, 31, 2);
+    assert.equal(newEnv.args[0][3], 'stateserver');
+    assert.closeTo(newEnv.args[0][4].length, 31, 2);
     // Check to make sure that the env creation callback switches envs.
     var createdEnv = {uuid: '123abc'};
-    newEnv.args[0][4](createdEnv);
+    newEnv.args[0][5](createdEnv);
     // After creating an env it should re-list them.
     assert.equal(listEnvs.callCount, 2);
     // Then switch to the new one.

--- a/jujugui/static/gui/src/app/components/env-switcher/test-env-switcher.js
+++ b/jujugui/static/gui/src/app/components/env-switcher/test-env-switcher.js
@@ -182,7 +182,7 @@ describe('EnvSwitcher', function() {
     var listSrv = sinon.stub();
     var newEnv = sinon.stub();
 
-    listSrv.callsArgWith(0, [{path: 'admin/gui'}]);
+    listSrv.callsArgWith(0, [{path: 'admin/foo'}]);
 
     var jem = {
       listEnvironments: listEnvs,
@@ -205,8 +205,8 @@ describe('EnvSwitcher', function() {
     assert.equal(newEnv.callCount, 1);
     assert.equal(newEnv.args[0][0], 'admin');
     assert.equal(newEnv.args[0][1], 'new-env-1');
-    assert.equal(newEnv.args[0][2], 'admin/gui');
-    assert.equal(newEnv.args[0][3], 'admin/gui');
+    assert.equal(newEnv.args[0][2], 'admin/foo');
+    assert.equal(newEnv.args[0][3], 'admin/foo');
     assert.closeTo(newEnv.args[0][4].length, 31, 2);
     // Check to make sure that the env creation callback switches envs.
     var createdEnv = {uuid: '123abc'};


### PR DESCRIPTION
* state server selecting logic is now part of env switcher
* jujulib now uses whatever state server name it is given