### PR TITLE
Set focus on login page

### DIFF
--- a/jujugui/static/gui/src/app/components/login/login.js
+++ b/jujugui/static/gui/src/app/components/login/login.js
@@ -29,6 +29,10 @@ YUI.add('login-component', function() {
       loginFailure: React.PropTypes.bool
     },
 
+    componentDidMount: function () {
+      this.refs.username.focus();
+    },
+
     /**
       Handles the form submit by calling the set credentials and login
       methods with the appropriate values.

--- a/jujugui/static/gui/src/app/components/login/test-login.js
+++ b/jujugui/static/gui/src/app/components/login/test-login.js
@@ -140,7 +140,7 @@ describe('LoginComponent', function() {
         envName="testenv"
         setCredentials={sinon.stub()}
         login={sinon.stub()}
-        loginFailure={true} />);
+        loginFailure={true} />, true);
     var instance = renderer.getMountedInstance();
     instance.refs = {username: {focus: focus}};
     instance.componentDidMount();

--- a/jujugui/static/gui/src/app/components/login/test-login.js
+++ b/jujugui/static/gui/src/app/components/login/test-login.js
@@ -133,4 +133,17 @@ describe('LoginComponent', function() {
     assert.equal(login.callCount, 1, 'login never called');
   });
 
+  it('can focus on the username field', function() {
+    var focus = sinon.stub();
+    var renderer = jsTestUtils.shallowRender(
+      <juju.components.Login
+        envName="testenv"
+        setCredentials={sinon.stub()}
+        login={sinon.stub()}
+        loginFailure={true} />);
+    var instance = renderer.getMountedInstance();
+    instance.refs = {username: {focus: focus}};
+    instance.componentDidMount();
+    assert.equal(focus.callCount, 1);
+  });
 });

--- a/jujugui/static/gui/src/app/components/machine-view/_machine-view.scss
+++ b/jujugui/static/gui/src/app/components/machine-view/_machine-view.scss
@@ -20,6 +20,7 @@
 
     &__column {
         @extend %scroll-children;
+        overflow-y: hidden;
         box-sizing: border-box;
         display: flex;
         flex-direction: column;


### PR DESCRIPTION
Set focus on the username on the login page (fixes #1101). Fixed the width of the machine column changing when opening the context menu (fixes #1120).