### PR TITLE
Cross model relations: offer details and remote service info.

### DIFF
--- a/jujugui/static/gui/src/app/models/handlers.js
+++ b/jujugui/static/gui/src/app/models/handlers.js
@@ -236,6 +236,34 @@ YUI.add('juju-delta-handlers', function(Y) {
     },
 
     /**
+      Handle remote service info coming from the juju-core delta, updating the
+      relevant database models.
+
+      @method remoteserviceInfo
+      @param {Object} db The app.models.models.Database instance.
+      @param {String} action The operation to be performed
+       ("add", "change" or "remove").
+      @param {Object} change The JSON entity information.
+      @param {String} kind The delta event type.
+     */
+    remoteserviceInfo: function(db, action, change) {
+      var status = change.Status || {};
+      var data = {
+        id: change.ServiceURL,
+        service: change.Name,
+        sourceId: change.EnvUUID,
+        life: change.Life,
+        status: {
+          current: status.Current,
+          message: status.Message,
+          data: status.Data,
+          since: status.Since
+        }
+      };
+      db.remoteServices.process_delta(action, data);
+    },
+
+    /**
       Handle relation info coming from the juju-core delta, updating the
       relevant database models.
 


### PR DESCRIPTION
Implement the missing ServiceOffers API call on the CrossModelRelations
facade. It is used to retrieve details on a offered remote service.

Also implement the model layer for remote services. It is represented
in the database by a RemoteService model, and its corresponding
model list.

A mega-watcher handler is also introduced in order to populate the
new models. As juju-core does not yet implement relating to remote
services it is not possible to really test the mega-watcher handler
at this time, but I followed to Go code and that logic should be
ready very soon anyway.

Finally, added an addDetails method on the RemoteService that can be
use to enhance the model instance (created on delta) with info
obtained from calling env.getOffer().

Note that sandbox mode is not supported yet.

I expect small tweaks will be required when the functionality is
completed in core, but for now this should be enough for proceeding
with visualization steps.