### PR TITLE
Specify height at end of animation.

### DIFF
--- a/jujugui/static/gui/src/app/components/notification-list-item/_notification-list-item.scss
+++ b/jujugui/static/gui/src/app/components/notification-list-item/_notification-list-item.scss
@@ -41,7 +41,7 @@
             }
 
             100% {
-                height: $environment-header-height;
+                height: auto;
                 opacity: 1;
             }
         }

--- a/jujugui/static/gui/src/app/components/notification-list-item/_notification-list-item.scss
+++ b/jujugui/static/gui/src/app/components/notification-list-item/_notification-list-item.scss
@@ -41,6 +41,7 @@
             }
 
             100% {
+                height: $environment-header-height;
                 opacity: 1;
             }
         }


### PR DESCRIPTION
Without a height explicitly set at the end of the animation, we're left to the whim of the browser developers. Safari seems to default back to a height of 0, while Chrome retains the previously specified height.

Fixes https://github.com/juju/juju-gui/issues/1173