### PR TITLE
Re-enable multiple relations

### DIFF
--- a/jujugui/static/gui/src/app/assets/css/base.scss
+++ b/jujugui/static/gui/src/app/assets/css/base.scss
@@ -484,12 +484,6 @@ th {
               color: $text-colour;
             }
 
-            &.add-relation {
-                .disabled {
-                    color: red;
-                }
-            }
-
             &:last-child {
                 border-bottom: none;
             }
@@ -513,10 +507,6 @@ th {
         li {
             border-top: 1px solid #e9e9e9;
         }
-    }
-
-    &#service-menu ul li {
-        padding-left: 36px;
     }
 }
 

--- a/jujugui/static/gui/src/app/templates/overview.handlebars
+++ b/jujugui/static/gui/src/app/templates/overview.handlebars
@@ -27,19 +27,6 @@
 
             </div>
         </div>
-        <div class="environment-menu" id="service-menu">
-            <div class="triangle">&nbsp;</div>
-            <ul>
-                <li class="add-relation">
-                    <svg class="svg-icon"
-                        viewBox="0 0 16 16"
-                        style="width:16px; height:16px;">
-                        <use xlink:href="#build_relation_16" />
-                    </svg>
-                    Build Relation
-                </li>
-            </ul>
-        </div>
         <div class="environment-menu" id="ambiguous-relation-menu">
             <div class="triangle">&nbsp;</div>
             <div class="menu-title">Select relation type:</div>

--- a/jujugui/static/gui/src/app/views/topology/relation.js
+++ b/jujugui/static/gui/src/app/views/topology/relation.js
@@ -71,14 +71,6 @@ YUI.add('juju-topology-relation', function(Y) {
            */
           click: {callback: 'draglineClicked'}
         },
-        '.add-relation': {
-          /**
-           * The user clicked on the "Build Relation" menu item.
-           *
-           * @method events.scene.add-relation.click
-           */
-          click: {callback: 'addRelButtonClicked'}
-        },
         '.zoom-plane': {
           mousemove: {callback: 'mousemove'}
         }
@@ -474,33 +466,6 @@ YUI.add('juju-topology-relation', function(Y) {
       topo.fire('clearState');
     },
 
-    addRelButtonClicked: function(data, context) {
-      var topo = context.get('component');
-      var box = topo.get('active_service');
-      var container = context.get('container');
-      var addRelationNode = container.one('.add-relation');
-
-      // If the link is disabled, which can happen if the charm is not yet
-      // loaded and we don't know the endpoints, then don't allow clicking on
-      // it.
-      if (addRelationNode.hasClass('disabled')) {
-        return;
-      }
-
-      // Signify that a relation is being drawn.
-      topo.fire('addRelationDragStart', {service: box});
-    },
-
-    /*
-     * Event handler for the add relation button.
-     */
-    addRelation: function(evt) {
-      var curr_action = this.get('currentServiceClickAction');
-      if (curr_action === 'show_service') {
-        this.set('currentServiceClickAction', 'addRelationStart');
-      } // Otherwise do nothing.
-    },
-
     /**
      * If the mouse moves and we are adding a relation, then the dragline
      * needs to be updated.
@@ -646,7 +611,6 @@ YUI.add('juju-topology-relation', function(Y) {
       } else {
         // TODO clean up, abstract
         self.cancelRelationBuild();
-        self.addRelation(); // Will clear the state.
       }
       // Signify that the relation drawing has ended.
       topo.fire('addRelationEnd');

--- a/jujugui/static/gui/src/app/views/topology/relation.js
+++ b/jujugui/static/gui/src/app/views/topology/relation.js
@@ -1139,12 +1139,13 @@ YUI.add('juju-topology-relation', function(Y) {
       // Set up the relation data.
       var endpoint1 = endpoints[0][0],
           endpoint2 = endpoints[1][0];
-      var relation_id = 'pending-' + endpoint1 + endpoint2;
+      var idBlock = `${endpoint1}${endpoint2}`;
+      var interfaceBlock = `${endpoints[0][1].name}${endpoints[1][1].name}`;
       var endpointData = utils.parseEndpointStrings(db, [endpoint1, endpoint2]);
       var match = utils.findEndpointMatch(endpointData);
       // Add the relation to the database.
       var relation = db.relations.add({
-        relation_id: relation_id,
+        relation_id: `pending-${idBlock}${interfaceBlock}`,
         'interface': match['interface'],
         endpoints: endpoints,
         pending: true,

--- a/jujugui/static/gui/src/test/test_service_module.js
+++ b/jujugui/static/gui/src/test/test_service_module.js
@@ -210,31 +210,6 @@ describe.skip('service module events', function() {
     view.destroy();
   });
 
-  it('should show the service menu', function() {
-    var box = topo.service_boxes.haproxy;
-    var menu = viewContainer.one('#service-menu');
-
-    assert.equal(menu.hasClass('active'), false);
-    serviceModule.showServiceMenu(box);
-    assert.equal(menu.hasClass('active'), true);
-    // Check no-op.
-    serviceModule.showServiceMenu(box);
-    assert.equal(menu.hasClass('active'), true);
-  });
-
-  it('should hide the service menu',
-     function() {
-       var box = topo.service_boxes.haproxy;
-       var menu = viewContainer.one('#service-menu');
-       serviceModule.showServiceMenu(box);
-       assert.equal(menu.hasClass('active'), true);
-       serviceModule.hideServiceMenu();
-       assert.equal(menu.hasClass('active'), true);
-       // Check no-op.
-       serviceModule.hideServiceMenu();
-       assert.equal(menu.hasClass('active'), true);
-     });
-
   it('should notify modules when service type is changed', function(done) {
     topo.on('rerenderRelations', function() {
       done();
@@ -252,32 +227,6 @@ describe.skip('service module events', function() {
     var menuStub = utils.makeStubMethod(serviceModule, 'showServiceMenu');
     this._cleanups.push(menuStub.reset);
     serviceModule.showServiceDetails({id: 'test'}, topo);
-  });
-
-  // Click the provided service so that the service menu is shown.
-  // Return the service menu.
-  var clickService = function(service) {
-    // Monkeypatch to avoid the click event handler bailing out early.
-    topo.service_boxes.haproxy.containsPoint = function() {
-      return true;
-    };
-    // Click the service.
-    service.simulate('click');
-    return viewContainer.one('#service-menu');
-  };
-
-  it('should handle touch/click events properly', function() {
-    var service = viewContainer.one('.service');
-    var menu = viewContainer.one('#service-menu');
-    assert.equal(menu.hasClass('active'), true);
-    serviceModule._touchstartServiceTap({
-      currentTarget: service,
-      touches: [{PageX: 0, PageY: 0}]
-    }, topo);
-    // Touch events should also fire click events, which will be ignored.
-    // Fire one manually here.
-    clickService(service);
-    assert.equal(menu.hasClass('active'), true);
   });
 
   it('must not process service clicks after a dragend', function() {

--- a/jujugui/static/gui/src/test/test_topology_relation.js
+++ b/jujugui/static/gui/src/test/test_topology_relation.js
@@ -65,52 +65,6 @@ describe('topology relation module', function() {
     assert.equal(firedEventName, 'clearState');
   });
 
-  it('fires \'addRelationStart\' event when making a relation', function() {
-    var flags = {
-      addRelationDragStart: 0
-    };
-    var topo = {
-      fire: function(e) {
-        flags[e] = 1;
-      },
-      // stubs
-      get: function(val) {
-        if (val === 'container') {
-          return {
-            one: function() {
-              return {
-                hasClass: function() { return false; }
-              };
-            }
-          };
-        }
-      }
-    };
-    // stubs
-    var context = {
-      get: function(val) {
-        if (val === 'component') { return topo; }
-        if (val === 'container') {
-          return {
-            one: function() {
-              return {
-                hasClass: function() { return false; },
-                getDOMNode: function() { return; }
-              };
-            }
-          };
-        }
-      },
-      addRelationDragStart: function() { return; },
-      mousemove: function() { return; },
-      addRelationStart: function() { return; }
-    };
-    view.addRelButtonClicked(null, context);
-    assert.deepEqual(flags, {
-      addRelationDragStart: 1
-    });
-  });
-
   it('fires \'addRelationEnd\' event when done making a relation', function() {
     var counter = 0;
     var topo = {
@@ -383,7 +337,7 @@ describe('topology relation module', function() {
     // Ensure the given relation includes the expected fields.
     var assertRelation = function(relation) {
       assert.strictEqual(
-          relation.get('relation_id'), 'pending-service1service2');
+          relation.get('relation_id'), 'pending-service1service2dbdb');
       assert.strictEqual(relation.get('display_name'), 'pending');
       assert.deepEqual(relation.get('endpoints'), endpoints);
       assert.strictEqual(relation.get('pending'), true);


### PR DESCRIPTION
This only allows multiple relations to be created for ghost services. Once a service is deployed there is a further bug down the line which prevents multiple relations from being formed.