### PR TITLE
Don't include containers in the machine count

### DIFF
--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -1939,7 +1939,7 @@ YUI.add('juju-gui', function(Y) {
       // Update the react views on database change
       this._renderEnvSizeDisplay(
         this.db.services.size(),
-        this.db.machines.size()
+        this.db.machines.filterByParent().length
       );
       this._renderDeployment();
       this._renderEnvSwitcher();


### PR DESCRIPTION
In the machine/canvas switcher the machine count was including the number of containers as well. Fixes #1285.