### PR TITLE
When scaling up services properly retreive their ids

### DIFF
--- a/jujugui/static/gui/src/app/components/machine-view/scale-up/scale-up.js
+++ b/jujugui/static/gui/src/app/components/machine-view/scale-up/scale-up.js
@@ -66,10 +66,11 @@ YUI.add('machine-view-scale-up', function() {
       @method _handleAddUnits
     */
     _handleAddUnits: function() {
+      var re = /(scaleUpUnit-)(.*)/;
       Object.keys(this.refs).forEach((ref) => {
-        var parts = ref.split('-');
-        if (parts[0] === 'scaleUpUnit') {
-          var service = this.props.services.getById(parts[1]);
+        var parts = re.exec(ref);
+        if (parts) {
+          var service = this.props.services.getById(parts[parts.length-1]);
           this.props.addGhostAndEcsUnits(service, this.refs[ref].value);
         }
       });

--- a/jujugui/static/gui/src/app/components/machine-view/scale-up/scale-up.js
+++ b/jujugui/static/gui/src/app/components/machine-view/scale-up/scale-up.js
@@ -70,7 +70,7 @@ YUI.add('machine-view-scale-up', function() {
       Object.keys(this.refs).forEach((ref) => {
         var parts = re.exec(ref);
         if (parts) {
-          var service = this.props.services.getById(parts[parts.length-1]);
+          var service = this.props.services.getById(parts[2]);
           this.props.addGhostAndEcsUnits(service, this.refs[ref].value);
         }
       });

--- a/jujugui/static/gui/src/app/components/machine-view/scale-up/test-scale-up.js
+++ b/jujugui/static/gui/src/app/components/machine-view/scale-up/test-scale-up.js
@@ -179,15 +179,51 @@ describe('MachineViewScaleUp', function() {
       '.generic-button--type-confirm');
     var input1 = output.refs['scaleUpUnit-111111$'];
     input1.value = '5';
-    //testUtils.Simulate.change(input1);
     var input2 = output.refs['scaleUpUnit-222222$'];
     input2.value = '9';
-    //testUtils.Simulate.change(input2);
     testUtils.Simulate.click(confirm);
     assert.equal(addGhostAndEcsUnits.callCount, 2);
     assert.equal(addGhostAndEcsUnits.args[0][0], '111111$');
     assert.equal(addGhostAndEcsUnits.args[0][1], '5');
     assert.equal(addGhostAndEcsUnits.args[1][0], '222222$');
     assert.equal(addGhostAndEcsUnits.args[1][1], '9');
+  });
+
+  it('can scale services with dashes in the name', () => {
+    var addGhostAndEcsUnits = sinon.stub();
+    var toggleScaleUp = sinon.stub();
+    var services = {
+      toArray: sinon.stub().returns([{
+        get: function (val) {
+          switch (val) {
+            case 'id':
+              return 'juju-gui';
+              break;
+            case 'name':
+              return 'juju-gui';
+              break;
+            case 'icon':
+              return 'juju-gui.svg';
+              break;
+          }
+        }
+      }]),
+      getById: function (val) {
+        return 'juju-gui';
+      }
+    };
+    var output = testUtils.renderIntoDocument(
+      <juju.components.MachineViewScaleUp
+        addGhostAndEcsUnits={addGhostAndEcsUnits}
+        services={services}
+        toggleScaleUp={toggleScaleUp} />, true);
+    var confirm = output.getDOMNode().querySelector(
+      '.generic-button--type-confirm');
+    var input1 = output.refs['scaleUpUnit-juju-gui'];
+    input1.value = '5';
+    testUtils.Simulate.click(confirm);
+    assert.equal(addGhostAndEcsUnits.callCount, 1);
+    assert.equal(addGhostAndEcsUnits.args[0][0], 'juju-gui');
+    assert.equal(addGhostAndEcsUnits.args[0][1], '5');
   });
 });


### PR DESCRIPTION
Fixes an issue where models which had services with dashes in their names would then make scaling via the machine view impossible (Fixes: #1108)