### PR TITLE
Temporarily add logout button to header

### DIFF
--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -714,6 +714,18 @@ YUI.add('juju-gui', function(Y) {
     },
 
     /**
+      Renders the Logout component.
+
+      @method _renderLogout
+    */
+    _renderLogout: function() {
+      ReactDOM.render(
+        <window.juju.components.Logout
+          logout={this.logout.bind(this)} />,
+        document.getElementById('profile-link-container'));
+    },
+
+    /**
       Renders the user profile component.
 
       @method _renderUserProfile
@@ -1569,6 +1581,8 @@ YUI.add('juju-gui', function(Y) {
       }
       this.set('loggedIn', false);
       this.env.logout();
+      this.maskVisibility(true);
+      this._renderLogin();
       return;
     },
 
@@ -1675,7 +1689,7 @@ YUI.add('juju-gui', function(Y) {
     onLogin: function(e) {
       if (e.data.result) {
         // The login was a success.
-        this.hideMask();
+        this.maskVisibility(false);
         this._emptySectionApp();
         var redirectPath = this.popLoginRedirectPath();
         this.set('loggedIn', true);
@@ -1840,15 +1854,11 @@ YUI.add('juju-gui', function(Y) {
       maasContainer.show();
     },
 
-    /**
-      Hides the fullscreen mask.
-
-      @method hideMask
-    */
-    hideMask: function() {
-      var mask = Y.one('#full-screen-mask');
+    maskVisibility: function(visibility = true) {
+      var mask = document.getElementById('full-screen-mask');
+      var display = visibility ? 'block' : 'none';
       if (mask) {
-        mask.hide();
+        mask.style.display = display;
       }
     },
 
@@ -1858,11 +1868,8 @@ YUI.add('juju-gui', function(Y) {
       @method showConnectingMask
     */
     showConnectingMask: function() {
-      var mask = document.getElementById('full-screen-mask');
+      this.maskVisibility(true);
       var msg = document.getElementById('loading-message');
-      if (mask) {
-        mask.style.display = 'block';
-      }
       if (msg) {
         msg.style.display = 'block';
       }
@@ -1961,6 +1968,7 @@ YUI.add('juju-gui', function(Y) {
 
       this._renderComponents();
       this._renderNotifications();
+      this._renderLogout();
 
       // Display the zoom message on page load.
       this._handleZoomMessage();
@@ -2222,6 +2230,7 @@ YUI.add('juju-gui', function(Y) {
     'local-inspector',
     'machine-view',
     'login-component',
+    'logout-component',
     'notification-list',
     'panel-component',
     'user-profile',

--- a/jujugui/static/gui/src/app/components/logout/logout.js
+++ b/jujugui/static/gui/src/app/components/logout/logout.js
@@ -1,0 +1,44 @@
+/*
+This file is part of the Juju GUI, which lets users view and manage Juju
+environments within a graphical interface (https://launchpad.net/juju-gui).
+Copyright (C) 2015 Canonical Ltd.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU Affero General Public License version 3, as published by
+the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero
+General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along
+with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+'use strict';
+
+YUI.add('logout-component', function() {
+
+  juju.components.Logout = React.createClass({
+
+    propTypes: {
+      logout: React.PropTypes.func.isRequired
+    },
+
+    logout: function(e) {
+      e.preventDefault();
+      this.props.logout();
+    },
+
+    render: function() {
+      return (
+        <span>
+          <a href="#" onClick={this.logout}>Logout</a>
+        </span>
+      );
+    }
+
+  });
+
+}, '0.1.0', { requires: []});

--- a/jujugui/static/gui/src/app/components/logout/test-logout.js
+++ b/jujugui/static/gui/src/app/components/logout/test-logout.js
@@ -1,0 +1,57 @@
+/*
+This file is part of the Juju GUI, which lets users view and manage Juju
+environments within a graphical interface (https://launchpad.net/juju-gui).
+Copyright (C) 2015 Canonical Ltd.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU Affero General Public License version 3, as published by
+the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero
+General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along
+with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+'use strict';
+
+var juju = {components: {}}; // eslint-disable-line no-unused-vars
+
+chai.config.includeStack = true;
+chai.config.truncateThreshold = 0;
+
+describe('Logout', () => {
+
+  beforeAll((done) => {
+    // By loading this file it adds the component to the juju components.
+    YUI().use('logout-component', () => { done(); });
+  });
+
+  it('renders properly', () => {
+    var logout = sinon.stub();
+    var output = jsTestUtils.shallowRender(
+      <juju.components.Logout
+        logout={logout} />);
+    var expected = (
+      <span>
+        <a href="#" onClick={output.props.children.props.onClick}>Logout</a>
+      </span>);
+    assert.deepEqual(output, expected);
+  });
+
+  it('calls the logout prop on click', () => {
+    var logout = sinon.stub();
+    var prevent = sinon.stub();
+    var output = jsTestUtils.shallowRender(
+      <juju.components.Logout
+        logout={logout} />);
+    assert.equal(logout.callCount, 0);
+    output.props.children.props.onClick({ preventDefault: prevent });
+    assert.equal(logout.callCount, 1);
+    assert.equal(prevent.callCount, 1);
+  });
+
+});

--- a/jujugui/static/gui/src/test/test_app.js
+++ b/jujugui/static/gui/src/test/test_app.js
@@ -757,7 +757,7 @@ describe('File drag over notification system', function() {
           Y.juju.App.prototype, 'popLoginRedirectPath', '/foo/bar');
       this._cleanups.push(popup.reset);
       var app = makeApp(true, this);
-      stubit(app, 'hideMask');
+      stubit(app, 'maskVisibility');
       stubit(app, 'navigate');
       stubit(app, 'dispatch');
       app.onLogin({ data: { result: true } });
@@ -783,7 +783,7 @@ describe('File drag over notification system', function() {
           Y.juju.App.prototype, 'popLoginRedirectPath', '/foo/bar#baz');
       this._cleanups.push(popup.reset);
       var app = makeApp(true, this);
-      stubit(app, 'hideMask');
+      stubit(app, 'maskVisibility');
       stubit(app, 'navigate');
       stubit(app, 'dispatch');
       app.onLogin({ data: { result: true } });
@@ -813,7 +813,7 @@ describe('File drag over notification system', function() {
       // See the "this.reset()" call in the callback below that cleans up.
       var stub = utils.makeStubMethod(Y.juju.App.prototype, 'onLogin');
       var app = makeApp(false, this);
-      utils.makeStubMethod(app, 'hideMask');
+      utils.makeStubMethod(app, 'maskVisibility');
       app.redirectPath = '/foo/bar/';
       app.location = {
         toString: function() {return '/login/';},
@@ -830,7 +830,7 @@ describe('File drag over notification system', function() {
         assert.equal(e.data.result, true);
         assert.equal(e.data.fromToken, true);
         this.passThroughToOriginalMethod(app);
-        assert.equal(app.hideMask.calledOnce(), true);
+        assert.equal(app.maskVisibility.calledOnce(), true);
         assert.equal(app.env.onceAfter.calledOnce(), true);
         var onceAfterArgs = app.env.onceAfter.lastArguments();
         assert.equal(onceAfterArgs[0], 'environmentNameChange');

--- a/jujugui/templates/index.html.mako
+++ b/jujugui/templates/index.html.mako
@@ -92,6 +92,8 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
           </li>
           <li id="header-search-container"
               class="header-banner__list-item header-banner__list-item--no-padding"></li>
+          <li id="profile-link-container"
+              class="header-banner__list-item"></li>
         </ul>
       </div>
       <div id="full-screen-mask">


### PR DESCRIPTION
The logout button will eventually be hidden under a profile link, but for now we just have a logout button. Fixes #1190 