### PR TITLE
Pass the hideDragOverNotification method into the bundle importer to fix failing tests

### DIFF
--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -525,7 +525,8 @@ YUI.add('juju-gui', function(Y) {
         env: this.env,
         fakebackend: new environments.FakeBackend({
           charmstore: this.get('charmstore')
-        })
+        }),
+        hideDragOverNotification: this._hideDragOverNotification.bind(this)
       });
 
       this.changesUtils = window.juju.utils.ChangesUtils;
@@ -821,7 +822,7 @@ YUI.add('juju-gui', function(Y) {
             this._renderDragOverNotification.bind(this)}
           importBundleFile={this.bundleImporter.importBundleFile.bind(
             this.bundleImporter)}
-          hideDragOverNotification={this._hideDragOverNotification.bind(this)}  
+          hideDragOverNotification={this._hideDragOverNotification.bind(this)}
           changeDescriptions={changeDescriptions}
           getUnplacedUnitCount={utils.getUnplacedUnitCount.bind(this,
               this.db.units)}

--- a/jujugui/static/gui/src/app/utils/bundle-importer.js
+++ b/jujugui/static/gui/src/app/utils/bundle-importer.js
@@ -33,6 +33,7 @@ YUI.add('bundle-importer', function(Y) {
     this.env = cfg.env;
     this.db = cfg.db;
     this.fakebackend = cfg.fakebackend;
+    this.hideDragOverNotification = cfg.hideDragOverNotification;
     this._dryRunIndex = -1;
     this._collectedServices = [];
   }
@@ -74,7 +75,7 @@ YUI.add('bundle-importer', function(Y) {
       var reader = this._generateFileReader();
       reader.onload = this._fileReaderOnload.bind(this, file);
       reader.readAsText(file);
-      app._hideDragOverNotification();
+      this.hideDragOverNotification();
       return reader; // Not intended for use. Returned for testing.
     },
 

--- a/jujugui/static/gui/src/test/test_bundle_importer.js
+++ b/jujugui/static/gui/src/test/test_bundle_importer.js
@@ -107,6 +107,8 @@ describe('Bundle Importer', function() {
               onload: '',
               readAsText: asText
             });
+        var hideNotification = utils.makeStubMethod(
+          bundleImporter, 'hideDragOverNotification');
         var onload = utils.makeStubMethod(bundleImporter, '_fileReaderOnload');
         this._cleanups.concat([generate.reset, onload.reset]);
         var reader = bundleImporter.importBundleFile('path/to/file');
@@ -114,6 +116,8 @@ describe('Bundle Importer', function() {
         assert.equal(asText.callCount(), 1);
         reader.onload();
         assert.equal(onload.callCount(), 1);
+        // Make sure we hide the bundle drag over notification.
+        assert.equal(hideNotification.callCount(), 1);
       });
 
       describe('FileReader onload callback', function() {


### PR DESCRIPTION
Because the hideDragOverNotification method wasn't passed in it was failing in the tests when it tried to access the app global.