### PR TITLE
Update dependencies when packaging

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -8,3 +8,5 @@ tag_name = {new_version}
 
 [bumpversion:file:package.json]
 
+[bumpversion:file:manifest.json]
+

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.8.1000
+current_version = 1.9.0
 commit = True
 tag = True
 tag_name = {new_version}

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,8 @@
 include HACKING.rst
 include MANIFEST.in
 include *.ini
+include requirements.txt
+include test-requirements.txt
 
 recursive-include jujugui/static *
 recursive-include jujugui/templates *
@@ -11,3 +13,4 @@ recursive-include jujugui/templates *
 recursive-exclude jujugui/static/gui/src *
 recursive-exclude jujugui/tests *
 recursive-exclude test *
+

--- a/Makefile
+++ b/Makefile
@@ -349,7 +349,7 @@ bumpversion: test-deps
 
 .PHONY: dist
 dist: gui test-deps
-	python setup.py sdist
+	python setup.py sdist --formats=bztar
 
 #######
 # CLEAN

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ BUILT_JS_ASSETS := $(GUIBUILD)/app/assets/javascripts
 JUJUGUI := lib/python*/site-packages/jujugui.egg-link
 FLAKE8 := bin/flake8
 PYRAMID := lib/python2.7/site-packages/pyramid
+PYTESTPKG := lib/python2.7/site-packages/pytest.py
 NODE_MODULES := node_modules
 MODULES := $(GUIBUILD)/modules.js
 MODULESMIN := $(GUIBUILD)/modules-min.js
@@ -277,22 +278,22 @@ update-downloadcache: $(CACHE)
 # DEPS
 ######
 # Use the pyramid install dir as our indicator that dependencies are installed.
-$(PYRAMID): $(PY) $(CACHE)
+$(PYRAMID): $(PY) $(CACHE) requirements.txt
 	$(call PIP,requirements.txt)
+	@touch $(PYRAMID)
 
 .PHONY: deps
-deps: $(PY) $(CACHE)
-	$(call PIP,requirements.txt)
+deps: $(PYRAMID)
 
 # Use the pytest binary as our indicator that the test dependencies are installed.
-$(PYTEST): $(PY) $(CACHE)
+$(PYTEST): $(PY) $(CACHE) test-requirements.txt
 	$(call PIP,test-requirements.txt)
+	@touch $(PYTEST)
 
 $(FLAKE8): $(PYTEST)
 
 .PHONY: test-deps
-test-deps: $(PY)
-	$(call PIP,test-requirements.txt)
+test-deps: $(PYTEST)
 
 $(SELENIUM): $(PY)
 	@# Because shelltoolbox requires ez_setup already installed before being

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Juju GUI",
   "manifest_version": 2,
-  "version": "1.8.1000",
+  "version": "1.9.0",
 
   "description": "Manage your Juju environment",
   "icons": {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Juju GUI",
   "manifest_version": 2,
-  "version": "0.2.0",
+  "version": "1.8.1000",
 
   "description": "Manage your Juju environment",
   "icons": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Juju Developers",
   "name": "juju-gui",
   "description": "Juju GUI build dependencies",
-  "version": "1.8.1000",
+  "version": "1.9.0",
   "homepage": "http://launchpad.net/juju-gui",
   "repository": {
     "type": "git",

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,15 @@
 import os
 
+from pip.download import PipSession
+from pip.req import parse_requirements
 from setuptools import setup, find_packages
 
+pip_session = PipSession()
+requirements = parse_requirements("requirements.txt", session=pip_session)
+test_requirements = parse_requirements("test-requirements.txt",
+                                       session=pip_session)
 
 here = os.path.abspath(os.path.dirname(__file__))
-requires = [
-    'pyramid',
-    'pyramid_mako',
-    'waitress',
-    'convoy',
-]
 
 
 setup(name='jujugui',
@@ -26,8 +26,8 @@ setup(name='jujugui',
       packages=find_packages(),
       include_package_data=True,
       zip_safe=False,
-      install_requires=requires,
-      tests_require=requires,
+      install_requires=[str(req.req) for req in requirements],
+      tests_require=[str(req.req) for req in test_requirements],
       test_suite="jujugui",
       entry_points="""\
       [paste.app_factory]

--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,14 @@ pip_session = PipSession()
 requirements = parse_requirements("requirements.txt", session=pip_session)
 test_requirements = parse_requirements("test-requirements.txt",
                                        session=pip_session)
+ignore_requirements = (
+    'libsass',
+    )
 
-here = os.path.abspath(os.path.dirname(__file__))
-
+install_requires = [str(req.req) for req in requirements
+                    if req.name not in ignore_requirements]
+tests_require = [str(req.req) for req in test_requirements
+                if req.name not in ignore_requirements]
 
 setup(name='jujugui',
       version='1.8.1000',
@@ -24,10 +29,10 @@ setup(name='jujugui',
       author='Juju UI Engineering Team',
       url='http://github.com/juju/juju-gui',
       packages=find_packages(),
-      include_package_data=True,
+      include_package_data=True,          # Refer to MANIFEST.in
       zip_safe=False,
-      install_requires=[str(req.req) for req in requirements],
-      tests_require=[str(req.req) for req in test_requirements],
+      install_requires=install_requires,
+      tests_require=tests_require,
       test_suite="jujugui",
       entry_points="""\
       [paste.app_factory]

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ tests_require = [str(req.req) for req in test_requirements
                 if req.name not in ignore_requirements]
 
 setup(name='jujugui',
-      version='1.8.1000',
+      version='1.9.0',
       description='jujugui',
       classifiers=[
           "Programming Language :: Python",


### PR DESCRIPTION
Rather than list items in setup.py, use requirements.txt and test-requirements.txt.
Explicitly reject libsass as it is only needed for building but not running the app.
Bump version to 1.9.0 in anticipation of beta 1 release.
Clean up some Makefile issues.