### PR TITLE
Use https for anonymous pulling of download-cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -271,7 +271,7 @@ watch:
 # Download cache
 ################
 $(CACHE):
-	git clone --depth=1 "git@github.com:juju/juju-gui-downloadcache.git" $(CACHE)
+	git clone --depth=1 "https://github.com/juju/juju-gui-downloadcache.git" $(CACHE)
 
 downloadcache: $(CACHE)
 


### PR DESCRIPTION
I wanted to build the GUI Into a lxc container that was not setup with my ssh setup. I needed to update the download-cache to be https so that I could do an anonymous pull of the download-cache and a one off build.