### PR TITLE
Make "fade" hide entirely.

### DIFF
--- a/jujugui/static/gui/src/app/assets/css/base.scss
+++ b/jujugui/static/gui/src/app/assets/css/base.scss
@@ -620,12 +620,13 @@ th {
         visibility: visible;
     }
     &.fade {
-        visibility: visible;
-        stroke-opacity: .2;
-
-        .service-icon {
-            opacity: .2;
-        }
+        /*
+          Put visibility on a delay so it gets hidden after the opacity is
+          finished transitioning.
+        */
+        transition: visibility 0s linear 0.4s, opacity 0.4s ease;
+        opacity: 0;
+        visibility: hidden;
     }
     &.hide {
         /*


### PR DESCRIPTION
Resolves: When you hide a service on the added services list, the service block on the canvas should disappear completely