### PR TITLE
Update user profile navigation

### DIFF
--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -746,6 +746,8 @@ YUI.add('juju-gui', function(Y) {
           username={username || 'anonymous'}
           charmstore={this.get('charmstore')} />,
         document.getElementById('charmbrowser-container'));
+      // The model name should not be visible when viewing the profile.
+      document.getElementById('environment-switcher').classList.add('hidden');
     },
 
     /**
@@ -1041,6 +1043,9 @@ YUI.add('juju-gui', function(Y) {
     },
 
     _emptySectionC: function() {
+      // If the model name has been hidden by the profile then show it again.
+      document.getElementById(
+        'environment-switcher').classList.remove('hidden');
       ReactDOM.unmountComponentAtNode(
         document.getElementById('charmbrowser-container'));
     },
@@ -1757,6 +1762,14 @@ YUI.add('juju-gui', function(Y) {
       console.log('switching to new socket URL:', socketUrl);
       if (this.get('sandbox')) {
         console.log('switching environments is not supported in sandbox');
+        // In the sandbox we need to close the profile page to simulate loading
+        // a model.
+        this.changeState({
+          sectionC: {
+            component: null,
+            metadata: null
+          }
+        });
       }
       if (username && password) {
         // We don't always get a new username and password when switching

--- a/jujugui/static/gui/src/app/assets/css/_header.scss
+++ b/jujugui/static/gui/src/app/assets/css/_header.scss
@@ -40,15 +40,7 @@
         &:before {
             content: '/';
             position: relative;
-            left: -5px;
-            top: 1px;
-            color: $mid-grey;
-        }
-
-        &:after {
-            content: '/';
-            position: relative;
-            right: -5px;
+            left: -7px;
             top: 1px;
             color: $mid-grey;
         }

--- a/jujugui/static/gui/src/app/components/env-switcher/_env-switcher.scss
+++ b/jujugui/static/gui/src/app/components/env-switcher/_env-switcher.scss
@@ -10,6 +10,14 @@
 
         .environment-name {
             font-size: 23px;
+
+            &:before {
+                content: '/';
+                position: relative;
+                left: -8px;
+                top: 1px;
+                color: $mid-grey;
+            }
         }
 
         &:focus {

--- a/jujugui/static/gui/src/app/components/user-profile/_user-profile.scss
+++ b/jujugui/static/gui/src/app/components/user-profile/_user-profile.scss
@@ -5,6 +5,9 @@
     bottom: 0;
     right: 0;
     left: 0;
+    background-color: $canvas-background;
+    border-top: 1px solid $mid-grey;
+    box-shadow: none;
 
     &__close {
         position: fixed;

--- a/jujugui/static/gui/src/app/components/user-profile/test-user-profile.js
+++ b/jujugui/static/gui/src/app/components/user-profile/test-user-profile.js
@@ -76,12 +76,6 @@ describe('UserProfile', () => {
       <juju.components.Panel
         instanceName="user-profile"
         visible={true}>
-        <span className="user-profile__close"
-          tabIndex="0" role="button"
-          onClick={instance.close}>
-          <juju.components.SvgIcon name="close_16"
-            size="16" />
-        </span>
         <div className="twelve-col">
           <div className="inner-wrapper">
             <juju.components.UserProfileHeader
@@ -360,7 +354,7 @@ describe('UserProfile', () => {
           </juju.components.UserProfileEntity>]}
         </ul>
       </div>);
-    assert.deepEqual(output.props.children[1].props.children, expected);
+    assert.deepEqual(output.props.children.props.children, expected);
   });
 
   it('does not pass the charmstore login if interactiveLogin is falsy', () => {
@@ -385,7 +379,7 @@ describe('UserProfile', () => {
         environmentCount={0}
         interactiveLogin={undefined}
         username="test-owner" />);
-    assert.deepEqual(output.props.children[1].props.children.props.children[0],
+    assert.deepEqual(output.props.children.props.children.props.children[0],
       expected);
   });
 
@@ -411,32 +405,6 @@ describe('UserProfile', () => {
     var instance = renderer.getMountedInstance();
     instance._interactiveLogin();
     assert.equal(charmstore.bakery.fetchMacaroonFromStaticPath.callCount, 1);
-  });
-
-  it('closes when clicking the close button', () => {
-    var changeState = sinon.stub();
-    var listEnvs = sinon.stub();
-    var output = jsTestUtils.shallowRender(
-      <juju.components.UserProfile
-        charmstore={{}}
-        changeState={changeState}
-        createSocketURL={sinon.stub()}
-        dbEnvironmentSet={sinon.stub()}
-        getDiagramURL={sinon.stub()}
-        switchEnv={sinon.stub()}
-        listEnvs={listEnvs}
-        showConnectingMask={sinon.stub()}
-        storeUser={sinon.stub()}
-        username="test-owner" />);
-
-    output.props.children[0].props.onClick();
-    assert.equal(changeState.callCount, 1);
-    assert.deepEqual(changeState.args[0][0], {
-      sectionC: {
-        component: null,
-        metadata: null
-      }
-    });
   });
 
   it('requests jem envs if jem is provided and updates state', () => {

--- a/jujugui/static/gui/src/app/components/user-profile/user-profile.js
+++ b/jujugui/static/gui/src/app/components/user-profile/user-profile.js
@@ -401,12 +401,6 @@ YUI.add('user-profile', function() {
         <juju.components.Panel
           instanceName="user-profile"
           visible={true}>
-          <span className="user-profile__close"
-            tabIndex="0" role="button"
-            onClick={this.close}>
-            <juju.components.SvgIcon name="close_16"
-              size="16" />
-          </span>
           <div className="twelve-col">
             <div className="inner-wrapper">
               <juju.components.UserProfileHeader

--- a/jujugui/static/gui/src/test/test_app.js
+++ b/jujugui/static/gui/src/test/test_app.js
@@ -59,7 +59,8 @@ describe('App', function() {
         'deployment-container',
         'login-container',
         'notifications-container',
-        'loading-message'
+        'loading-message',
+        'environment-switcher'
       ];
       container = Y.Node.create('<div>');
       container.set('id', 'test-container');

--- a/jujugui/templates/index.html.mako
+++ b/jujugui/templates/index.html.mako
@@ -81,7 +81,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
             % endif
           </li>
           <li id="user-name" class="header-banner__list-item">
-            <a class="header-banner__link--breadcrumb" href="#">
+            <a class="header-banner__link--breadcrumb" href="/profile/">
               anonymous
             </a>
           </li>


### PR DESCRIPTION
Update the user profile page interactions to appear as a level above the model. The user profile is supposed to appear like a page before viewing a model. As such the close button has been removed, the styling as been updated and you can now navigate to the profile from clicking the username in the header breadcrumb. Fixes #1396