### PR TITLE
Force machine removal when destroying from MV

### DIFF
--- a/jujugui/static/gui/src/app/components/machine-view/machine/machine.js
+++ b/jujugui/static/gui/src/app/components/machine-view/machine/machine.js
@@ -147,7 +147,7 @@ YUI.add('machine-view-machine', function() {
       @method _destroyMachine
     */
     _destroyMachine: function() {
-      this.props.destroyMachines([this.props.machine.id]);
+      this.props.destroyMachines([this.props.machine.id], true);
     },
 
     /**

--- a/jujugui/static/gui/src/app/store/env/go.js
+++ b/jujugui/static/gui/src/app/store/env/go.js
@@ -1239,7 +1239,7 @@ YUI.add('juju-env-go', function(Y) {
 
       @method destroyMachines
     */
-    destroyMachines: function(params, force, callback, options) {
+    destroyMachines: function(names, force, callback, options) {
       var ecs = this.get('ecs');
       var args = ecs._getArgs(arguments);
       if (options && options.immediate) {

--- a/jujugui/static/gui/src/app/utils/environment-change-set.js
+++ b/jujugui/static/gui/src/app/utils/environment-change-set.js
@@ -482,6 +482,7 @@ YUI.add('environment-change-set', function(Y) {
       this.currentIndex += 1;
       this.currentCommit = [];
       this.fire('changeSetModified');
+      this.get('db').fire('update');
     },
 
     /**
@@ -505,7 +506,16 @@ YUI.add('environment-change-set', function(Y) {
           services.getById(command.args[0]).set('deleted', false);
           break;
         case '_destroyMachines':
+          var machineId = command.args[0][0];
+          // Set the parent machine to not be deleted.
           machines.getById(command.args[0]).deleted = false;
+          // Set the containers of the parent machine to not be deleted.
+          machines.filterByAncestor(machineId).forEach(machine => {
+            machine.deleted = false;
+          });
+          units.filterByMachine(machineId, true).forEach(unit => {
+            unit.deleted = false;
+          });
           break;
         case '_set_config':
           var service = services.getById(command.args[0]);

--- a/jujugui/static/gui/src/test/test_env_change_set.js
+++ b/jujugui/static/gui/src/test/test_env_change_set.js
@@ -923,9 +923,17 @@ describe('Environment Change Set', function() {
                 }
               };
             },
+            filterByAncestor: function() {
+              return [];
+            },
+            reset: function() {},
+            detachAll: function() {},
+            destroy: function() {},
             free: testUtils.makeStubFunction()
           },
           units: {
+            detachAll: function() {},
+            destroy: function() {},
             filterByMachine: function() {
               return [];
             }}
@@ -952,9 +960,15 @@ describe('Environment Change Set', function() {
           getById: function() {
             return {};
           },
+          detachAll: function() {},
+          destroy: function() {},
+          reset: function() {},
           remove: stubRemove
         };
         ecs.get('db').units = {
+          detachAll: function() {},
+          destroy: function() {},
+          reset: function() {},
           filterByMachine: function() {
             return [];
           }
@@ -970,6 +984,9 @@ describe('Environment Change Set', function() {
             ecs, '_destroyQueuedMachine');
         this._cleanups.push(stubDestroy.reset);
         ecs.get('db').machines = {
+          detachAll: function() {},
+          destroy: function() {},
+          reset: function() {},
           getById: function() {
             return { units: []};
           }
@@ -991,10 +1008,16 @@ describe('Environment Change Set', function() {
       it('removes uncommitted units from machines', function() {
         var stubRemove = testUtils.makeStubFunction();
         ecs.get('db').machines = {
+          detachAll: function() {},
+          destroy: function() {},
           getById: function() {},
+          reset: function() {},
           remove: stubRemove
         };
         ecs.get('db').units = {
+          detachAll: function() {},
+          destroy: function() {},
+          reset: function() {},
           filterByMachine: function() {}
         };
         ecs.changeSet = {
@@ -1032,11 +1055,20 @@ describe('Environment Change Set', function() {
               set: testUtils.makeStubFunction()
             };
           },
+          filterByAncestor: function() {
+            return [];
+          },
+          reset: function() {},
+          detachAll: function() {},
+          destroy: function() {},
           free: testUtils.makeStubFunction()
         };
         db.units = {
           revive: function() { return { set: stubSet }; },
           free: function() {},
+          reset: function() {},
+          detachAll: function() {},
+          destroy: function() {},
           filterByMachine: function() {
             return [unit];
           }
@@ -1044,6 +1076,63 @@ describe('Environment Change Set', function() {
         ecs._lazyDestroyMachines([['baz'], function() {}]);
         assert.deepEqual(unit, {});
         assert.deepEqual(stubSet.lastArguments(), ['machine', null]);
+      });
+
+      it('marks nested containers and units as deleted', function() {
+        var cmdArgs = ['abc123', true, function() {}];
+        var unit = {
+          // Required so it's treated as a real unit and not a ghost.
+          agent_state: 'running',
+          deleted: null
+        };
+        var machine = {
+          deleted: null
+        };
+        ecs.get('db').machines = {
+          detachAll: function() {},
+          destroy: function() {},
+          reset: function() {},
+          free: function() {},
+          revive: function(obj) {
+            return {
+              set: function(key, value) {
+                obj[key] = value;
+              }
+            };
+          },
+          getById: function() {
+            return {
+              id: cmdArgs[0],
+              parentId: 0
+            };
+          },
+          filterByAncestor: function(machineId) {
+            assert.equal(machineId, cmdArgs[0]);
+            return [machine];
+          }
+        };
+        ecs.get('db').units = {
+          detachAll: function() {},
+          destroy: function() {},
+          reset: function() {},
+          getById: function() {},
+          free: function() {},
+          revive: function(obj) {
+            return {
+              set: function(key, value) {
+                obj[key] = value;
+              }
+            };
+          },
+          filterByMachine: function(machineId, includeChildren) {
+            assert.equal(machineId, cmdArgs[0]);
+            assert.equal(includeChildren, true);
+            return [unit];
+          }
+        };
+        ecs._lazyDestroyMachines(cmdArgs);
+        assert.equal(unit.deleted, true, 'unit not set as deleted');
+        assert.equal(machine.deleted, true, 'machine not set as deleted');
       });
     });
 

--- a/jujugui/static/gui/src/test/test_env_change_set.js
+++ b/jujugui/static/gui/src/test/test_env_change_set.js
@@ -622,13 +622,29 @@ describe('Environment Change Set', function() {
     it('undeletes deleted machines', function() {
       var db = ecs.get('db');
       var attrs = {deleted: true};
+      var machine = {
+        deleted: true
+      };
+      var unit = {
+        deleted: true
+      };
       db.machines = {
         getById: function() {
           return attrs;
+        },
+        filterByAncestor: function() {
+          return [machine];
+        }
+      };
+      db.units = {
+        filterByMachine: function() {
+          return [unit];
         }
       };
       ecs._clearFromDB({method: '_destroyMachines', args: [1]});
       assert.deepEqual(attrs, {deleted: false});
+      assert.equal(machine.deleted, false);
+      assert.equal(unit.deleted, false);
     });
 
     it('backs out config changes', function() {


### PR DESCRIPTION
When deleting machines from the machine view it's assumed that the user understands that they will destroy all child machines and units. This implements that functionality. (Fixes #1104)