### PR TITLE
Update facades to support Juju 2.0 login

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -380,7 +380,7 @@ bumpversion: deps
 	bin/bumpversion $(VPART)
 
 .PHONY: dist
-dist: clean-all gui test-deps collect-requirements
+dist: clean-all deps fast-babel gui test-deps collect-requirements
 	python setup.py sdist --formats=bztar
 
 #######

--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -448,7 +448,8 @@ YUI.add('juju-gui', function(Y) {
           user: user,
           password: password,
           readOnly: this.get('readOnly'),
-          conn: this.get('conn')
+          conn: this.get('conn'),
+          jujuCoreVersion: this.get('jujuCoreVersion')
         };
         var webModule = environments.web;
         if (this.get('sandbox')) {

--- a/jujugui/static/gui/src/app/store/env/base.js
+++ b/jujugui/static/gui/src/app/store/env/base.js
@@ -94,6 +94,13 @@ YUI.add('juju-env-base', function(Y) {
   BaseEnvironment.NAME = 'base-env';
   BaseEnvironment.ATTRS = {
     /**
+      The version of Juju core.
+
+      @attribute jujuCoreVersion
+      @type {String}
+    */
+    'jujuCoreVersion': {},
+    /**
       The websocket URL to connect to.
 
       @attribute socket_url

--- a/jujugui/static/gui/src/app/store/env/base.js
+++ b/jujugui/static/gui/src/app/store/env/base.js
@@ -99,7 +99,9 @@ YUI.add('juju-env-base', function(Y) {
       @attribute jujuCoreVersion
       @type {String}
     */
-    'jujuCoreVersion': {},
+    'jujuCoreVersion': {
+      value: ''
+    },
     /**
       The websocket URL to connect to.
 

--- a/jujugui/static/gui/src/app/store/env/go.js
+++ b/jujugui/static/gui/src/app/store/env/go.js
@@ -515,8 +515,10 @@ YUI.add('juju-env-go', function(Y) {
           Password: credentials.password
         };
         // If the user is connecting to juju-core 2.0 or higher then we need
-        // to use the new params arguments.
-        if (utils.compareSemver(this.get('jujuCoreVersion'), '2.0.0') > -1) {
+        // to use the new params arguments. This is comparing against '2'
+        // because Juju doesn't properly stick to semver and sometimes returns
+        // versions that do not properly validate as semver.
+        if (utils.compareSemver(this.get('jujuCoreVersion'), '2') > -1) {
           params = {
             'auth-tag': user,
             credentials: password

--- a/jujugui/static/gui/src/app/store/env/go.js
+++ b/jujugui/static/gui/src/app/store/env/go.js
@@ -516,7 +516,7 @@ YUI.add('juju-env-go', function(Y) {
         };
         // If the user is connecting to juju-core 2.0 or higher then we need
         // to use the new params arguments.
-        if (utils.compareSemver(this.get('jujuCoreVersion'), '2.0.0') > -1) {
+        if (utils.compareSemver(this.get('jujuCoreVersion'), '2.0.0') === -1) {
           params = {
             'auth-tag': user,
             credentials: password

--- a/jujugui/static/gui/src/app/store/env/go.js
+++ b/jujugui/static/gui/src/app/store/env/go.js
@@ -252,9 +252,12 @@ YUI.add('juju-env-go', function(Y) {
       if (!op.Params) {
         op.Params = {};
       }
-      var version = this.facadeVersions[facade] || 0;
-      if (version !== 0) {
-        op.Version = version;
+      // Only try and determine the version if none is provided.
+      if (!op.Version) {
+        var version = this.facadeVersions[facade] || 0;
+        if (version !== 0) {
+          op.Version = version;
+        }
       }
       var msg = Y.JSON.stringify(op);
       this.ws.send(msg);
@@ -506,22 +509,25 @@ YUI.add('juju-env-go', function(Y) {
       if (credentials && credentials.areAvailable) {
         var user = credentials.user;
         var password = credentials.password;
+        var version = 0;
         var params = {
-          'auth-tag': user,
-          credentials: password
+          AuthTag: credentials.user,
+          Password: credentials.password
         };
         // If the user is connecting to juju-core 2.0 or higher then we need
         // to use the new params arguments.
         if (utils.compareSemver(this.get('jujuCoreVersion'), '2.0.0') > -1) {
           params = {
-            AuthTag: credentials.user,
-            Password: credentials.password
+            'auth-tag': user,
+            credentials: password
           };
+          version = 2;
         }
         this._send_rpc({
           Type: 'Admin',
           Request: 'Login',
-          Params: params
+          Params: params,
+          Version: version
         }, this.handleLogin);
         this.pendingLoginResponse = true;
       } else {

--- a/jujugui/static/gui/src/app/store/env/go.js
+++ b/jujugui/static/gui/src/app/store/env/go.js
@@ -516,7 +516,7 @@ YUI.add('juju-env-go', function(Y) {
         };
         // If the user is connecting to juju-core 2.0 or higher then we need
         // to use the new params arguments.
-        if (utils.compareSemver(this.get('jujuCoreVersion'), '2.0.0') === -1) {
+        if (utils.compareSemver(this.get('jujuCoreVersion'), '2.0.0') > -1) {
           params = {
             'auth-tag': user,
             credentials: password

--- a/jujugui/static/gui/src/app/store/env/go.js
+++ b/jujugui/static/gui/src/app/store/env/go.js
@@ -504,13 +504,24 @@ YUI.add('juju-env-go', function(Y) {
       }
       var credentials = this.getCredentials();
       if (credentials && credentials.areAvailable) {
+        var user = credentials.user;
+        var password = credentials.password;
+        var params = {
+          'auth-tag': user,
+          credentials: password
+        };
+        // If the user is connecting to juju-core 2.0 or higher then we need
+        // to use the new params arguments.
+        if (utils.compareSemver(this.get('jujuCoreVersion'), '2.0.0') > -1) {
+          params = {
+            AuthTag: credentials.user,
+            Password: credentials.password
+          };
+        }
         this._send_rpc({
           Type: 'Admin',
           Request: 'Login',
-          Params: {
-            AuthTag: credentials.user,
-            Password: credentials.password
-          }
+          Params: params
         }, this.handleLogin);
         this.pendingLoginResponse = true;
       } else {

--- a/jujugui/static/gui/src/app/views/utils.js
+++ b/jujugui/static/gui/src/app/views/utils.js
@@ -1857,6 +1857,31 @@ YUI.add('juju-view-utils', function(Y) {
       charmName, services, counter += 1) : name;
   };
 
+  /**
+    Compare two semver version strings and return if one is
+    older than the other.
+
+    @method compareSemver
+    @param {String} a Version.
+    @param {String} b Version to compare to.
+    @param {Boolean} If a is older than b.
+  */
+  utils.compareSemver = function(a, b) {
+    a = a.split('-')[0];
+    b = b.split('-')[0];
+    var pa = a.split('.');
+    var pb = b.split('.');
+    for (var i = 0; i < 3; i++) {
+      var na = Number(pa[i]);
+      var nb = Number(pb[i]);
+      if (na > nb) return 1;
+      if (nb > na) return -1;
+      if (!isNaN(na) && isNaN(nb)) return 1;
+      if (isNaN(na) && !isNaN(nb)) return -1;
+    }
+    return 0;
+  };
+
 }, '0.1.0', {
   requires: [
     'base-build',

--- a/jujugui/static/gui/src/app/views/utils.js
+++ b/jujugui/static/gui/src/app/views/utils.js
@@ -1864,7 +1864,8 @@ YUI.add('juju-view-utils', function(Y) {
     @method compareSemver
     @param {String} a Version.
     @param {String} b Version to compare to.
-    @param {Boolean} If a is older than b.
+    @param {Integer} returns -1 if a is older than b, 0 if a is equal to b,
+      and 1 if a is newer than b.
   */
   utils.compareSemver = function(a, b) {
     a = a.split('-')[0];

--- a/jujugui/static/gui/src/test/test_env_go.js
+++ b/jujugui/static/gui/src/test/test_env_go.js
@@ -240,7 +240,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     });
 
     describe('login', function() {
-      it('sends the correct login message', function() {
+      it('sends the correct login message for juju < 2.0', function() {
         env.set('jujuCoreVersion', '1.23');
         noopHandleLogin();
         env.login();
@@ -251,6 +251,21 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
           RequestId: 1,
           Params: {AuthTag: 'user-user', Password: 'password'},
           Version: 0
+        };
+        assert.deepEqual(expected, last_message);
+      });
+
+      it('sends the correct login message for juju > 2.0', function() {
+        env.set('jujuCoreVersion', '2.0');
+        noopHandleLogin();
+        env.login();
+        var last_message = conn.last_message();
+        var expected = {
+          Type: 'Admin',
+          Request: 'Login',
+          RequestId: 1,
+          Params: {'auth-tag': 'user-user', credentials: 'password'},
+          Version: 2
         };
         assert.deepEqual(expected, last_message);
       });

--- a/jujugui/static/gui/src/test/test_env_go.js
+++ b/jujugui/static/gui/src/test/test_env_go.js
@@ -241,6 +241,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
     describe('login', function() {
       it('sends the correct login message', function() {
+        env.set('jujuCoreVersion', '1.23');
         noopHandleLogin();
         env.login();
         var last_message = conn.last_message();
@@ -248,7 +249,8 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
           Type: 'Admin',
           Request: 'Login',
           RequestId: 1,
-          Params: {AuthTag: 'user-user', Password: 'password'}
+          Params: {AuthTag: 'user-user', Password: 'password'},
+          Version: 0
         };
         assert.deepEqual(expected, last_message);
       });

--- a/jujugui/static/gui/src/test/test_utils.js
+++ b/jujugui/static/gui/src/test/test_utils.js
@@ -1193,6 +1193,53 @@ describe('utilities', function() {
     });
   });
 
+  describe('compareSemver', function() {
+    var utils;
+
+    before(function(done) {
+      YUI(GlobalConfig).use(['juju-view-utils'], function(Y) {
+        utils = Y.namespace('juju.views.utils');
+        done();
+      });
+    });
+
+    it('properly compares semver values', function() {
+      var versions = [
+        '1.2.3',
+        '2.0-alpha-foo-bar',
+        '4.11.6',
+        '4.2.0',
+        '1.5.19',
+        '1.5.5',
+        '1.5.5-foo',
+        '3.7.1-alpha-foo',
+        '4.1.3',
+        '2.3.1',
+        '10.5.5',
+        '5.1',
+        '11.3.0'
+      ];
+
+      assert.deepEqual(
+        versions.sort(utils.compareSemver), [
+          '1.2.3',
+          '1.5.5',
+          '1.5.5-foo',
+          '1.5.19',
+          '2.0-alpha-foo-bar',
+          '2.3.1',
+          '3.7.1-alpha-foo',
+          '4.1.3',
+          '4.2.0',
+          '4.11.6',
+          '5.1',
+          '10.5.5',
+          '11.3.0'
+        ]);
+    });
+
+  });
+
   describe('linkify', function() {
     var utils;
 


### PR DESCRIPTION
When juju-core updated to 2.0 they updated many of the facades. This is the first branch of supporting multiple facades. We have to rely on the juju version because we don't get a list of supported facades until we have logged in.