### PR TITLE
Correctly increment service names without using the service count

### DIFF
--- a/jujugui/static/gui/src/app/models/models.js
+++ b/jujugui/static/gui/src/app/models/models.js
@@ -700,9 +700,10 @@ YUI.add('juju-models', function(Y) {
 
      @method ghostService
      @param {Model} charm to add.
+     @param {String} charmName An optional name for this charm.
      @return {Model} Ghosted Service model.
    */
-    ghostService: function(charm) {
+    ghostService: function(charm, charmName) {
       var config = charm && charm.get('config');
       var randomId, invalid = true;
 
@@ -719,8 +720,10 @@ YUI.add('juju-models', function(Y) {
       } while (invalid);
 
       var charmId = charm.get('id');
-      var charmName = charm.get('package_name');
-      var name = utils.generateServiceName(charmName, charmId, this);
+      if (!charmName) {
+        charmName = charm.get('package_name');
+      }
+      var name = utils.generateServiceName(charmName, this);
       var ghostService = this.create({
         // Creating a temporary id because it's undefined by default.
         id: randomId,

--- a/jujugui/static/gui/src/app/views/utils.js
+++ b/jujugui/static/gui/src/app/views/utils.js
@@ -1846,7 +1846,9 @@ YUI.add('juju-view-utils', function(Y) {
   */
   utils.generateServiceName = function(
     charmName, charmId, services, ignoreSelf) {
-    // Loop through each service and grab its charmid to see if it matches.
+    // Find the highest counter from the existing services. We can't just
+    // use the number of services as there could be duplicate names if services
+    // have been removed.
     var highestCounter = Math.max.apply(Math, services.map((service) => {
       // Remove the version number from the charm id as we don't care about the
       // version when comparing charms.
@@ -1854,7 +1856,9 @@ YUI.add('juju-view-utils', function(Y) {
       var providedCharmId = utils._extractCharmName(charmId);
       // If we have a matching charm then increase the count.
       if (serviceCharmId === providedCharmId) {
-        // Remove the service name and dash from the name to get the counter.
+        // Remove the service name and dash to get the counter. It is done this
+        // way so that we can get just the counter from the string and don't get
+        // false positives from names with dashes in them.
         var counter = service.get('name').replace(
           charmName, '').replace('-', '');
         if (counter === '') {

--- a/jujugui/static/gui/src/test/test_bundle_importer.js
+++ b/jujugui/static/gui/src/test/test_bundle_importer.js
@@ -359,8 +359,8 @@ describe('Bundle Importer', function() {
         // There was a bug where their names would clash and they would get
         // combined into a single service on deploy.
         assert.equal(db.services.item(3).get('charm'), 'cs:precise/mysql-51');
-        assert.equal(db.services.item(3).get('name'), 'mysql-slave-a');
-        assert.equal(db.services.item(3).get('displayName'), '(mysql-slave-a)');
+        assert.equal(db.services.item(3).get('name'), 'mysql-slave');
+        assert.equal(db.services.item(3).get('displayName'), '(mysql-slave)');
         // Machines
         assert.equal(db.machines.item(0).id, 'new0');
         assert.equal(db.machines.item(1).id, 'new1');

--- a/jujugui/static/gui/src/test/test_ghost_deployer_extension.js
+++ b/jujugui/static/gui/src/test/test_ghost_deployer_extension.js
@@ -162,11 +162,27 @@ describe('Ghost Deployer Extension', function() {
     ghostDeployer.db.services = new Y.juju.models.ServiceList();
     var services = ghostDeployer.db.services;
     services.ghostService(charm);
-    services.ghostService(charm);
+    var service2 = services.ghostService(charm);
     services.item(0).destroy();
-    services.ghostService(charm);
+    var service3 = services.ghostService(charm);
     assert.equal(services.item(0).get('name'), 'django-a');
+    assert.equal(services.item(0).get('id'), service2.get('id'));
     assert.equal(services.item(1).get('name'), 'django-b');
+    assert.equal(services.item(1).get('id'), service3.get('id'));
+  });
+
+  it('increments the name with middle deleted services', function() {
+    var charm = makeCharm();
+    ghostDeployer.db.services = new Y.juju.models.ServiceList();
+    var services = ghostDeployer.db.services;
+    services.ghostService(charm);
+    services.ghostService(charm);
+    services.ghostService(charm);
+    services.item(1).destroy();
+    services.ghostService(charm);
+    assert.equal(services.item(0).get('name'), 'django');
+    assert.equal(services.item(1).get('name'), 'django-b');
+    assert.equal(services.item(2).get('name'), 'django-c');
   });
 
   it('can create a ghost unit', function() {

--- a/jujugui/static/gui/src/test/test_ghost_deployer_extension.js
+++ b/jujugui/static/gui/src/test/test_ghost_deployer_extension.js
@@ -157,6 +157,18 @@ describe('Ghost Deployer Extension', function() {
     assert.equal(services.item(3).get('name'), 'mysql-a');
   });
 
+  it('increments the name with deleted services', function() {
+    var charm = makeCharm();
+    ghostDeployer.db.services = new Y.juju.models.ServiceList();
+    var services = ghostDeployer.db.services;
+    services.ghostService(charm);
+    services.ghostService(charm);
+    services.item(0).destroy();
+    services.ghostService(charm);
+    assert.equal(services.item(0).get('name'), 'django-a');
+    assert.equal(services.item(1).get('name'), 'django-b');
+  });
+
   it('can create a ghost unit', function() {
     var charm = makeCharm();
     ghostDeployer.deployService(charm);

--- a/jujugui/static/gui/src/test/test_ghost_deployer_extension.js
+++ b/jujugui/static/gui/src/test/test_ghost_deployer_extension.js
@@ -157,7 +157,49 @@ describe('Ghost Deployer Extension', function() {
     assert.equal(services.item(3).get('name'), 'mysql-a');
   });
 
-  it('increments the name with deleted services', function() {
+  it('increments subset names for duplicate services', function() {
+    var mysql = {
+      id: 'cs:trusty/mysql',
+      name: 'mysql',
+      package_name: 'mysql',
+      is_subordinate: false
+    };
+    var mysqlSlave = {
+      id: 'cs:trusty/mysql-slave',
+      name: 'mysql-slave',
+      package_name: 'mysql-slave',
+      is_subordinate: false
+    };
+    ghostDeployer.db.services = new Y.juju.models.ServiceList();
+    var services = ghostDeployer.db.services;
+    services.ghostService(new Y.Model(mysqlSlave));
+    services.ghostService(new Y.Model(mysql));
+    assert.equal(services.item(0).get('name'), 'mysql-slave');
+    assert.equal(services.item(1).get('name'), 'mysql');
+  });
+
+  it('increments subset custom names for duplicate services', function() {
+    var mysql = {
+      id: 'cs:trusty/mysql',
+      name: 'my-mysql',
+      package_name: 'my-mysql',
+      is_subordinate: false
+    };
+    var mysqlSlave = {
+      id: 'cs:trusty/mysql',
+      name: 'my-mysql-slave',
+      package_name: 'my-mysql-slave',
+      is_subordinate: false
+    };
+    ghostDeployer.db.services = new Y.juju.models.ServiceList();
+    var services = ghostDeployer.db.services;
+    services.ghostService(new Y.Model(mysqlSlave));
+    services.ghostService(new Y.Model(mysql));
+    assert.equal(services.item(0).get('name'), 'my-mysql-slave');
+    assert.equal(services.item(1).get('name'), 'my-mysql');
+  });
+
+  it('uses the default name if available', function() {
     var charm = makeCharm();
     ghostDeployer.db.services = new Y.juju.models.ServiceList();
     var services = ghostDeployer.db.services;
@@ -167,7 +209,7 @@ describe('Ghost Deployer Extension', function() {
     var service3 = services.ghostService(charm);
     assert.equal(services.item(0).get('name'), 'django-a');
     assert.equal(services.item(0).get('id'), service2.get('id'));
-    assert.equal(services.item(1).get('name'), 'django-b');
+    assert.equal(services.item(1).get('name'), 'django');
     assert.equal(services.item(1).get('id'), service3.get('id'));
   });
 
@@ -182,7 +224,7 @@ describe('Ghost Deployer Extension', function() {
     services.ghostService(charm);
     assert.equal(services.item(0).get('name'), 'django');
     assert.equal(services.item(1).get('name'), 'django-b');
-    assert.equal(services.item(2).get('name'), 'django-c');
+    assert.equal(services.item(2).get('name'), 'django-a');
   });
 
   it('can create a ghost unit', function() {

--- a/jujugui/static/gui/src/test/test_utils.js
+++ b/jujugui/static/gui/src/test/test_utils.js
@@ -1156,6 +1156,43 @@ describe('utilities', function() {
     });
   });
 
+  describe('letterToNum', function() {
+    var utils;
+
+    before(function(done) {
+      YUI(GlobalConfig).use('juju-view-utils', function(Y) {
+        utils = Y.juju.views.utils;
+        done();
+      });
+    });
+
+    it('converts letters to numbers correctly', function() {
+      // Map of numbers and output to check. This list isn't exhaustive
+      // but checks some important milestones for common issues with this
+      // technique.
+      var mapping = {
+        a: 1,
+        b: 2,
+        j: 10,
+        o: 15,
+        z: 26,
+        aa: 27,
+        ab: 28,
+        az: 52,
+        ba: 53,
+        bb: 54,
+        aaa: 703,
+        abt: 748,
+        bxf: 1982
+      };
+      Object.keys(mapping).forEach(function(key) {
+        assert.equal(
+          utils.letterToNum(key), mapping[key],
+          key + ' did not properly convert to ' + mapping[key]);
+      });
+    });
+  });
+
   describe('linkify', function() {
     var utils;
 


### PR DESCRIPTION
The service names were using the service count to prevent collisions, however if services were removed and others there were duplicate names. This increments the highest number instead. Fixes #1309.