### PR TITLE
Correctly flag promulgated bundles

### DIFF
--- a/jujugui/static/gui/src/app/models/bundle.js
+++ b/jujugui/static/gui/src/app/models/bundle.js
@@ -214,8 +214,12 @@ YUI.add('juju-bundle-models', function(Y) {
 
           @method getter
          */
-        getter: function() {
-          return this.get('promulgated');
+        getter: function(val) {
+          var promulgated = this.get('promulgated');
+          // Set the value from the promulgated flag otherwise use the provided
+          // value. The promulgated flag may not be used anymore, but it has
+          // been left here for backwards compatibility.
+          return promulgated === undefined ? val : promulgated;
         }
       },
       owner: {},

--- a/jujugui/static/gui/src/app/utils/jujulib-conversion-utils.js
+++ b/jujugui/static/gui/src/app/utils/jujulib-conversion-utils.js
@@ -27,7 +27,7 @@ YUI.add('jujulib-utils', function(Y) {
 
   var juju = Y.namespace('juju');
 
-  /** 
+  /**
     Munge jujulib style entity data into juju GUI models.
 
     @function processEntityData

--- a/jujugui/static/gui/src/test/test_model_bundle.js
+++ b/jujugui/static/gui/src/test/test_model_bundle.js
@@ -107,6 +107,11 @@ describe('The bundle model', function() {
     assert.equal(instance.get('is_approved'), true);
   });
 
+  it('sets is_approved if promulgated is not provided', function() {
+    instance = new models.Bundle({is_approved: true});
+    assert.equal(instance.get('is_approved'), true);
+  });
+
   it('must store the title', function() {
     expected = 'My Bountiful Bundle';
     data.title = expected;


### PR DESCRIPTION
Proumulgated bundles were not appearing in the Recommended search results as the data was not being correctly set up in the model. Fixes #1342.