### PR TITLE
Update facade handling.

### DIFF
--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -37,8 +37,7 @@ YUI.add('juju-gui', function(Y) {
   var juju = Y.namespace('juju'),
       models = Y.namespace('juju.models'),
       views = Y.namespace('juju.views'),
-      widgets = Y.namespace('juju.widgets'),
-      bundleNotifications = juju.BundleNotifications;
+      widgets = Y.namespace('juju.widgets');
 
   var components = window.juju.components; // eslint-disable-line no-unused-vars
 
@@ -1135,7 +1134,7 @@ YUI.add('juju-gui', function(Y) {
       @method _renderEnvSwitcher
     */
     _renderEnvSwitcher: function() {
-      if(!this.env.facadeSupported('EnvironmentManager')) {
+      if(this.env.findFacadeVersion('ModelManager') === null) {
         // We do not want to show the model switcher if it isn't supported as
         // it throws an error in the browser console and confuses the user
         // as it's visible but not functional.
@@ -1748,8 +1747,6 @@ YUI.add('juju-gui', function(Y) {
         if (redirectPath.indexOf('#') > -1) {
           this.dispatch();
         }
-        // Start observing bundle deployments.
-        bundleNotifications.watchAll(this.env, this.db);
       } else {
         this._renderLogin(true);
       }

--- a/jujugui/static/gui/src/test/test_app.js
+++ b/jujugui/static/gui/src/test/test_app.js
@@ -691,6 +691,7 @@ describe('App', function() {
         assert.deepEqual(conn.last_message(), {
           RequestId: 1,
           Type: 'GUIToken',
+          Version: 0,
           Request: 'Login',
           Params: {Token: 'demoToken'}
         });
@@ -710,6 +711,7 @@ describe('App', function() {
         assert.deepEqual(conn.last_message(), {
           RequestId: 1,
           Type: 'GUIToken',
+          Version: 0,
           Request: 'Login',
           Params: {Token: 'demoToken'}
         });
@@ -806,18 +808,6 @@ describe('App', function() {
         '/foo/bar#baz',
         { overrideAllNamespaces: true }]);
       assert.equal(app.dispatch.calledOnce(), true);
-    });
-
-    it('retrieves the bundle deployments status on login', function() {
-      var app = makeApp(true, this);
-      app.onLogin({data: {result: true}});
-      var expectedMessage = {
-        RequestId: 2, // The first request is the login one.
-        Type: 'Deployer',
-        Request: 'Status',
-        Params: {}
-      };
-      assert.deepEqual(conn.last_message(), expectedMessage);
     });
 
     // XXX This test causes intermittent cascading failures when run in CI.

--- a/jujugui/static/gui/src/test/test_bundle_import_notifications.js
+++ b/jujugui/static/gui/src/test/test_bundle_import_notifications.js
@@ -144,6 +144,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
         conn: conn, user: 'user', password: 'password'
       }, 'go');
       env.connect();
+      env.set('facades', {Deployer: [0]});
       this._cleanups.push(env.close.bind(env));
       db = {notifications: {add: testUtils.makeStubFunction()}};
       bundleNotifications._watchDeployment = testUtils.makeStubFunction();
@@ -158,6 +159,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       var expectedMessage = {
         RequestId: 1,
         Type: 'Deployer',
+        Version: 0,
         Request: 'Status',
         Params: {}
       };
@@ -184,25 +186,6 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
         level: 'error'
       };
       assert.deepEqual(args[0], expectedNotification);
-    });
-
-    it('handles not implemented status errors', function() {
-      // Mock "console.log" so that it is possible to collect logs.
-      var mockLog = testUtils.makeStubMethod(console, 'log');
-      bundleNotifications.watchAll(env, db);
-      // Simulate a response from the server.
-      var err = 'no such request - method Deployer.Status is not implemented';
-      conn.msg({RequestId: 1, Response: {}, Error: err});
-      // No bundles are being watched.
-      assert.strictEqual(bundleNotifications._watchDeployment.called(), false);
-      // The not implemented error is not notified.
-      assert.strictEqual(db.notifications.add.called(), false);
-      // The error is still logged.
-      assert.strictEqual(mockLog.callCount(), 1);
-      var lastArgs = mockLog.lastArguments();
-      assert.strictEqual(lastArgs.length, 1);
-      assert.strictEqual(
-        lastArgs[0], 'GUI server bundle endpoints not supported: ' + err);
     });
 
     it('starts watching started/pending deployments', function() {


### PR DESCRIPTION
So that it is simpler to check for available facade
versions and to switch between endpoint implementations.

Initial work to drop support for Deployer GUI server facade.