### PR TITLE
Fixes for precise using pip 1.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,8 @@ SELENIUM := lib/python2.7/site-packages/selenium-2.47.3-py2.7.egg/selenium/selen
 REACT_ASSETS := $(BUILT_JS_ASSETS)/react-with-addons.js $(BUILT_JS_ASSETS)/react-with-addons.min.js
 
 CACHE := $(shell pwd)/downloadcache
-PYTHON_CACHE := file:///$(CACHE)/python
+PYTHON_FILES := $(CACHE)/python
+PYTHON_CACHE := file:///$(PYTHON_FILES)
 WHEEL_CACHE := file:///$(CACHE)/wheels/generic
 LSB_WHEEL_CACHE := file:///$(CACHE)/wheels/$(shell lsb_release -c -s)
 COLLECTED_REQUIREMENTS := collected-requirements
@@ -48,6 +49,8 @@ STATIC_CSS_FILES = \
 	$(GUIBUILD)/app/assets/stylesheets/normalize.css \
 	$(GUIBUILD)/app/assets/stylesheets/prettify.css \
 	$(GUIBUILD)/app/assets/stylesheets/cssgrids-responsive-min.css
+
+LSB_RELEASE = $(shell lsb_release -cs)
 
 .PHONY: help
 help:
@@ -292,11 +295,17 @@ clean-downloadcache:
 update-downloadcache: $(CACHE)
 	cd $(CACHE) && git pull origin master || true
 
+ifeq ($(LSB_RELEASE),precise)
+  COLLECT_CMD=@cp $(PYTHON_FILES)/* $(COLLECTED_REQUIREMENTS)
+else
+  COLLECT_CMD=bin/pip install -d $(COLLECTED_REQUIREMENTS) --no-index --no-dependencies --find-links $(WHEEL_CACHE) --find-links $(PYTHON_CACHE) -r requirements.txt
+endif
+
 .PHONY: collect-requirements
 collect-requirements: deps
 	-@rm -rf $(COLLECTED_REQUIREMENTS)
 	@mkdir $(COLLECTED_REQUIREMENTS)
-	bin/pip install -d $(COLLECTED_REQUIREMENTS) --no-compile --no-index --no-dependencies --find-links $(WHEEL_CACHE) --find-links $(PYTHON_CACHE) -r requirements.txt
+	$(COLLECT_CMD)
 	@# Arch-specific wheels cannot be used.
 	-@rm -rf $(COLLECTED_REQUIREMENTS)/zope.interface*
 	-@rm -rf $(COLLECTED_REQUIREMENTS)/MarkupSafe*

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # PipSession is not available in older pips.
 try:
     from pip.download import PipSession
-except:
+except ImportError:
     # Precise has an old version of pip that lacks PipSession.
     PipSession = None
 from pip.req import parse_requirements
@@ -15,8 +15,7 @@ else:
     # and requires options.skip_requirements_regex to be present.
     from collections import namedtuple
     options = namedtuple('Options', 'skip_requirements_regex')
-    options.skip_requirements_regex = None
-    kwargs = dict(options=options)
+    kwargs = dict(options=options(skip_requirements_regex=None))
 
 requirements = parse_requirements("requirements.txt", **kwargs)
 test_requirements = parse_requirements("test-requirements.txt", **kwargs)


### PR DESCRIPTION
Forward progress on juju-gui installation left support for poor precise precarious.

Modern conveniences that aren't available in pip 1.1:
* Use of wheels
* PipSession
* Correctly working parse_requirements. As a work-around an options object must be present that includes a 'skip_requirements_regex' attribute.