### PR TITLE
Use the full name for collapsing charms

### DIFF
--- a/jujugui/static/gui/src/app/components/charmbrowser/charmbrowser.js
+++ b/jujugui/static/gui/src/app/components/charmbrowser/charmbrowser.js
@@ -21,6 +21,10 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 YUI.add('charmbrowser-component', function() {
 
   juju.components.Charmbrowser = React.createClass({
+    propTypes: {
+      utils: React.PropTypes.object.isRequired
+    },
+
     /**
       Get the current state of the charmbrowser.
 
@@ -112,6 +116,7 @@ YUI.add('charmbrowser-component', function() {
               <juju.components.Store
                 charmstoreSearch={this.props.charmstoreSearch}
                 changeState={this.props.changeState}
+                getName={utils.getName}
                 seriesList={this.props.series}
                 makeEntityModel={this.props.makeEntityModel} />
           );
@@ -121,6 +126,7 @@ YUI.add('charmbrowser-component', function() {
               <juju.components.SearchResults
                 changeState={this.props.changeState}
                 charmstoreSearch={this.props.charmstoreSearch}
+                getName={utils.getName}
                 makeEntityModel={this.props.makeEntityModel}
                 query={metadata.search}
                 seriesList={this.props.series}

--- a/jujugui/static/gui/src/app/components/charmbrowser/test-charmbrowser.js
+++ b/jujugui/static/gui/src/app/components/charmbrowser/test-charmbrowser.js
@@ -52,13 +52,15 @@ describe('Charmbrowser', function() {
     var changeState = sinon.stub();
     var charmstoreSearch = sinon.stub();
     var makeEntityModel = sinon.spy();
+    var utils = {getName: sinon.stub()};
     var renderer = jsTestUtils.shallowRender(
       <juju.components.Charmbrowser
         appState={appState}
         makeEntityModel={makeEntityModel}
         changeState={changeState}
         series={series}
-        charmstoreSearch={charmstoreSearch} />, true);
+        charmstoreSearch={charmstoreSearch}
+        utils={utils} />, true);
     var instance = renderer.getMountedInstance();
     var output = renderer.getRenderOutput();
     var expected = (
@@ -70,6 +72,7 @@ describe('Charmbrowser', function() {
             ref="charmbrowser">
             <juju.components.SearchResults
               changeState={changeState}
+              getName={utils.getName}
               seriesList={series}
               makeEntityModel={makeEntityModel}
               query={query}
@@ -97,7 +100,8 @@ describe('Charmbrowser', function() {
     var renderer = jsTestUtils.shallowRender(
       <juju.components.Charmbrowser
         appState={appState}
-        changeState={changeState} />, true);
+        changeState={changeState}
+        utils={{}} />, true);
     var instance = renderer.getMountedInstance();
     var output = renderer.getRenderOutput();
     assert.deepEqual(output,
@@ -124,6 +128,7 @@ describe('Charmbrowser', function() {
       }};
     var charmstoreSearch = sinon.stub();
     var changeState = sinon.stub();
+    var utils = {getName: sinon.stub()};
     var makeEntityModel = sinon.spy();
     var seriesList = sinon.stub();
     var renderer = jsTestUtils.shallowRender(
@@ -132,10 +137,11 @@ describe('Charmbrowser', function() {
         charmstoreSearch={charmstoreSearch}
         makeEntityModel={makeEntityModel}
         series={seriesList}
-        changeState={changeState} />, true);
+        changeState={changeState}
+        utils={utils} />, true);
     var instance = renderer.getMountedInstance();
     var output = renderer.getRenderOutput();
-    assert.deepEqual(output,
+    var expected = (
         <juju.components.Panel
           instanceName="white-box"
           clickAction={instance._close}
@@ -145,10 +151,12 @@ describe('Charmbrowser', function() {
             <juju.components.Store
               makeEntityModel={makeEntityModel}
               charmstoreSearch={charmstoreSearch}
+              getName={utils.getName}
               seriesList={seriesList}
               changeState={changeState} />
           </div>
         </juju.components.Panel>);
+    assert.deepEqual(output, expected);
   });
 
   it('displays entity details when the app state calls for it', function() {

--- a/jujugui/static/gui/src/app/components/login/test-login.js
+++ b/jujugui/static/gui/src/app/components/login/test-login.js
@@ -94,6 +94,7 @@ describe('LoginComponent', function() {
     var output = jsTestUtils.shallowRender(
       <juju.components.Login
         envName="testenv"
+        helpMessage="Exterminate!"
         setCredentials={sinon.stub()}
         login={sinon.stub()}
         loginFailure={true} />);
@@ -111,6 +112,7 @@ describe('LoginComponent', function() {
     var component = testUtils.renderIntoDocument(
       <juju.components.Login
         envName="testenv"
+        helpMessage="Exterminate!"
         setCredentials={setCredentials}
         login={login} />);
     component.refs.username.value = 'foo';
@@ -131,6 +133,7 @@ describe('LoginComponent', function() {
     var renderer = jsTestUtils.shallowRender(
       <juju.components.Login
         envName="testenv"
+        helpMessage="Exterminate!"
         setCredentials={sinon.stub()}
         login={sinon.stub()}
         loginFailure={true} />, true);

--- a/jujugui/static/gui/src/app/components/search-results/search-results.js
+++ b/jujugui/static/gui/src/app/components/search-results/search-results.js
@@ -21,6 +21,10 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 YUI.add('search-results', function(Y) {
 
   juju.components.SearchResults = React.createClass({
+    propTypes: {
+      getName: React.PropTypes.func.isRequired
+    },
+
     searchXhr: null,
 
      /**
@@ -32,17 +36,24 @@ YUI.add('search-results', function(Y) {
 
       @method collapseSeries
       @param {Array} entities The entities in their uncollapsed state.
+      @param {Function} getName The util for getting names from the charm ids.
+      @returns {Array} The entities with collapsed series.
      */
-    collapseSeries: function(entities) {
-      function entityKey(entity) {
-        return [entity.name, entity.owner, entity.type, entity.promulgated];
+    collapseSeries: function(entities, getName) {
+      function entityKey(entity, getName) {
+        return [
+          getName(entity.id),
+          entity.owner,
+          entity.type,
+          entity.promulgated
+        ];
       }
 
       var collapsedEntities = {},
           orderedKeys = [];
       for (var i = 0, l = entities.length; i < l; i++) {
         var entity = entities[i],
-            key = entityKey(entity),
+            key = entityKey(entity, getName),
             series = entity.series,
             url = entity.url || '',
             value = {name: series, url: url};
@@ -80,8 +91,9 @@ YUI.add('search-results', function(Y) {
           // Ensure downloads and URL are present.
           entity.downloads = entity.downloads || 0;
           entity.url = entity.url || '';
+          var name = getName(entity.id);
           entity.id = entity.series.length > 0 ?
-              entity.series[0].name + '/' + entity.name : entity.name;
+              entity.series[0].name + '/' + name : name;
           collapsedEntities[key] = entity;
           // Save the key so we can preserve sort order.
           orderedKeys.push(key);
@@ -115,7 +127,7 @@ YUI.add('search-results', function(Y) {
         return model.toEntity();
       }, this);
       var activeComponent;
-      results = this.collapseSeries(results);
+      results = this.collapseSeries(results, this.props.getName);
       // Split the results into promulgated and normal.
       var promulgatedResults = [],
           normalResults = [];

--- a/jujugui/static/gui/src/app/components/search-results/test-search-results.js
+++ b/jujugui/static/gui/src/app/components/search-results/test-search-results.js
@@ -43,6 +43,7 @@ describe('SearchResults', function() {
       var query = 'spinach';
       var output = jsTestUtils.shallowRender(
           <juju.components.SearchResults
+            getName={sinon.stub()}
             query={query} />);
       assert.deepEqual(output,
         <div className="search-results">
@@ -57,7 +58,8 @@ describe('SearchResults', function() {
       var shallowRenderer = jsTestUtils.shallowRender(
           <juju.components.SearchResults
             query="nothing here"
-            charmstoreSearch={charmstoreSearch} />, true);
+            charmstoreSearch={charmstoreSearch}
+            getName={sinon.stub()} />, true);
       shallowRenderer.getMountedInstance().componentDidMount();
       var output = shallowRenderer.getRenderOutput();
       assert.deepEqual(output,
@@ -85,7 +87,8 @@ describe('SearchResults', function() {
       var shallowRenderer = jsTestUtils.shallowRender(
           <juju.components.SearchResults
             query="nothing here"
-            charmstoreSearch={charmstoreSearch} />, true);
+            charmstoreSearch={charmstoreSearch}
+            getName={sinon.stub()} />, true);
       var instance = shallowRenderer.getMountedInstance();
       instance.componentDidMount();
       var output = shallowRenderer.getRenderOutput();
@@ -134,6 +137,7 @@ describe('SearchResults', function() {
             query={query}
             seriesList={series}
             charmstoreSearch={charmstoreSearch}
+            getName={sinon.stub()}
             makeEntityModel={makeEntityModel} />, true);
       var instance = shallowRenderer.getMountedInstance();
       instance.componentDidMount();
@@ -152,6 +156,9 @@ describe('SearchResults', function() {
 
     it('can render the search results', function() {
       var changeState = sinon.spy();
+      var getName = (val) => {
+        return val;
+      };
       var sortItems = [{
         label: 'Default',
         value: ''
@@ -245,11 +252,12 @@ describe('SearchResults', function() {
             seriesList={series}
             changeState={changeState}
             charmstoreSearch={charmstoreSearch}
+            getName={getName}
             makeEntityModel={makeEntityModel} />, true);
       var instance = shallowRenderer.getMountedInstance();
       instance.componentDidMount();
       var output = shallowRenderer.getRenderOutput();
-      assert.deepEqual(output,
+      var expected = (
         <div className="search-results">
           <div className="row no-padding-top">
             <div className="inner-wrapper list-block">
@@ -316,6 +324,7 @@ describe('SearchResults', function() {
             </div>
           </div>
         </div>);
+      assert.deepEqual(output, expected);
     });
   });
 
@@ -331,12 +340,16 @@ describe('SearchResults', function() {
     });
 
     it('collapses identical charms with different series', function() {
+      var getName = (val) => {
+        return val;
+      };
       var entities = [
-        {name: 'foo', owner: 'bar', type: 'charm', series: 'trusty'},
-        {name: 'foo', owner: 'bar', type: 'charm', series: 'precise'},
-        {name: 'foo', owner: 'baz', type: 'charm', series: 'vivid'}
+        {id: 'foo', name: 'foo', owner: 'bar', type: 'charm', series: 'trusty'},
+        {id: 'foo', name: 'foo', owner: 'bar', type: 'charm',
+          series: 'precise'},
+        {id: 'foo', name: 'foo', owner: 'baz', type: 'charm', series: 'vivid'}
       ];
-      var actual = searchResults.collapseSeries(entities),
+      var actual = searchResults.collapseSeries(entities, getName),
           first = entities[0],
           last = entities[2];
       var expected = [{
@@ -360,28 +373,40 @@ describe('SearchResults', function() {
     });
 
     it('aggregates downloads when collapsing charms', function() {
+      var getName = sinon.stub();
       var entities = [
         {name: 'c1', owner: 'o1', type: 'c', series: 's1', downloads: 1},
         {name: 'c1', owner: 'o1', type: 'c', series: 's2', downloads: 5},
         {name: 'c1', owner: 'o2', type: 'c', series: 's3', downloads: 3}
       ];
-      var actual = searchResults.collapseSeries(entities);
+      var actual = searchResults.collapseSeries(entities, getName);
       assert.equal(actual[0].downloads, 6, 'downloads not aggregated');
       assert.equal(actual[1].downloads, 3, 'downloads improperly aggregated');
     });
 
     it('maintains sort order when collapsing charms', function() {
+      var getName = (val) => {
+        return val;
+      };
       var entities = [
-        {name: 'foo1', owner: 'bar', type: 'c', series: 's1', downloads: 6},
-        {name: 'foo2', owner: 'bar', type: 'c', series: 's1', downloads: 5},
-        {name: 'foo1', owner: 'bar', type: 'c', series: 's2', downloads: 4},
-        {name: 'foo3', owner: 'bar', type: 'c', series: 's1', downloads: 4},
-        {name: 'foo2', owner: 'bar', type: 'c', series: 's1', downloads: 3},
-        {name: 'foo3', owner: 'bar', type: 'c', series: 's3', downloads: 3},
-        {name: 'foo3', owner: 'bar', type: 'c', series: 's4', downloads: 3},
-        {name: 'foo3', owner: 'bar', type: 'c', series: 's5', downloads: 3}
+        {id: 'foo1', name: 'foo1', owner: 'bar', type: 'c', series: 's1',
+          downloads: 6},
+        {id: 'foo2', name: 'foo2', owner: 'bar', type: 'c', series: 's1',
+          downloads: 5},
+        {id: 'foo1', name: 'foo1', owner: 'bar', type: 'c', series: 's2',
+          downloads: 4},
+        {id: 'foo3', name: 'foo3', owner: 'bar', type: 'c', series: 's1',
+          downloads: 4},
+        {id: 'foo2', name: 'foo2', owner: 'bar', type: 'c', series: 's1',
+          downloads: 3},
+        {id: 'foo3', name: 'foo3', owner: 'bar', type: 'c', series: 's3',
+          downloads: 3},
+        {id: 'foo3', name: 'foo3', owner: 'bar', type: 'c', series: 's4',
+          downloads: 3},
+        {id: 'foo3', name: 'foo3', owner: 'bar', type: 'c', series: 's5',
+          downloads: 3}
       ];
-      var actual = searchResults.collapseSeries(entities);
+      var actual = searchResults.collapseSeries(entities, getName);
       assert.equal(actual[0].name, 'foo1',
                    'foo1 did not maintain sort position');
       assert.equal(actual[0].downloads, 10,
@@ -397,12 +422,13 @@ describe('SearchResults', function() {
     });
 
     it('sorts the series within collapsed results', function() {
+      var getName = sinon.stub();
       var entities = [
         {name: 'c1', owner: 'o1', type: 'c', series: 'trusty'},
         {name: 'c1', owner: 'o1', type: 'c', series: 'precise'},
         {name: 'c1', owner: 'o1', type: 'c', series: 'vivid'}
       ];
-      var actual = searchResults.collapseSeries(entities),
+      var actual = searchResults.collapseSeries(entities, getName),
           actualSeries = actual[0].series,
           seriesNames = [];
       for (var i = 0, l = actualSeries.length; i < l; i++) {
@@ -412,12 +438,13 @@ describe('SearchResults', function() {
     });
 
     it('de-dupes the series within collapsed results', function() {
+      var getName = sinon.stub();
       var entities = [
         {name: 'c1', owner: 'o1', type: 'c', series: 'trusty'},
         {name: 'c1', owner: 'o1', type: 'c', series: 'precise'},
         {name: 'c1', owner: 'o1', type: 'c', series: 'trusty'}
       ];
-      var actual = searchResults.collapseSeries(entities),
+      var actual = searchResults.collapseSeries(entities, getName),
           actualSeries = actual[0].series,
           seriesNames = [];
       for (var i = 0, l = actualSeries.length; i < l; i++) {
@@ -573,7 +600,8 @@ describe('SearchResults', function() {
           <juju.components.SearchResults
             changeState={changeState}
             query={query}
-            charmstoreSearch={charmstoreSearch} />, true);
+            charmstoreSearch={charmstoreSearch}
+            getName={sinon.stub()} />, true);
       shallowRenderer.getMountedInstance().componentDidMount();
       shallowRenderer.unmount();
       assert.equal(abort.callCount, 1);

--- a/jujugui/static/gui/src/app/components/store/store.js
+++ b/jujugui/static/gui/src/app/components/store/store.js
@@ -21,6 +21,9 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 YUI.add('store', function() {
 
   juju.components.Store = React.createClass({
+    propTypes: {
+      getName: React.PropTypes.func.isRequired
+    },
 
     render: function() {
       return (
@@ -32,6 +35,7 @@ YUI.add('store', function() {
           <juju.components.SearchResults
             changeState={this.props.changeState}
             charmstoreSearch={this.props.charmstoreSearch}
+            getName={this.props.getName}
             makeEntityModel={this.props.makeEntityModel}
             seriesList={this.props.seriesList}
             inline={true}
@@ -42,5 +46,6 @@ YUI.add('store', function() {
   });
 
 }, '0.1.0', { requires: [
-  'mid-point'
+  'mid-point',
+  'search-results'
 ]});

--- a/jujugui/static/gui/src/app/components/store/test-store.js
+++ b/jujugui/static/gui/src/app/components/store/test-store.js
@@ -33,11 +33,13 @@ describe('Store', function() {
   it('can render correctly', function() {
     var changeState = sinon.stub();
     var charmstoreSearch = sinon.stub();
+    var getName = sinon.stub();
     var makeEntityModel = sinon.stub();
     var seriesList = sinon.stub();
     var output = jsTestUtils.shallowRender(
       <juju.components.Store
         charmstoreSearch={charmstoreSearch}
+        getName={getName}
         makeEntityModel={makeEntityModel}
         seriesList={seriesList}
         changeState={changeState} />);
@@ -50,6 +52,7 @@ describe('Store', function() {
         <juju.components.SearchResults
           changeState={changeState}
           charmstoreSearch={charmstoreSearch}
+          getName={getName}
           makeEntityModel={makeEntityModel}
           seriesList={seriesList}
           inline={true}

--- a/jujugui/static/gui/src/app/views/utils.js
+++ b/jujugui/static/gui/src/app/views/utils.js
@@ -1362,6 +1362,22 @@ YUI.add('juju-view-utils', function(Y) {
     return parts[0];
   };
 
+  /**
+    Return the name from the given charm ID.
+
+    @method getName
+    @param {String} id A fully qualified charm ID, like
+      "cs:trusty/django-42" or "cs:~frankban/utopic/juju-gui-0"
+    @return {String} The charm name.
+  */
+  utils.getName = function(id) {
+    var parts = id.split('/');
+    // The last part will be the name and version number e.g. juju-gui-0.
+    var idParts = parts[parts.length - 1].split('-');
+    // Remove the version number from the end.
+    return idParts.splice(0, idParts.length - 1).join('-');
+  };
+
   /*
     pluralize is a helper that handles pluralization of strings.
     The requirement for pluralization is based on the passed in object,

--- a/jujugui/static/gui/src/test/test_utils.js
+++ b/jujugui/static/gui/src/test/test_utils.js
@@ -545,6 +545,25 @@ describe('utilities', function() {
   });
 })();
 
+(function() {
+
+  describe('utils.getName', function() {
+    var utils;
+
+    before(function(done) {
+      YUI(GlobalConfig).use('juju-view-utils', function(Y) {
+        utils = Y.namespace('juju.views.utils');
+        done();
+      });
+    });
+
+    it('returns the name of a charmstore charm', function() {
+      var name = utils.getName('cs:~uros/precise/rails-server-47');
+      assert.strictEqual(name, 'rails-server');
+    });
+
+  });
+})();
 
 (function() {
   describe('DecoratedRelation and RelationCollection', function() {


### PR DESCRIPTION
Charms with names that didn't match their ids were being collapsed incorrectly.