### PR TITLE
Display placement errors

### DIFF
--- a/jujugui/static/gui/src/app/utils/environment-change-set.js
+++ b/jujugui/static/gui/src/app/utils/environment-change-set.js
@@ -1271,6 +1271,11 @@ YUI.add('environment-change-set', function(Y) {
       var error = this.validateUnitPlacement(
           unit, db.machines.getById(machineId));
       if (error) {
+        db.notifications.add({
+          title: 'Error placing unit',
+          message: 'Error placing unit: ' + error,
+          level: 'error'
+        });
         return error;
       }
       // When placeUnit is called the unit could have been already placed on a

--- a/jujugui/static/gui/src/test/test_env_change_set.js
+++ b/jujugui/static/gui/src/test/test_env_change_set.js
@@ -1766,11 +1766,15 @@ describe('Environment Change Set', function() {
       });
 
       it('does not apply changes if unit placement is not valid', function() {
+        var addStub = testUtils.makeStubFunction();
+        ecs.get('db').notifications = {add: addStub};
         mockValidateUnitPlacement = testUtils.makeStubMethod(
             ecs, 'validateUnitPlacement', 'bad wolf');
         this._cleanups.push(mockValidateUnitPlacement.reset);
         var err = ecs.placeUnit(unit, machineId);
         assert.strictEqual(err, 'bad wolf');
+        // A notification should have been added.
+        assert.equal(addStub.callCount(), 1);
         // No parents have been added to the changeset record.
         assert.strictEqual(ecs.changeSet.a.parents.length, 0);
         // The machine id has not been set on the unit.


### PR DESCRIPTION
Display a notification if there are errors when placing a unit on a machine. Fixes https://github.com/juju/juju-gui/issues/1134.