### PR TITLE
Handle multi-series charms gracefully.

### DIFF
--- a/jujugui/static/gui/src/app/components/entity-header/entity-header.js
+++ b/jujugui/static/gui/src/app/components/entity-header/entity-header.js
@@ -160,6 +160,26 @@ YUI.add('entity-header', function() {
         'https://plus.google.com/share?url=',
         this._getStoreURL(entity)
       ].join('');
+      // XXX kadams54, 2016-01-04: the deployAction var will need to be removed
+      // once we fully support multi-series charms.
+      var deployAction;
+      // If the entity is not a charm OR it is a charm and has the series set,
+      // display a button. Otherwise display a "not supported" message.
+      if (entity.type !== 'charm' || entity.series) {
+        deployAction = (
+          <juju.components.GenericButton
+            ref="deployAction"
+            action={this._handleDeployClick}
+            type="confirm"
+            title="Add to canvas" />
+        );
+      } else {
+        deployAction = (
+          <div ref="deployAction">
+            This type of charm can only be deployed from the command line.
+          </div>
+        );
+      }
 
       return (
         <div className="row-hero"
@@ -208,11 +228,7 @@ YUI.add('entity-header', function() {
               <div className="four-col last-col no-margin-bottom">
                 <juju.components.CopyToClipboard
                   value={'juju deploy ' + entity.id} />
-                <juju.components.GenericButton
-                  ref="deployButton"
-                  action={this._handleDeployClick}
-                  type="confirm"
-                  title="Add to canvas" />
+                {deployAction}
               </div>
             </div>
           </header>

--- a/jujugui/static/gui/src/app/components/entity-header/test-entity-header.js
+++ b/jujugui/static/gui/src/app/components/entity-header/test-entity-header.js
@@ -70,7 +70,9 @@ describe('EntityHeader', function() {
                   <a href="https://launchpad.net/~test-owner"
                     target="_blank">test-owner</a>
                 </li>
-                {null}
+                <li className="entity-header__series">
+                  trusty
+                </li>
               </ul>
               <ul className="entity-header__social-list">
                 <li>
@@ -78,7 +80,7 @@ describe('EntityHeader', function() {
                     target="_blank"
                     href={'https://twitter.com/intent/tweet?text=django%20' +
                       'charm&via=ubuntu_cloud&url=https%3A%2F%2Fjujucharms' +
-                      '.com%2Fdjango%2F%2F'}>
+                      '.com%2Fdjango%2Ftrusty%2F'}>
                     <juju.components.SvgIcon
                       name="icon-social-twitter"
                       size="35"/>
@@ -88,7 +90,7 @@ describe('EntityHeader', function() {
                   <a id="item-googleplus"
                     target="_blank"
                     href={'https://plus.google.com/share?url=https%3A%2F%2F' +
-                      'jujucharms.com%2Fdjango%2F%2F'}>
+                      'jujucharms.com%2Fdjango%2Ftrusty%2F'}>
                     <juju.components.SvgIcon
                       name="icon-social-google"
                       size="35"/>
@@ -100,7 +102,7 @@ describe('EntityHeader', function() {
               <juju.components.CopyToClipboard
                 value="juju deploy cs:django" />
               <juju.components.GenericButton
-                ref="deployButton"
+                ref="deployAction"
                 action={instance._handleDeployClick}
                 type="confirm"
                 title="Add to canvas" />
@@ -117,9 +119,22 @@ describe('EntityHeader', function() {
         entityModel={mockEntity}
         changeState={sinon.spy()}
         deployService={sinon.spy()} />);
-    var deployButton = output.refs.deployButton;
-    assert.equal(deployButton.props.type, 'confirm');
-    assert.equal(deployButton.props.title, 'Add to canvas');
+    var deployAction = output.refs.deployAction;
+    assert.equal(deployAction.props.type, 'confirm');
+    assert.equal(deployAction.props.title, 'Add to canvas');
+  });
+
+  it('displays an unsupported message for multi-series charms', function() {
+    mockEntity.set('series', undefined);
+    var output = testUtils.renderIntoDocument(
+      <juju.components.EntityHeader
+        entityModel={mockEntity}
+        changeState={sinon.spy()}
+        deployService={sinon.spy()} />);
+    var deployAction = output.refs.deployAction;
+    var textContent = deployAction.props.children;
+    assert.equal(textContent, 'This type of charm can only be deployed from ' +
+      'the command line.');
   });
 
   it('adds a charm when the add button is clicked', function() {
@@ -134,9 +149,9 @@ describe('EntityHeader', function() {
         deployService={deployService}
         changeState={changeState}
         entityModel={mockEntity} />);
-    var deployButton = output.refs.deployButton;
+    var deployAction = output.refs.deployAction;
     // Simulate a click.
-    deployButton.props.action();
+    deployAction.props.action();
     assert.equal(deployService.callCount, 1);
     assert.equal(deployService.args[0][0], mockEntity);
     assert.equal(changeState.callCount, 1);
@@ -161,9 +176,9 @@ describe('EntityHeader', function() {
         deployService={deployService}
         changeState={changeState}
         entityModel={entity} />);
-    var deployButton = output.refs.deployButton;
+    var deployAction = output.refs.deployAction;
     // Simulate a click.
-    deployButton.props.action();
+    deployAction.props.action();
     assert.equal(getBundleYAML.callCount, 1);
     assert.equal(getBundleYAML.args[0][0], 'django-cluster');
     assert.equal(importBundleYAML.callCount, 1);
@@ -185,9 +200,9 @@ describe('EntityHeader', function() {
         changeState={changeState}
         entityModel={entity}
         addNotification={addNotification} />);
-    var deployButton = output.refs.deployButton;
+    var deployAction = output.refs.deployAction;
     // Simulate a click.
-    deployButton.props.action();
+    deployAction.props.action();
     assert.equal(addNotification.callCount, 1);
     assert.deepEqual(
       addNotification.args[0][0].title, 'Bundle failed to deploy');

--- a/jujugui/static/gui/src/app/models/charm.js
+++ b/jujugui/static/gui/src/app/models/charm.js
@@ -28,7 +28,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 YUI.add('juju-charm-models', function(Y) {
 
   var models = Y.namespace('juju.models');
-  var charmIdRe = /^(?:(\w+):)?(?:~(\S+)\/)?(\w+)\/(\S+?)(?:-(\d+|HEAD))?$/;
+  var charmIdRe = /^(?:(\w+):)?(?:~([\w-\.]+)\/)?(?:(\w+)\/)?([\w-\.]+?)(?:-(\d+|HEAD))?$/;  // eslint-disable-line max-len
   var idElements = ['scheme', 'owner', 'series', 'package_name', 'revision'];
   var simpleCharmIdRe = /^(?:(\w+):)?(?!:~)(\w+)$/;
   var simpleIdElements = ['scheme', 'package_name'];
@@ -426,7 +426,7 @@ YUI.add('juju-charm-models', function(Y) {
             this.get('series'),
             (this.get('package_name') + revision),
             'json'
-          ].join('/');
+          ].filter(function(val) { return val; }).join('/');
         }
       },
       /**

--- a/jujugui/static/gui/src/app/utils/component-test-utils.js
+++ b/jujugui/static/gui/src/app/utils/component-test-utils.js
@@ -167,6 +167,7 @@ var jsTestUtils = {
         iconPath: 'data:image/gif;base64,',
         tags: ['database'],
         options: {},
+        series: 'trusty',
         files: files
       };
     } else {
@@ -185,6 +186,7 @@ var jsTestUtils = {
         entityType: 'charm',
         iconPath: 'data:image/gif;base64,',
         tags: ['database'],
+        series: 'trusty',
         files: files,
         options: {
           username: {

--- a/jujugui/static/gui/src/test/test_model.js
+++ b/jujugui/static/gui/src/test/test_model.js
@@ -58,6 +58,22 @@ describe('test_model.js', function() {
           '~alt-bac/precise/openstack-dashboard/json');
     });
 
+    it('must accept charm ids with periods.', function() {
+      var charm = new models.Charm(
+          {id: 'cs:~alt.bac/precise/openstack-dashboard-0'});
+      assert.equal(charm.get('owner'), 'alt.bac');
+      assert.equal(charm.get('charm_path'),
+          '~alt.bac/precise/openstack-dashboard-0/json');
+    });
+
+    it('must accept charm ids without series.', function() {
+      var charm = new models.Charm(
+          {id: 'cs:~alt-bac/openstack-dashboard'});
+      assert.isUndefined(charm.get('series'));
+      assert.equal(charm.get('charm_path'),
+          '~alt-bac/openstack-dashboard/json');
+    });
+
     it('must be able to parse hyphenated owner names', function() {
       // Note that an earlier version of the parsing code did not handle
       // hyphens in user names, so this test intentionally includes one.
@@ -68,7 +84,7 @@ describe('test_model.js', function() {
 
     it('must reject bad charm ids.', function() {
       try {
-        new models.Charm({id: 'foobar'});
+        new models.Charm({id: ''});
         assert.fail('Should have thrown an error');
       } catch (e) {
         e.should.equal(


### PR DESCRIPTION
Multi-series charms are starting to roll out. We don't yet support deploying them, so we need to 1) display them in search results and details views but 2) not allow deploying in the GUI.

Fixes https://github.com/juju/juju-gui/issues/1159