### PR TITLE
Improve closing WebSocket connections.

### DIFF
--- a/jujugui/static/gui/src/app/store/env/base.js
+++ b/jujugui/static/gui/src/app/store/env/base.js
@@ -221,7 +221,6 @@ YUI.add('juju-env-base', function(Y) {
       // Consider the user unauthenticated until proven otherwise.
       this.userIsAuthenticated = false;
       this.failedAuthentication = false;
-      this.pinger = null;
       // Populate our credentials if they don't already exist.
       var credentials = this.getCredentials() || {};
       if (Y.Lang.isValue(this.get('user'))) {
@@ -278,12 +277,23 @@ YUI.add('juju-env-base', function(Y) {
     */
     close: function() {
       if (this.ws) {
-        this.ws.close();
+        this.beforeClose(this.ws.close.bind(this.ws));
       }
-      if (this.pinger) {
-        clearInterval(this.pinger);
-        this.pinger = null;
-      }
+    },
+
+    /**
+      Define optional operations to be performed before closing the WebSocket
+      connection. This method, as defined here, only calls the given callback
+      as it is intended to be overridden by subclasses. Implementations are
+      responsible of calling the given callback that effectively closes the
+      WebSocket connection.
+
+      @method beforeClose
+      @param {Function} callback A callable that must be called by the
+        function and that actually closes the connection.
+    */
+    beforeClose: function(callback) {
+      callback();
     },
 
     /**

--- a/jujugui/static/gui/src/app/store/env/sandbox.js
+++ b/jujugui/static/gui/src/app/store/env/sandbox.js
@@ -693,6 +693,19 @@ YUI.add('juju-env-sandbox', function(Y) {
     },
 
     /**
+    Handle AllWatcher Stop messages.
+
+    @method handleAllWatcherStop
+    @param {Object} data The contents of the API arguments.
+    @param {Object} client The active ClientConnection.
+    @param {Object} state An instance of FakeBackend.
+    */
+    handleAllWatcherStop: function(data, client, state) {
+      clearInterval(this.deltaIntervalId);
+      client.receive({RequestId: data.RequestId, Response: {}});
+    },
+
+    /**
     Receive a basic response. Several API calls simply return a request ID
     and an error (if there is one); this utility method handles those cases.
 

--- a/jujugui/static/gui/src/test/test_env.js
+++ b/jujugui/static/gui/src/test/test_env.js
@@ -48,6 +48,33 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       env.destroy();
     });
 
+    it('calls "beforeClose" when the connection is closed', function() {
+      var closed = false;
+      var conn = new ClientConnection({
+        juju: {
+          open: function() {},
+          close: function() {
+            closed = true;
+          }
+        }
+      });
+      var env = new environments.BaseEnvironment({conn: conn});
+      env.connect();
+      var called = false;
+      env.beforeClose = function(callback) {
+        called = true;
+        // The connection is still open.
+        assert.strictEqual(closed, false, 'connection unexpectedly closed');
+        // Close the connection.
+        callback();
+        assert.strictEqual(closed, true, 'connection not closed');
+      };
+      env.close();
+      // The beforeClose method has been called.
+      assert.strictEqual(called, true, 'before hook not called');
+      env.destroy();
+    });
+
     it('uses the module-defined sessionStorage.', function() {
       var conn = new ClientConnection({juju: {open: function() {}}});
       var env = new environments.BaseEnvironment({conn: conn});

--- a/jujugui/static/gui/src/test/test_env_go.js
+++ b/jujugui/static/gui/src/test/test_env_go.js
@@ -2211,6 +2211,28 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       assert.equal(msg.Id, env._allWatcherId);
     });
 
+    it('stops the mega-watcher', function() {
+      // This is normally set by _watchAll, we'll fake it here.
+      env._allWatcherId = 42;
+      // Make the request.
+      var callback = utils.makeStubFunction();
+      env._stopWatching(callback);
+      // Mimic response.
+      conn.msg({RequestId: 1, Response: {}});
+      // The callback has been called.
+      assert.strictEqual(callback.calledOnce(), true, 'callback not');
+      assert.strictEqual(env._allWatcherId, null);
+      // The request has been properly sent.
+      assert.deepEqual({
+        RequestId: 1,
+        Type: 'AllWatcher',
+        Version: 0,
+        Request: 'Stop',
+        Id: 42,
+        Params: {}
+      }, conn.last_message());
+    });
+
     it('fires "_rpc_response" message after an RPC response', function(done) {
       // We don't want the real response, we just want to be sure the event is
       // fired.


### PR DESCRIPTION
Properly shut down the mega-watcher before quitting
the connection, because that's The_Right_Thing to do and
so that close acks are not delayed when the GUI is
connected directly to core.

Also better define responsibilities between the base
environemnt and the Go implementation when a connection
needs to be closed.