### PR TITLE
Set autoplace units to be the default on commit

### DIFF
--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -143,8 +143,8 @@ YUI.add('juju-gui', function(Y) {
                   environmentName: this.env.get('environmentName'),
                   'force-containers': localStorage.getItem('force-containers'),
                   'disable-cookie': localStorage.getItem('disable-cookie'),
-                  'auto-place-default': localStorage.getItem(
-                      'auto-place-default')
+                  'disable-auto-place': localStorage.getItem(
+                      'disable-auto-place')
                 })
             );
 

--- a/jujugui/static/gui/src/app/components/deployment/deployment.js
+++ b/jujugui/static/gui/src/app/components/deployment/deployment.js
@@ -36,7 +36,7 @@ YUI.add('deployment-component', function() {
       // Setting a default state object.
       var state = {
         hasCommits: false,
-        autoPlace: !!localStorage.getItem('auto-place-default')
+        autoPlace: !localStorage.getItem('auto-place-default')
       };
       return this.generateState(this.props, state);
     },

--- a/jujugui/static/gui/src/app/components/deployment/deployment.js
+++ b/jujugui/static/gui/src/app/components/deployment/deployment.js
@@ -36,7 +36,7 @@ YUI.add('deployment-component', function() {
       // Setting a default state object.
       var state = {
         hasCommits: false,
-        autoPlace: !localStorage.getItem('auto-place-default')
+        autoPlace: !localStorage.getItem('disable-auto-place')
       };
       return this.generateState(this.props, state);
     },

--- a/jujugui/static/gui/src/app/components/deployment/test-deployment.js
+++ b/jujugui/static/gui/src/app/components/deployment/test-deployment.js
@@ -75,13 +75,15 @@ describe('Deployment', function() {
     var currentChangeSet = sinon.stub();
     var exportEnvironmentFile = sinon.stub();
     var generateChangeDescription = sinon.stub();
+    var autoPlaceUnits = sinon.stub();
     var shallowRenderer = jsTestUtils.shallowRender(
       <juju.components.Deployment
         ecsCommit={sinon.stub()}
         exportEnvironmentFile={exportEnvironmentFile}
         generateChangeDescription={generateChangeDescription}
         activeComponent="deployment-summary"
-        currentChangeSet={currentChangeSet} />, true);
+        currentChangeSet={currentChangeSet}
+        autoPlaceUnits={autoPlaceUnits} />, true);
     var output = shallowRenderer.getRenderOutput();
     output.props.children.props.deployButtonAction();
     shallowRenderer.render(
@@ -165,7 +167,7 @@ describe('Deployment', function() {
               output.props.children.props.handleViewMachinesClick}
           handlePlacementChange={
               output.props.children.props.handlePlacementChange}
-          autoPlace={false}
+          autoPlace={true}
           getUnplacedUnitCount={getUnplacedUnitCount} />
       </div>);
   });
@@ -223,7 +225,7 @@ describe('Deployment', function() {
         activeComponent="deployment-summary" />);
     output.props.children.props.deployButtonAction();
     assert.equal(ecsCommit.callCount, 1);
-    assert.equal(autoPlaceUnits.callCount, 0);
+    assert.equal(autoPlaceUnits.callCount, 1);
   });
 
   it('can automatically place units on commit', function() {

--- a/jujugui/static/gui/src/app/templates/shortcuts.handlebars
+++ b/jujugui/static/gui/src/app/templates/shortcuts.handlebars
@@ -47,13 +47,13 @@
         <label for="environment-name">Change the name of this environment in the GUI.</label>
       </div>
       <div class="two-col">
-        <input type="checkbox" name="auto-place-default"
-        id="auto-place-default"
-        {{#if auto-place-default }} checked="checked" {{/if}}
+        <input type="checkbox" name="disable-auto-place"
+        id="disable-auto-place"
+        {{#if disable-auto-place }} checked="checked" {{/if}}
         />
       </div>
       <div class="three-col last-col">
-        <label for="auto-place-default">Default to automatically place units on commit.</label>
+        <label for="auto-place-default">Default to not automatically place units on commit.</label>
       </div>
       <div class="two-col">
         <input type="button" class="button" name="save-settings" id="save-settings" value="Save"/>


### PR DESCRIPTION
Having auto-place of units not be the default action was causing people to be confused as to why their services weren't starting. This sets auto-place as the default action, people in the know are still able to disable it if desired. Fixes #1169 