### PR TITLE
Don't display unplaced units for subordinates.

### DIFF
--- a/jujugui/static/gui/src/app/components/machine-view/machine-view.js
+++ b/jujugui/static/gui/src/app/components/machine-view/machine-view.js
@@ -130,6 +130,12 @@ YUI.add('machine-view', function() {
     */
     _generateUnplacedUnits: function() {
       var units = this.props.units.filterByMachine();
+      units = units.filter((unit) => {
+        var service = this.props.services.getById(unit.service);
+        if (!service.get('subordinate')) {
+          return unit;
+        }
+      });
       if (units.length === 0) {
         var icon;
         var content;
@@ -155,8 +161,7 @@ YUI.add('machine-view', function() {
       }
       units.forEach((unit) => {
         var service = this.props.services.getById(unit.service);
-        if (placingUnit && unit.id === placingUnit.id ||
-          service.get('subordinate')) {
+        if (placingUnit && unit.id === placingUnit.id) {
           return;
         }
         components.push(

--- a/jujugui/static/gui/src/app/components/machine-view/machine-view.js
+++ b/jujugui/static/gui/src/app/components/machine-view/machine-view.js
@@ -155,7 +155,8 @@ YUI.add('machine-view', function() {
       }
       units.forEach((unit) => {
         var service = this.props.services.getById(unit.service);
-        if (placingUnit && unit.id === placingUnit.id) {
+        if (placingUnit && unit.id === placingUnit.id ||
+          service.get('subordinate')) {
           return;
         }
         components.push(

--- a/jujugui/static/gui/src/app/components/machine-view/test-machine-view.js
+++ b/jujugui/static/gui/src/app/components/machine-view/test-machine-view.js
@@ -403,6 +403,50 @@ describe('MachineView', function() {
       .props.children[1], expected);
   });
 
+  it('displays onboarding if there are only subordinate units', function() {
+    var unitList = [{
+      id: 'django/0',
+      service: 'django'
+    }, {
+      id: 'django/1',
+      service: 'django'
+    }];
+    var units = {
+      filterByMachine: sinon.stub().returns(unitList)
+    };
+    var getStub = sinon.stub();
+    getStub.withArgs('icon').returns('django.svg');
+    getStub.withArgs('subordinate').returns(true);
+    var services = {
+      size: sinon.stub().returns(1),
+      getById: sinon.stub().returns({
+        get: getStub
+      })
+    };
+    var output = jsTestUtils.shallowRender(
+      // The component is wrapped to handle drag and drop, but we just want to
+      // test the internal component so we access it via DecoratedComponent.
+      <juju.components.MachineView.DecoratedComponent
+        addGhostAndEcsUnits={sinon.stub()}
+        autoPlaceUnits={sinon.stub()}
+        createMachine={sinon.stub()}
+        destroyMachines={sinon.stub()}
+        environmentName="My Env"
+        machines={machines}
+        placeUnit={sinon.stub()}
+        removeUnits={sinon.stub()}
+        units={units}
+        services={services} />);
+    var expected = (
+      <div className="machine-view__column-onboarding">
+        <juju.components.SvgIcon name="task-done_16"
+          size="16" />
+        You have placed all of your units
+      </div>);
+    assert.deepEqual(
+      output.props.children.props.children[0].props.children[1], expected);
+  });
+
   it('can auto place units', function() {
     var autoPlaceUnits = sinon.stub();
     var unitList = [{
@@ -415,10 +459,13 @@ describe('MachineView', function() {
     var units = {
       filterByMachine: sinon.stub().returns(unitList)
     };
+    var getStub = sinon.stub();
+    getStub.withArgs('icon').returns('django.svg');
+    getStub.withArgs('subordinate').returns(false);
     var services = {
       size: sinon.stub().returns(1),
       getById: sinon.stub().returns({
-        get: sinon.stub().returns('django.svg')
+        get: getStub
       })
     };
     var output = jsTestUtils.shallowRender(

--- a/jujugui/static/gui/src/app/components/machine-view/test-machine-view.js
+++ b/jujugui/static/gui/src/app/components/machine-view/test-machine-view.js
@@ -294,10 +294,13 @@ describe('MachineView', function() {
     var units = {
       filterByMachine: sinon.stub().returns(unitList)
     };
+    var getStub = sinon.stub();
+    getStub.withArgs('icon').returns('django.svg');
+    getStub.withArgs('subordinate').returns(false);
     var services = {
       size: sinon.stub().returns(1),
       getById: sinon.stub().returns({
-        get: sinon.stub().returns('django.svg')
+        get: getStub
       })
     };
     var renderer = jsTestUtils.shallowRender(
@@ -336,6 +339,64 @@ describe('MachineView', function() {
           removeUnit={instance._removeUnit}
           selectMachine={instance.selectMachine}
           unit={unitList[1]} />
+      </ul>);
+    assert.deepEqual(
+      output.props.children.props.children[0].props.children[1]
+      .props.children[1], expected);
+  });
+
+  it('does not display unplaced subordinate units', function() {
+    var autoPlaceUnits = sinon.stub();
+    var createMachine = sinon.stub();
+    var placeUnit = sinon.stub();
+    var removeUnits = sinon.stub();
+    var unitList = [{
+      id: 'django/0',
+      service: 'django'
+    }, {
+      id: 'django/1',
+      service: 'django'
+    }];
+    var units = {
+      filterByMachine: sinon.stub().returns(unitList)
+    };
+    var getStub = sinon.stub();
+    getStub.withArgs('icon').returns('django.svg');
+    getStub.withArgs('subordinate').onFirstCall().returns(false)
+      .onSecondCall().returns(true);
+    var services = {
+      size: sinon.stub().returns(1),
+      getById: sinon.stub().returns({
+        get: getStub
+      })
+    };
+    var renderer = jsTestUtils.shallowRender(
+      // The component is wrapped to handle drag and drop, but we just want to
+      // test the internal component so we access it via DecoratedComponent.
+      <juju.components.MachineView.DecoratedComponent
+        addGhostAndEcsUnits={sinon.stub()}
+        autoPlaceUnits={autoPlaceUnits}
+        createMachine={createMachine}
+        destroyMachines={sinon.stub()}
+        environmentName="My Env"
+        machines={machines}
+        placeUnit={placeUnit}
+        removeUnits={removeUnits}
+        services={services}
+        units={units} />, true);
+    var instance = renderer.getMountedInstance();
+    var output = renderer.getRenderOutput();
+    var expected = (
+      <ul className="machine-view__list">
+        {[<juju.components.MachineViewUnplacedUnit
+          createMachine={createMachine}
+          icon="django.svg"
+          key="django/0"
+          machines={machines}
+          removeUnit={instance._removeUnit}
+          placeUnit={placeUnit}
+          selectMachine={instance.selectMachine}
+          unit={unitList[0]} />]}
       </ul>);
     assert.deepEqual(
       output.props.children.props.children[0].props.children[1]


### PR DESCRIPTION
Subordinates should not appear as units in the unplaced unit list. Fixes #1265.