### PR TITLE
Add the charm to the model before setting the charm

### DIFF
--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -926,6 +926,8 @@ YUI.add('juju-gui', function(Y) {
             unexposeService={this.env.unexpose.bind(this.env)}
             getAvailableVersions={charmstore.getAvailableVersions.bind(
                 charmstore)}
+            getMacaroon={charmstore.bakery.getMacaroon.bind(charmstore.bakery)}
+            addCharm={this.env.addCharm.bind(this.env)}
             setCharm={this.env.setCharm.bind(this.env)}
             getCharm={this.env.get_charm.bind(this.env)}
             getUnitStatusCounts={utils.getUnitStatusCounts}

--- a/jujugui/static/gui/src/app/components/inspector-change-version/inspector-change-version.js
+++ b/jujugui/static/gui/src/app/components/inspector-change-version/inspector-change-version.js
@@ -68,13 +68,40 @@ YUI.add('inspector-change-version', function() {
     },
 
     /**
-    The callable to be passed to the version item to change versions.
+      The callable to be passed to the version item to change versions.
 
-      @method _versionButtonAction
-      @param {String} charmId The charm id.
-      @param {Object} e The click event.
+        @method _versionButtonAction
+        @param {String} charmId The charm id.
+        @param {Object} e The click event.
     */
     _versionButtonAction: function(charmId, e) {
+      // Fetch the macaroon if one is available so that they can add private
+      // charms to their models.
+      var macaroon = this.props.getMacaroon();
+      // In Juju 2.0+ we have to add the charm before we set it. This is just
+      // good practice for 1.25.
+      this.props.addCharm(charmId, macaroon,
+        this._addCharmCallback.bind(this, charmId), {
+          // XXX hatch: the ecs doesn't yet support addCharm so we are going to
+          // send the command to juju immedaitely.
+          immediate: true
+        });
+    },
+
+    /**
+      Callback for handlign the results of addCharm
+
+      @method _addCharmCallback
+      @param {String} charmId The charm id.
+      @param {Object} data The response object from the addCharm call in the
+        format {err, url}.
+    */
+    _addCharmCallback: function(charmId, data) {
+      var error = data.err;
+      if (error) {
+        this._addFailureNotification(charmId, error);
+        return;
+      }
       this.props.setCharm(this.props.service.get('id'), charmId, false, false,
           this._setCharmCallback.bind(this, charmId));
     },

--- a/jujugui/static/gui/src/app/components/inspector-change-version/inspector-change-version.js
+++ b/jujugui/static/gui/src/app/components/inspector-change-version/inspector-change-version.js
@@ -89,7 +89,7 @@ YUI.add('inspector-change-version', function() {
     },
 
     /**
-      Callback for handlign the results of addCharm
+      Callback for handling the results of addCharm.
 
       @method _addCharmCallback
       @param {String} charmId The charm id.

--- a/jujugui/static/gui/src/app/components/inspector-change-version/test-inspector-change-version.js
+++ b/jujugui/static/gui/src/app/components/inspector-change-version/test-inspector-change-version.js
@@ -242,6 +242,8 @@ describe('InspectorChangeVersion', function() {
   it('can change charm version', function() {
     var changeState = sinon.stub();
     var serviceSet = sinon.stub();
+    var getMacaroon = sinon.stub().returns('macaroon');
+    var addCharm = sinon.stub();
     var service = {
       get: sinon.stub().returns('django'),
       set: serviceSet
@@ -256,20 +258,64 @@ describe('InspectorChangeVersion', function() {
           changeState={changeState}
           charmId="cs:django-5"
           service={service}
+          getMacaroon={getMacaroon}
+          addCharm={addCharm}
           setCharm={setCharm}
           getCharm={getCharm}
           getAvailableVersions={getAvailableVersions} />, true);
     shallowRenderer.getMountedInstance().componentDidMount();
     var output = shallowRenderer.getRenderOutput();
     output.props.children[1].props.children[0].props.buttonAction();
+    // We need to fetch a macaroon if there is one.
+    assert.equal(getMacaroon.callCount, 1);
+    // The charm needs to be added to the model first.
+    assert.equal(addCharm.callCount, 1);
+    assert.equal(addCharm.args[0][0], 'cs:django-4');
+    assert.equal(addCharm.args[0][1], 'macaroon');
+    // Call the callback
+    addCharm.args[0][2]({});
     assert.equal(serviceSet.callCount, 1);
     assert.equal(serviceSet.args[0][1], 'cs:django-4');
+  });
+
+  it('adds a notification if it can not add a charm', function() {
+    var addNotification = sinon.stub();
+    var changeState = sinon.stub();
+    var serviceSet = sinon.stub();
+    var getMacaroon = sinon.stub().returns('macaroon');
+    var setCharm = sinon.stub();
+    var service = {
+      get: sinon.stub().returns('django'),
+      set: serviceSet
+    };
+    var addCharm = sinon.stub().callsArgWith(2, {err: 'error'});
+    var getCharm = sinon.stub();
+    var getAvailableVersions = sinon.stub().callsArgWith(1, null, [
+      'cs:django-4', 'cs:django-5', 'cs:django-6'
+    ]);
+    var shallowRenderer = jsTestUtils.shallowRender(
+        <juju.components.InspectorChangeVersion
+          changeState={changeState}
+          charmId="cs:django-5"
+          getMacaroon={getMacaroon}
+          addCharm={addCharm}
+          service={service}
+          addNotification={addNotification}
+          setCharm={setCharm}
+          getCharm={getCharm}
+          getAvailableVersions={getAvailableVersions} />, true);
+    shallowRenderer.getMountedInstance().componentDidMount();
+    var output = shallowRenderer.getRenderOutput();
+    output.props.children[1].props.children[0].props.buttonAction();
+    assert.equal(addNotification.callCount, 1);
   });
 
   it('adds a notification if it can not set a charm', function() {
     var addNotification = sinon.stub();
     var changeState = sinon.stub();
     var serviceSet = sinon.stub();
+    var getMacaroon = sinon.stub().returns('macaroon');
+    var addCharm = sinon.stub();
     var service = {
       get: sinon.stub().returns('django'),
       set: serviceSet
@@ -285,12 +331,16 @@ describe('InspectorChangeVersion', function() {
           charmId="cs:django-5"
           service={service}
           addNotification={addNotification}
+          getMacaroon={getMacaroon}
+          addCharm={addCharm}
           setCharm={setCharm}
           getCharm={getCharm}
           getAvailableVersions={getAvailableVersions} />, true);
     shallowRenderer.getMountedInstance().componentDidMount();
     var output = shallowRenderer.getRenderOutput();
     output.props.children[1].props.children[0].props.buttonAction();
+    // call the addCharm callback
+    addCharm.args[0][2]({});
     assert.equal(addNotification.callCount, 1);
   });
 
@@ -298,6 +348,8 @@ describe('InspectorChangeVersion', function() {
     var addNotification = sinon.stub();
     var changeState = sinon.stub();
     var serviceSet = sinon.stub();
+    var getMacaroon = sinon.stub().returns('macaroon');
+    var addCharm = sinon.stub();
     var service = {
       get: sinon.stub().returns('django'),
       set: serviceSet
@@ -313,12 +365,16 @@ describe('InspectorChangeVersion', function() {
           charmId="cs:django-5"
           service={service}
           addNotification={addNotification}
+          getMacaroon={getMacaroon}
+          addCharm={addCharm}
           setCharm={setCharm}
           getCharm={getCharm}
           getAvailableVersions={getAvailableVersions} />, true);
     shallowRenderer.getMountedInstance().componentDidMount();
     var output = shallowRenderer.getRenderOutput();
     output.props.children[1].props.children[0].props.buttonAction();
+    // call the addCharm callback
+    addCharm.args[0][2]({});
     assert.equal(addNotification.callCount, 1);
   });
 

--- a/jujugui/static/gui/src/app/components/inspector/inspector.js
+++ b/jujugui/static/gui/src/app/components/inspector/inspector.js
@@ -271,6 +271,8 @@ YUI.add('inspector-component', function() {
                 addNotification={this.props.addNotification}
                 charmId={service.get('charm')}
                 service={service}
+                getMacaroon={this.props.getMacaroon}
+                addCharm={this.props.addCharm}
                 setCharm={this.props.setCharm}
                 getCharm={this.props.getCharm}
                 getAvailableVersions={this.props.getAvailableVersions} />,

--- a/jujugui/static/gui/src/app/components/inspector/test-inspector.js
+++ b/jujugui/static/gui/src/app/components/inspector/test-inspector.js
@@ -485,6 +485,8 @@ describe('Inspector', function() {
     var addNotification = sinon.stub();
     var changeState = sinon.stub();
     var service = sinon.stub();
+    var getMacaroon = sinon.stub();
+    var addCharm = sinon.stub();
     var setCharm = sinon.stub();
     var getCharm = sinon.stub();
     var getAvailableVersions = sinon.stub();
@@ -504,6 +506,8 @@ describe('Inspector', function() {
       <juju.components.Inspector
         addNotification={addNotification}
         changeState={changeState}
+        getMacaroon={getMacaroon}
+        addCharm={addCharm}
         setCharm={setCharm}
         getCharm={getCharm}
         getAvailableVersions={getAvailableVersions}
@@ -517,6 +521,8 @@ describe('Inspector', function() {
         changeState={changeState}
         charmId="cs:demo"
         service={service}
+        getMacaroon={getMacaroon}
+        addCharm={addCharm}
         setCharm={setCharm}
         getCharm={getCharm}
         getAvailableVersions={getAvailableVersions} />);


### PR DESCRIPTION
Juju 2.0 requires you to add the charm to the model before setting the service to that charm version. This adds that functionality to the inspectors change version component.