### PR TITLE
Juju env: store available Juju API facades.

### DIFF
--- a/jujugui/static/gui/src/test/index.html
+++ b/jujugui/static/gui/src/test/index.html
@@ -110,12 +110,9 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
         appropriate spot -->
   <script src="test_app.js"></script>
   <script src="test_app_hotkeys.js"></script>
-  <script src="test_application_notifications.js"></script>
   <script src="test_bakery.js"></script>
   <script src="test_cache.js"></script>
-  <script src="test_charmstore_apiv4.js"></script>
   <script src="test_ui_state.js"></script>
-  <script src="test_bundle_module.js"></script>
   <script src="test_bundle_importer.js"></script>
   <script src="test_bundle_import_notifications.js"></script>
   <script src="test_changes_utils.js"></script>
@@ -159,7 +156,6 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       position matches on setBusy: expected 100 to equal 109.09090423583984 -->
   <script src="test_panzoom.js"></script>
   <script src="test_prettify.js"></script>
-  <script src="test_resizing_textarea.js"></script>
   <script src="test_routing.js"></script>
   <script src="test_sandbox.js"></script>
   <script src="test_sandbox_go.js"></script>
@@ -167,7 +163,6 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
   <!-- FIXME: tests leave DOM elements behind. -->
   <script src="test_service_module.js"></script>
 
-  <script src="test_scale_up_view.js"></script>
   <script src="test_simulator.js"></script>
 
   <!-- FIXME: feature flags depend on code loaded by the startup test. -->

--- a/jujugui/static/gui/src/test/test_sandbox_go.js
+++ b/jujugui/static/gui/src/test/test_sandbox_go.js
@@ -49,6 +49,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       client = new sandboxModule.ClientConnection({juju: juju});
       ecs = new ns.EnvironmentChangeSet({db: state.db});
       env = new environmentsModule.GoEnvironment({conn: client, ecs: ecs});
+      env.set('facades', {'Service': [2]});
     });
 
     afterEach(function() {
@@ -145,6 +146,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
         // Add in the error indicator so the deepEqual is comparing apples to
         // apples.
         data.Error = false;
+        data.Response = {Facades: sandboxModule.Facades};
         assert.deepEqual(Y.JSON.parse(received.data), data);
         assert.isTrue(state.get('authenticated'));
         done();
@@ -386,17 +388,18 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       client.send(Y.JSON.stringify(data));
     });
 
-    it('can deploy.', function(done) {
+    it('can deploy', function(done) {
       // We begin logged in.  See utils.makeFakeBackend.
       var data = {
-        Type: 'Client',
-        Request: 'ServiceDeploy',
-        Params: {
+        Type: 'Service',
+        Request: 'ServicesDeploy',
+        Version: 2,
+        Params: {Services: [{
           CharmUrl: 'cs:precise/wordpress-27',
           ServiceName: 'kumquat',
           ConfigYAML: 'engine: apache',
           NumUnits: 2
-        },
+        }]},
         RequestId: 42
       };
       client.onmessage = function(received) {


### PR DESCRIPTION
Use this info to switch between legacy and new
service deploy facade.
This demonstrates how to use info provided by Juju
on login to enable/disable features and use the proper
facade when possible.

This is a WIP, it misses the handleServiceServicesDeploy sandbox method, but it's already reviewable in this current state.