### PR TITLE
Update model name when switching models

### DIFF
--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -629,6 +629,9 @@ YUI.add('juju-gui', function(Y) {
       this.db.relations.after(
           ['add', 'remove', '*:change'],
           this.on_database_changed, this);
+      this.db.environment.after(
+          ['add', 'remove', '*:change'],
+          this.on_database_changed, this);
       this.db.notifications.after('add', this._renderNotifications, this);
 
       // When someone wants a charm to be deployed they fire an event and we

--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -1008,6 +1008,7 @@ YUI.add('juju-gui', function(Y) {
           jem={this.jem}
           envList={this.get('environmentList')}
           changeState={this.changeState.bind(this)}
+          showConnectingMask={this.showConnectingMask.bind(this)}
           authDetails={this.get('auth')} />,
         document.getElementById('environment-switcher'));
     },
@@ -1736,6 +1737,22 @@ YUI.add('juju-gui', function(Y) {
     },
 
     /**
+      Shows the connecting to Juju environment mask.
+
+      @method showConnectingMask
+    */
+    showConnectingMask: function() {
+      var mask = document.getElementById('full-screen-mask');
+      var msg = document.getElementById('loading-message');
+      if (mask) {
+        mask.style.display = 'block';
+      }
+      if (msg) {
+        msg.style.display = 'block';
+      }
+    },
+
+    /**
      * Record environment default series changes in our model.
      *
      * The provider type arrives asynchronously.  Instead of updating the
@@ -1801,7 +1818,6 @@ YUI.add('juju-gui', function(Y) {
       if (!this.renderEnvironment) {
         next(); return;
       }
-      this.hideMask();
       var options = {
         getModelURL: Y.bind(this.getModelURL, this),
         nsRouter: this.nsRouter,

--- a/jujugui/static/gui/src/app/components/env-list/env-list.js
+++ b/jujugui/static/gui/src/app/components/env-list/env-list.js
@@ -48,6 +48,7 @@ YUI.add('env-list', function() {
         envs.push(
           <li className="env-list__environment"
             data-id={env.uuid}
+            data-name={envName}
             onClick={this.props.handleEnvClick}
             key={env.uuid}>
             {envName}

--- a/jujugui/static/gui/src/app/components/env-list/test-env-list.js
+++ b/jujugui/static/gui/src/app/components/env-list/test-env-list.js
@@ -42,12 +42,14 @@ describe('EnvList', function() {
     assert.deepEqual(output.props.children[0].props.children, [
       <li className="env-list__environment"
         data-id={envs[0].uuid}
+        data-name={envs[0].name}
         onClick={undefined}
         key={envs[0].uuid}>
         {envs[0].name}
       </li>,
       <li className="env-list__environment"
         data-id={envs[1].uuid}
+        data-name={envs[1].path}
         onClick={undefined}
         key={envs[1].uuid}>
         {envs[1].path}

--- a/jujugui/static/gui/src/app/components/env-switcher/env-switcher.js
+++ b/jujugui/static/gui/src/app/components/env-switcher/env-switcher.js
@@ -26,7 +26,8 @@ YUI.add('env-switcher', function() {
       jem: React.PropTypes.object,
       env: React.PropTypes.object,
       environmentName: React.PropTypes.string,
-      app: React.PropTypes.object
+      app: React.PropTypes.object,
+      showConnectingMask: React.PropTypes.func
     },
 
     getInitialState: function() {
@@ -115,6 +116,7 @@ YUI.add('env-switcher', function() {
     */
     handleEnvClick: function(e) {
       var currentTarget = e.currentTarget;
+      this.props.showConnectingMask();
       this.setState({showEnvList: false});
       this.setState({envName: currentTarget.getAttribute('data-name')});
       this.switchEnv(currentTarget.getAttribute('data-id'));

--- a/jujugui/static/gui/src/app/components/env-switcher/env-switcher.js
+++ b/jujugui/static/gui/src/app/components/env-switcher/env-switcher.js
@@ -31,6 +31,7 @@ YUI.add('env-switcher', function() {
 
     getInitialState: function() {
       return {
+        envName: this.props.environmentName,
         showEnvList: false,
         envList: []
       };
@@ -38,6 +39,16 @@ YUI.add('env-switcher', function() {
 
     componentDidMount: function() {
       this.updateEnvList();
+    },
+
+    componentWillReceiveProps: function(nextProps) {
+      // We only want to take the environment name that's being passed in if
+      // there is none displayed. Else rely on what the user has selected to
+      // avoid a long delay in updating the selected environment via the
+      // megawatcher.
+      if (!this.state.envName) {
+        this.setState({envName: nextProps.environmentName});
+      }
     },
 
     /**
@@ -103,9 +114,10 @@ YUI.add('env-switcher', function() {
       @param {Object} e The click event.
     */
     handleEnvClick: function(e) {
-      var uuid = e.currentTarget.getAttribute('data-id');
+      var currentTarget = e.currentTarget;
       this.setState({showEnvList: false});
-      this.switchEnv(uuid);
+      this.setState({envName: currentTarget.getAttribute('data-name')});
+      this.switchEnv(currentTarget.getAttribute('data-id'));
     },
 
     /**
@@ -233,7 +245,7 @@ YUI.add('env-switcher', function() {
             className="env-switcher--toggle"
             onClick={this.toggleEnvList}>
             <span className="environment-name">
-              {this.props.environmentName}
+              {this.state.envName}
             </span>
             <juju.components.SvgIcon name="chevron_down_16"
               size="16" />

--- a/jujugui/static/gui/src/app/components/env-switcher/env-switcher.js
+++ b/jujugui/static/gui/src/app/components/env-switcher/env-switcher.js
@@ -182,6 +182,7 @@ YUI.add('env-switcher', function() {
         console.log(err);
         return;
       }
+      this.setState({envName: data.name || data.path});
       this.updateEnvList(this.switchEnv.bind(this, data.uuid));
     },
 

--- a/jujugui/static/gui/src/app/components/env-switcher/test-env-switcher.js
+++ b/jujugui/static/gui/src/app/components/env-switcher/test-env-switcher.js
@@ -146,6 +146,7 @@ describe('EnvSwitcher', function() {
     }];
     var listEnvs = sinon.stub();
     var switchEnv = sinon.stub();
+    var mask = sinon.stub();
     var jem = {
       listEnvironments: listEnvs
     };
@@ -154,6 +155,7 @@ describe('EnvSwitcher', function() {
     };
     var renderer = jsTestUtils.shallowRender(
       <juju.components.EnvSwitcher
+        showConnectingMask={mask}
         jem={jem}
         app={app} />, true);
     var instance = renderer.getMountedInstance();
@@ -164,7 +166,13 @@ describe('EnvSwitcher', function() {
         getAttribute: () => 'abc123'
       }
     });
+    assert.equal(mask.callCount, 1);
     assert.equal(switchEnv.callCount, 1);
+    assert.deepEqual(instance.state, {
+      showEnvList: false,
+      envName: 'abc123',
+      envList: envs
+    });
     assert.deepEqual(switchEnv.args[0], [
       envs[0].uuid, envs[0].user, envs[0].password
     ]);

--- a/jujugui/static/gui/src/app/components/env-switcher/test-env-switcher.js
+++ b/jujugui/static/gui/src/app/components/env-switcher/test-env-switcher.js
@@ -225,7 +225,10 @@ describe('EnvSwitcher', function() {
     assert.equal(newEnv.args[0][3], 'admin/foo');
     assert.equal(newEnv.args[0][4].length > 10, true);
     // Check to make sure that the env creation callback switches envs.
-    var createdEnv = {uuid: '123abc'};
+    var createdEnv = {
+      uuid: '123abc',
+      name: 'newname'
+    };
     newEnv.args[0][5](null, createdEnv);
     // After creating an env it should re-list them.
     assert.equal(listEnvs.callCount, 2);
@@ -233,6 +236,8 @@ describe('EnvSwitcher', function() {
     envs.push(createdEnv);
     listEnvs.args[1][0](null, envs);
     assert.equal(switchEnv.callCount, 1);
+    // After creating a new env it should update the envName state
+    assert.equal(instance.state.envName, 'newname');
   }
 
   it('can call to create a new env (JEM)', function() {


### PR DESCRIPTION
When switching models we now mask the canvas and show the "connecting to environment" message while we wait for the appropriate deltas. Fixes #1070 