### PR TITLE
Remove allowInspector from state.js

### DIFF
--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -1030,9 +1030,6 @@ YUI.add('juju-gui', function(Y) {
     */
     _setupUIState: function(sandbox, baseUrl) {
       this.state = new models.UIState({
-        // Disallow routing to inspectors if we are in sandbox mode; the
-        // model to be inspected will not be available.
-        allowInspector: !sandbox,
         baseUrl: baseUrl || '',
         dispatchers: {}
       });

--- a/jujugui/static/gui/src/app/views/state.js
+++ b/jujugui/static/gui/src/app/views/state.js
@@ -438,23 +438,10 @@ YUI.add('juju-app-state', function(Y) {
         // We check if it's at 0 index in case someone has a service/machine
         // called 'inspector' or 'machine' etc.
         if (part.indexOf('inspector') === 0) {
-          // Only add to state if we are allowed to use inspectors.
-          if (this.get('allowInspector')) {
-            state.sectionA = this._addToSection({
-              component: 'inspector',
-              metadata: this._parseInspectorUrl(part, hash)
-            });
-          } else {
-            // XXX Note, in the future, this should redirect to a proper URL.
-            // This will be part of the validation work which is coming up.
-            // Makyo 2014-05-07
-
-            // If we were not allowed to use inspectors, that was only for the
-            // initial state, where the models would not exist.  Now that the
-            // models might exist from working in the sandbox, allow routing
-            // inspectors.
-            this.set('allowInspector', true);
-          }
+          state.sectionA = this._addToSection({
+            component: 'inspector',
+            metadata: this._parseInspectorUrl(part, hash)
+          });
         } else if (part.indexOf('machine') === 0) {
           state.sectionB = this._addToSection({
             component: 'machine',
@@ -704,16 +691,6 @@ YUI.add('juju-app-state', function(Y) {
 
   }, {
     ATTRS: {
-      /**
-       * Whether or not to allow initial inspector routes.
-       *
-       * @attribute allowInspector
-       * @default true
-       * @type {Boolean}
-       */
-      allowInspector: {
-        value: true
-      },
       /**
        * The baseurl for dispatching.
        *

--- a/jujugui/static/gui/src/test/test_ui_state.js
+++ b/jujugui/static/gui/src/test/test_ui_state.js
@@ -972,20 +972,6 @@ describe('UI State object', function() {
       assert.equal(state._sanitizeHash(hash), 'foo');
     });
 
-    it('ignores inspector URLs if so instructed', function() {
-      var req = buildRequest('/inspector/mysql');
-      var saveStub = testUtils.makeStubMethod(state, 'saveState');
-      this._cleanups.push(saveStub.reset);
-      state.set('allowInspector', false);
-      assert.deepEqual(
-          state.loadRequest(req),
-          { sectionA: {}, sectionB: {}, sectionC: {} },
-          'inspector was added to state anyway');
-      assert.isTrue(saveStub.calledOnce(),
-          'saveState was still called');
-      assert.isTrue(state.get('allowInspector'),
-          'allowInspector was not reset');
-    });
   });
 
   describe('generateUrl', function() {


### PR DESCRIPTION
The allowInspector was an artifact of the previous UI system. It's now handled by the inspector rendering code. If the service it's trying to show doesn't exist it simply navigates away. This was causing the added-services-view to require two clicks to navigate into services on bundle deploys.