### PR TITLE
Improve facade version handling.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Makefile to help automate tasks
+# Makefile to help automate tasks.
 PY := bin/python
 PYTEST := bin/py.test
 GUISRC := jujugui/static/gui/src

--- a/jujugui/static/gui/src/app/store/env/sandbox.js
+++ b/jujugui/static/gui/src/app/store/env/sandbox.js
@@ -174,7 +174,8 @@ YUI.add('juju-env-sandbox', function(Y) {
 
   sandboxModule.ClientConnection = ClientConnection;
   sandboxModule.Facades = [
-    {Name: 'Service', Versions: [2]}
+    {Name: 'Service', Versions: [2]},
+    {Name: 'EnvironmentManager', Versions: [1]}
   ];
 
   /**
@@ -710,6 +711,34 @@ YUI.add('juju-env-sandbox', function(Y) {
         response.Error = result.error;
       }
       client.receive(response);
+    },
+
+    /**
+    Handle Client.AddCharm messages.
+
+    @method handleClientAddCharm
+    @param {Object} data The contents of the API arguments.
+    @param {Object} client The active ClientConnection.
+    @param {Object} state An instance of FakeBackend.
+    @return {undefined} Side effects only.
+    */
+    handleClientAddCharm: function(data, client, state) {
+      // In sandbox mode there is no need for adding a charm before simulating
+      // its deployment.
+      client.receive({RequestId: data.RequestId, Response: {}});
+    },
+
+    /**
+    Handle Client.AddCharmWithAuthorization messages.
+
+    @method handleClientAddCharmWithAuthorization
+    @param {Object} data The contents of the API arguments.
+    @param {Object} client The active ClientConnection.
+    @param {Object} state An instance of FakeBackend.
+    @return {undefined} Side effects only.
+    */
+    handleClientAddCharmWithAuthorization: function(data, client, state) {
+      this.handleClientAddCharm(data, client, state);
     },
 
     /**


### PR DESCRIPTION
Improve how facades are handled. Implement an environment 
method (facadeSupported) that can be used to dynamically
enable/disable features (and their corresponding API calls)
based on the Juju API currently connected.
This must be used in the future, for instance, to enable or
disable controller models' creation. This is already used
for switching between new Service.ServicesDeply and legacy
Client.ServiceDeploy methods.

Some default facades are also hardcoded so that we still
support very old juju environments and sandbox mode.

Also implement the AddCharm API call. This will be used in
the future before deploying services. The corresponding
ECS call is not yet implemented, and will be once the call
is enabled.