### PR TITLE
Add RELEASE_PROCESS.rst

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -373,7 +373,7 @@ ci-check: clean-downloadcache deps fast-babel check
 # Packaging
 ###########
 .PHONY: bumpversion
-bumpversion: test-deps
+bumpversion: deps
 	bin/bumpversion $(VPART)
 
 .PHONY: dist

--- a/RELEASE_PROCESS.rst
+++ b/RELEASE_PROCESS.rst
@@ -3,6 +3,7 @@ Prepare for the Release
 
 Clone a fresh copy from the root repo. Do not attempt a release in your
 current working repository as the following commands expect a fresh clone.
+Make the clone using:
 
 ::
 
@@ -11,7 +12,10 @@ current working repository as the following commands expect a fresh clone.
 
 Increment the version number using the ``make bumpversion`` target.  If you
 are incrementing the patch (major.minor.patch) number then that's all you need
-to do, otherwise invoke it as, e.g., ``VPART=minor make bumpversion``
+to do, otherwise invoke it as, e.g., ``VPART=minor make bumpversion``.  Note
+that the ``bumpversion`` command will increment the version and do a ``git
+commit`` so you'll need to ensure your ``user.name`` and ``user.email`` are set
+properly first.
 
 Test the release
 ----------------
@@ -19,7 +23,7 @@ Test the release
 ::
 
      make check
-     
+
 
 Push to github
 --------------

--- a/RELEASE_PROCESS.rst
+++ b/RELEASE_PROCESS.rst
@@ -1,0 +1,39 @@
+Prepare for the Release
+-----------------------
+
+Clone a fresh copy from the root repo. Do not attempt a release in your
+current working repository as the following commands expect a fresh clone.
+
+::
+
+     git clone --branch master git@github.com:juju/juju-gui.git
+     cd juju-gui
+
+Increment the version number using the ``make bumpversion`` target.  If you
+are incrementing the patch (major.minor.patch) number then that's all you need
+to do, otherwise invoke it as, e.g., ``VPART=minor make bumpversion``
+
+Test the release
+----------------
+
+::
+
+     make check
+     
+
+Push to github
+--------------
+
+::
+
+     git push origin master
+
+
+Merge changes to develop
+------------------------
+
+::
+
+     git checkout develop
+     git merge master
+     git push origin develop


### PR DESCRIPTION
Document our release process so it is repeatable.  Following this pattern gets rid of the race of tagging and landing code.

Note that what I describe here bypasses the review process and landing machinery.  How evil is that?  Mimics what we have always done on other projects.