### PR TITLE
Dont add to removed

### DIFF
--- a/jujugui/static/gui/src/app/components/machine-view/add-machine/add-machine.js
+++ b/jujugui/static/gui/src/app/components/machine-view/add-machine/add-machine.js
@@ -189,6 +189,9 @@ YUI.add('machine-view-add-machine', function() {
       var components = [];
       var machines = this.props.machines.filterByParent();
       machines.forEach((machine) => {
+        if (machine.deleted) {
+          return;
+        }
         components.push(
           <option
             key={machine.id}
@@ -220,6 +223,9 @@ YUI.add('machine-view-add-machine', function() {
           {machineId}/root-container
         </option>);
       containers.forEach((container) => {
+        if (container.deleted) {
+          return;
+        }
         components.push(
           <option
             key={container.id}

--- a/jujugui/static/gui/src/app/components/machine-view/add-machine/test-add-machine.js
+++ b/jujugui/static/gui/src/app/components/machine-view/add-machine/test-add-machine.js
@@ -111,6 +111,11 @@ describe('MachineViewAddMachine', function() {
       }, {
         id: 'new1',
         displayName: 'new1'
+      }, {
+        // Deleted machines should not appear in the list of options.
+        id: 'new2',
+        deleted: true,
+        displayName: 'new2'
       }])
     };
     var renderer = jsTestUtils.shallowRender(
@@ -160,6 +165,11 @@ describe('MachineViewAddMachine', function() {
       }, {
         id: 'new0/lxc/new1',
         displayName: 'new0/lxc/new1'
+      }, {
+        // Deleted containers should not appear in the list of options.
+        id: 'new0/lxc/new2',
+        deleted: true,
+        displayName: 'new0/lxc/new2'
       }])
     };
     var renderer = jsTestUtils.shallowRender(

--- a/jujugui/static/gui/src/app/components/machine-view/machine-view.js
+++ b/jujugui/static/gui/src/app/components/machine-view/machine-view.js
@@ -363,7 +363,13 @@ YUI.add('machine-view', function() {
       @method _addContainer
     */
     _addContainer: function() {
-      if (this.state.selectedMachine) {
+      var selectedMachine = this.state.selectedMachine;
+      var deleted = false;
+      if (selectedMachine) {
+        var machine = this.props.machines.getById(selectedMachine);
+        deleted = machine.deleted;
+      }
+      if (this.state.selectedMachine && !deleted) {
         this.setState({showAddContainer: true});
       }
     },

--- a/jujugui/static/gui/src/app/components/machine-view/machine/machine.js
+++ b/jujugui/static/gui/src/app/components/machine-view/machine/machine.js
@@ -33,6 +33,17 @@ YUI.add('machine-view-machine', function() {
     drop: function (props, monitor, component) {
       var item = monitor.getItem();
       props.dropUnit(item.unit, props.machine.id);
+    },
+
+    /**
+      Called to check whether something can be dropped on the component.
+
+      @method drop
+      @param {Object} props The component props.
+      @param {Object} monitor A DropTargetMonitor.
+    */
+    canDrop: function (props, monitor) {
+      return !props.machine.deleted;
     }
   };
 
@@ -45,6 +56,7 @@ YUI.add('machine-view-machine', function() {
   */
   function collect(connect, monitor) {
     return {
+      canDrop: monitor.canDrop(),
       connectDropTarget: connect.dropTarget(),
       isOver: monitor.isOver()
     };
@@ -171,7 +183,7 @@ YUI.add('machine-view-machine', function() {
     _generateClasses: function() {
       var machine = this.props.machine;
       var classes = {
-        'machine-view__machine--drop': this.props.isOver,
+        'machine-view__machine--drop': this.props.isOver && this.props.canDrop,
         'machine-view__machine--selected': this.props.selected,
         'machine-view__machine--uncommitted': machine.deleted ||
           machine.commitStatus === 'uncommitted',

--- a/jujugui/static/gui/src/app/components/machine-view/machine/test-machine.js
+++ b/jujugui/static/gui/src/app/components/machine-view/machine/test-machine.js
@@ -148,6 +148,7 @@ describe('MachineViewMachine', function() {
       // The component is wrapped to handle drag and drop, but we just want to
       // test the internal component so we access it via DecoratedComponent.
       <juju.components.MachineViewMachine.DecoratedComponent
+        canDrop={true}
         connectDropTarget={jsTestUtils.connectDropTarget}
         isOver={true}
         machine={machine}

--- a/jujugui/static/gui/src/app/components/machine-view/test-machine-view.js
+++ b/jujugui/static/gui/src/app/components/machine-view/test-machine-view.js
@@ -1078,6 +1078,78 @@ describe('MachineView', function() {
       output.props.children.props.children[2].props.children[1], expected);
   });
 
+  it('does not show an add container form for deleted machines', function() {
+    var machines = {
+      filterByParent: function(arg) {
+        if (arg == 'new0') {
+          return [{id: 'new0/lxc/0'}];
+        }
+        return [{id: 'new0'}];
+      },
+      getById: sinon.stub().returns({
+        id: 'new0',
+        deleted: true,
+        commitStatus: 'committed'
+      })
+    };
+    var units = {
+      filterByMachine: sinon.stub().returns([])
+    };
+    var services = {
+      size: sinon.stub().returns(0)
+    };
+    var createMachine = sinon.stub();
+    var destroyMachines = sinon.stub();
+    var removeUnits = sinon.stub();
+    var renderer = jsTestUtils.shallowRender(
+      // The component is wrapped to handle drag and drop, but we just want to
+      // test the internal component so we access it via DecoratedComponent.
+      <juju.components.MachineView.DecoratedComponent
+        addGhostAndEcsUnits={sinon.stub()}
+        createMachine={createMachine}
+        destroyMachines={destroyMachines}
+        environmentName="My Env"
+        units={units}
+        removeUnits={removeUnits}
+        services={services}
+        machines={machines} />, true);
+    var instance = renderer.getMountedInstance();
+    instance._addContainer();
+    var output = renderer.getRenderOutput();
+    var expected = (
+      <div className="machine-view__column-content">
+        {undefined}
+        <ul className="machine-view__list">
+          <juju.components.MachineViewMachine
+            destroyMachines={destroyMachines}
+            dropUnit={instance._dropUnit}
+            key="new0"
+            machine={{
+              commitStatus: 'committed',
+              deleted: true,
+              displayName: 'Root container',
+              id: 'new0',
+              root: true
+            }}
+            removeUnit={instance._removeUnit}
+            services={services}
+            type="container"
+            units={units} />
+          <juju.components.MachineViewMachine
+            destroyMachines={destroyMachines}
+            dropUnit={instance._dropUnit}
+            key="new0/lxc/0"
+            machine={{id: 'new0/lxc/0'}}
+            removeUnit={instance._removeUnit}
+            services={services}
+            type="container"
+            units={units} />
+        </ul>
+      </div>);
+    assert.deepEqual(
+      output.props.children.props.children[2].props.children[1], expected);
+  });
+
   it('can remove a unit', function() {
     var machines = {
       filterByParent: function(arg) {


### PR DESCRIPTION
Don't allow units or containers to be added to removed machines or containers. Fixes https://github.com/juju/juju-gui/issues/1122.