### PR TITLE
Add service visibility toggles to the services list

### DIFF
--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -810,6 +810,7 @@ YUI.add('juju-gui', function(Y) {
           <components.AddedServicesList
             services={db.services}
             updateUnitFlags={db.updateUnitFlags.bind(db)}
+            findRelatedServices={db.findRelatedServices.bind(db)}
             findUnrelatedServices={db.findUnrelatedServices.bind(db)}
             setMVVisibility={db.setMVVisibility.bind(db)}
             getUnitStatusCounts={utils.getUnitStatusCounts}

--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -802,13 +802,16 @@ YUI.add('juju-gui', function(Y) {
     */
     _renderAddedServices: function(services) {
       var utils = views.utils;
-      var services = this.db.services.toArray();
+      var db = this.db;
       ReactDOM.render(
         <components.Panel
           instanceName="inspector-panel"
-          visible={services.length > 0}>
+          visible={db.services.size() > 0}>
           <components.AddedServicesList
-            services={services}
+            services={db.services}
+            updateUnitFlags={db.updateUnitFlags.bind(db)}
+            findUnrelatedServices={db.findUnrelatedServices.bind(db)}
+            setMVVisibility={db.setMVVisibility.bind(db)}
             getUnitStatusCounts={utils.getUnitStatusCounts}
             changeState={this.changeState.bind(this)} />
         </components.Panel>,

--- a/jujugui/static/gui/src/app/assets/css/_mixins.scss
+++ b/jujugui/static/gui/src/app/assets/css/_mixins.scss
@@ -180,7 +180,6 @@
 @mixin notification($background) {
     $size: 24px;
     box-sizing: border-box;
-    float: right;
     min-width: $size;
     height: $size;
     padding: 0 7px;

--- a/jujugui/static/gui/src/app/assets/svgs/focused_16.svg
+++ b/jujugui/static/gui/src/app/assets/svgs/focused_16.svg
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16.008831"
+   height="16.008839"
+   viewBox="0 0 4.2356699 4.2356721"
+   version="1.1"
+   id="svg6296"
+   inkscape:version="0.91+devel r"
+   sodipodi:docname="focused_16.svg">
+  <defs
+     id="defs6290" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="30.357661"
+     inkscape:cx="23.804784"
+     inkscape:cy="19.810772"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     units="px" />
+  <metadata
+     id="metadata6293">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(278.05002,-10.805024)">
+    <rect
+       y="10.806193"
+       x="-278.04886"
+       height="4.2333336"
+       width="4.2333336"
+       id="rect6312"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:1.32291675;marker:none;enable-background:accumulate"
+       inkscape:export-filename="./g6986.png"
+       inkscape:export-xdpi="191.99951"
+       inkscape:export-ydpi="191.99951" />
+    <circle
+       r="0.52916735"
+       cy="12.92286"
+       cx="-275.93222"
+       id="circle6314"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.26458335;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:10.79999924;stroke-opacity:1;marker:none;enable-background:accumulate"
+       inkscape:export-filename="./g6986.png"
+       inkscape:export-xdpi="191.99951"
+       inkscape:export-ydpi="191.99951" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.26458332;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:10.79999924;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m -275.93218,11.599718 c -0.72906,0 -1.32292,0.593858 -1.32292,1.322917 0,0.729059 0.59386,1.322917 1.32292,1.322917 0.72906,0 1.32291,-0.593858 1.32291,-1.322917 0,-0.729059 -0.59385,-1.322917 -1.32291,-1.322917 z m 0,0.264584 c 0.58606,0 1.05833,0.472265 1.05833,1.058333 0,0.586068 -0.47227,1.058333 -1.05833,1.058333 -0.58607,0 -1.05834,-0.472265 -1.05834,-1.058333 0,-0.586068 0.47227,-1.058333 1.05834,-1.058333 z"
+       id="circle6316"
+       inkscape:connector-curvature="0"
+       inkscape:export-filename="./g6986.png"
+       inkscape:export-xdpi="191.99951"
+       inkscape:export-ydpi="191.99951" />
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.52916664;marker:none;enable-background:accumulate"
+       d="m -278.05002,11.655066 c 0,0 0.51257,0.164698 1.05929,0.210225 8e-5,-7.7e-5 10e-5,-10e-5 10e-5,0 1.1e-4,-1.06e-4 3e-5,-5e-6 1e-4,-1.6e-5 3e-5,-9.5e-5 0,0 -2.6e-4,-0.0019 8e-5,-10e-5 4e-5,-10e-6 1e-4,0 -0.0536,-0.570833 -0.2112,-1.057166 -0.2112,-1.057166 z"
+       id="path6318"
+       inkscape:connector-curvature="0"
+       inkscape:transform-center-x="6.0022147"
+       inkscape:transform-center-y="-5.998435"
+       sodipodi:nodetypes="ccsssccc"
+       inkscape:export-filename="./g6986.png"
+       inkscape:export-xdpi="191.99951"
+       inkscape:export-ydpi="191.99951" />
+    <path
+       sodipodi:nodetypes="ccsssccc"
+       inkscape:transform-center-y="-6.0022147"
+       inkscape:transform-center-x="-5.998435"
+       inkscape:connector-curvature="0"
+       id="path6087"
+       d="m -274.66439,10.805024 c 0,0 -0.1647,0.512572 -0.21023,1.059291 8e-5,7.9e-5 1.1e-4,1.03e-4 0,1.03e-4 1.1e-4,1.08e-4 10e-6,2.4e-5 2e-5,9.8e-5 10e-5,2.6e-5 0,0 0.002,-2.65e-4 10e-5,8.2e-5 10e-6,4.5e-5 0,1.03e-4 0.57084,-0.05361 1.05717,-0.211201 1.05717,-0.211201 z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.52916664;marker:none;enable-background:accumulate"
+       inkscape:export-filename="./g6986.png"
+       inkscape:export-xdpi="191.99951"
+       inkscape:export-ydpi="191.99951" />
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.52916664;marker:none;enable-background:accumulate"
+       d="m -273.81435,14.190653 c 0,0 -0.51257,-0.164698 -1.05929,-0.210224 -8e-5,7.6e-5 -10e-5,10e-5 -10e-5,0 -1.1e-4,1.05e-4 -3e-5,5e-6 -10e-5,1.5e-5 -3e-5,9.6e-5 0,0 2.6e-4,0.0019 -8e-5,10e-5 -4e-5,1e-5 -10e-5,0 0.0536,0.570833 0.2112,1.057166 0.2112,1.057166 z"
+       id="path6089"
+       inkscape:connector-curvature="0"
+       inkscape:transform-center-x="-6.0022147"
+       inkscape:transform-center-y="5.998435"
+       sodipodi:nodetypes="ccsssccc"
+       inkscape:export-filename="./g6986.png"
+       inkscape:export-xdpi="191.99951"
+       inkscape:export-ydpi="191.99951" />
+    <path
+       sodipodi:nodetypes="ccsssccc"
+       inkscape:transform-center-y="6.0022147"
+       inkscape:transform-center-x="5.998435"
+       inkscape:connector-curvature="0"
+       id="path6094"
+       d="m -277.19998,15.040696 c 0,0 0.1647,-0.512572 0.21023,-1.059291 -8e-5,-7.9e-5 -10e-5,-1.03e-4 0,-1.03e-4 -1.1e-4,-1.09e-4 -10e-6,-2.4e-5 -2e-5,-9.8e-5 -9e-5,-2.7e-5 0,0 -0.002,2.64e-4 -1e-4,-8.2e-5 -1e-5,-4.5e-5 0,-1.03e-4 -0.57083,0.05361 -1.05717,0.211201 -1.05717,0.211201 z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.52916664;marker:none;enable-background:accumulate"
+       inkscape:export-filename="./g6986.png"
+       inkscape:export-xdpi="191.99951"
+       inkscape:export-ydpi="191.99951" />
+  </g>
+</svg>

--- a/jujugui/static/gui/src/app/assets/svgs/hide_16.svg
+++ b/jujugui/static/gui/src/app/assets/svgs/hide_16.svg
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="15.999999"
+   id="svg5918"
+   version="1.1"
+   inkscape:version="0.91pre2 r"
+   viewBox="0 0 16 15.999999"
+   sodipodi:docname="hide_16.svg">
+  <defs
+     id="defs5920">
+    <clipPath
+       id="clipPath16"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path18"
+         d="m 0,595.28 841.89,0 L 841.89,0 0,0 0,595.28 Z" />
+    </clipPath>
+    <clipPath
+       id="clipPath16-0"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path18-1"
+         d="m 0,595.28 841.89,0 L 841.89,0 0,0 0,595.28 Z" />
+    </clipPath>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#dedede"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="30.357661"
+     inkscape:cx="6.4437892"
+     inkscape:cy="7.4631759"
+     inkscape:document-units="px"
+     inkscape:current-layer="g5756"
+     showgrid="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0.2"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:object-paths="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:object-nodes="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-midpoints="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-center="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4137"
+       originx="-0.00011296354px"
+       originy="-8.999973px" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5923">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-182.93849,-560.7201)">
+    <g
+       style="display:inline"
+       transform="matrix(0.66666607,0,0,0.66666668,-633.06096,6.8119427)"
+       id="g5687" />
+    <g
+       style="display:inline"
+       id="g5346"
+       transform="translate(-769.06151,404.35792)">
+      <g
+         style="display:inline"
+         id="g5756"
+         transform="matrix(0.66666668,0,0,0.66666668,610.66666,4.120729)">
+        <rect
+           y="228.3622"
+           x="512"
+           height="24"
+           width="24"
+           id="rect5758"
+           style="opacity:0.21171169;fill:none;stroke:none" />
+        <path
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.30762327;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           d="M 8 2.9980469 C 2.7721864 2.9980469 0.17382814 7.6816406 0.17382812 7.6816406 L -0.001953125 8 L 0.17382812 8.3164062 C 0.17382812 8.3164062 0.85472567 9.5340016 2.2109375 10.728516 L 4.0957031 8.84375 A 4.0000434 4.0000434 0 0 1 4 8 A 4.0000434 4.0000434 0 0 1 8 4 A 4.0000434 4.0000434 0 0 1 8.8457031 4.09375 L 9.7539062 3.1855469 C 9.2058282 3.0685047 8.6226186 2.9980469 8 2.9980469 z M 11.357422 3.703125 L 10.316406 4.7441406 A 4.0000434 4.0000434 0 0 1 12 8 A 4.0000434 4.0000434 0 0 1 8 12 A 4.0000434 4.0000434 0 0 1 4.7441406 10.316406 L 3.421875 11.638672 C 4.6179801 12.403716 6.1385709 13.001953 8 13.001953 C 13.227807 13.001953 15.826172 8.3164062 15.826172 8.3164062 L 16.001953 8 L 15.826172 7.6816406 C 15.826172 7.6816406 14.338949 5.0099078 11.357422 3.703125 z "
+           transform="matrix(1.5,0,0,1.5,512,228.36217)"
+           id="path5760" />
+        <path
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           d="M 9.2324219 5.828125 L 5.828125 9.2324219 A 2.5 2.5 0 0 0 8 10.5 A 2.5 2.5 0 0 0 10.5 8 A 2.5 2.5 0 0 0 9.2324219 5.828125 z "
+           transform="matrix(1.5,0,0,1.5,512,228.36217)"
+           id="circle5764" />
+        <path
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#808080;stroke-width:2.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           d="m 513.5,250.8622 21,-21"
+           id="path5768-9"
+           inkscape:connector-curvature="0" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/jujugui/static/gui/src/app/assets/svgs/show_16.svg
+++ b/jujugui/static/gui/src/app/assets/svgs/show_16.svg
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="15.999999"
+   id="svg5918"
+   version="1.1"
+   inkscape:version="0.91pre2 r"
+   viewBox="0 0 16 15.999999"
+   sodipodi:docname="show_16.svg">
+  <defs
+     id="defs5920">
+    <clipPath
+       id="clipPath16"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path18"
+         d="m 0,595.28 841.89,0 L 841.89,0 0,0 0,595.28 Z" />
+    </clipPath>
+    <clipPath
+       id="clipPath16-0"
+       clipPathUnits="userSpaceOnUse">
+      <path
+         inkscape:connector-curvature="0"
+         id="path18-1"
+         d="m 0,595.28 841.89,0 L 841.89,0 0,0 0,595.28 Z" />
+    </clipPath>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#dedede"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="30.357661"
+     inkscape:cx="6.4437892"
+     inkscape:cy="7.4631759"
+     inkscape:document-units="px"
+     inkscape:current-layer="g5696"
+     showgrid="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0.2"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:object-paths="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:object-nodes="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-midpoints="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-center="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4137"
+       originx="-0.00011296354px"
+       originy="-8.999973px" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5923">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-182.93849,-560.7201)">
+    <g
+       style="display:inline"
+       transform="matrix(0.66666607,0,0,0.66666668,-633.06096,6.8119427)"
+       id="g5687" />
+    <g
+       style="display:inline"
+       id="g5346"
+       transform="translate(-769.06151,404.35792)">
+      <g
+         style="display:inline"
+         transform="matrix(0.66666668,0,0,0.66666668,610.66666,4.1207307)"
+         id="g5696">
+        <rect
+           style="opacity:0.21171169;fill:none;stroke:none"
+           id="rect5698"
+           width="24"
+           height="24"
+           x="512"
+           y="228.3622" />
+        <path
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.30762327;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           d="M 8 2.9980469 C 2.7721865 2.9980469 0.17382813 7.6816406 0.17382812 7.6816406 L -0.001953125 8 L 0.17382812 8.3164062 C 0.17382812 8.3164062 2.7721865 13.001953 8 13.001953 C 13.227807 13.001953 15.826172 8.3164062 15.826172 8.3164062 L 16.001953 8 L 15.826172 7.6816406 C 15.826172 7.6816406 13.227807 2.9980469 8 2.9980469 z M 8 4 A 4.0000433 4.0000433 0 0 1 12 8 A 4.0000433 4.0000433 0 0 1 8 12 A 4.0000433 4.0000433 0 0 1 4 8 A 4.0000433 4.0000433 0 0 1 8 4 z "
+           transform="matrix(1.5,0,0,1.5,512,228.36217)"
+           id="path5700" />
+        <path
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           d="M 8 5.5 A 2.5 2.5 0 0 0 5.5 8 A 2.5 2.5 0 0 0 8 10.5 A 2.5 2.5 0 0 0 10.5 8 A 2.5 2.5 0 0 0 10.386719 7.265625 A 1.25 1.25 0 0 1 9.25 8 A 1.25 1.25 0 0 1 8 6.75 A 1.25 1.25 0 0 1 8.7382812 5.6113281 A 2.5 2.5 0 0 0 8 5.5 z "
+           transform="matrix(1.5,0,0,1.5,512,228.36217)"
+           id="circle5704" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/jujugui/static/gui/src/app/assets/svgs/unfocused_16.svg
+++ b/jujugui/static/gui/src/app/assets/svgs/unfocused_16.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16.008831"
+   height="16.008839"
+   viewBox="0 0 4.2356699 4.2356721"
+   version="1.1"
+   id="svg6296"
+   inkscape:version="0.91+devel r"
+   sodipodi:docname="unfocused_16.svg">
+  <defs
+     id="defs6290" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="30.357661"
+     inkscape:cx="23.804784"
+     inkscape:cy="19.810772"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     units="px" />
+  <metadata
+     id="metadata6293">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(278.05002,-10.805024)">
+    <rect
+       y="10.806193"
+       x="-278.04886"
+       height="4.2333336"
+       width="4.2333336"
+       id="rect6312"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:1.32291675;marker:none;enable-background:accumulate"
+       inkscape:export-filename="./g6986.png"
+       inkscape:export-xdpi="191.99951"
+       inkscape:export-ydpi="191.99951" />
+    <circle
+       r="0.52916735"
+       cy="12.92286"
+       cx="-275.93222"
+       id="circle6314"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.26458335;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:10.79999924;stroke-opacity:1;marker:none;enable-background:accumulate"
+       inkscape:export-filename="./g6986.png"
+       inkscape:export-xdpi="191.99951"
+       inkscape:export-ydpi="191.99951" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.26458332;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:10.79999924;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m -275.93218,11.599718 c -0.72906,0 -1.32292,0.593858 -1.32292,1.322917 0,0.729059 0.59386,1.322917 1.32292,1.322917 0.72906,0 1.32291,-0.593858 1.32291,-1.322917 0,-0.729059 -0.59385,-1.322917 -1.32291,-1.322917 z m 0,0.264584 c 0.58606,0 1.05833,0.472265 1.05833,1.058333 0,0.586068 -0.47227,1.058333 -1.05833,1.058333 -0.58607,0 -1.05834,-0.472265 -1.05834,-1.058333 0,-0.586068 0.47227,-1.058333 1.05834,-1.058333 z"
+       id="circle6316"
+       inkscape:connector-curvature="0"
+       inkscape:export-filename="./g6986.png"
+       inkscape:export-xdpi="191.99951"
+       inkscape:export-ydpi="191.99951" />
+  </g>
+</svg>

--- a/jujugui/static/gui/src/app/components/added-services-list-item/added-services-list-item.js
+++ b/jujugui/static/gui/src/app/components/added-services-list-item/added-services-list-item.js
@@ -139,7 +139,7 @@ YUI.add('added-services-list-item', function() {
       var statusData = this._getPriorityUnits(service.units.toArray());
       var statusIndicator = this._renderStatusIndicator(statusData);
       var focusIcon = state.focus ? 'focused_16' : 'unfocused_16';
-      var highlightIcon = state.highlight ? 'highlight_16' : 'unhighlight_16';
+      var highlightIcon = state.highlight ? 'show_16' : 'hide_16';
       return (
         <li className="inspector-view__list-item"
             data-serviceid={service.id}

--- a/jujugui/static/gui/src/app/components/added-services-list-item/added-services-list-item.js
+++ b/jujugui/static/gui/src/app/components/added-services-list-item/added-services-list-item.js
@@ -22,6 +22,13 @@ YUI.add('added-services-list-item', function() {
 
   juju.components.AddedServicesListItem = React.createClass({
 
+    propTypes: {
+      focusService: React.PropTypes.func.isRequired,
+      getUnitStatusCounts: React.PropTypes.func.isRequired,
+      changeState: React.PropTypes.func.isRequired,
+      service: React.PropTypes.object.isRequired
+    },
+
     getInitialState: function() {
       return {
         focus: false,
@@ -100,7 +107,12 @@ YUI.add('added-services-list-item', function() {
       // We need to stop the propagation so that the click event doesn't
       // bubble up to the list item and navigate away.
       e.stopPropagation();
-      this.setState({focus: !this.state.focus});
+      var focus = !this.state.focus;
+      this.setState({focus: focus});
+      if (focus) {
+        this.setState({highlight: false});
+      }
+      this.props.focusService(this.props.service.get('id'));
     },
 
     /**

--- a/jujugui/static/gui/src/app/components/added-services-list-item/added-services-list-item.js
+++ b/jujugui/static/gui/src/app/components/added-services-list-item/added-services-list-item.js
@@ -25,6 +25,8 @@ YUI.add('added-services-list-item', function() {
     propTypes: {
       focusService: React.PropTypes.func.isRequired,
       unfocusService: React.PropTypes.func.isRequired,
+      fadeService: React.PropTypes.func.isRequired,
+      unfadeService: React.PropTypes.func.isRequired,
       getUnitStatusCounts: React.PropTypes.func.isRequired,
       changeState: React.PropTypes.func.isRequired,
       service: React.PropTypes.object.isRequired
@@ -33,7 +35,7 @@ YUI.add('added-services-list-item', function() {
     getInitialState: function() {
       return {
         focus: false,
-        highlight: false
+        fade: false
       };
     },
 
@@ -113,7 +115,7 @@ YUI.add('added-services-list-item', function() {
       this.setState({focus: focus});
       var serviceId = props.service.get('id');
       if (focus) {
-        this.setState({highlight: false});
+        this.setState({fade: false});
         props.focusService(serviceId);
       } else {
         props.unfocusService(serviceId);
@@ -130,7 +132,16 @@ YUI.add('added-services-list-item', function() {
       // We need to stop the propagation so that the click event doesn't
       // bubble up to the list item and navigate away.
       e.stopPropagation();
-      this.setState({highlight: !this.state.highlight});
+      var props = this.props;
+      var fade = !this.state.fade;
+      this.setState({fade: fade});
+      var serviceId = props.service.get('id');
+      if (fade) {
+        this.setState({focus: false});
+        props.fadeService(serviceId);
+      } else {
+        props.unfadeService(serviceId);
+      }
     },
 
     render: function() {
@@ -139,7 +150,7 @@ YUI.add('added-services-list-item', function() {
       var statusData = this._getPriorityUnits(service.units.toArray());
       var statusIndicator = this._renderStatusIndicator(statusData);
       var focusIcon = state.focus ? 'focused_16' : 'unfocused_16';
-      var highlightIcon = state.highlight ? 'show_16' : 'hide_16';
+      var highlightIcon = state.fade ? 'hide_16' : 'show_16';
       return (
         <li className="inspector-view__list-item"
             data-serviceid={service.id}

--- a/jujugui/static/gui/src/app/components/added-services-list-item/added-services-list-item.js
+++ b/jujugui/static/gui/src/app/components/added-services-list-item/added-services-list-item.js
@@ -22,6 +22,13 @@ YUI.add('added-services-list-item', function() {
 
   juju.components.AddedServicesListItem = React.createClass({
 
+    getInitialState: function() {
+      return {
+        focus: false,
+        highlight: false
+      };
+    },
+
     /**
       Parses the supplied unit data to return the status color and number
       to display.
@@ -83,10 +90,39 @@ YUI.add('added-services-list-item', function() {
       this.props.changeState(state);
     },
 
+    /**
+      Toggles the focus attribute on the service
+
+      @method _toggleFocus
+      @param {Object} e The click event.
+    */
+    _toggleFocus: function(e) {
+      // We need to stop the propagation so that the click event doesn't
+      // bubble up to the list item and navigate away.
+      e.stopPropagation();
+      this.setState({focus: !this.state.focus});
+    },
+
+    /**
+      Toggles the highlight attribute on the service
+
+      @method _toggleHighlight
+      @param {Object} e The click event.
+    */
+    _toggleHighlight: function(e) {
+      // We need to stop the propagation so that the click event doesn't
+      // bubble up to the list item and navigate away.
+      e.stopPropagation();
+      this.setState({highlight: !this.state.highlight});
+    },
+
     render: function() {
+      var state = this.state;
       var service = this.props.service.getAttrs();
       var statusData = this._getPriorityUnits(service.units.toArray());
       var statusIndicator = this._renderStatusIndicator(statusData);
+      var focusIcon = state.focus ? 'focused_16' : 'unfocused_16';
+      var highlightIcon = state.highlight ? 'highlight_16' : 'unhighlight_16';
       return (
         <li className="inspector-view__list-item"
             data-serviceid={service.id}
@@ -101,11 +137,27 @@ YUI.add('added-services-list-item', function() {
           <span className="inspector-view__item-name">
             {service.name}
           </span>
-          {statusIndicator}
+          <span className="inspector-view__status-block">
+            <span
+              className="inspector-view__visibility-toggle"
+              onClick={this._toggleFocus}>
+              <juju.components.SvgIcon name={focusIcon} size="16"/>
+            </span>
+            <span
+              className="inspector-view__visibility-toggle"
+              onClick={this._toggleHighlight}>
+              <juju.components.SvgIcon name={highlightIcon} size="16"/>
+            </span>
+            {statusIndicator}
+          </span>
         </li>
       );
     }
 
   });
 
-}, '0.1.0', { requires: []});
+}, '0.1.0', {
+  requires: [
+    'svg-icon'
+  ]
+});

--- a/jujugui/static/gui/src/app/components/added-services-list-item/added-services-list-item.js
+++ b/jujugui/static/gui/src/app/components/added-services-list-item/added-services-list-item.js
@@ -33,10 +33,17 @@ YUI.add('added-services-list-item', function() {
     },
 
     getInitialState: function() {
+      var service = this.props.service;
       return {
-        focus: false,
-        fade: false
+        focus: service.get('highlight') || false,
+        fade: service.get('fade') || false
       };
+    },
+
+    componentWillReceiveProps: function(nextProps) {
+      var service = this.props.service;
+      this.setState({focus: service.get('highlight')});
+      this.setState({fade: service.get('fade')});
     },
 
     /**

--- a/jujugui/static/gui/src/app/components/added-services-list-item/added-services-list-item.js
+++ b/jujugui/static/gui/src/app/components/added-services-list-item/added-services-list-item.js
@@ -24,6 +24,7 @@ YUI.add('added-services-list-item', function() {
 
     propTypes: {
       focusService: React.PropTypes.func.isRequired,
+      unfocusService: React.PropTypes.func.isRequired,
       getUnitStatusCounts: React.PropTypes.func.isRequired,
       changeState: React.PropTypes.func.isRequired,
       service: React.PropTypes.object.isRequired
@@ -107,12 +108,16 @@ YUI.add('added-services-list-item', function() {
       // We need to stop the propagation so that the click event doesn't
       // bubble up to the list item and navigate away.
       e.stopPropagation();
+      var props = this.props;
       var focus = !this.state.focus;
       this.setState({focus: focus});
+      var serviceId = props.service.get('id');
       if (focus) {
         this.setState({highlight: false});
+        props.focusService(serviceId);
+      } else {
+        props.unfocusService(serviceId);
       }
-      this.props.focusService(this.props.service.get('id'));
     },
 
     /**

--- a/jujugui/static/gui/src/app/components/added-services-list-item/added-services-list-item.js
+++ b/jujugui/static/gui/src/app/components/added-services-list-item/added-services-list-item.js
@@ -175,11 +175,13 @@ YUI.add('added-services-list-item', function() {
           <span className="inspector-view__status-block">
             <span
               className="inspector-view__visibility-toggle"
+              ref="focusVisibilityIcon"
               onClick={this._toggleFocus}>
               <juju.components.SvgIcon name={focusIcon} size="16"/>
             </span>
             <span
               className="inspector-view__visibility-toggle"
+              ref="fadeVisibilityIcon"
               onClick={this._toggleHighlight}>
               <juju.components.SvgIcon name={highlightIcon} size="16"/>
             </span>

--- a/jujugui/static/gui/src/app/components/added-services-list-item/added-services-list-item.js
+++ b/jujugui/static/gui/src/app/components/added-services-list-item/added-services-list-item.js
@@ -151,6 +151,13 @@ YUI.add('added-services-list-item', function() {
       }
     },
 
+    _generateClassName: function() {
+      return classNames(
+        'inspector-view__list-item',
+        this.state.focus || this.state.fade ? 'visibility-toggled' : false
+      );
+    },
+
     render: function() {
       var state = this.state;
       var service = this.props.service.getAttrs();
@@ -159,7 +166,7 @@ YUI.add('added-services-list-item', function() {
       var focusIcon = state.focus ? 'focused_16' : 'unfocused_16';
       var highlightIcon = state.fade ? 'hide_16' : 'show_16';
       return (
-        <li className="inspector-view__list-item"
+        <li className={this._generateClassName()}
             data-serviceid={service.id}
             onClick={this._onClickHandler}
             tabIndex="0"

--- a/jujugui/static/gui/src/app/components/added-services-list-item/test-added-services-list-item.js
+++ b/jujugui/static/gui/src/app/components/added-services-list-item/test-added-services-list-item.js
@@ -552,6 +552,11 @@ describe('AddedServicesListItem', function() {
         getUnitStatusCounts={sinon.stub()}
         service={service} />);
 
+    // Check that the container has the proper classes when no visibility
+    // toggle is active.
+    assert.equal(
+      ReactDOM.findDOMNode(instance).classList,
+      'inspector-view__list-item');
     // Toggle focus on.
     assert.equal(instance.state.fade, false);
     testUtils.Simulate.click(instance.refs.fadeVisibilityIcon);
@@ -559,6 +564,11 @@ describe('AddedServicesListItem', function() {
     assert.equal(fadeService.callCount, 1);
     assert.equal(unfadeService.callCount, 0);
     assert.equal(fadeService.args[0][0], 'wordpress');
+    // Check that the container has the proper classes when a visibility
+    // toggle is active.
+    assert.equal(
+      ReactDOM.findDOMNode(instance).classList,
+      'inspector-view__list-item visibility-toggled');
 
     // Toggle focus off.
     testUtils.Simulate.click(instance.refs.fadeVisibilityIcon);

--- a/jujugui/static/gui/src/app/components/added-services-list-item/test-added-services-list-item.js
+++ b/jujugui/static/gui/src/app/components/added-services-list-item/test-added-services-list-item.js
@@ -40,7 +40,7 @@ describe('AddedServicesListItem', function() {
     });
   }
 
-  it('renders the icon, count and display name', function() {
+  it('renders the icon, count, visibility toggles and display name', () => {
     var service = {
       getAttrs: function() {
         return {
@@ -49,12 +49,24 @@ describe('AddedServicesListItem', function() {
             toArray: function() {
               return [];
             }}};
+      },
+      get: function() {
+        return false;
       }};
-    var output = jsTestUtils.shallowRender(
+    var renderer = jsTestUtils.shallowRender(
         <juju.components.AddedServicesListItem
+          focusService={sinon.stub()}
+          unfocusService={sinon.stub()}
+          fadeService={sinon.stub()}
+          unfadeService={sinon.stub()}
+          changeState={sinon.stub()}
           getUnitStatusCounts={getUnitStatusCounts()}
-          service={service} />);
-    assert.deepEqual(output,
+          service={service} />, true);
+
+    var output = renderer.getRenderOutput();
+    var instance = renderer.getMountedInstance();
+
+    var expected = (
       <li className="inspector-view__list-item"
           data-serviceid="demo"
           onClick={output.props.onClick}
@@ -66,8 +78,23 @@ describe('AddedServicesListItem', function() {
         <span className="inspector-view__item-name">
           demo
         </span>
-        {undefined}
+        <span className="inspector-view__status-block">
+          <span
+            className="inspector-view__visibility-toggle"
+            ref="focusVisibilityIcon"
+            onClick={instance._toggleFocus}>
+            <juju.components.SvgIcon name="unfocused_16" size="16"/>
+          </span>
+          <span
+            className="inspector-view__visibility-toggle"
+            ref="fadeVisibilityIcon"
+            onClick={instance._toggleHighlight}>
+            <juju.components.SvgIcon name="show_16" size="16"/>
+          </span>
+          {undefined}
+        </span>
       </li>);
+    assert.deepEqual(output, expected);
   });
 
   it('only shows the status icon for pending, uncommitted, error', function() {
@@ -104,11 +131,23 @@ describe('AddedServicesListItem', function() {
               toArray: function() {
                 return [{agent_state: status.name}];
               }}};
+        },
+        get: function() {
+          return false;
         }};
-      var output = jsTestUtils.shallowRender(
+      var renderer = jsTestUtils.shallowRender(
           <juju.components.AddedServicesListItem
+            focusService={sinon.stub()}
+            unfocusService={sinon.stub()}
+            fadeService={sinon.stub()}
+            unfadeService={sinon.stub()}
+            changeState={sinon.stub()}
             getUnitStatusCounts={status.statusCounts}
-            service={service} />);
+            service={service} />, true);
+
+      var output = renderer.getRenderOutput();
+      var instance = renderer.getMountedInstance();
+
       assert.deepEqual(output,
         <li className="inspector-view__list-item"
             data-serviceid="demo"
@@ -121,7 +160,21 @@ describe('AddedServicesListItem', function() {
           <span className="inspector-view__item-name">
             demo
           </span>
-          {statusIcon(status)}
+          <span className="inspector-view__status-block">
+            <span
+              className="inspector-view__visibility-toggle"
+              ref="focusVisibilityIcon"
+              onClick={instance._toggleFocus}>
+              <juju.components.SvgIcon name="unfocused_16" size="16"/>
+            </span>
+            <span
+              className="inspector-view__visibility-toggle"
+              ref="fadeVisibilityIcon"
+              onClick={instance._toggleHighlight}>
+              <juju.components.SvgIcon name="show_16" size="16"/>
+            </span>
+            {statusIcon(status)}
+          </span>
         </li>);
     });
   });
@@ -135,11 +188,24 @@ describe('AddedServicesListItem', function() {
             toArray: function() {
               return [{agent_state: 'unknown-state'}];
             }}};
+      },
+      get: function() {
+        return false;
       }};
-    var output = jsTestUtils.shallowRender(
+
+    var renderer = jsTestUtils.shallowRender(
       <juju.components.AddedServicesListItem
+        focusService={sinon.stub()}
+        unfocusService={sinon.stub()}
+        fadeService={sinon.stub()}
+        unfadeService={sinon.stub()}
+        changeState={sinon.stub()}
         getUnitStatusCounts={getUnitStatusCounts()}
-        service={service} />);
+        service={service} />, true);
+
+    var output = renderer.getRenderOutput();
+    var instance = renderer.getMountedInstance();
+
     assert.deepEqual(output,
         <li className="inspector-view__list-item"
             data-serviceid="demo"
@@ -152,7 +218,21 @@ describe('AddedServicesListItem', function() {
           <span className="inspector-view__item-name">
             demo
           </span>
-          {undefined}
+          <span className="inspector-view__status-block">
+            <span
+              className="inspector-view__visibility-toggle"
+              ref="focusVisibilityIcon"
+              onClick={instance._toggleFocus}>
+              <juju.components.SvgIcon name="unfocused_16" size="16"/>
+            </span>
+            <span
+              className="inspector-view__visibility-toggle"
+              ref="fadeVisibilityIcon"
+              onClick={instance._toggleHighlight}>
+              <juju.components.SvgIcon name="show_16" size="16"/>
+            </span>
+            {undefined}
+          </span>
         </li>);
   });
 
@@ -165,11 +245,23 @@ describe('AddedServicesListItem', function() {
             toArray: function() {
               return [{agent_state: 'pending'}, {agent_state: 'error'}];
             }}};
+      },
+      get: function() {
+        return false;
       }};
-    var output = jsTestUtils.shallowRender(
+    var renderer = jsTestUtils.shallowRender(
       <juju.components.AddedServicesListItem
+        focusService={sinon.stub()}
+        unfocusService={sinon.stub()}
+        fadeService={sinon.stub()}
+        unfadeService={sinon.stub()}
+        changeState={sinon.stub()}
         getUnitStatusCounts={getUnitStatusCounts(1, 1)}
-        service={service} />);
+        service={service} />, true);
+
+    var output = renderer.getRenderOutput();
+    var instance = renderer.getMountedInstance();
+
     assert.deepEqual(output,
         <li className="inspector-view__list-item"
             data-serviceid="demo"
@@ -182,7 +274,21 @@ describe('AddedServicesListItem', function() {
           <span className="inspector-view__item-name">
             demo
           </span>
-          <span className="inspector-view__status--error">1</span>
+          <span className="inspector-view__status-block">
+            <span
+              className="inspector-view__visibility-toggle"
+              ref="focusVisibilityIcon"
+              onClick={instance._toggleFocus}>
+              <juju.components.SvgIcon name="unfocused_16" size="16"/>
+            </span>
+            <span
+              className="inspector-view__visibility-toggle"
+              ref="fadeVisibilityIcon"
+              onClick={instance._toggleHighlight}>
+              <juju.components.SvgIcon name="show_16" size="16"/>
+            </span>
+            <span className="inspector-view__status--error">1</span>
+          </span>
         </li>);
   });
 
@@ -195,11 +301,23 @@ describe('AddedServicesListItem', function() {
             toArray: function() {
               return [{agent_state: 'uncommitted'}, {agent_state: 'pending'}];
             }}};
+      },
+      get: function() {
+        return false;
       }};
-    var output = jsTestUtils.shallowRender(
+    var renderer = jsTestUtils.shallowRender(
       <juju.components.AddedServicesListItem
+        focusService={sinon.stub()}
+        unfocusService={sinon.stub()}
+        fadeService={sinon.stub()}
+        unfadeService={sinon.stub()}
+        changeState={sinon.stub()}
         getUnitStatusCounts={getUnitStatusCounts(0, 1, 1)}
-        service={service} />);
+        service={service} />, true);
+
+    var output = renderer.getRenderOutput();
+    var instance = renderer.getMountedInstance();
+
     assert.deepEqual(output,
         <li className="inspector-view__list-item"
             data-serviceid="demo"
@@ -212,7 +330,21 @@ describe('AddedServicesListItem', function() {
           <span className="inspector-view__item-name">
             demo
           </span>
-          <span className="inspector-view__status--pending">1</span>
+          <span className="inspector-view__status-block">
+            <span
+              className="inspector-view__visibility-toggle"
+              ref="focusVisibilityIcon"
+              onClick={instance._toggleFocus}>
+              <juju.components.SvgIcon name="unfocused_16" size="16"/>
+            </span>
+            <span
+              className="inspector-view__visibility-toggle"
+              ref="fadeVisibilityIcon"
+              onClick={instance._toggleHighlight}>
+              <juju.components.SvgIcon name="show_16" size="16"/>
+            </span>
+            <span className="inspector-view__status--pending">1</span>
+          </span>
         </li>);
   });
 
@@ -225,11 +357,18 @@ describe('AddedServicesListItem', function() {
             toArray: function() {
               return [];
             }}};
+      },
+      get: function() {
+        return false;
       }};
     var changeStub = sinon.stub();
     var shallowRenderer = testUtils.createRenderer();
     shallowRenderer.render(
         <juju.components.AddedServicesListItem
+          focusService={sinon.stub()}
+          unfocusService={sinon.stub()}
+          fadeService={sinon.stub()}
+          unfadeService={sinon.stub()}
           changeState={changeStub}
           getUnitStatusCounts={getUnitStatusCounts()}
           service={service} />);
@@ -246,6 +385,187 @@ describe('AddedServicesListItem', function() {
         metadata: { id: 'serviceId' }
       }
     });
+  });
+
+  it('correctly sets the visibility icons status on render', () => {
+    var service = {
+      getAttrs: function() {
+        return {
+          icon: 'icon.gif', unit_count: '2', name: 'demo', id: 'demo',
+          units: {
+            toArray: function() {
+              return [{agent_state: 'uncommitted'}, {agent_state: 'pending'}];
+            }}};
+      },
+      get: function() {
+        return true;
+      }};
+    var renderer = jsTestUtils.shallowRender(
+      <juju.components.AddedServicesListItem
+        focusService={sinon.stub()}
+        unfocusService={sinon.stub()}
+        fadeService={sinon.stub()}
+        unfadeService={sinon.stub()}
+        changeState={sinon.stub()}
+        getUnitStatusCounts={sinon.stub()}
+        service={service} />, true);
+
+    var instance = renderer.getMountedInstance();
+    assert.equal(instance.state.focus, true);
+    assert.equal(instance.state.fade, true);
+
+    // This is ugly but we have to check that the proper name prop was passed
+    // to the SvgIcon component.
+    var output = renderer.getRenderOutput();
+    assert.deepEqual(
+      output.props.children[4].props.children[0].props.children,
+      <juju.components.SvgIcon name="focused_16" size="16"/>);
+    assert.deepEqual(
+      output.props.children[4].props.children[1].props.children,
+      <juju.components.SvgIcon name="hide_16" size="16"/>);
+  });
+
+  it('correctly sets the visibility icons status on re-render', () => {
+    var service = {
+      getAttrs: function() {
+        return {
+          icon: 'icon.gif', unit_count: '2', name: 'demo', id: 'demo',
+          units: {
+            toArray: function() {
+              return [{agent_state: 'uncommitted'}, {agent_state: 'pending'}];
+            }}};
+      },
+      get: function() {
+        return true;
+      }};
+    var renderer = jsTestUtils.shallowRender(
+      <juju.components.AddedServicesListItem
+        focusService={sinon.stub()}
+        unfocusService={sinon.stub()}
+        fadeService={sinon.stub()}
+        unfadeService={sinon.stub()}
+        changeState={sinon.stub()}
+        getUnitStatusCounts={sinon.stub()}
+        service={service} />, true);
+
+    var instance = renderer.getMountedInstance();
+    assert.equal(instance.state.focus, true);
+    assert.equal(instance.state.fade, true);
+
+    // This is ugly but we have to check that the proper name prop was passed
+    // to the SvgIcon component.
+    var output = renderer.getRenderOutput();
+    assert.deepEqual(
+      output.props.children[4].props.children[0].props.children,
+      <juju.components.SvgIcon name="focused_16" size="16"/>);
+    assert.deepEqual(
+      output.props.children[4].props.children[1].props.children,
+      <juju.components.SvgIcon name="hide_16" size="16"/>);
+    // Re-render to trigger the componentWillReceiveProps.
+    renderer.render(
+      <juju.components.AddedServicesListItem
+        focusService={sinon.stub()}
+        unfocusService={sinon.stub()}
+        fadeService={sinon.stub()}
+        unfadeService={sinon.stub()}
+        changeState={sinon.stub()}
+        getUnitStatusCounts={sinon.stub()}
+        service={service} />);
+    var output = renderer.getRenderOutput();
+    assert.deepEqual(
+      output.props.children[4].props.children[0].props.children,
+      <juju.components.SvgIcon name="focused_16" size="16"/>);
+    assert.deepEqual(
+      output.props.children[4].props.children[1].props.children,
+      <juju.components.SvgIcon name="hide_16" size="16"/>);
+  });
+
+  it('toggles the focus icon and calls the correct prop on click', () => {
+    var service = {
+      getAttrs: function() {
+        return {
+          icon: 'icon.gif', unit_count: '2', name: 'demo', id: 'demo',
+          units: {
+            toArray: function() {
+              return [{agent_state: 'uncommitted'}, {agent_state: 'pending'}];
+            }}};
+      },
+      get: function(key) {
+        if (key === 'id') {
+          return 'wordpress';
+        }
+        return false;
+      }};
+    var focusService = sinon.stub();
+    var unfocusService = sinon.stub();
+    var instance = testUtils.renderIntoDocument(
+      <juju.components.AddedServicesListItem
+        focusService={focusService}
+        unfocusService={unfocusService}
+        fadeService={sinon.stub()}
+        unfadeService={sinon.stub()}
+        changeState={sinon.stub()}
+        getUnitStatusCounts={sinon.stub()}
+        service={service} />);
+
+    // Toggle focus on.
+    assert.equal(instance.state.focus, false);
+    testUtils.Simulate.click(instance.refs.focusVisibilityIcon);
+    assert.equal(instance.state.focus, true);
+    assert.equal(focusService.callCount, 1);
+    assert.equal(unfocusService.callCount, 0);
+    assert.equal(focusService.args[0][0], 'wordpress');
+
+    // Toggle focus off.
+    testUtils.Simulate.click(instance.refs.focusVisibilityIcon);
+    assert.equal(instance.state.focus, false);
+    assert.equal(focusService.callCount, 1);
+    assert.equal(unfocusService.callCount, 1);
+    assert.equal(focusService.args[0][0], 'wordpress');
+  });
+
+  it('toggles the highlight icon and calls the correct prop on click', () => {
+    var service = {
+      getAttrs: function() {
+        return {
+          icon: 'icon.gif', unit_count: '2', name: 'demo', id: 'demo',
+          units: {
+            toArray: function() {
+              return [{agent_state: 'uncommitted'}, {agent_state: 'pending'}];
+            }}};
+      },
+      get: function(key) {
+        if (key === 'id') {
+          return 'wordpress';
+        }
+        return false;
+      }};
+    var fadeService = sinon.stub();
+    var unfadeService = sinon.stub();
+    var instance = testUtils.renderIntoDocument(
+      <juju.components.AddedServicesListItem
+        focusService={sinon.stub()}
+        unfocusService={sinon.stub()}
+        fadeService={fadeService}
+        unfadeService={unfadeService}
+        changeState={sinon.stub()}
+        getUnitStatusCounts={sinon.stub()}
+        service={service} />);
+
+    // Toggle focus on.
+    assert.equal(instance.state.fade, false);
+    testUtils.Simulate.click(instance.refs.fadeVisibilityIcon);
+    assert.equal(instance.state.fade, true);
+    assert.equal(fadeService.callCount, 1);
+    assert.equal(unfadeService.callCount, 0);
+    assert.equal(fadeService.args[0][0], 'wordpress');
+
+    // Toggle focus off.
+    testUtils.Simulate.click(instance.refs.fadeVisibilityIcon);
+    assert.equal(instance.state.fade, false);
+    assert.equal(fadeService.callCount, 1);
+    assert.equal(unfadeService.callCount, 1);
+    assert.equal(fadeService.args[0][0], 'wordpress');
   });
 
 });

--- a/jujugui/static/gui/src/app/components/added-services-list/_added-services-list.scss
+++ b/jujugui/static/gui/src/app/components/added-services-list/_added-services-list.scss
@@ -26,6 +26,9 @@
             background-color: $light-grey;
 
         }
+        &.visibility-toggled .inspector-view__visibility-toggle {
+          visibility: visible;
+        }
         &:hover .inspector-view__visibility-toggle {
             visibility: visible;
         }

--- a/jujugui/static/gui/src/app/components/added-services-list/_added-services-list.scss
+++ b/jujugui/static/gui/src/app/components/added-services-list/_added-services-list.scss
@@ -48,6 +48,15 @@
         color: $warm-grey;
     }
 
+    &__visibility-toggle {
+        vertical-align: middle;
+        padding: 0 10px;
+    }
+
+    &__status-block {
+        float: right;
+    }
+
     &__status {
         &--error {
             @include notification($error);

--- a/jujugui/static/gui/src/app/components/added-services-list/_added-services-list.scss
+++ b/jujugui/static/gui/src/app/components/added-services-list/_added-services-list.scss
@@ -24,6 +24,10 @@
         &:active,
         &:hover {
             background-color: $light-grey;
+
+        }
+        &:hover .inspector-view__visibility-toggle {
+            visibility: visible;
         }
     }
 
@@ -38,7 +42,7 @@
     &__item-name {
         overflow: hidden;
         display: inline-block;
-        max-width: 165px;
+        max-width: 110px;
         text-overflow: ellipsis;
         white-space: nowrap;
         vertical-align: text-bottom;
@@ -49,6 +53,7 @@
     }
 
     &__visibility-toggle {
+        visibility: hidden;
         vertical-align: middle;
         padding: 0 15px 0 0;
     }

--- a/jujugui/static/gui/src/app/components/added-services-list/_added-services-list.scss
+++ b/jujugui/static/gui/src/app/components/added-services-list/_added-services-list.scss
@@ -24,13 +24,19 @@
         &:active,
         &:hover {
             background-color: $light-grey;
-
+        }
+        &:hover .inspector-view__item-name {
+            max-width: 105px;
+        }
+        &.visibility-toggled .inspector-view__item-name {
+            max-width: 105px;
         }
         &.visibility-toggled .inspector-view__visibility-toggle {
-          visibility: visible;
+            display: inline-block;
+
         }
         &:hover .inspector-view__visibility-toggle {
-            visibility: visible;
+            display: inline-block;
         }
     }
 
@@ -45,7 +51,7 @@
     &__item-name {
         overflow: hidden;
         display: inline-block;
-        max-width: 110px;
+        max-width: 165px;
         text-overflow: ellipsis;
         white-space: nowrap;
         vertical-align: text-bottom;
@@ -56,7 +62,7 @@
     }
 
     &__visibility-toggle {
-        visibility: hidden;
+        display: none;
         vertical-align: middle;
         padding: 0 15px 0 0;
     }

--- a/jujugui/static/gui/src/app/components/added-services-list/_added-services-list.scss
+++ b/jujugui/static/gui/src/app/components/added-services-list/_added-services-list.scss
@@ -50,7 +50,7 @@
 
     &__visibility-toggle {
         vertical-align: middle;
-        padding: 0 10px;
+        padding: 0 15px 0 0;
     }
 
     &__status-block {

--- a/jujugui/static/gui/src/app/components/added-services-list/added-services-list.js
+++ b/jujugui/static/gui/src/app/components/added-services-list/added-services-list.js
@@ -22,9 +22,18 @@ YUI.add('added-services-list', function() {
 
   juju.components.AddedServicesList = React.createClass({
 
+    propTypes: {
+      changeState: React.PropTypes.func.isRequired,
+      getUnitStatusCounts: React.PropTypes.func.isRequired,
+      services: React.PropTypes.object.isRequired,
+      updateUnitFlags: React.PropTypes.func.isRequired,
+      findUnrelatedServices: React.PropTypes.func.isRequired,
+      setMVVisibility: React.PropTypes.func.isRequired
+    },
+
     generateItemList: function(services) {
       var items = [];
-      services.forEach((service) => {
+      services.each((service) => {
         items.push(
             <juju.components.AddedServicesListItem
               // We use the 'name' instead of the 'id' here because when a
@@ -35,9 +44,29 @@ YUI.add('added-services-list', function() {
               key={service.get('name')}
               changeState={this.props.changeState}
               getUnitStatusCounts={this.props.getUnitStatusCounts}
+              focusService={this.focusService}
               service={service} />);
       });
       return items;
+    },
+
+    /**
+      Executes the appropriate methods on the db to focus the specified
+      service icon.
+
+      @method focusService
+      @param {String} serviceId The id for the service to focus.
+    */
+    focusService: function(serviceId) {
+      var props = this.props;
+      var service = props.services.getById(serviceId);
+      service.set('highlight', true);
+      props.updateUnitFlags(service, 'highlight');
+      var unrelated = props.findUnrelatedServices(service);
+      unrelated.each(function(model) {
+        model.set('hide', true);
+      });
+      props.setMVVisibility(serviceId, true);
     },
 
     render: function() {

--- a/jujugui/static/gui/src/app/components/added-services-list/added-services-list.js
+++ b/jujugui/static/gui/src/app/components/added-services-list/added-services-list.js
@@ -46,6 +46,8 @@ YUI.add('added-services-list', function() {
               getUnitStatusCounts={this.props.getUnitStatusCounts}
               focusService={this.focusService}
               unfocusService={this.unfocusService}
+              fadeService={this.fadeService}
+              unfadeService={this.unfadeService}
               ref={'AddedServicesListItem-' + service.get('id')}
               service={service} />);
       });
@@ -104,6 +106,28 @@ YUI.add('added-services-list', function() {
         model.set('hide', false);
       });
       props.setMVVisibility(serviceId, false);
+    },
+
+    /**
+      Sets the fade attribute on the supplied service id to true.
+
+      @method fadeService
+      @param {String} serviceId The service Id to fade.
+    */
+    fadeService: function(serviceId) {
+      var service = this.props.services.getById(serviceId);
+      service.set('fade', true);
+    },
+
+    /**
+      Sets the fade attribute on the supplied service id to false.
+
+      @method unfadeService
+      @param {String} serviceId The service Id to unfade.
+    */
+    unfadeService: function(serviceId) {
+      var service = this.props.services.getById(serviceId);
+      service.set('fade', false);
     },
 
     /**

--- a/jujugui/static/gui/src/app/components/added-services-list/added-services-list.js
+++ b/jujugui/static/gui/src/app/components/added-services-list/added-services-list.js
@@ -45,6 +45,7 @@ YUI.add('added-services-list', function() {
               changeState={this.props.changeState}
               getUnitStatusCounts={this.props.getUnitStatusCounts}
               focusService={this.focusService}
+              unfocusService={this.unfocusService}
               service={service} />);
       });
       return items;
@@ -67,6 +68,26 @@ YUI.add('added-services-list', function() {
         model.set('hide', true);
       });
       props.setMVVisibility(serviceId, true);
+    },
+
+    /**
+      Executes the appropriate methods on the db to unfocus the specified
+      service icon.
+
+      @method unfocusService
+      @param {String} serviceId The id for the service to unfocus.
+    */
+    unfocusService: function(serviceId) {
+      var props = this.props;
+      var service = props.services.getById(serviceId);
+      service.set('highlight', false);
+      props.updateUnitFlags(service, 'highlight');
+      // Unrelated services need to be unfaded.
+      var unrelated = props.findUnrelatedServices(service);
+      unrelated.each(function(model) {
+        model.set('hide', false);
+      });
+      props.setMVVisibility(serviceId, false);
     },
 
     render: function() {

--- a/jujugui/static/gui/src/app/components/added-services-list/added-services-list.js
+++ b/jujugui/static/gui/src/app/components/added-services-list/added-services-list.js
@@ -27,6 +27,7 @@ YUI.add('added-services-list', function() {
       getUnitStatusCounts: React.PropTypes.func.isRequired,
       services: React.PropTypes.object.isRequired,
       updateUnitFlags: React.PropTypes.func.isRequired,
+      findRelatedServices: React.PropTypes.func.isRequired,
       findUnrelatedServices: React.PropTypes.func.isRequired,
       setMVVisibility: React.PropTypes.func.isRequired
     },

--- a/jujugui/static/gui/src/app/components/added-services-list/test-added-services-list.js
+++ b/jujugui/static/gui/src/app/components/added-services-list/test-added-services-list.js
@@ -270,6 +270,65 @@ describe('AddedServicesList', () => {
     assert.equal(setMVVisibility.callCount, 1);
   });
 
-  it('performs the necessary work to fade a service');
-  it('performs the necessary work to unfade a service');
+  it('performs the necessary work to fade a service', () => {
+    var serviceSet = sinon.stub();
+    var services = {
+      each: (cb) => {
+        cb({
+          get: () => 'trusty/wordpress',
+          set: serviceSet
+        });
+      },
+      getById: () => {
+        return {
+          set: serviceSet
+        };
+      }};
+    var renderer = jsTestUtils.shallowRender(
+        <juju.components.AddedServicesList
+          updateUnitFlags={sinon.stub()}
+          findRelatedServices={sinon.stub()}
+          findUnrelatedServices={sinon.stub()}
+          setMVVisibility={sinon.stub()}
+          changeState={sinon.stub()}
+          getUnitStatusCounts={sinon.stub()}
+          services={services}/>, true);
+
+    var instance = renderer.getMountedInstance();
+    // Call the fade Service method which would be passed down to the children.
+    instance.fadeService('trusty/wordpress');
+    assert.equal(serviceSet.callCount, 1);
+    assert.deepEqual(serviceSet.args[0], ['fade', true]);
+  });
+
+  it('performs the necessary work to unfade a service', () => {
+    var serviceSet = sinon.stub();
+    var services = {
+      each: (cb) => {
+        cb({
+          get: () => 'trusty/wordpress',
+          set: serviceSet
+        });
+      },
+      getById: () => {
+        return {
+          set: serviceSet
+        };
+      }};
+    var renderer = jsTestUtils.shallowRender(
+        <juju.components.AddedServicesList
+          updateUnitFlags={sinon.stub()}
+          findRelatedServices={sinon.stub()}
+          findUnrelatedServices={sinon.stub()}
+          setMVVisibility={sinon.stub()}
+          changeState={sinon.stub()}
+          getUnitStatusCounts={sinon.stub()}
+          services={services}/>, true);
+
+    var instance = renderer.getMountedInstance();
+    // Call the fade Service method which would be passed down to the children.
+    instance.unfadeService('trusty/wordpress');
+    assert.equal(serviceSet.callCount, 1);
+    assert.deepEqual(serviceSet.args[0], ['fade', false]);
+  });
 });

--- a/jujugui/static/gui/src/app/components/added-services-list/test-added-services-list.js
+++ b/jujugui/static/gui/src/app/components/added-services-list/test-added-services-list.js
@@ -21,43 +21,255 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 var juju = {components: {}}; // eslint-disable-line no-unused-vars
 var testUtils = React.addons.TestUtils;
 
-describe('AddedServicesList', function() {
+describe('AddedServicesList', () => {
 
-  beforeAll(function(done) {
+  beforeAll((done) => {
     // By loading this file it adds the component to the juju components.
-    YUI().use('added-services-list', function() { done(); });
+    YUI().use('added-services-list', () => { done(); });
   });
 
-  it('generates a list of added services list items', function() {
-    var services = [{get: () => 1}, {get: () => 2}, {get: () => 3}];
-    var changeState = 'changeStateCallable';
+  it('generates a list of added services list items', () => {
+    var allServices = [{get: () => 1}, {get: () => 2}, {get: () => 3}];
+    var services = {
+      each: (cb) => {
+        allServices.forEach(cb);
+      }
+    };
 
-    var shallowRenderer = testUtils.createRenderer();
+    var changeState = sinon.stub();
     var getUnitStatusCounts = sinon.stub();
-    shallowRenderer.render(
+    var renderer = jsTestUtils.shallowRender(
         <juju.components.AddedServicesList
+          updateUnitFlags={sinon.stub()}
+          findRelatedServices={sinon.stub()}
+          findUnrelatedServices={sinon.stub()}
+          setMVVisibility={sinon.stub()}
           changeState={changeState}
           getUnitStatusCounts={getUnitStatusCounts}
-          services={services}/>);
+          services={services}/>, true);
 
-    var output = shallowRenderer.getRenderOutput();
-    assert.deepEqual(output.props.children,
-      <ul className="added-services-list inspector-view__list">
-        <juju.components.AddedServicesListItem
-          key={services[0].get()}
-          changeState={changeState}
-          getUnitStatusCounts={getUnitStatusCounts}
-          service={services[0]} />
-        <juju.components.AddedServicesListItem
-          key={services[1].get()}
-          changeState={changeState}
-          getUnitStatusCounts={getUnitStatusCounts}
-          service={services[1]} />
-        <juju.components.AddedServicesListItem
-          key={services[2].get()}
-          changeState={changeState}
-          getUnitStatusCounts={getUnitStatusCounts}
-          service={services[2]} />
-      </ul>);
+    var output = renderer.getRenderOutput();
+    var instance = renderer.getMountedInstance();
+
+    var expected = (
+      <div className="inspector-view">
+        <ul className="added-services-list inspector-view__list">
+          <juju.components.AddedServicesListItem
+            key={allServices[0].get()}
+            changeState={changeState}
+            getUnitStatusCounts={getUnitStatusCounts}
+            focusService={instance.focusService}
+            unfocusService={instance.unfocusService}
+            fadeService={instance.fadeService}
+            unfadeService={instance.unfadeService}
+            ref={'AddedServicesListItem-' + allServices[0].get()}
+            service={allServices[0]} />
+          <juju.components.AddedServicesListItem
+            key={allServices[1].get()}
+            changeState={changeState}
+            getUnitStatusCounts={getUnitStatusCounts}
+            focusService={instance.focusService}
+            unfocusService={instance.unfocusService}
+            fadeService={instance.fadeService}
+            unfadeService={instance.unfadeService}
+            ref={'AddedServicesListItem-' + allServices[1].get()}
+            service={allServices[1]} />
+          <juju.components.AddedServicesListItem
+            key={allServices[2].get()}
+            changeState={changeState}
+            getUnitStatusCounts={getUnitStatusCounts}
+            focusService={instance.focusService}
+            unfocusService={instance.unfocusService}
+            fadeService={instance.fadeService}
+            unfadeService={instance.unfadeService}
+            ref={'AddedServicesListItem-' + allServices[2].get()}
+            service={allServices[2]} />
+        </ul>
+      </div>);
+
+    assert.deepEqual(output, expected);
   });
+
+  it('performs the necessary work to focus a service', () => {
+    var allServices = [{
+      get: () => 'trusty/wordpress',
+      set: sinon.stub(),
+      setAttrs: sinon.stub()
+    }, {
+      get: () => 'trusty/apache',
+      set: sinon.stub(),
+      setAttrs: sinon.stub()
+    }, {
+      get: () => 'trusty/mysql',
+      set: sinon.stub(),
+      setAttrs: sinon.stub()
+    }];
+    var services = {
+      each: (cb) => {
+        allServices.forEach(cb);
+      },
+      getById: (id) => {
+        var service;
+        allServices.some((s) => {
+          if (s.get('id') === id) {
+            service = s;
+            return true;
+          }
+        });
+        return service;
+      }
+    };
+    var updateUnitFlags = sinon.stub();
+    var findRelatedServices = sinon.stub();
+    var relatedModelStub = sinon.stub();
+    findRelatedServices.returns({
+      each: (cb) => {
+        cb({set: relatedModelStub});
+      }
+    });
+    var findUnRelatedServices = sinon.stub();
+    var unRelatedModelStub = sinon.stub();
+    findUnRelatedServices.returns({
+      each: (cb) => {
+        cb({set: unRelatedModelStub});
+      }
+    });
+    var setMVVisibility = sinon.stub();
+    var renderer = jsTestUtils.shallowRender(
+        <juju.components.AddedServicesList
+          updateUnitFlags={updateUnitFlags}
+          findRelatedServices={findRelatedServices}
+          findUnrelatedServices={findUnRelatedServices}
+          setMVVisibility={setMVVisibility}
+          changeState={sinon.stub()}
+          getUnitStatusCounts={sinon.stub()}
+          services={services}/>, true);
+
+    var instance = renderer.getMountedInstance();
+    // Because shallowRenderer doesn't support refs this fakes a refs property
+    // on the instance which is needed for the final step in the focus process.
+    instance.refs = {
+      'AddedServicesListItem-trusty/wordpress': {setState: sinon.stub()},
+      'AddedServicesListItem-trusty/apache': {setState: sinon.stub()},
+      'AddedServicesListItem-trusty/mysql': {setState: sinon.stub()}
+    };
+    // Call the focus method that was passed down into the list item.
+    instance.focusService('trusty/wordpress');
+    // It needs to update the unit flags on the service
+    assert.equal(updateUnitFlags.callCount, 1);
+    assert.deepEqual(updateUnitFlags.args[0], [
+      allServices[0],
+      'highlight'
+    ]);
+    // We need to fetch the related and unrelated services and then set
+    // the appropriate hide value.
+    assert.equal(relatedModelStub.callCount, 1);
+    assert.deepEqual(relatedModelStub.args[0], ['hide', false]);
+    assert.equal(unRelatedModelStub.callCount, 1);
+    assert.deepEqual(unRelatedModelStub.args[0], ['hide', true]);
+    // Set the focus indicator on all other service models except the one that
+    // the user had clicked on.
+    // In this test the user clicked on 'wordpress' so the others need to be
+    // set to false
+    assert.equal(allServices[0].set.callCount, 0);
+    assert.equal(allServices[1].set.callCount, 1);
+    assert.deepEqual(allServices[1].set.args[0], ['highlight', false]);
+    assert.equal(allServices[2].set.callCount, 1);
+    assert.deepEqual(allServices[2].set.args[0], ['highlight', false]);
+    // It then has to set the proper values for the machine view visibility.
+    assert.equal(setMVVisibility.callCount, 1);
+    // Now we have to disable the focus state on all of the added services
+    // list items that the user didn't interact with.
+    var refs = instance.refs;
+    assert.equal(
+      refs['AddedServicesListItem-trusty/wordpress'].setState.callCount, 0);
+    assert.equal(
+      refs['AddedServicesListItem-trusty/apache'].setState.callCount, 1);
+    assert.deepEqual(
+      refs['AddedServicesListItem-trusty/apache'].setState.args[0],
+      [{focus: false}]);
+    assert.equal(
+      refs['AddedServicesListItem-trusty/mysql'].setState.callCount, 1);
+    assert.deepEqual(
+      refs['AddedServicesListItem-trusty/mysql'].setState.args[0],
+      [{focus: false}]);
+  });
+
+  it('performs the necessary work to unfocus a service', () => {
+    var allServices = [{
+      get: () => 'trusty/wordpress',
+      set: sinon.stub(),
+      setAttrs: sinon.stub()
+    }, {
+      get: () => 'trusty/apache',
+      set: sinon.stub(),
+      setAttrs: sinon.stub()
+    }, {
+      get: () => 'trusty/mysql',
+      set: sinon.stub(),
+      setAttrs: sinon.stub()
+    }];
+    var services = {
+      each: (cb) => {
+        allServices.forEach(cb);
+      },
+      getById: (id) => {
+        var service;
+        allServices.some((s) => {
+          if (s.get('id') === id) {
+            service = s;
+            return true;
+          }
+        });
+        return service;
+      }
+    };
+    var updateUnitFlags = sinon.stub();
+    var findRelatedServices = sinon.stub();
+    var relatedModelStub = sinon.stub();
+    findRelatedServices.returns({
+      each: (cb) => {
+        cb({set: relatedModelStub});
+      }
+    });
+    var findUnRelatedServices = sinon.stub();
+    var unRelatedModelStub = sinon.stub();
+    findUnRelatedServices.returns({
+      each: (cb) => {
+        cb({set: unRelatedModelStub});
+      }
+    });
+    var setMVVisibility = sinon.stub();
+    var renderer = jsTestUtils.shallowRender(
+        <juju.components.AddedServicesList
+          updateUnitFlags={updateUnitFlags}
+          findRelatedServices={findRelatedServices}
+          findUnrelatedServices={findUnRelatedServices}
+          setMVVisibility={setMVVisibility}
+          changeState={sinon.stub()}
+          getUnitStatusCounts={sinon.stub()}
+          services={services}/>, true);
+
+    var instance = renderer.getMountedInstance();
+    // Call the unfocus method that was passed down into the list item.
+    instance.unfocusService('trusty/wordpress');
+    // Check that the service highlight was set to false
+    assert.equal(allServices[0].set.callCount, 1);
+    assert.deepEqual(allServices[0].set.args[0], ['highlight', false]);
+    // It needs to update the unit flags on the service
+    assert.equal(updateUnitFlags.callCount, 1);
+    assert.deepEqual(updateUnitFlags.args[0], [
+      allServices[0],
+      'highlight'
+    ]);
+    // We need to fetch the unrelated services and then set
+    // the appropriate hide value.
+    assert.equal(unRelatedModelStub.callCount, 1);
+    assert.deepEqual(unRelatedModelStub.args[0], ['hide', false]);
+    // It then has to set the proper values for the machine view visibility.
+    assert.equal(setMVVisibility.callCount, 1);
+  });
+
+  it('performs the necessary work to fade a service');
+  it('performs the necessary work to unfade a service');
 });

--- a/jujugui/static/gui/src/app/components/added-services-list/test-added-services-list.js
+++ b/jujugui/static/gui/src/app/components/added-services-list/test-added-services-list.js
@@ -19,7 +19,6 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 'use strict';
 
 var juju = {components: {}}; // eslint-disable-line no-unused-vars
-var testUtils = React.addons.TestUtils;
 
 describe('AddedServicesList', () => {
 

--- a/jujugui/static/gui/src/app/components/entity-content/test-entity-content.js
+++ b/jujugui/static/gui/src/app/components/entity-content/test-entity-content.js
@@ -163,7 +163,6 @@ describe('EntityContent', function() {
         {undefined}
       </div>
     );
-    debugger;
     assert.deepEqual(output, expected);
   });
 

--- a/jujugui/static/gui/src/app/models/models.js
+++ b/jujugui/static/gui/src/app/models/models.js
@@ -2631,16 +2631,18 @@ YUI.add('juju-models', function(Y) {
 
     /**
       Returns a list of the deployed (both uncommitted and committed) services
-      that are not related to the provided service.
+      that are related to the provided service.
 
-      @method findUnrelatedServices
+      @method findRelatedServices
       @param {Object} service The origin service.
-      @return {Y.ModelList} A ModelList of the unrelated services.
+      @param {Boolean} asArray If you want the results returned as an array of
+        service names or a model list.
+      @return {Y.ModelList|Array} A ModelList of related services or an array
+        of service names.
     */
-    findUnrelatedServices: function(service) {
+    findRelatedServices: function(service, asArray) {
       var relationData = utils.getRelationDataForService(this, service);
-      var related = [service.get('name')],  // Add own name to related list.
-          unrelated;
+      var related = [service.get('name')];  // Add own name to related list.
       // Compile the list of related services.
       relationData.forEach(function(relation) {
         // Some relations (e.g., peer relations) may not have the far endpoint
@@ -2649,8 +2651,26 @@ YUI.add('juju-models', function(Y) {
           related.push(relation.far.service);
         }
       });
+      if (asArray) {
+        return related;
+      }
+      return this.services.filter({asList: true}, function(s) {
+        return related.indexOf(s.get('name') === 1);
+      });
+    },
+
+    /**
+      Returns a list of the deployed (both uncommitted and committed) services
+      that are not related to the provided service.
+
+      @method findUnrelatedServices
+      @param {Object} service The origin service.
+      @return {Y.ModelList} A ModelList of the unrelated services.
+    */
+    findUnrelatedServices: function(service) {
+      var related = this.findRelatedServices(service, true);
       // Find the unrelated by filtering out the related.
-      unrelated = this.services.filter({asList: true}, function(s) {
+      var unrelated = this.services.filter({asList: true}, function(s) {
         return related.indexOf(s.get('name')) === -1;
       });
       return unrelated;

--- a/jujugui/static/gui/src/app/models/models.js
+++ b/jujugui/static/gui/src/app/models/models.js
@@ -2655,7 +2655,7 @@ YUI.add('juju-models', function(Y) {
         return related;
       }
       return this.services.filter({asList: true}, function(s) {
-        return related.indexOf(s.get('name') === 1);
+        return related.indexOf(s.get('name')) > -1;
       });
     },
 

--- a/jujugui/static/gui/src/test/test_model.js
+++ b/jujugui/static/gui/src/test/test_model.js
@@ -169,6 +169,29 @@ describe('test_model.js', function() {
       assert.equal(unit.urlName, 'mysql2-0');
     });
 
+    it('finds related services', function() {
+      var db = new models.Database(),
+          service = new models.Service({name: 'mysql'});
+      db.services.add([
+        {id: 'mysql', name: 'mysql'},
+        {id: 'wordpress', name: 'wordpress'},
+        {id: 'haproxy', name: 'haproxy'}
+      ]);
+      var relations = [
+        {far: {service: 'wordpress'}}
+      ];
+      var stub = utils.makeStubMethod(viewUtils, 'getRelationDataForService',
+                                      relations);
+      this._cleanups.push(stub.reset);
+      var related = db.findRelatedServices(service);
+      related.each(function(s) {
+        console.log(s.getAttrs());
+      });
+      assert.equal(related.size(), 2);
+      assert.equal(related.item(0).get('name'), 'mysql');
+      assert.equal(related.item(1).get('name'), 'wordpress');
+    });
+
     it('finds unrelated services', function() {
       var db = new models.Database(),
           service = new models.Service({name: 'mysql'});


### PR DESCRIPTION
Clicking the two new buttons in the added services list allows the user to fade and highlight specific services.