### PR TITLE
Correctly switch models from user profile page

### DIFF
--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -725,6 +725,7 @@ YUI.add('juju-gui', function(Y) {
           listEnvs={this.env.listEnvs.bind(this.env)}
           changeState={this.changeState.bind(this)}
           switchEnv={this.switchEnv.bind(this)}
+          dbEnvironmentSet={this.db.environment.set.bind(this.db.environment)}
           createSocketURL={this.createSocketURL.bind(this)} />,
         document.getElementById('charmbrowser-container'));
     },

--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -1118,6 +1118,7 @@ YUI.add('juju-gui', function(Y) {
           app={this}
           env={this.env}
           environmentName={this.db.environment.get('name')}
+          dbEnvironmentSet={this.db.environment.set.bind(this.db.environment)}
           jem={this.jem}
           envList={this.get('environmentList')}
           changeState={this.changeState.bind(this)}

--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -726,7 +726,8 @@ YUI.add('juju-gui', function(Y) {
           changeState={this.changeState.bind(this)}
           switchEnv={this.switchEnv.bind(this)}
           dbEnvironmentSet={this.db.environment.set.bind(this.db.environment)}
-          createSocketURL={this.createSocketURL.bind(this)} />,
+          createSocketURL={this.createSocketURL.bind(this)}
+          showConnectingMask={this.showConnectingMask.bind(this)} />,
         document.getElementById('charmbrowser-container'));
     },
 

--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -724,7 +724,8 @@ YUI.add('juju-gui', function(Y) {
           jem={this.jem}
           listEnvs={this.env.listEnvs.bind(this.env)}
           changeState={this.changeState.bind(this)}
-          switchEnv={this.switchEnv.bind(this)} />,
+          switchEnv={this.switchEnv.bind(this)}
+          createSocketURL={this.createSocketURL.bind(this)} />,
         document.getElementById('charmbrowser-container'));
     },
 

--- a/jujugui/static/gui/src/app/components/env-switcher/env-switcher.js
+++ b/jujugui/static/gui/src/app/components/env-switcher/env-switcher.js
@@ -27,7 +27,7 @@ YUI.add('env-switcher', function() {
       env: React.PropTypes.object,
       environmentName: React.PropTypes.string,
       app: React.PropTypes.object,
-      showConnectingMask: React.PropTypes.func,
+      showConnectingMask: React.PropTypes.func.isRequired,
       dbEnvironmentSet: React.PropTypes.func.isRequired
     },
 

--- a/jujugui/static/gui/src/app/components/env-switcher/env-switcher.js
+++ b/jujugui/static/gui/src/app/components/env-switcher/env-switcher.js
@@ -27,12 +27,12 @@ YUI.add('env-switcher', function() {
       env: React.PropTypes.object,
       environmentName: React.PropTypes.string,
       app: React.PropTypes.object,
-      showConnectingMask: React.PropTypes.func
+      showConnectingMask: React.PropTypes.func,
+      dbEnvironmentSet: React.PropTypes.func.isRequired
     },
 
     getInitialState: function() {
       return {
-        envName: this.props.environmentName,
         showEnvList: false,
         envList: []
       };
@@ -40,16 +40,6 @@ YUI.add('env-switcher', function() {
 
     componentDidMount: function() {
       this.updateEnvList();
-    },
-
-    componentWillReceiveProps: function(nextProps) {
-      // We only want to take the environment name that's being passed in if
-      // there is none displayed. Else rely on what the user has selected to
-      // avoid a long delay in updating the selected environment via the
-      // megawatcher.
-      if (!this.state.envName) {
-        this.setState({envName: nextProps.environmentName});
-      }
     },
 
     /**
@@ -116,9 +106,10 @@ YUI.add('env-switcher', function() {
     */
     handleEnvClick: function(e) {
       var currentTarget = e.currentTarget;
-      this.props.showConnectingMask();
+      var props = this.props;
+      props.showConnectingMask();
       this.setState({showEnvList: false});
-      this.setState({envName: currentTarget.getAttribute('data-name')});
+      props.dbEnvironmentSet('name', currentTarget.getAttribute('data-name'));
       this.switchEnv(currentTarget.getAttribute('data-id'));
     },
 
@@ -182,7 +173,7 @@ YUI.add('env-switcher', function() {
         console.log(err);
         return;
       }
-      this.setState({envName: data.name || data.path});
+      this.props.dbEnvironmentSet('name', data.name || data.path);
       this.updateEnvList(this.switchEnv.bind(this, data.uuid));
     },
 
@@ -253,7 +244,7 @@ YUI.add('env-switcher', function() {
             className="env-switcher--toggle"
             onClick={this.toggleEnvList}>
             <span className="environment-name">
-              {this.state.envName}
+              {this.props.environmentName}
             </span>
             <juju.components.SvgIcon name="chevron_down_16"
               size="16" />

--- a/jujugui/static/gui/src/app/components/env-switcher/test-env-switcher.js
+++ b/jujugui/static/gui/src/app/components/env-switcher/test-env-switcher.js
@@ -33,6 +33,8 @@ describe('EnvSwitcher', function() {
   it('renders the closed switcher component', function() {
     var output = jsTestUtils.shallowRender(
       <juju.components.EnvSwitcher
+        showConnectingMask={sinon.stub()}
+        dbEnvironmentSet={sinon.stub()}
         environmentName="MyEnv" />);
     assert.deepEqual(output,
       <div className="env-switcher">
@@ -55,6 +57,8 @@ describe('EnvSwitcher', function() {
     };
     var renderer = jsTestUtils.shallowRender(
       <juju.components.EnvSwitcher
+        showConnectingMask={sinon.stub()}
+        dbEnvironmentSet={sinon.stub()}
         env={env} />, true);
     var output = renderer.getRenderOutput();
     // Click the toggler
@@ -64,6 +68,8 @@ describe('EnvSwitcher', function() {
 
     renderer.render(
       <juju.components.EnvSwitcher
+        showConnectingMask={sinon.stub()}
+        dbEnvironmentSet={sinon.stub()}
         env={env} />);
 
     var instance = renderer.getMountedInstance();
@@ -84,6 +90,8 @@ describe('EnvSwitcher', function() {
     };
     var renderer = jsTestUtils.shallowRender(
       <juju.components.EnvSwitcher
+        showConnectingMask={sinon.stub()}
+        dbEnvironmentSet={sinon.stub()}
         jem={jem} />, true);
     var instance = renderer.getMountedInstance();
     instance.componentDidMount();
@@ -102,6 +110,8 @@ describe('EnvSwitcher', function() {
     };
     var renderer = jsTestUtils.shallowRender(
       <juju.components.EnvSwitcher
+        showConnectingMask={sinon.stub()}
+        dbEnvironmentSet={sinon.stub()}
         env={env} />, true);
     var instance = renderer.getMountedInstance();
     instance.componentDidMount();
@@ -119,6 +129,8 @@ describe('EnvSwitcher', function() {
     };
     var renderer = jsTestUtils.shallowRender(
       <juju.components.EnvSwitcher
+        showConnectingMask={sinon.stub()}
+        dbEnvironmentSet={sinon.stub()}
         env={env} />, true);
     var output = renderer.getRenderOutput();
     var instance = renderer.getMountedInstance();
@@ -158,6 +170,7 @@ describe('EnvSwitcher', function() {
     };
     var renderer = jsTestUtils.shallowRender(
       <juju.components.EnvSwitcher
+        dbEnvironmentSet={sinon.stub()}
         showConnectingMask={mask}
         jem={jem}
         app={app} />, true);
@@ -173,7 +186,6 @@ describe('EnvSwitcher', function() {
     assert.equal(switchEnv.callCount, 1);
     assert.deepEqual(instance.state, {
       showEnvList: false,
-      envName: 'abc123',
       envList: envs
     });
     assert.deepEqual(switchEnv.args[0], [
@@ -211,8 +223,11 @@ describe('EnvSwitcher', function() {
       createSocketURL: createSocketURL,
       switchEnv: switchEnv
     };
+    var dbset = sinon.stub();
     var renderer = jsTestUtils.shallowRender(
       <juju.components.EnvSwitcher
+        showConnectingMask={sinon.stub()}
+        dbEnvironmentSet={dbset}
         jem={jem}
         app={app} />, true);
     var instance = renderer.getMountedInstance();
@@ -242,8 +257,10 @@ describe('EnvSwitcher', function() {
     envs.push(createdEnv);
     listEnvs.args[1][0](null, envs);
     assert.equal(switchEnv.callCount, 1);
-    // After creating a new env it should update the envName state
-    assert.equal(instance.state.envName, 'newname');
+    // After creating a new env it should call to update the environment name
+    // in the db.
+    assert.equal(dbset.callCount, 1);
+    assert.deepEqual(dbset.args[0], ['name', 'newname']);
   }
 
   it('can call to create a new env (JEM)', function() {
@@ -271,6 +288,8 @@ describe('EnvSwitcher', function() {
     };
     var renderer = jsTestUtils.shallowRender(
       <juju.components.EnvSwitcher
+        showConnectingMask={sinon.stub()}
+        dbEnvironmentSet={sinon.stub()}
         env={env} />, true);
     var instance = renderer.getMountedInstance();
     instance.componentDidMount();
@@ -291,6 +310,8 @@ describe('EnvSwitcher', function() {
     var changeState = sinon.stub();
     var renderer = jsTestUtils.shallowRender(
       <juju.components.EnvSwitcher
+        showConnectingMask={sinon.stub()}
+        dbEnvironmentSet={sinon.stub()}
         changeState={changeState} />, true);
     var instance = renderer.getMountedInstance();
     instance.showUserProfile();

--- a/jujugui/static/gui/src/app/components/user-profile-list/test-user-profile-list.js
+++ b/jujugui/static/gui/src/app/components/user-profile-list/test-user-profile-list.js
@@ -85,15 +85,21 @@ describe('UserProfileList', () => {
             className="user-profile-list__header-row"
             key="TestList-header-row">
             <div
-              className="user-profile-list__line-item" key="abc123-uuid">
+              className="user-profile-list__line-item"
+              data-key="uuid"
+              key="abc123-uuid">
               uuid
             </div>
             <div
-              className="user-profile-list__line-item" key="abc123-ship">
+              className="user-profile-list__line-item"
+              data-key="ship"
+              key="abc123-ship">
               ship
             </div>
             <div
-              className="user-profile-list__line-item" key="abc123-pilot">
+              className="user-profile-list__line-item"
+              data-key="pilot"
+              key="abc123-pilot">
               pilot
             </div>
           </li>
@@ -102,13 +108,22 @@ describe('UserProfileList', () => {
             key={data[0].uuid}
             data-uuid={data[0].uuid}
             onClick={instance._switchEnv}>
-            <div className="user-profile-list__line-item" key="abc123-uuid">
+            <div
+              className="user-profile-list__line-item"
+              data-key="uuid"
+              key="abc123-uuid">
               {data[0].uuid}
             </div>
-            <div className="user-profile-list__line-item" key="abc123-ship">
+            <div
+              className="user-profile-list__line-item"
+              data-key="ship"
+              key="abc123-ship">
               {data[0].ship}
             </div>
-            <div className="user-profile-list__line-item" key="abc123-pilot">
+            <div
+              className="user-profile-list__line-item"
+              data-key="pilot"
+              key="abc123-pilot">
               {data[0].pilot}
             </div>
           </li>
@@ -117,13 +132,22 @@ describe('UserProfileList', () => {
             key={data[1].uuid}
             data-uuid={data[1].uuid}
             onClick={instance._switchEnv}>
-            <div className="user-profile-list__line-item" key="123abc-uuid">
+            <div
+              className="user-profile-list__line-item"
+              data-key="uuid"
+              key="123abc-uuid">
               {data[1].uuid}
             </div>
-            <div className="user-profile-list__line-item" key="123abc-ship">
+            <div
+              className="user-profile-list__line-item"
+              data-key="ship"
+              key="123abc-ship">
               {data[1].ship}
             </div>
-            <div className="user-profile-list__line-item" key="123abc-pilot">
+            <div
+              className="user-profile-list__line-item"
+              data-key="pilot"
+              key="123abc-pilot">
               {data[1].pilot}
             </div>
           </li>
@@ -164,11 +188,15 @@ describe('UserProfileList', () => {
             className="user-profile-list__header-row"
             key="TestList-header-row">
             <div
-              className="user-profile-list__line-item" key="abc123-uuid">
+              className="user-profile-list__line-item"
+              data-key="uuid"
+              key="abc123-uuid">
               uuid
             </div>
             <div
-              className="user-profile-list__line-item" key="abc123-ship">
+              className="user-profile-list__line-item"
+              data-key="ship"
+              key="abc123-ship">
               ship
             </div>
           </li>
@@ -177,10 +205,16 @@ describe('UserProfileList', () => {
             key={data[0].uuid}
             data-uuid={data[0].uuid}
             onClick={instance._switchEnv}>
-            <div className="user-profile-list__line-item" key="abc123-uuid">
+            <div
+              className="user-profile-list__line-item"
+              data-key="uuid"
+              key="abc123-uuid">
               {data[0].uuid}
             </div>
-            <div className="user-profile-list__line-item" key="abc123-ship">
+            <div
+              className="user-profile-list__line-item"
+              data-key="ship"
+              key="abc123-ship">
               {data[0].ship}
             </div>
           </li>
@@ -194,7 +228,7 @@ describe('UserProfileList', () => {
     var data = [{
       uuid: 'abc123',
       ship: 'tardis',
-      pilot: 'the dr'
+      name: 'the dr'
     }];
     var switchEnv = sinon.stub();
     var component = testUtils.renderIntoDocument(
@@ -207,7 +241,7 @@ describe('UserProfileList', () => {
       ReactDOM.findDOMNode(component)
               .querySelector('.user-profile-list__item-row'));
     assert.equal(switchEnv.callCount, 1);
-    assert.equal(switchEnv.args[0][0], 'abc123');
+    assert.deepEqual(switchEnv.args[0], ['abc123', 'the dr']);
   });
 
 });

--- a/jujugui/static/gui/src/app/components/user-profile-list/user-profile-list.js
+++ b/jujugui/static/gui/src/app/components/user-profile-list/user-profile-list.js
@@ -46,11 +46,12 @@ YUI.add('user-profile-list', function() {
           if (!valid) { return; }
         }
         var value = showKeys ? key : item[key];
-        var key = `${item[this.props.uuidKey]}-${key}`;
+        var reactKey = `${item[this.props.uuidKey]}-${key}`;
         items.push(
           <div
             className="user-profile-list__line-item"
-            key={key}>
+            data-key={key}
+            key={reactKey}>
             {value}
           </div>);
       });
@@ -122,7 +123,10 @@ YUI.add('user-profile-list', function() {
       @param {Object} e The click event.
     */
     _switchEnv: function(e) {
-      this.props.switchEnv(e.currentTarget.getAttribute('data-uuid'));
+      var currentTarget = e.currentTarget;
+      this.props.switchEnv(
+        currentTarget.getAttribute('data-uuid'),
+        currentTarget.querySelector('[data-key=name]').innerText);
     },
 
     render: function () {

--- a/jujugui/static/gui/src/app/components/user-profile/test-user-profile.js
+++ b/jujugui/static/gui/src/app/components/user-profile/test-user-profile.js
@@ -35,6 +35,7 @@ describe('UserProfile', () => {
       <juju.components.UserProfile
         jem={jem}
         switchEnv={sinon.stub()}
+        showConnectingMask={sinon.stub()}
         changeState={sinon.stub()} />, true);
     var instance = component.getMountedInstance();
     var output = component.getRenderOutput();
@@ -68,6 +69,7 @@ describe('UserProfile', () => {
       <juju.components.UserProfile
         switchEnv={sinon.stub()}
         listEnvs={listEnvs}
+        showConnectingMask={sinon.stub()}
         changeState={changeState} />);
 
     output.props.children[0].props.onClick();
@@ -88,6 +90,7 @@ describe('UserProfile', () => {
       <juju.components.UserProfile
         switchEnv={sinon.stub()}
         changeState={sinon.stub()}
+        showConnectingMask={sinon.stub()}
         jem={jem} />, true);
     var instance = component.getMountedInstance();
 
@@ -103,6 +106,7 @@ describe('UserProfile', () => {
       <juju.components.UserProfile
         switchEnv={sinon.stub()}
         changeState={sinon.stub()}
+        showConnectingMask={sinon.stub()}
         listEnvs={listEnvs} />, true);
     var instance = component.getMountedInstance();
 
@@ -118,6 +122,9 @@ describe('UserProfile', () => {
     var switchEnv = sinon.stub();
     var changeState = sinon.stub();
     var listEnvs = sinon.stub();
+    var showMask = sinon.stub();
+    var createSocketURL = sinon.stub().returns('gensocketurl');
+    var dbset = sinon.stub();
     var envs = [{
       uuid: 'abc123',
       user: 'foo',
@@ -126,17 +133,27 @@ describe('UserProfile', () => {
     var component = jsTestUtils.shallowRender(
       <juju.components.UserProfile
         switchEnv={switchEnv}
+        createSocketURL={createSocketURL}
         changeState={changeState}
+        showConnectingMask={showMask}
+        dbEnvironmentSet={dbset}
         listEnvs={listEnvs} />, true);
     var instance = component.getMountedInstance();
     // Call the callback for the listEnvs call to populate the state.
     listEnvs.args[0][1](envs);
     // Call the method that's passed down. We test that this method is correctly
     // passed down in the initial 'happy path' full rendering test.
-    instance.switchEnv('abc123');
+    instance.switchEnv('abc123', 'modelname');
+    // Make sure we show the canvas loading mask when switching models.
+    assert.equal(showMask.callCount, 1);
+    // We need to call to generate the proper socket URL.
+    assert.equal(createSocketURL.callCount, 1);
     // Check that switchEnv is called with the proper values.
     assert.equal(switchEnv.callCount, 1, 'switchEnv not called');
-    assert.deepEqual(switchEnv.args[0], ['abc123', 'foo', 'bar']);
+    assert.deepEqual(switchEnv.args[0], ['gensocketurl', 'foo', 'bar']);
+    // The database needs to be updated with the new model name.
+    assert.equal(dbset.callCount, 1);
+    assert.deepEqual(dbset.args[0], ['name', 'modelname']);
     // Make sure we close the profile page when switching envs.
     assert.equal(changeState.callCount, 1, 'changeState not called');
     assert.deepEqual(changeState.args[0][0], {

--- a/jujugui/static/gui/src/app/components/user-profile/user-profile.js
+++ b/jujugui/static/gui/src/app/components/user-profile/user-profile.js
@@ -27,6 +27,7 @@ YUI.add('user-profile', function() {
       listEnvs: React.PropTypes.func,
       switchEnv: React.PropTypes.func.isRequired,
       changeState: React.PropTypes.func.isRequired,
+      dbEnvironmentSet: React.PropTypes.func.isRequired,
       createSocketURL: React.PropTypes.func.isRequired
     },
 
@@ -81,11 +82,13 @@ YUI.add('user-profile', function() {
 
       @method switchEnv
       @param {String} uuid The env UUID.
+      @param {String} name The env name.
     */
-    switchEnv: function(uuid) {
+    switchEnv: function(uuid, name) {
       var username = '';
       var password = '';
       var address, port;
+      var props = this.props;
       var found = this.state.envList.some((env) => {
         if (env.uuid === uuid) {
           username = env.user;
@@ -101,8 +104,9 @@ YUI.add('user-profile', function() {
       if (!found) {
         console.log('No user credentials for env: ', uuid);
       }
-      var socketUrl = this.props.createSocketURL(address, port, uuid);
-      this.props.switchEnv(socketUrl, username, password);
+      var socketUrl = props.createSocketURL(address, port, uuid);
+      props.switchEnv(socketUrl, username, password);
+      props.dbEnvironmentSet('name', name);
       this.close();
     },
 

--- a/jujugui/static/gui/src/app/components/user-profile/user-profile.js
+++ b/jujugui/static/gui/src/app/components/user-profile/user-profile.js
@@ -28,7 +28,8 @@ YUI.add('user-profile', function() {
       switchEnv: React.PropTypes.func.isRequired,
       changeState: React.PropTypes.func.isRequired,
       dbEnvironmentSet: React.PropTypes.func.isRequired,
-      createSocketURL: React.PropTypes.func.isRequired
+      createSocketURL: React.PropTypes.func.isRequired,
+      showConnectingMask: React.PropTypes.func.isRequired,
     },
 
     getInitialState: function() {
@@ -89,6 +90,7 @@ YUI.add('user-profile', function() {
       var password = '';
       var address, port;
       var props = this.props;
+      props.showConnectingMask();
       var found = this.state.envList.some((env) => {
         if (env.uuid === uuid) {
           username = env.user;

--- a/jujugui/static/gui/src/app/components/user-profile/user-profile.js
+++ b/jujugui/static/gui/src/app/components/user-profile/user-profile.js
@@ -26,7 +26,8 @@ YUI.add('user-profile', function() {
       jem: React.PropTypes.object,
       listEnvs: React.PropTypes.func,
       switchEnv: React.PropTypes.func.isRequired,
-      changeState: React.PropTypes.func.isRequired
+      changeState: React.PropTypes.func.isRequired,
+      createSocketURL: React.PropTypes.func.isRequired
     },
 
     getInitialState: function() {
@@ -84,17 +85,24 @@ YUI.add('user-profile', function() {
     switchEnv: function(uuid) {
       var username = '';
       var password = '';
+      var address, port;
       var found = this.state.envList.some((env) => {
         if (env.uuid === uuid) {
           username = env.user;
           password = env.password;
+          if (env['host-ports']) {
+            var hostport = env['host-ports'][0].split(':');
+            address = hostport[0];
+            port = hostport[1];
+          }
           return true;
         }
       });
       if (!found) {
         console.log('No user credentials for env: ', uuid);
       }
-      this.props.switchEnv(uuid, username, password);
+      var socketUrl = this.props.createSocketURL(address, port, uuid);
+      this.props.switchEnv(socketUrl, username, password);
       this.close();
     },
 


### PR DESCRIPTION
When switching models from the profile page it wasn't properly generating the socket url (see #1196). This also fixes an issue where switching from the profile page wasn't updating the model switcher model name. Fixes #1186 