### PR TITLE
Handle bzr-revisions missing in extra-info.

### DIFF
--- a/jujugui/static/gui/src/app/assets/javascripts/jujulib/juju.js
+++ b/jujugui/static/gui/src/app/assets/javascripts/jujulib/juju.js
@@ -311,7 +311,7 @@ var module = module;
         // If the id has a user segment then it has not been promulgated.
         is_approved: data.Id.indexOf('~') > 0 ? false : true,
         owner: bzrOwner,
-        revisions: extraInfo['bzr-revisions'],
+        revisions: extraInfo['bzr-revisions'] || [],
         code_source: {
           location: extraInfo['bzr-url']
         }

--- a/jujugui/static/gui/src/app/assets/javascripts/jujulib/test-jujulib-charmstore.js
+++ b/jujugui/static/gui/src/app/assets/javascripts/jujulib/test-jujulib-charmstore.js
@@ -198,6 +198,29 @@ describe('jujulib charmstore', function() {
       });
     });
 
+    it('handles missing extra-info data', function() {
+      var data = {
+        Id: 'cs:trusty/mongodb-9',
+        Meta: {
+          'charm-metadata': {
+            Name: 'mongodb',
+            Provides: {}
+          },
+          'extra-info': {},
+          'charm-related': {
+            Requires: {'ceph-client': {id: 'cs:foo'}},
+            Provides: {haproxy: {id: 'cs:bar'}}
+          },
+          'charm-config': {Options: {}},
+          stats: {ArchiveDownloadCount: 42}
+        }
+      };
+      var processed = charmstore._processEntityQueryData(data);
+      assert.strictEqual(processed.owner, undefined);
+      assert.strictEqual(processed.code_source.location, undefined);
+      assert.deepEqual(processed.revisions, []);
+    });
+
     it('can properly transform v4 bundle data to v3', function() {
       var data = {
         Id: 'cs:~charmers/bundle/mongodb-cluster-4',


### PR DESCRIPTION
Do not freeze when showing charm details in the case bzr-revisions is not there.