### PR TITLE
Properly keep units selected on re-renders

### DIFF
--- a/jujugui/static/gui/src/app/components/unit-list-item/test-unit-list-item.js
+++ b/jujugui/static/gui/src/app/components/unit-list-item/test-unit-list-item.js
@@ -117,42 +117,6 @@ describe('UnitListItem', () => {
     assert.equal(whenChanged.args[0][0], true);
   });
 
-  it('updates the checked status based on updating props', () => {
-    var shallowRenderer = jsTestUtils.shallowRender(
-        <juju.components.UnitListItem
-          key="unique"
-          checked={false}
-          label="unit-name"
-          unitId="apache/2"
-        />, true);
-    var output = shallowRenderer.getRenderOutput();
-    assert.deepEqual(
-      output.props.children.props.children[0],
-      <input
-        type="checkbox"
-        id="unit-name-unit"
-        onClick={output.props.children.props.children[0].props.onClick}
-        onChange={output.props.children.props.children[0].props.onChange}
-        checked={false} />);
-
-    shallowRenderer.render(<juju.components.UnitListItem
-      key="unique"
-      checked={true}
-      label="unit-name"
-      unitId="apache/2"
-    />);
-
-    output = shallowRenderer.getRenderOutput();
-    assert.deepEqual(
-      output.props.children.props.children[0],
-      <input
-        type="checkbox"
-        id="unit-name-unit"
-        onClick={output.props.children.props.children[0].props.onClick}
-        onChange={output.props.children.props.children[0].props.onChange}
-        checked={true} />);
-  });
-
   it('does not bubble the click event when clicking a checkbox', () => {
     var actionStub = sinon.stub();
     // Need to render the full component here as shallowRenderer does not yet

--- a/jujugui/static/gui/src/app/components/unit-list-item/unit-list-item.js
+++ b/jujugui/static/gui/src/app/components/unit-list-item/unit-list-item.js
@@ -57,7 +57,7 @@ YUI.add('unit-list-item', function() {
     getInitialState: function() {
       // Setting a default state object.
       return {
-        checked: this.props.checked
+        checked: false
       };
     },
 
@@ -87,10 +87,6 @@ YUI.add('unit-list-item', function() {
     */
     _stopBubble: function(e) {
       e.stopPropagation();
-    },
-
-    componentWillReceiveProps: function(nextProps) {
-      this.setState({checked: nextProps.checked});
     },
 
     render: function() {

--- a/jujugui/static/gui/src/app/components/unit-list/test-unit-list.js
+++ b/jujugui/static/gui/src/app/components/unit-list/test-unit-list.js
@@ -46,24 +46,22 @@ describe('UnitList', () => {
     ];
     assert.deepEqual(children, [
       <juju.components.UnitListItem
+        ref="select-all"
         key="select-all"
         className="select-all"
         label="Select all units"
-        checked={false}
         whenChanged={children[0].props.whenChanged}/>,
       <juju.components.UnitListItem
         key={units[0].displayName}
         ref={refs[0]}
         label={units[0].displayName}
         action={children[1].props.action}
-        checked={false}
         unitId="mysql/0" />,
       <juju.components.UnitListItem
         key={units[1].displayName}
         ref={refs[1]}
         label={units[1].displayName}
         action={children[2].props.action}
-        checked={false}
         unitId="mysql/1" />
     ]);
   });
@@ -89,30 +87,28 @@ describe('UnitList', () => {
     ];
     assert.deepEqual(children, [
       <juju.components.UnitListItem
+        ref="select-all-0"
         key="select-all-0"
         className="select-all"
         label="hook failed: install"
-        checked={false}
         whenChanged={children[0].props.whenChanged}/>,
       <juju.components.UnitListItem
         key={units[0].displayName}
         ref={refs[0]}
         label={units[0].displayName}
         action={children[1].props.action}
-        checked={false}
         unitId="mysql/0" />,
       <juju.components.UnitListItem
+        ref="select-all-1"
         key="select-all-1"
         className="select-all"
         label="hook failed: config-changed"
-        checked={false}
         whenChanged={children[2].props.whenChanged}/>,
       <juju.components.UnitListItem
         key={units[1].displayName}
         ref={refs[1]}
         label={units[1].displayName}
         action={children[3].props.action}
-        checked={false}
         unitId="mysql/1" />
     ]);
   });
@@ -156,47 +152,18 @@ describe('UnitList', () => {
       displayName: 'mysql/1',
       id: 'mysql/1'
     }];
-    var shallowRenderer = jsTestUtils.shallowRender(
-        <juju.components.UnitList
-          units={units} />, true);
-    var output = shallowRenderer.getRenderOutput();
-    var selectAll = output.props.children[1].props.children[0];
-
-    // Trigger the select callback;
-    selectAll.props.whenChanged(true);
-    // re-render the component
-    shallowRenderer.render(
-        <juju.components.UnitList
-          units={units} />);
-    output = shallowRenderer.getRenderOutput();
-
-    var children = output.props.children[1].props.children;
-    var refs = [
-      'UnitListItem-' + units[0].id,
-      'UnitListItem-' + units[1].id
-    ];
-    assert.deepEqual(children, [
-      <juju.components.UnitListItem
-        key="select-all"
-        className="select-all"
-        label="Select all units"
-        checked={true}
-        whenChanged={children[0].props.whenChanged}/>,
-      <juju.components.UnitListItem
-        key={units[0].displayName}
-        ref={refs[0]}
-        label={units[0].displayName}
-        action={output.props.children[1].props.children[1].props.action}
-        checked={true}
-        unitId="mysql/0" />,
-      <juju.components.UnitListItem
-        key={units[1].displayName}
-        ref={refs[1]}
-        label={units[1].displayName}
-        action={output.props.children[1].props.children[2].props.action}
-        checked={true}
-        unitId="mysql/1" />
-    ]);
+    // shallowRenderer doesn't support state so need to render it.
+    var component = testUtils.renderIntoDocument(
+      <juju.components.UnitList units={units} />);
+    var refs = component.refs;
+    // We want to make sure that they are not checked first.
+    assert.deepEqual(refs['UnitListItem-mysql/0'].state, {checked: false});
+    assert.deepEqual(refs['UnitListItem-mysql/0'].state, {checked: false});
+    // Activate the select all toggle.
+    refs['select-all'].props.whenChanged(true);
+    // Now check that they are all checked.
+    assert.deepEqual(refs['UnitListItem-mysql/0'].state, {checked: true});
+    assert.deepEqual(refs['UnitListItem-mysql/0'].state, {checked: true});
   });
 
   it('navigates to the unit when a list item is clicked', function() {

--- a/jujugui/static/gui/src/app/components/unit-list/unit-list.js
+++ b/jujugui/static/gui/src/app/components/unit-list/unit-list.js
@@ -23,18 +23,6 @@ YUI.add('unit-list', function() {
   juju.components.UnitList = React.createClass({
 
     /**
-      Get the current state of the inspector.
-
-      @method getInitialState
-      @returns {String} The current state.
-    */
-    getInitialState: function() {
-      // Setting a default state object.
-      return {
-        selectAll: {}
-      };
-    },
-    /**
       Fires changeState to update the UI based on the component clicked.
 
       @method _navigate
@@ -60,18 +48,15 @@ YUI.add('unit-list', function() {
         checked.
     */
     _selectAllUnits: function(group, checked) {
-      var selectAll = this.state.selectAll;
       if (checked === undefined) {
-        checked = !selectAll[group];
+        checked = false;
       }
-      if (group === null) {
-        Object.keys(selectAll).forEach(function(key) {
-          selectAll[key] = checked;
+      var groups = this._generateGroups();
+      groups[group].units.forEach((unit) => {
+        this.refs['UnitListItem-' + unit.id].setState({
+          checked: checked
         });
-      } else {
-        selectAll[group] = checked;
-      }
-      this.setState({selectAll: selectAll});
+      });
     },
 
     /**
@@ -124,27 +109,24 @@ YUI.add('unit-list', function() {
     */
     _generateUnitList: function(group) {
       var key = group.key;
-      var checked = this.state.selectAll[key] || false;
-      var components = [
+      var unitList = [
         <juju.components.UnitListItem
           key={key}
           label={group.label}
-          checked={checked}
           className='select-all'
           whenChanged={this._selectAllUnits.bind(this, key)}/>
       ];
       group.units.forEach((unit) => {
         var ref = 'UnitListItem-' + unit.id;
-        components.push(
+        unitList.push(
           <juju.components.UnitListItem
             key={unit.displayName}
             ref={ref}
             label={unit.displayName}
             action={this._unitItemAction}
-            checked={checked}
             unitId={unit.id} />);
       });
-      return components;
+      return unitList;
     },
 
     /**
@@ -163,14 +145,14 @@ YUI.add('unit-list', function() {
     },
 
     /**
-      Generate the groups of units.
+      Generate the groups of units for the service.
 
-      @returns {Object} The list components
+      @method _generateGroups
+      @returns {Object} The groups of units for the service.
     */
-    _generateListGroups: function() {
+    _generateGroups: function() {
       var units = this.props.units;
-      var components = [];
-      var groups = [];
+      var groups = {};
       if (this.props.unitStatus === 'error') {
         var errors = {};
         units.forEach(function(unit) {
@@ -181,20 +163,34 @@ YUI.add('unit-list', function() {
           errors[agentState].push(unit);
         });
         Object.keys(errors).forEach(function (error, i) {
-          groups.push({
+          var key = 'select-all-' + i;
+          groups[key] = {
             label: error,
             units: errors[error],
-            key: 'select-all-' + i
-          });
+            key: key
+          };
         });
       } else {
-        groups.push({
+        var key = 'select-all';
+        groups[key] = {
           label: 'Select all units',
           units: units,
-          key: 'select-all'
-        });
+          key: key
+        };
       }
-      groups.forEach(function(group) {
+      return groups;
+    },
+
+    /**
+      Generate the groups of units.
+
+      @returns {Object} The list components
+    */
+    _generateListGroups: function() {
+      var components = [];
+      var groups = this._generateGroups();
+      Object.keys(groups).forEach(function(key) {
+        var group = groups[key];
         components = components.concat(this._generateUnitList(group));
       }, this);
       return components;

--- a/jujugui/static/gui/src/app/components/unit-list/unit-list.js
+++ b/jujugui/static/gui/src/app/components/unit-list/unit-list.js
@@ -48,15 +48,25 @@ YUI.add('unit-list', function() {
         checked.
     */
     _selectAllUnits: function(group, checked) {
+      var setChecked = (key, groups) => {
+        groups[key].units.forEach((unit) => {
+          this.refs['UnitListItem-' + unit.id].setState({
+            checked: checked
+          });
+        });
+      };
       if (checked === undefined) {
         checked = false;
       }
       var groups = this._generateGroups();
-      groups[group].units.forEach((unit) => {
-        this.refs['UnitListItem-' + unit.id].setState({
-          checked: checked
-        });
-      });
+      if (group === null) {
+        for (var key in groups) {
+          setChecked(key, groups);
+        }
+      } else {
+        setChecked(group, groups);
+      }
+
     },
 
     /**
@@ -112,6 +122,7 @@ YUI.add('unit-list', function() {
       var unitList = [
         <juju.components.UnitListItem
           key={key}
+          ref={key}
           label={group.label}
           className='select-all'
           whenChanged={this._selectAllUnits.bind(this, key)}/>
@@ -220,6 +231,7 @@ YUI.add('unit-list', function() {
   });
 
 }, '0.1.0', { requires: [
+  'overview-action',
   'button-row',
   'unit-list-item'
 ]});


### PR DESCRIPTION
The checked units in the unit lists were getting unchecked every time the list rerendered. This updates that functionality so that the selecting persists correctly through updates and un/select-alls