### PR TITLE
Syntax highlight code blocks in markdown.

### DIFF
--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -989,6 +989,15 @@ YUI.add('juju-gui', function(Y) {
       var state = this.state;
       var utils = views.utils;
       var charmstore = this.get('charmstore');
+      // Configure syntax highlighting for the markdown renderer.
+      marked.setOptions({
+        highlight: function(code, lang) {
+          var language = Prism.languages[lang];
+          if (language) {
+            return Prism.highlight(code, language);
+          }
+        }
+      });
       ReactDOM.render(
         <components.Charmbrowser
           charmstoreSearch={charmstore.search.bind(charmstore)}

--- a/jujugui/static/gui/src/test/index.html
+++ b/jujugui/static/gui/src/test/index.html
@@ -75,7 +75,8 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
   <!-- Load up YUI base, app modules, and test utils -->
   <!-- Since only the tests depend on these files and the prod tests disable
        the YUI loader, we have to include them manually here. -->
-  <script src="/dev/combo?app/assets/javascripts/bind-function-pollyfill.js&app/assets/javascripts/react-with-addons.js&app/assets/javascripts/react-dom.js&app/assets/javascripts/classnames.js&app/assets/javascripts/react-click-outside.js&app/assets/javascripts/ReactDnD.min.js&app/assets/javascripts/ReactDnDHTML5Backend.min.js&app/assets/javascripts/marked.js&app/assets/javascripts/prism.js&app/assets/javascripts/prism-languages.js"></script>
+  <!-- data-manual tells the Prism syntax highlighting lib to not auto-highlight -->
+  <script data-manual src="/dev/combo?app/assets/javascripts/bind-function-pollyfill.js&app/assets/javascripts/react-with-addons.js&app/assets/javascripts/react-dom.js&app/assets/javascripts/classnames.js&app/assets/javascripts/react-click-outside.js&app/assets/javascripts/ReactDnD.min.js&app/assets/javascripts/ReactDnDHTML5Backend.min.js&app/assets/javascripts/marked.js&app/assets/javascripts/prism.js&app/assets/javascripts/prism-languages.js"></script>
   <script src="/dev/combo?app/components/templates.js&app/components/helpers.js"></script>
   <script src="/dev/combo?app/assets/javascripts/yui/yui/yui.js&app/assets/javascripts/yui/loader/loader.js&app/assets/javascripts/d3.js&app/assets/javascripts/jujulib/juju.js"></script>
   <script src="/dev/combo?modules.js"></script>

--- a/jujugui/templates/index.html.mako
+++ b/jujugui/templates/index.html.mako
@@ -336,12 +336,14 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       'use strict' and d3 doesn't work under strict.
     -->
     % if raw:
-    <script src="${convoy_url}?app/assets/javascripts/react-with-addons.js&app/assets/javascripts/react-dom.js&app/assets/javascripts/classnames.js&app/assets/javascripts/clipboard.js&app/assets/javascripts/react-click-outside.js&app/assets/javascripts/ReactDnD.min.js&app/assets/javascripts/ReactDnDHTML5Backend.min.js&app/assets/javascripts/marked.js&app/assets/javascripts/prism.js&app/assets/javascripts/prism-languages.js"></script>
+    <!-- data-manual tells the Prism syntax highlighting lib to not auto-highlight -->
+    <script data-manual src="${convoy_url}?app/assets/javascripts/react-with-addons.js&app/assets/javascripts/react-dom.js&app/assets/javascripts/classnames.js&app/assets/javascripts/clipboard.js&app/assets/javascripts/react-click-outside.js&app/assets/javascripts/ReactDnD.min.js&app/assets/javascripts/ReactDnDHTML5Backend.min.js&app/assets/javascripts/marked.js&app/assets/javascripts/prism.js&app/assets/javascripts/prism-languages.js"></script>
     <script src="${convoy_url}?app/assets/javascripts/yui/yui/yui.js&app/assets/javascripts/yui/loader/loader.js&app/assets/javascripts/d3.js"></script>
     <script src="${convoy_url}?modules.js"></script>
     <script src="${convoy_url}?app/store/env/bakery.js&app/assets/javascripts/jujulib/juju.js"></script>
     % else:
-    <script src="${convoy_url}?app/assets/javascripts/react-with-addons.min.js&app/assets/javascripts/react-dom.min.js&app/assets/javascripts/classnames-min.js&app/assets/javascripts/clipboard.min.js&app/assets/javascripts/react-click-outside.js&app/assets/javascripts/ReactDnD.min.js&app/assets/javascripts/ReactDnDHTML5Backend.min.js&app/assets/javascripts/marked.min.js&app/assets/javascripts/prism.min.js&app/assets/javascripts/prism-languages-min.js"></script>
+    <!-- data-manual tells the Prism syntax highlighting lib to not auto-highlight -->
+    <script data-manual src="${convoy_url}?app/assets/javascripts/react-with-addons.min.js&app/assets/javascripts/react-dom.min.js&app/assets/javascripts/classnames-min.js&app/assets/javascripts/clipboard.min.js&app/assets/javascripts/react-click-outside.js&app/assets/javascripts/ReactDnD.min.js&app/assets/javascripts/ReactDnDHTML5Backend.min.js&app/assets/javascripts/marked.min.js&app/assets/javascripts/prism.min.js&app/assets/javascripts/prism-languages-min.js"></script>
     <script src="${convoy_url}?app/assets/javascripts/yui/yui/yui-min.js&app/assets/javascripts/yui/loader/loader-min.js&app/assets/javascripts/d3-min.js"></script>
     <script src="${convoy_url}?modules-min.js"></script>
     <script src="${convoy_url}?app/store/env/bakery-min.js&app/assets/javascripts/jujulib/juju-min.js"></script>


### PR DESCRIPTION
Also set data-manual on script tags so that Prism doesn't scan the entire DOM for stuff to highlight.