### PR TITLE
Start migrating API calls to Juju 2.0.

### DIFF
--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -1043,7 +1043,8 @@ YUI.add('juju-gui', function(Y) {
       @method _renderEnvSwitcher
     */
     _renderEnvSwitcher: function() {
-      if(this.env.findFacadeVersion('ModelManager') === null) {
+      if(this.env.findFacadeVersion('ModelManager') === null &&
+         this.env.findFacadeVersion('EnvironmentManager') === null) {
         // We do not want to show the model switcher if it isn't supported as
         // it throws an error in the browser console and confuses the user
         // as it's visible but not functional.
@@ -1719,6 +1720,7 @@ YUI.add('juju-gui', function(Y) {
       @param {String} password The password for the new environment.
     */
     switchEnv: function(socketUrl, username, password) {
+      console.log('switching to new socket URL:', socketUrl);
       if (this.get('sandbox')) {
         console.log('switching environments is not supported in sandbox');
       }

--- a/jujugui/static/gui/src/app/assets/javascripts/reconnecting-websocket.js
+++ b/jujugui/static/gui/src/app/assets/javascripts/reconnecting-websocket.js
@@ -108,12 +108,16 @@ function ReconnectingWebSocket(url, protocols) {
             ws = null;
             if (forcedClose) {
                 self.readyState = WebSocket.CLOSED;
+                if (self.debug || ReconnectingWebSocket.debugAll) {
+                    console.debug('ReconnectingWebSocket', 'onclose', url);
+                }
                 self.onclose(event);
             } else {
                 self.readyState = WebSocket.CONNECTING;
                 if (!reconnectAttempt && !timedOut) {
                     if (self.debug || ReconnectingWebSocket.debugAll) {
-                        console.debug('ReconnectingWebSocket', 'onclose', url);
+                        console.debug(
+                            'ReconnectingWebSocket', 'onclose reconnect', url);
                     }
                     self.onclose(event);
                 }

--- a/jujugui/static/gui/src/app/components/env-switcher/env-switcher.js
+++ b/jujugui/static/gui/src/app/components/env-switcher/env-switcher.js
@@ -194,7 +194,8 @@ YUI.add('env-switcher', function() {
       // We need to coerce error types returned by JES vs JEM into one error.
       var err = data.err || error;
       if (err) {
-        console.log(err);
+        // XXX frankban: the error should be surfaced to the user.
+        console.log('error creating new model:', err);
         return;
       }
       this.props.dbEnvironmentSet('name', data.name || data.path);


### PR DESCRIPTION
Handle ModelManager calls, and also Model(Get|Info) Client calls.
Also improve createNev so that in theory it is able to create
new models in all provider types.