### PR TITLE
Ability to specify a custom env name

### DIFF
--- a/jujugui/static/gui/src/app/assets/css/_components.scss
+++ b/jujugui/static/gui/src/app/assets/css/_components.scss
@@ -5,6 +5,7 @@
 @import "../../components/deployment-summary/deployment-summary";
 @import "../../components/deployment-summary-change-item/deployment-summary-change-item";
 @import "../../components/env-size-display/env-size-display";
+@import "../../components/env-list/env-list";
 @import "../../components/entity-content/entity-content";
 @import "../../components/entity-content-config-option/entity-content-config-option";
 @import "../../components/entity-content-diagram/entity-content-diagram";

--- a/jujugui/static/gui/src/app/components/button-row/_button-row.scss
+++ b/jujugui/static/gui/src/app/components/button-row/_button-row.scss
@@ -2,3 +2,7 @@
     @extend %fade-in;
     padding: 10px;
 }
+
+.env-list-panel .button-row {
+  padding: 0;
+}

--- a/jujugui/static/gui/src/app/components/env-list/_env-list.scss
+++ b/jujugui/static/gui/src/app/components/env-list/_env-list.scss
@@ -6,9 +6,9 @@
     .env-list {
         &__input {
             box-sizing: border-box;
-            padding: 18px 10px;
+            padding: 10px 10px 8px 10px;
             margin: 10px 0;
-            height: 28px;
+            height: 100%;
             width: 100%;
         }
 

--- a/jujugui/static/gui/src/app/components/env-list/_env-list.scss
+++ b/jujugui/static/gui/src/app/components/env-list/_env-list.scss
@@ -1,0 +1,26 @@
+.env-list-panel {
+    box-sizing: border-box;
+    width: 275px;
+    padding: 20px;
+
+    .env-list {
+        &__input {
+            box-sizing: border-box;
+            padding: 18px 10px;
+            margin: 10px 0;
+            height: 28px;
+            width: 100%;
+        }
+
+        &__environment {
+            list-style-type: none;
+            padding: 10px 10px;
+            margin-top: 10px
+        }
+
+        &__environment:hover {
+            background-color: $light-grey;
+            cursor: pointer;
+        }
+    }
+}

--- a/jujugui/static/gui/src/app/components/env-list/env-list.js
+++ b/jujugui/static/gui/src/app/components/env-list/env-list.js
@@ -30,7 +30,8 @@ YUI.add('env-list', function() {
 
     getInitialState: function() {
         return {
-          envs: this.props.envs
+          envs: this.props.envs,
+          envName: '',
         };
     },
 
@@ -55,11 +56,32 @@ YUI.add('env-list', function() {
       return envs;
     },
 
+    /**
+      Environment name input change handler. Sets the envName state value
+      with the value of the input.
+
+      @method envNameChange
+      @param {Object} e The change event.
+    */
+    envNameChange: function(e) {
+      this.setState({envName: e.target.value});
+    },
+
+    /**
+      Calls the createNewEnv prop passing it the current envName state value.
+
+      @method createNewEnv
+    */
+    createNewEnv: function() {
+      var name = this.state.envName;
+      this.props.createNewEnv(this.state.envName);
+    },
+
     render: function() {
       var actionButtons = [{
         title: 'New',
         type: 'confirm',
-        action: this.props.createNewEnv
+        action: this.createNewEnv
       }];
 
       return (
@@ -73,6 +95,7 @@ YUI.add('env-list', function() {
             type="text"
             name="envName"
             placeholder="New environment name"
+            onChange={this.envNameChange}
             className="env-list__input" />
           <juju.components.ButtonRow buttons={actionButtons} />
         </juju.components.Panel>

--- a/jujugui/static/gui/src/app/components/env-list/env-list.js
+++ b/jujugui/static/gui/src/app/components/env-list/env-list.js
@@ -69,6 +69,11 @@ YUI.add('env-list', function() {
           <ul className="env-list">
             {this.generateEnvList()}
           </ul>
+          <input
+            type="text"
+            name="envName"
+            placeholder="New environment name"
+            className="env-list__input" />
           <juju.components.ButtonRow buttons={actionButtons} />
         </juju.components.Panel>
       );

--- a/jujugui/static/gui/src/app/components/env-list/env-list.js
+++ b/jujugui/static/gui/src/app/components/env-list/env-list.js
@@ -96,7 +96,8 @@ YUI.add('env-list', function() {
             name="envName"
             placeholder="New environment name"
             onChange={this.envNameChange}
-            className="env-list__input" />
+            className="env-list__input"
+            ref="envName"/>
           <juju.components.ButtonRow buttons={actionButtons} />
         </juju.components.Panel>
       );

--- a/jujugui/static/gui/src/app/components/env-list/test-env-list.js
+++ b/jujugui/static/gui/src/app/components/env-list/test-env-list.js
@@ -65,15 +65,22 @@ describe('EnvList', function() {
     assert.equal(handleEnvClick.callCount, 1);
   });
 
-  it('createNewEnv prop passed to buttonRow', function() {
+  it('createNewEnv prop passed to buttonRow passes envName', function() {
     var envs = [{ uuid: 'abc123', name: 'the name' }];
     var createNewEnv = sinon.stub();
-    var output = jsTestUtils.shallowRender(
+    var component = testUtils.renderIntoDocument(
       <juju.components.EnvList
         envs={envs}
         createNewEnv={createNewEnv} />);
-    output.props.children[1].props.buttons[0].action();
+    // Set the new environment name
+    component.refs.envName.value = 'new env name';
+    testUtils.Simulate.change(component.refs.envName);
+
+    testUtils.Simulate.click(
+        ReactDOM.findDOMNode(component).querySelector('.generic-button'));
+
     assert.equal(createNewEnv.callCount, 1);
+    assert.equal(createNewEnv.args[0][0], 'new env name');
   });
 
 });

--- a/jujugui/static/gui/src/app/components/env-switcher/_env-switcher.scss
+++ b/jujugui/static/gui/src/app/components/env-switcher/_env-switcher.scss
@@ -9,18 +9,3 @@
       cursor: pointer;
     }
 }
-
-.env-list {
-    width: 275px;
-
-    &__environment {
-        list-style-type: none;
-        padding: 20px;
-        margin-top: 10px
-    }
-
-    &__environment:hover {
-        background-color: $light-grey;
-        cursor: pointer;
-    }
-}

--- a/jujugui/static/gui/src/app/components/env-switcher/env-switcher.js
+++ b/jujugui/static/gui/src/app/components/env-switcher/env-switcher.js
@@ -129,9 +129,7 @@ YUI.add('env-switcher', function() {
       if (auth && auth.user && auth.user.name) {
         envOwnerName = auth.user.name;
       }
-      // XXX For now we will create a new env with an auto-incrementing
-      // number at the end. Users will be able to customize their env names
-      // once there is UX for it.
+      // Use the custom provided name or fall back to an auto-incremented one.
       var envName = customEnvName || 'new-env-' + this.state.envList.length;
       // Generates an alphanumeric string
       var randomString = () => Math.random().toString(36).slice(2);

--- a/jujugui/static/gui/src/app/components/env-switcher/env-switcher.js
+++ b/jujugui/static/gui/src/app/components/env-switcher/env-switcher.js
@@ -121,7 +121,7 @@ YUI.add('env-switcher', function() {
 
       @method createNewEnv
     */
-    createNewEnv: function() {
+    createNewEnv: function(customEnvName) {
       this.setState({showEnvList: false});
       var jem = this.props.jem;
       var envOwnerName = 'admin';
@@ -132,7 +132,7 @@ YUI.add('env-switcher', function() {
       // XXX For now we will create a new env with an auto-incrementing
       // number at the end. Users will be able to customize their env names
       // once there is UX for it.
-      var envName = 'new-env-' + this.state.envList.length;
+      var envName = customEnvName || 'new-env-' + this.state.envList.length;
       // Generates an alphanumeric string
       var randomString = () => Math.random().toString(36).slice(2);
       var password = randomString() + randomString();

--- a/jujugui/static/gui/src/app/components/env-switcher/test-env-switcher.js
+++ b/jujugui/static/gui/src/app/components/env-switcher/test-env-switcher.js
@@ -169,7 +169,10 @@ describe('EnvSwitcher', function() {
     ]);
   });
 
-  it('can call to create a new env (JEM)', function() {
+  // To fully test the new env creation it has to be tested accepting a custom
+  // name as well. So there are two tests which call this method passing it
+  // different data.
+  function createNewJEMEnvTest(envName) {
     // To create a new environment you click a button in a sub component. this
     // excersizes the method that gets passed down.
     var envs = [{
@@ -201,10 +204,14 @@ describe('EnvSwitcher', function() {
     instance.componentDidMount();
     listEnvs.args[0][0](envs);
     // Previous code is to set up the state of the component.
-    instance.createNewEnv();
+    instance.createNewEnv(envName);
     assert.equal(newEnv.callCount, 1);
     assert.equal(newEnv.args[0][0], 'admin');
-    assert.equal(newEnv.args[0][1], 'new-env-1');
+    // First we check that the env name is not undefined.
+    assert.notEqual(newEnv.args[0][1], undefined);
+    // Then we check to see if it matches either the name passed in, or what
+    // it shoudl generate if it was passed in.
+    assert.equal(newEnv.args[0][1], envName || 'new-env-1');
     assert.equal(newEnv.args[0][2], 'admin/foo');
     assert.equal(newEnv.args[0][3], 'admin/foo');
     assert.closeTo(newEnv.args[0][4].length, 31, 2);
@@ -217,6 +224,14 @@ describe('EnvSwitcher', function() {
     envs.push(createdEnv);
     listEnvs.args[1][0](envs);
     assert.equal(switchEnv.callCount, 1);
+  }
+
+  it('can call to create a new env (JEM)', function() {
+    createNewJEMEnvTest();
+  });
+
+  it('can use a custom env name if provided (JEM)', function() {
+    createNewJEMEnvTest('custom-env-name');
   });
 
   it('can call to create a new env (JES)', function() {


### PR DESCRIPTION
As an interim feature we allow the user to specify their new environments name prior to creation if they don't want the auto-incremented name.