### PR TITLE
Add charmstore log in to user profile view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ Session.vim
 tags
 test/extracted_startup_code
 test/test_startup.js
+.tern-project
 upload_release.py
 .vagrant
 virtualenv

--- a/development.ini
+++ b/development.ini
@@ -18,7 +18,7 @@ jujugui.socketTemplate = /environment/$uuid/api
 
 
 # JEM/IdM connections
-jujugui.interactive_login = false
+jujugui.interactive_login = true
 jujugui.jem_url =
 
 ###

--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -744,7 +744,9 @@ YUI.add('juju-gui', function(Y) {
           switchEnv={this.switchEnv.bind(this)}
           dbEnvironmentSet={this.db.environment.set.bind(this.db.environment)}
           createSocketURL={this.createSocketURL.bind(this)}
-          showConnectingMask={this.showConnectingMask.bind(this)} />,
+          showConnectingMask={this.showConnectingMask.bind(this)}
+          interactiveLogin={this.get('interactiveLogin')}
+          charmstore={this.get('charmstore')} />,
         document.getElementById('charmbrowser-container'));
     },
 
@@ -1322,6 +1324,7 @@ YUI.add('juju-gui', function(Y) {
           webhandler: new Y.juju.environments.web.WebHandler(),
           interactive: this.get('interactiveLogin'),
           setCookiePath: charmstoreURL + apiPath + '/set-auth-cookie',
+          staticMacaroonPath: `${charmstoreURL}${apiPath}/macaroon`,
           serviceName: 'charmstore'
         });
         this.set('charmstore', new Charmstore(charmstoreURL, apiPath, bakery));

--- a/jujugui/static/gui/src/app/components/user-profile/test-user-profile.js
+++ b/jujugui/static/gui/src/app/components/user-profile/test-user-profile.js
@@ -36,6 +36,7 @@ describe('UserProfile', () => {
         jem={jem}
         switchEnv={sinon.stub()}
         showConnectingMask={sinon.stub()}
+        interactiveLogin={true}
         changeState={sinon.stub()} />, true);
     var instance = component.getMountedInstance();
     var output = component.getRenderOutput();
@@ -57,9 +58,43 @@ describe('UserProfile', () => {
           uuidKey="uuid"
           switchEnv={instance.switchEnv}
           whitelist={whitelist}/>
+        <juju.components.GenericButton
+          title="Log in to the charmstore"
+          action={instance._interactiveLogin} />
       </juju.components.Panel>
     );
     assert.deepEqual(output, expected);
+  });
+
+  it('does not display charmstore log in if interactiveLogin is falsy', () => {
+    var output = jsTestUtils.shallowRender(
+      <juju.components.UserProfile
+        switchEnv={sinon.stub()}
+        listEnvs={sinon.stub()}
+        showConnectingMask={sinon.stub()}
+        changeState={sinon.stub()}
+        createSocketURL={sinon.stub()}
+        interactiveLogin={false} />);
+    assert.equal(output.props.children[3], '');
+  });
+
+  it('clicks to log in to charmstore fetch macaroons from the bakery', () => {
+    var charmstore = {
+      bakery: {
+        fetchMacaroonFromStaticPath: sinon.stub()
+      }
+    };
+    var output = jsTestUtils.shallowRender(
+      <juju.components.UserProfile
+        switchEnv={sinon.stub()}
+        listEnvs={sinon.stub()}
+        showConnectingMask={sinon.stub()}
+        changeState={sinon.stub()}
+        createSocketURL={sinon.stub()}
+        charmstore={charmstore}
+        interactiveLogin={true} />);
+    output.props.children[3].props.action();
+    assert.equal(charmstore.bakery.fetchMacaroonFromStaticPath.callCount, 1);
   });
 
   it('closes when clicking the close button', () => {

--- a/jujugui/static/gui/src/app/components/user-profile/user-profile.js
+++ b/jujugui/static/gui/src/app/components/user-profile/user-profile.js
@@ -30,6 +30,8 @@ YUI.add('user-profile', function() {
       dbEnvironmentSet: React.PropTypes.func.isRequired,
       createSocketURL: React.PropTypes.func.isRequired,
       showConnectingMask: React.PropTypes.func.isRequired,
+      charmstore: React.PropTypes.object,
+      interactiveLogin: React.PropTypes.bool
     },
 
     getInitialState: function() {
@@ -121,8 +123,34 @@ YUI.add('user-profile', function() {
       });
     },
 
+    /**
+      Calls the bakery to get a charmstore macaroon.
+
+      @method _interactiveLogin
+    */
+    _interactiveLogin: function() {
+      var bakery = this.props.charmstore.bakery;
+      bakery.fetchMacaroonFromStaticPath(this._fetchMacaroonCallback);
+    },
+
+    /**
+      Callback for fetching the macaroon.
+
+      @method _fetchMacaroonCallback
+      @param {String|Object|Null} The error response from the callback.
+      @param {String} The resolved macaroon.
+    */
+    _fetchMacaroonCallback: function(err, macaroon) {
+
+    },
+
+
     render: function() {
       var whitelist = ['path', 'name', 'user', 'uuid', 'host-ports'];
+      var interactiveLogin = this.props.interactiveLogin ?
+        <juju.components.GenericButton
+          title="Log in to the charmstore"
+          action={this._interactiveLogin} /> : '';
       return (
         <juju.components.Panel
           instanceName="user-profile"
@@ -140,6 +168,7 @@ YUI.add('user-profile', function() {
             uuidKey="uuid"
             switchEnv={this.switchEnv}
             whitelist={whitelist}/>
+          {interactiveLogin}
         </juju.components.Panel>
       );
     }
@@ -150,6 +179,7 @@ YUI.add('user-profile', function() {
   requires: [
     'svg-icon',
     'panel-component',
+    'generic-button',
     'user-profile-header',
     'user-profile-list'
   ]

--- a/jujugui/static/gui/src/app/components/user-profile/user-profile.js
+++ b/jujugui/static/gui/src/app/components/user-profile/user-profile.js
@@ -140,9 +140,7 @@ YUI.add('user-profile', function() {
       @param {String|Object|Null} The error response from the callback.
       @param {String} The resolved macaroon.
     */
-    _fetchMacaroonCallback: function(err, macaroon) {
-
-    },
+    _fetchMacaroonCallback: function(err, macaroon) {},
 
 
     render: function() {

--- a/jujugui/static/gui/src/app/store/env/bakery.js
+++ b/jujugui/static/gui/src/app/store/env/bakery.js
@@ -93,7 +93,7 @@ YUI.add('juju-env-bakery', function(Y) {
           return;
         }
         if (!this.staticMacaroonPath) {
-          callback('Charmstore macaroon path was not defined.');
+          callback('Static macaroon path was not defined.');
           return;
         }
         this.webhandler.sendGetRequest(

--- a/jujugui/static/gui/src/app/store/env/bakery.js
+++ b/jujugui/static/gui/src/app/store/env/bakery.js
@@ -298,9 +298,6 @@ YUI.add('juju-env-bakery', function(Y) {
       _successfulDischarges: function (originalRequest, jsonMacaroon) {
         var prefix = this.macaroonName + '=';
         document.cookie = prefix + btoa(JSON.stringify(jsonMacaroon));
-        window.addEventListener('unload', function() {
-          document.cookie = prefix + ';';
-        });
         originalRequest();
       },
 

--- a/jujugui/static/gui/src/app/store/env/bakery.js
+++ b/jujugui/static/gui/src/app/store/env/bakery.js
@@ -116,6 +116,7 @@ YUI.add('juju-env-bakery', function(Y) {
           macaroon = JSON.parse(res.target.responseText);
         } catch(e) {
           callback(e);
+          return;
         }
         this._authenticate(macaroon, function() {
           callback(null, this._getMacaroon());


### PR DESCRIPTION
Adds a button into the profile view to give the user the ability to log into the charmstore. This is intentionally unstyled as there is extensive markup and styling changes that need to be done to this view.