### PR TITLE
Do not hide the service you're creating a relation from

### DIFF
--- a/jujugui/static/gui/src/app/views/topology/relation.js
+++ b/jujugui/static/gui/src/app/views/topology/relation.js
@@ -872,7 +872,7 @@ YUI.add('juju-topology-relation', function(Y) {
               .classed('selectable-service', true)
               .filter(function(d) {
                 return (d.id in invalidRelationTargets &&
-                          d.id !== service.id);
+                          d.id !== service.get('id'));
               });
       topo.fire('fade', { selection: sel,
         serviceNames: Object.keys(invalidRelationTargets) });


### PR DESCRIPTION
When creating a relation it should hide services you cannot relate to but leave the source service still visible. Fixes #1153 