### PR TITLE
Revert sorting of the plus on the canvas 

### DIFF
--- a/jujugui/static/gui/src/app/views/topology/service.js
+++ b/jujugui/static/gui/src/app/views/topology/service.js
@@ -694,21 +694,15 @@ YUI.add('juju-topology-service', function(Y) {
       @param {String} id The selected service id.
     */
     _raiseToTop: function(selectedId) {
-      d3.selectAll('.the-canvas .service, .the-canvas .plus-service')
-        .sort((a, b) => {
-          // The plus is undefined and it should always be at the top.
-          if (!a) {
-            return 1;
-          } else if (!b) {
-            return -1;
-          } else if (a.id === selectedId) {
-            return 1;
-          } else if (b.id === selectedId) {
-            return -1;
-          } else {
-            return 0;
-          }
-        });
+      d3.selectAll('.the-canvas .service').sort((a, b) => {
+        if (a.id === selectedId) {
+          return 1;
+        } else if (b.id === selectedId) {
+          return -1;
+        } else {
+          return 0;
+        }
+      });
     },
 
     /**


### PR DESCRIPTION
In #1276 we had sorted the services and included the Plus button. This caused d3 to panic when the plus button was at the bottom of the list causing it to capture the service clicks. Fixes #1289 