### PR TITLE
Stop infinite redirect and show inspector on deploy

### DIFF
--- a/jujugui/static/gui/src/app/components/entity-header/entity-header.js
+++ b/jujugui/static/gui/src/app/components/entity-header/entity-header.js
@@ -54,7 +54,6 @@ YUI.add('entity-header', function() {
       var entity = entityModel.toEntity();
       if (entity.type === 'charm') {
         this.props.deployService(entityModel);
-        this._closeEntityDetails();
       } else {
         var id = entity.id.replace('cs:', '');
         this.props.getBundleYAML(id, this._getBundleYAMLCallback);

--- a/jujugui/static/gui/src/app/components/entity-header/test-entity-header.js
+++ b/jujugui/static/gui/src/app/components/entity-header/test-entity-header.js
@@ -154,13 +154,6 @@ describe('EntityHeader', function() {
     deployAction.props.action();
     assert.equal(deployService.callCount, 1);
     assert.equal(deployService.args[0][0], mockEntity);
-    assert.equal(changeState.callCount, 1);
-    assert.deepEqual(changeState.args[0][0], {
-      sectionC: {
-        component: null,
-        metadata: null
-      }
-    });
   });
 
   it('adds a bundle when the add button is clicked', function() {

--- a/jujugui/static/gui/src/app/views/ghost-deployer-extension.js
+++ b/jujugui/static/gui/src/app/views/ghost-deployer-extension.js
@@ -108,6 +108,10 @@ YUI.add('ghost-deployer-extension', function(Y) {
             id: ghostService.get('id'),
             localType: null
           }
+        },
+        sectionC: {
+          component: null,
+          metadata: null
         }});
     },
 

--- a/jujugui/static/gui/src/test/test_ghost_deployer_extension.js
+++ b/jujugui/static/gui/src/test/test_ghost_deployer_extension.js
@@ -130,7 +130,11 @@ describe('Ghost Deployer Extension', function() {
         metadata: {
           id: 'ghost-service-id',
           localType: null
-        }}});
+        }},
+      sectionC: {
+        component: null,
+        metadata: null
+      }});
   });
 
   it('increments the name for duplicate ghost services', function() {


### PR DESCRIPTION
Due to a limitation of how the state system and YUI's `navigate` method works state cannot be updated too quickly. Even though we were firing the changestate events properly, the `navigate` method was not updating the url before the next changestate event was fired. Because the url was never updated the state wasn't updated so the subsequent navigates would be for invalid urls and the state would get out of sync. The state system needs to be rewritten and use a different pushstate layer. 

This fix is to simply avoid making the two changestate calls to close together by making the deployService also close the charmbrowser when you deploy a service.

Fixes #1219, #1217 