### PR TITLE
Pan to center on load in real Models

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,8 @@ help:
 	@echo "test - run python tests with the default Python"
 	@echo "test-deps - install the test dependencies"
 	@echo "test-js-karma - run newer js tests in terminal; primarily for CI build"
-	@echo "test-js-phantom - run older js tests in terminal"
+	@echo "test-mocha-phantom - run older js tests that have not transitioned to karma in the terminal"
+	@echo "test-mocha-karma - run older js tests that have transitioned to karma in the terminal"
 	@echo "update-downloadcache - update the download cache"
 
 

--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -1838,6 +1838,9 @@ YUI.add('juju-gui', function(Y) {
       this.env.close();
       this.db.reset();
       this.db.fire('update');
+      // Reset canvas centering to new env will center on load.
+      var topo = this.views.environment.instance.topo;
+      topo.modules.ServiceModule.centerOnLoad = true;
     },
 
     /**

--- a/jujugui/static/gui/src/test/test_app.js
+++ b/jujugui/static/gui/src/test/test_app.js
@@ -1143,7 +1143,7 @@ describe('File drag over notification system', function() {
       assert.isTrue(app.db.resetCalled, 'db was not reset.');
       assert.equal(app.db.fireSignal, 'update', 'db was not updated.');
       var topo = app.views.environment.instance.topo;
-      assert.isTrue(topop.modules.ServiceModule.centerOnLoad,
+      assert.isTrue(topo.modules.ServiceModule.centerOnLoad,
                     'canvas centering was not reset.');
     });
 

--- a/jujugui/static/gui/src/test/test_app.js
+++ b/jujugui/static/gui/src/test/test_app.js
@@ -1114,6 +1114,17 @@ describe('File drag over notification system', function() {
         reset: function() { this.resetCalled = true; },
         fire: function(signal) { this.fireSignal = signal; }
       };
+      // Create a mock topology instance for the switchEnv setting the
+      // centerOnLoad property on the topology.
+      app.views.environment.instance = {
+        topo: {
+          modules: {
+            ServiceModule: {
+              centerOnLoad: false
+            }
+          }
+        }
+      };
       app.env = fake_env;
       app.db = fake_db;
       return app;

--- a/jujugui/static/gui/src/test/test_app.js
+++ b/jujugui/static/gui/src/test/test_app.js
@@ -1142,6 +1142,9 @@ describe('File drag over notification system', function() {
       assert.isTrue(app.env.closeCalled, 'env was not closed.');
       assert.isTrue(app.db.resetCalled, 'db was not reset.');
       assert.equal(app.db.fireSignal, 'update', 'db was not updated.');
+      var topo = app.views.environment.instance.topo;
+      assert.isTrue(topop.modules.ServiceModule.centerOnLoad,
+                    'canvas centering was not reset.');
     });
 
     it('sets credentials based on existence of jem', function() {

--- a/jujugui/static/gui/src/test/test_service_module.js
+++ b/jujugui/static/gui/src/test/test_service_module.js
@@ -147,7 +147,13 @@ describe('service updates', function() {
   });
 
   it('should center on first load', function(done) {
+    var callCount = 0;
     serviceModule.panToCenter = function() {
+      callCount += 1;
+      if (callCount > 1) {
+        assert.fail('panToCenter should only be called once on load');
+        done();
+      }
       assert.equal(serviceModule.centerOnLoad, false);
       done();
     };
@@ -155,6 +161,8 @@ describe('service updates', function() {
       id: 'foo',
       subordinate: false
     });
+    serviceModule.update();
+    // Call it a second time to see if it fails.
     serviceModule.update();
   });
 });

--- a/jujugui/static/gui/src/test/test_service_module.js
+++ b/jujugui/static/gui/src/test/test_service_module.js
@@ -145,6 +145,18 @@ describe('service updates', function() {
     serviceModule.update();
     assert.equal(service.select('.service-block').attr('cx'), 65);
   });
+
+  it('should center on first load', function(done) {
+    serviceModule.panToCenter = function() {
+      assert.equal(serviceModule.centerOnLoad, false);
+      done();
+    };
+    db.services.add({
+      id: 'foo',
+      subordinate: false
+    });
+    serviceModule.update();
+  });
 });
 
 


### PR DESCRIPTION
When loading the GUI in a fresh environment it's possible that services are placed off screen so this will automatically center the viewport on the deployed services on load and model change. Fixes #1167 