### PR TITLE
Resize on subordinate status change

### DIFF
--- a/jujugui/static/gui/src/app/views/topology/service.js
+++ b/jujugui/static/gui/src/app/views/topology/service.js
@@ -146,7 +146,7 @@ YUI.add('juju-topology-service', function(Y) {
       });
     node.select('.service-icon')
       .attr('transform', function(d) {
-        return d.subordinate ? 'translate(17, 17)' : 'translate(47, 47)'
+        return d.subordinate ? 'translate(17, 17)' : 'translate(47, 47)';
       });
     node.select('.relation-button')
       .attr('transform', function(d) {

--- a/jujugui/static/gui/src/app/views/topology/service.js
+++ b/jujugui/static/gui/src/app/views/topology/service.js
@@ -84,6 +84,9 @@ YUI.add('juju-topology-service', function(Y) {
           annotations = service.get('annotations'),
           x, y;
 
+      // Set widths and heights.
+      d.subordinate ? d.w = d.h = 130 : d.w = d.h = 190;
+
       // If there are no annotations or the service is being dragged
       if (!annotations || d.inDrag) {
         return;
@@ -123,12 +126,32 @@ YUI.add('juju-topology-service', function(Y) {
     // Size the node for drawing.
     node.attr({
       'width': function(box) {
-        box.subordinate ? box.w = 130 : box.w = 190; return box.w;
+        return box.w;
       },
       'height': function(box) {
-        box.subordinate ? box.h = 130 : box.h = 190; return box.h;
+        return box.h;
       }
     });
+    node.select('.service-block')
+      .attr({
+        'cx': function(d) { return d.subordinate ? 65 : 95; },
+        'cy': function(d) { return d.subordinate ? 65 : 95; },
+        'r': function(d) { return d.subordinate ? 60 : 90; }
+      });
+    node.select('.service-block__halo')
+      .attr({
+        'cx': function(d) { return d.subordinate ? 65 : 95; },
+        'cy': function(d) { return d.subordinate ? 65 : 95; },
+        'r': function(d) { return d.subordinate ? 80 : 110; }
+      });
+    node.select('.service-icon')
+      .attr('transform', function(d) {
+        return d.subordinate ? 'translate(17, 17)' : 'translate(47, 47)'
+      });
+    node.select('.relation-button')
+      .attr('transform', function(d) {
+        return 'translate(' + [d.subordinate ? 65 : 95, 30] + ')';
+      });
 
     var rerenderRelations = false;
     node.select('.service-block').each(function(d) {
@@ -190,9 +213,9 @@ YUI.add('juju-topology-service', function(Y) {
 
     // Draw a subordinate relation indicator.
     var subRelationIndicator = node.filter(function(d) {
-      return d.subordinate &&
-          d3.select(this)
-          .select('.sub-rel-block').empty();
+      return d3.select(this)
+        .select('.sub-rel-block').empty() &&
+        d.subordinate;
     })
         .insert('g', ':first-child')
         .attr('class', 'sub-rel-block')

--- a/jujugui/static/gui/src/test/test_service_module.js
+++ b/jujugui/static/gui/src/test/test_service_module.js
@@ -99,6 +99,54 @@ describe('service module annotations', function() {
      });
 });
 
+describe('service updates', function() {
+  var db, models, utils, viewContainer, views, serviceModule;
+
+  before(function(done) {
+    YUI(GlobalConfig).use([
+      'juju-gui',
+      'juju-models',
+      'juju-tests-utils',
+      'juju-views',
+      'juju-view-environment',
+      'node',
+      'node-event-simulate'],
+    function(Y) {
+      models = Y.namespace('juju.models');
+      utils = Y.namespace('juju-tests.utils');
+      views = Y.namespace('juju.views');
+      done();
+    });
+  });
+
+  beforeEach(function() {
+    viewContainer = utils.makeContainer(this);
+    db = new models.Database();
+    var view = new views.environment(
+        { container: viewContainer,
+          db: db,
+          env: {
+            update_annotations: function() {}
+          }});
+    view.render();
+    view.rendered();
+    serviceModule = view.topo.modules.ServiceModule;
+  });
+
+  it('should resize when subordinate status changes', function() {
+    db.services.add({
+      id: 'foo',
+      subordinate: false
+    });
+    serviceModule.update();
+    var service = serviceModule.get('component').vis.select('.service');
+    assert.equal(service.select('.service-block').attr('cx'), 95);
+    db.services.item(0).set('subordinate', true);
+    serviceModule.update();
+    assert.equal(service.select('.service-block').attr('cx'), 65);
+  });
+});
+
 
 // Aug 21 2015 - Jeff - These tests fail spuriously in phantomjs. Skipping
 // until we can revisit and dedicate time to tracking down the issue.


### PR DESCRIPTION
This appropriately deals with all cases of a service moving between subordinate and not subordinate status except one (moving from subordinate back to non-subordinate service, there is a rendering issue with the add-relation button showing up off to the side, which appears in chrome).  As this situation has not cropped up (would be impossible in core\*), I'm leaving it until we find a way to fix that rendering

\* Why we're receiving subordinate information separate from environment status is the root of the problem, but not addressed in this card.  This card only touches on the display of services.