### PR TITLE
Implement Service.AddUnits API call.

### DIFF
--- a/jujugui/static/gui/src/app/store/env/go.js
+++ b/jujugui/static/gui/src/app/store/env/go.js
@@ -92,15 +92,15 @@ YUI.add('juju-env-go', function(Y) {
     structure, with Scope and Directive fields.
 
     @method parsePlacement
-    @param {String} machineTo The string placement.
+    @param {String} toMachine The string placement.
     @return {Object} A structure including Scope and Directive fields, or
       null if no placement is specified.
   */
-  var parsePlacement = function(machineTo) {
-    if (!machineTo) {
+  var parsePlacement = function(toMachine) {
+    if (!toMachine) {
       return null;
     }
-    var parts = machineTo.split(':');
+    var parts = toMachine.split(':');
     if (parts.length === 2) {
       return {Scope: parts[0], Directive: parts[1]};
     }

--- a/jujugui/static/gui/src/app/store/env/go.js
+++ b/jujugui/static/gui/src/app/store/env/go.js
@@ -84,6 +84,33 @@ YUI.add('juju-env-go', function(Y) {
     return newObj;
   };
 
+  // Define the special machine scope used to specify unit placements.
+  var MACHINE_SCOPE = '#';
+
+  /**
+    Attempt to parse the specified string and create a corresponding placement
+    structure, with Scope and Directive fields.
+
+    @method parsePlacement
+    @param {String} machineTo The string placement.
+    @return {Object} A structure including Scope and Directive fields, or
+      null if no placement is specified.
+  */
+  var parsePlacement = function(machineTo) {
+    if (!machineTo) {
+      return null;
+    }
+    var parts = machineTo.split(':');
+    if (parts.length === 2) {
+      return {Scope: parts[0], Directive: parts[1]};
+    }
+    var part = parts[0];
+    if (part === LXC.value || part === KVM.value) {
+      return {Scope: part, Directive: ''};
+    }
+    return {Scope: MACHINE_SCOPE, Directive: part};
+  };
+
   /**
      Return an object containing all the key/value pairs of the given "obj",
      converting all the values to strings.
@@ -1488,50 +1515,51 @@ YUI.add('juju-env-go', function(Y) {
       @return {undefined} Sends a message to the server only.
     */
     _add_unit: function(service, numUnits, toMachine, callback) {
-      var intermediateCallback;
-      if (callback) {
-        // Capture the callback, service and numUnits.  No context is passed.
-        intermediateCallback = Y.bind(
-            this._handleAddUnit, null, callback, service, numUnits);
+      // Define the API callback.
+      var handleAddUnit = function(userCallback, data) {
+        if (!userCallback) {
+          console.log('data returned by addUnit API call:', data);
+          return;
+        }
+        var transformedData = {
+          err: data.Error,
+          service_name: service
+        };
+        if (data.Error) {
+          transformedData.num_units = numUnits;
+        } else {
+          var units = data.Response.Units;
+          transformedData.result = units;
+          transformedData.num_units = units.length;
+        }
+        // Call the original user callback.
+        userCallback(transformedData);
+      }.bind(this, callback);
+
+      // Make the call.
+      var version = this.findFacadeVersion('Service');
+      if (version === null || version < 3) {
+        // Use legacy Juju API for adding units.
+        this._send_rpc({
+          Type: 'Client',
+          Request: 'AddServiceUnits',
+          Params: {
+            ServiceName: service,
+            NumUnits: numUnits,
+            ToMachineSpec: toMachine
+          }
+        }, handleAddUnit);
+        return;
       }
       this._send_rpc({
-        Type: 'Client',
-        Request: 'AddServiceUnits',
+        Type: 'Service',
+        Request: 'AddUnits',
         Params: {
           ServiceName: service,
           NumUnits: numUnits,
-          ToMachineSpec: toMachine
+          Placement: [parsePlacement(toMachine)]
         }
-      }, intermediateCallback);
-    },
-
-    /**
-      Transform the data returned from the juju-core add_unit call into that
-      suitable for the user callback.
-
-      @method _handleAddUnit
-      @static
-      @param {Function} userCallback The callback originally submitted by the
-        call site.
-      @param {String} service The name of the service.  Passed in since it
-        is not part of the response.
-      @param {Integer} numUnits The number of added units.
-      @param {Object} data The response returned by the server.
-    */
-    _handleAddUnit: function(userCallback, service, numUnits, data) {
-      var transformedData = {
-        err: data.Error,
-        service_name: service
-      };
-      if (data.Error) {
-        transformedData.num_units = numUnits;
-      } else {
-        var units = data.Response.Units;
-        transformedData.result = units;
-        transformedData.num_units = units.length;
-      }
-      // Call the original user callback.
-      userCallback(transformedData);
+      }, handleAddUnit);
     },
 
     /**
@@ -2915,6 +2943,7 @@ YUI.add('juju-env-go', function(Y) {
   environments.createRelationKey = createRelationKey;
   environments.GoEnvironment = GoEnvironment;
   environments.lowerObjectKeys = lowerObjectKeys;
+  environments.parsePlacement = parsePlacement;
   environments.stringifyObjectValues = stringifyObjectValues;
   environments.machineJobs = machineJobs;
 

--- a/jujugui/static/gui/src/app/store/env/sandbox.js
+++ b/jujugui/static/gui/src/app/store/env/sandbox.js
@@ -1117,17 +1117,21 @@ YUI.add('juju-env-sandbox', function(Y) {
     },
 
     /**
-    Handle AddServiceUnits messages
+    Handle Service.AddUnits messages
 
-    @method handleClientAddServiceUnits
+    @method handleServiceAddUnits
     @param {Object} data The contents of the API arguments.
     @param {Object} client The active ClientConnection.
     @param {Object} state An instance of FakeBackend.
     @return {undefined} Side effects only.
     */
-    handleClientAddServiceUnits: function(data, client, state) {
-      var reply = state.addUnit(data.Params.ServiceName, data.Params.NumUnits,
-          data.Params.ToMachineSpec);
+    handleServiceAddUnits: function(data, client, state) {
+      var args = data.Params;
+      var toMachine;
+      if (args.Placement && args.Placement[0]) {
+        toMachine = args.Placement[0].Directive;
+      }
+      var reply = state.addUnit(args.ServiceName, args.NumUnits, toMachine);
       var units = [];
       if (!reply.error) {
         units = reply.units.map(function(u) {return u.id;});

--- a/jujugui/static/gui/src/test/test_sandbox_go.js
+++ b/jujugui/static/gui/src/test/test_sandbox_go.js
@@ -970,8 +970,8 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     function generateServices(callback) {
       state.deploy('cs:precise/wordpress-27', function(service) {
         var data = {
-          Type: 'Client',
-          Request: 'AddServiceUnits',
+          Type: 'Service',
+          Request: 'AddUnits',
           Params: {
             ServiceName: 'wordpress',
             NumUnits: 2
@@ -1097,8 +1097,8 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
         function(done) {
           state.deploy('cs:precise/wordpress-27', function(service) {
             var data = {
-              Type: 'Client',
-              Request: 'AddServiceUnits',
+              Type: 'Service',
+              Request: 'AddUnits',
               Params: {
                 ServiceName: 'noservice',
                 NumUnits: 2


### PR DESCRIPTION
This is used to add units in a way compatible with Juju 2.0 and lower.
This needs to be QAed as usual on embedded 2.0 and charmed 1.25: add units, place them to specific machines, check everything works well and no console errors are printed.