### PR TITLE
Do not execute button actions as well as submit forms.

### DIFF
--- a/jujugui/static/gui/src/app/components/generic-button/generic-button.js
+++ b/jujugui/static/gui/src/app/components/generic-button/generic-button.js
@@ -51,7 +51,9 @@ YUI.add('generic-button', function() {
     _handleClick: function(e) {
       // Don't bubble the click the parent.
       e.stopPropagation();
-      if (!this.props.disabled) {
+      // If submit is true then typically no action is provided because it
+      // is submitting a form.
+      if (!this.props.disabled && this.props.action) {
         this.props.action();
       }
     },

--- a/jujugui/static/gui/src/app/components/generic-button/test-generic-button.js
+++ b/jujugui/static/gui/src/app/components/generic-button/test-generic-button.js
@@ -53,6 +53,16 @@ describe('GenericButton', function() {
     assert.equal(callbackStub.callCount, 0);
   });
 
+  it('does not call the callable if not provided', function() {
+    // This is checking that code is not executed and so there are no side
+    // effects to check. No syntax error is considered a success.
+    var output = jsTestUtils.shallowRender(
+        <juju.components.GenericButton />);
+    output.props.onClick({
+      stopPropagation: sinon.stub()
+    });
+  });
+
   it('stop the event propogating when clicked', function() {
     var callbackStub = sinon.stub();
     var stopPropagation = sinon.stub();

--- a/jujugui/static/gui/src/app/components/scale-service/scale-service.js
+++ b/jujugui/static/gui/src/app/components/scale-service/scale-service.js
@@ -121,7 +121,6 @@ YUI.add('scale-service', function() {
     render: function() {
       var buttons = [{
         title: 'Confirm',
-        action: this._scaleUpService,
         submit: true
       }];
 

--- a/jujugui/static/gui/src/app/components/scale-service/test-scale-service.js
+++ b/jujugui/static/gui/src/app/components/scale-service/test-scale-service.js
@@ -98,9 +98,9 @@ describe('ScaleService', function() {
     disk.value = 'd i s k';
     testUtils.Simulate.change(disk);
 
-    // Click the submit button in the ButtonRow component.
-    var button = ReactDOM.findDOMNode(output).querySelector('button');
-    testUtils.Simulate.click(button);
+    // Submit the scale-service form.
+    var form = ReactDOM.findDOMNode(output);
+    testUtils.Simulate.submit(form);
     assert.equal(createMachineStub.callCount, 1);
     assert.equal(addGhostStub.callCount, 0);
     assert.equal(changeStateStub.callCount, 1);
@@ -140,9 +140,9 @@ describe('ScaleService', function() {
     var unitCount = output.refs.numUnitsInput;
     unitCount.value = 3;
     testUtils.Simulate.change(unitCount);
-    // Click the submit button in the ButtonRow component.
-    var button = ReactDOM.findDOMNode(output).querySelector('button');
-    testUtils.Simulate.click(button);
+    // Submit the scale-service form.
+    var form = ReactDOM.findDOMNode(output);
+    testUtils.Simulate.submit(form);
     assert.equal(createMachineStub.callCount, 0);
     assert.equal(addGhostStub.callCount, 1);
     assert.equal(changeStateStub.callCount, 1);


### PR DESCRIPTION
The scale-up form was being submitted by the generic-button component which triggered the scale up but then was also executing the provided action callable. This stops passing that callable to the submit button and makes it optional in generic-button. Fixes #1318