### PR TITLE
Add Clear changes button

### DIFF
--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -799,6 +799,7 @@ YUI.add('juju-gui', function(Y) {
           changeState={this.changeState.bind(this)}
           services={services.toArray()}
           ecsCommit={ecs.commit.bind(ecs, env)}
+          ecsClear={ecs.clear.bind(ecs)}
           exportEnvironmentFile={
             utils.exportEnvironmentFile.bind(utils, this.db)}
           changeDescriptions={changeDescriptions}

--- a/jujugui/static/gui/src/app/components/deployment-summary/deployment-summary.js
+++ b/jujugui/static/gui/src/app/components/deployment-summary/deployment-summary.js
@@ -22,6 +22,10 @@ YUI.add('deployment-summary', function() {
 
   juju.components.DeploymentSummary = React.createClass({
 
+    propTypes: {
+      summaryClearAction: React.PropTypes.func.isRequired
+    },
+
     /**
       Generate the list of change items.
 
@@ -79,6 +83,10 @@ YUI.add('deployment-summary', function() {
               </ul>
             </div>
             <div className="deployment-summary__footer">
+              <juju.components.GenericButton
+                type="clear-changes"
+                action={this.props.summaryClearAction}
+                title="Clear changes" />
               <juju.components.GenericButton
                 action={this.props.deployButtonAction}
                 type="confirm"

--- a/jujugui/static/gui/src/app/components/deployment-summary/test-deployment-summary.js
+++ b/jujugui/static/gui/src/app/components/deployment-summary/test-deployment-summary.js
@@ -32,6 +32,7 @@ describe('DeploymentSummary', function() {
 
   it('can display a list of changes', function() {
     var getUnplacedUnitCount = sinon.stub().returns(0);
+    var summaryClearAction = sinon.stub();
     var handleViewMachinesClick = sinon.stub();
     var handlePlacementChange = sinon.stub();
     var closeButtonAction = sinon.stub();
@@ -56,6 +57,7 @@ describe('DeploymentSummary', function() {
         'deployment-summary__list-header';
     var output = jsTestUtils.shallowRender(
       <juju.components.DeploymentSummary
+        summaryClearAction={summaryClearAction}
         getUnplacedUnitCount={getUnplacedUnitCount}
         changeDescriptions={changeDescriptions}
         deployButtonAction={deployButtonAction}
@@ -98,6 +100,10 @@ describe('DeploymentSummary', function() {
             </ul>
           </div>
           <div className="deployment-summary__footer">
+            <juju.components.GenericButton
+              type="clear-changes"
+              action={summaryClearAction}
+              title="Clear changes" />
             <juju.components.GenericButton
               action={deployButtonAction}
               type="confirm"

--- a/jujugui/static/gui/src/app/components/deployment/deployment.js
+++ b/jujugui/static/gui/src/app/components/deployment/deployment.js
@@ -22,7 +22,8 @@ YUI.add('deployment-component', function() {
 
   juju.components.Deployment = React.createClass({
     propTypes: {
-      exportEnvironmentFile: React.PropTypes.func.isRequired
+      exportEnvironmentFile: React.PropTypes.func.isRequired,
+      ecsClear: React.PropTypes.func.isRequired
     },
 
     /**
@@ -78,6 +79,7 @@ YUI.add('deployment-component', function() {
               this.props.changeDescriptions;
           state.activeChild = {
             component: <juju.components.DeploymentSummary
+              summaryClearAction={this._summaryClearAction}
               deployButtonAction={this._summaryDeployAction}
               closeButtonAction={this._summaryCloseAction}
               changeDescriptions={changeDescriptions}
@@ -124,6 +126,17 @@ YUI.add('deployment-component', function() {
     */
     _barDeployAction: function() {
       this._changeActiveComponent('deployment-summary');
+    },
+
+    /**
+      Handles calling to clear the ecs and then closing the deployment
+      summary.
+
+      @method _summaryClearAction
+    */
+    _summaryClearAction: function() {
+      this.props.ecsClear();
+      this._changeActiveComponent('deployment-bar');
     },
 
     /**

--- a/jujugui/static/gui/src/app/components/deployment/test-deployment.js
+++ b/jujugui/static/gui/src/app/components/deployment/test-deployment.js
@@ -144,9 +144,11 @@ describe('Deployment', function() {
     var currentChangeSet = sinon.stub();
     var exportEnvironmentFile = sinon.stub();
     var getUnplacedUnitCount = sinon.stub();
+    var ecsClear = sinon.stub();
     var changeDescriptions = {};
     var output = jsTestUtils.shallowRender(
       <juju.components.Deployment
+        ecsClear={ecsClear}
         currentChangeSet={currentChangeSet}
         changeDescriptions={changeDescriptions}
         exportEnvironmentFile={exportEnvironmentFile}
@@ -155,6 +157,7 @@ describe('Deployment', function() {
     assert.deepEqual(output,
       <div className="deployment-view">
         <juju.components.DeploymentSummary
+          summaryClearAction={output.props.children.props.summaryClearAction}
           deployButtonAction={output.props.children.props.deployButtonAction}
           closeButtonAction={output.props.children.props.closeButtonAction}
           changeDescriptions={changeDescriptions}

--- a/jujugui/static/gui/src/app/components/generic-button/_generic-button.scss
+++ b/jujugui/static/gui/src/app/components/generic-button/_generic-button.scss
@@ -48,6 +48,10 @@
 .deployment-summary .generic-button {
     padding-left: 60px;
     padding-right: 60px;
+
+    &--type-clear-changes {
+        float: left;
+    }
 }
 
 .entity-details .generic-button {


### PR DESCRIPTION
Add a "Clear changes" button to the deployment bar summary to clear all changes out of the ECS. (Fixes #1100)