### PR TITLE
Eslint only()

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,3 +16,4 @@ rules:
   no-debugger: 1
   no-unused-vars: [2, {args: "none"}]
   indent: [2, 2, {SwitchCase: 1, VariableDeclarator: 2}]
+  no-single-tests: 1

--- a/Makefile
+++ b/Makefile
@@ -316,7 +316,7 @@ lint: $(FLAKE8)
 
 .PHONY: lint-js
 lint-js: $(NODE_MODULES)
-	$(NODE_MODULES)/.bin/eslint $(GUISRC)
+	$(NODE_MODULES)/.bin/eslint --rulesdir eslint-rules/ $(GUISRC)
 
 .PHONY: test
 test: $(PYTEST)

--- a/eslint-rules/no-single-tests.js
+++ b/eslint-rules/no-single-tests.js
@@ -1,0 +1,17 @@
+module.exports = function(context) {
+    return {
+        Identifier: function(node) {
+            var nodeName = node.name;
+            if (nodeName === 'only') {
+                var parentName = node.parent.object.name;
+                if (parentName === 'it' || parentName === 'describe') {
+                    context.report(node, '.only() was left in a test');
+                }
+            } else if (nodeName === 'fdescribe') {
+                context.report(node, 'fdescribe() was left in a test');
+            } else if (nodeName === 'fit') {
+                context.report(node, 'fit() was left in a test');
+            }
+        }
+    };
+};


### PR DESCRIPTION
Add lint errors if .only() fit() or fdescribe() are left in tests.