### PR TITLE
Display statuses for units in the machine view

### DIFF
--- a/jujugui/static/gui/src/app/components/added-services-list-item/test-added-services-list-item.js
+++ b/jujugui/static/gui/src/app/components/added-services-list-item/test-added-services-list-item.js
@@ -57,6 +57,7 @@ describe('AddedServicesListItem', function() {
           unfadeService={sinon.stub()}
           changeState={sinon.stub()}
           getUnitStatusCounts={getUnitStatusCounts()}
+          panToService={sinon.stub()}
           service={mockService} />, true);
 
     var output = renderer.getRenderOutput();
@@ -141,6 +142,7 @@ describe('AddedServicesListItem', function() {
             unfadeService={sinon.stub()}
             changeState={sinon.stub()}
             getUnitStatusCounts={status.statusCounts}
+            panToService={sinon.stub()}
             service={service} />, true);
 
       var output = renderer.getRenderOutput();
@@ -201,6 +203,7 @@ describe('AddedServicesListItem', function() {
         unfadeService={sinon.stub()}
         changeState={sinon.stub()}
         getUnitStatusCounts={getUnitStatusCounts()}
+        panToService={sinon.stub()}
         service={service} />, true);
 
     var output = renderer.getRenderOutput();
@@ -259,6 +262,7 @@ describe('AddedServicesListItem', function() {
         unfadeService={sinon.stub()}
         changeState={sinon.stub()}
         getUnitStatusCounts={getUnitStatusCounts(1, 1)}
+        panToService={sinon.stub()}
         service={service} />, true);
 
     var output = renderer.getRenderOutput();
@@ -317,6 +321,7 @@ describe('AddedServicesListItem', function() {
         unfadeService={sinon.stub()}
         changeState={sinon.stub()}
         getUnitStatusCounts={getUnitStatusCounts(0, 1, 1)}
+        panToService={sinon.stub()}
         service={service} />, true);
 
     var output = renderer.getRenderOutput();
@@ -408,6 +413,7 @@ describe('AddedServicesListItem', function() {
         unfadeService={sinon.stub()}
         changeState={sinon.stub()}
         getUnitStatusCounts={sinon.stub()}
+        panToService={sinon.stub()}
         service={mockService} />, true);
 
     // This is ugly but we have to check that the proper name prop was passed
@@ -433,6 +439,7 @@ describe('AddedServicesListItem', function() {
         unfadeService={sinon.stub()}
         changeState={sinon.stub()}
         getUnitStatusCounts={sinon.stub()}
+        panToService={sinon.stub()}
         service={mockService} />, true);
 
     // This is ugly but we have to check that the proper name prop was passed
@@ -453,6 +460,7 @@ describe('AddedServicesListItem', function() {
         unfadeService={sinon.stub()}
         changeState={sinon.stub()}
         getUnitStatusCounts={sinon.stub()}
+        panToService={sinon.stub()}
         service={mockService} />);
     var output = renderer.getRenderOutput();
     assert.deepEqual(
@@ -475,6 +483,7 @@ describe('AddedServicesListItem', function() {
         unfadeService={sinon.stub()}
         changeState={sinon.stub()}
         getUnitStatusCounts={sinon.stub()}
+        panToService={sinon.stub()}
         service={mockService} />);
 
     // Toggle focus on.
@@ -503,6 +512,7 @@ describe('AddedServicesListItem', function() {
         unfadeService={unfadeService}
         changeState={sinon.stub()}
         getUnitStatusCounts={sinon.stub()}
+        panToService={sinon.stub()}
         service={mockService} />);
 
     // Toggle focus on.
@@ -535,9 +545,14 @@ describe('AddedServicesListItem', function() {
     var output = jsTestUtils.shallowRender(
         <juju.components.AddedServicesListItem
           changeState={changeStub}
+          fadeService={sinon.stub()}
+          focusService={sinon.stub()}
           hoverService={hoverService}
           getUnitStatusCounts={getUnitStatusCounts()}
-          service={service} />);
+          panToService={sinon.stub()}
+          service={service}
+          unfadeService={sinon.stub()}
+          unfocusService={sinon.stub()} />);
     output.props.onMouseEnter();
     assert.equal(hoverService.callCount, 1);
     assert.equal(hoverService.args[0][0], 'apache2');
@@ -560,9 +575,14 @@ describe('AddedServicesListItem', function() {
     var output = jsTestUtils.shallowRender(
         <juju.components.AddedServicesListItem
           changeState={changeStub}
+          fadeService={sinon.stub()}
+          focusService={sinon.stub()}
           hoverService={hoverService}
           getUnitStatusCounts={getUnitStatusCounts()}
-          service={service} />);
+          panToService={sinon.stub()}
+          service={service}
+          unfadeService={sinon.stub()}
+          unfocusService={sinon.stub()} />);
     output.props.onMouseLeave();
     assert.equal(hoverService.callCount, 1);
     assert.equal(hoverService.args[0][0], 'apache2');

--- a/jujugui/static/gui/src/app/components/machine-view/machine-unit/_machine-unit.scss
+++ b/jujugui/static/gui/src/app/components/machine-view/machine-unit/_machine-unit.scss
@@ -7,6 +7,18 @@
         }
     }
 
+    &--error {
+        .machine-view__machine-unit-icon {
+            border: 1px solid $error;
+        }
+    }
+
+    &--pending {
+        .machine-view__machine-unit-icon {
+            border: 1px solid $pending;
+        }
+    }
+
     &-icon {
         display: inline-block;
         margin-right: 10px;

--- a/jujugui/static/gui/src/app/components/machine-view/machine-unit/machine-unit.js
+++ b/jujugui/static/gui/src/app/components/machine-view/machine-unit/machine-unit.js
@@ -74,13 +74,16 @@ YUI.add('machine-view-machine-unit', function() {
     */
     _generateClasses: function() {
       var unit = this.props.unit;
+      var agentState = unit.agent_state;
+      var status = unit.deleted || !agentState ? 'uncommitted' : agentState;
+      var classes = {
+        'machine-view__machine-unit--draggable': this.props.canDrag,
+        'machine-view__machine-unit--dragged': this.props.isDragging
+      };
+      classes['machine-view__machine-unit--' + status] = true;
       return classNames(
-        'machine-view__machine-unit', {
-          'machine-view__machine-unit--uncommitted':
-            unit.deleted || !unit.agent_state,
-          'machine-view__machine-unit--draggable': this.props.canDrag,
-          'machine-view__machine-unit--dragged': this.props.isDragging
-        });
+        'machine-view__machine-unit',
+        classes);
     },
 
     render: function() {

--- a/jujugui/static/gui/src/app/components/machine-view/machine-unit/test-machine-unit.js
+++ b/jujugui/static/gui/src/app/components/machine-view/machine-unit/test-machine-unit.js
@@ -63,7 +63,8 @@ describe('MachineViewMachineUnit', function() {
         unit={unit} />, true);
     var output = renderer.getRenderOutput();
     var expected = (
-      <li className="machine-view__machine-unit">
+      <li className={'machine-view__machine-unit ' +
+        'machine-view__machine-unit--started'}>
         <span className="machine-view__machine-unit-icon">
           <img
             alt="django/7"
@@ -87,7 +88,8 @@ describe('MachineViewMachineUnit', function() {
         service={service}
         unit={unit} />);
     var expected = (
-      <li className="machine-view__machine-unit">
+      <li className={'machine-view__machine-unit ' +
+        'machine-view__machine-unit--started'}>
         <span className="machine-view__machine-unit-icon">
           <img
             alt="django/7"
@@ -117,7 +119,8 @@ describe('MachineViewMachineUnit', function() {
         unit={unit} />);
     var expected = (
       <li className={'machine-view__machine-unit ' +
-        'machine-view__machine-unit--dragged'}>
+        'machine-view__machine-unit--dragged ' +
+        'machine-view__machine-unit--started'}>
         {output.props.children}
       </li>);
     assert.deepEqual(output, expected);
@@ -153,7 +156,8 @@ describe('MachineViewMachineUnit', function() {
         unit={unit} />);
     var expected = (
       <li className={'machine-view__machine-unit ' +
-        'machine-view__machine-unit--draggable'}>
+        'machine-view__machine-unit--draggable ' +
+        'machine-view__machine-unit--started'}>
         {output.props.children}
       </li>);
     assert.deepEqual(output, expected);


### PR DESCRIPTION
Add borders to the units in the machine view to represent their status. Fixes #1296.