### PR TITLE
Clear cookies, user, and charmstore cookie redirect

### DIFF
--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -711,12 +711,16 @@ YUI.add('juju-gui', function(Y) {
       }
       // If the charmbrowser is open then don't show the logout link.
       var visible = !this.state.getState('current', 'sectionC', 'metadata');
-      var bakery = this.get('charmstore').bakery;
+      var charmstore = this.get('charmstore');
+      var bakery = charmstore.bakery;
       ReactDOM.render(
         <window.juju.components.Logout
           logout={this.logout.bind(this)}
-          visible={visible}
-          clearCookie={bakery.clearCookie.bind(bakery)} />,
+          clearCookie={bakery.clearCookie.bind(bakery)}
+          charmstoreLogoutUrl={charmstore.getLogoutUrl()}
+          getUser={this.getUser.bind(this, 'charmstore')}
+          clearUser={this.clearUser.bind(this, 'charmstore')}
+          visible={visible} />,
         document.getElementById('profile-link-container'));
     },
 
@@ -2046,6 +2050,27 @@ YUI.add('juju-gui', function(Y) {
         this.cookieHandler.check();
       }
       next();
+    },
+
+    /**
+      Get the user info for the supplied service.
+
+      @method getUser
+      @param {String} service The service the macaroon comes from.
+      @return {Object} The user information.
+    */
+    getUser: function(service) {
+      return this.get('users')[service];
+    },
+
+    /**
+      Clears the user info for the supplied service.
+
+      @method clearUser
+      @param {String} service The service the macaroon comes from.
+    */
+    clearUser: function(service) {
+      delete this.get('users')[service];
     },
 
     /**

--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -711,10 +711,12 @@ YUI.add('juju-gui', function(Y) {
       }
       // If the charmbrowser is open then don't show the logout link.
       var visible = !this.state.getState('current', 'sectionC', 'metadata');
+      var bakery = this.get('charmstore').bakery;
       ReactDOM.render(
         <window.juju.components.Logout
           logout={this.logout.bind(this)}
-          visible={visible} />,
+          visible={visible}
+          clearCookie={bakery.clearCookie.bind(bakery)} />,
         document.getElementById('profile-link-container'));
     },
 

--- a/jujugui/static/gui/src/app/assets/javascripts/jujulib/juju.js
+++ b/jujugui/static/gui/src/app/assets/javascripts/jujulib/juju.js
@@ -226,6 +226,16 @@ var module = module;
   }
 
   charmstore.prototype = {
+
+    /**
+      Returns the url that you need to visit to log out of the charmstore.
+
+      @method getLogoutUrl
+      @return {String} The url to visit to log out.
+    */
+    getLogoutUrl: function() {
+      return this._generatePath('logout');
+    },
     /**
       Generates a path to the charmstore apiv4 based on the query and endpoint
       params passed in.

--- a/jujugui/static/gui/src/app/assets/javascripts/jujulib/test-jujulib-charmstore.js
+++ b/jujugui/static/gui/src/app/assets/javascripts/jujulib/test-jujulib-charmstore.js
@@ -29,6 +29,13 @@ describe('jujulib charmstore', function() {
     });
   });
 
+  describe('getLogoutUrl', function() {
+    it('returns a valid logout url', function() {
+      var path = charmstore.getLogoutUrl();
+      assert.equal(path, 'local/v4/logout');
+    });
+  });
+
   describe('_transformQueryResults', function() {
     var data = {
       Results: [

--- a/jujugui/static/gui/src/app/components/logout/logout.js
+++ b/jujugui/static/gui/src/app/components/logout/logout.js
@@ -25,12 +25,22 @@ YUI.add('logout-component', function() {
     propTypes: {
       logout: React.PropTypes.func.isRequired,
       visible: React.PropTypes.bool.isRequired,
-      clearCookie: React.PropTypes.func.isRequired
+      clearCookie: React.PropTypes.func.isRequired,
+      charmstoreLogoutUrl: React.PropTypes.string.isRequired,
+      getUser: React.PropTypes.func.isRequired,
+      clearUser: React.PropTypes.func.isRequired
     },
 
     logout: function(e) {
       var props = this.props;
-      e.preventDefault();
+      if (!props.getUser()) {
+        // If we don't have stored user information for the charmstore then
+        // the user isn't logged in so there is no point to redirect
+        // them to another page to log out.
+        e.preventDefault();
+      }
+      // Clear the user data on log out.
+      props.clearUser();
       props.clearCookie();
       props.logout();
     },
@@ -53,8 +63,9 @@ YUI.add('logout-component', function() {
     render: function() {
       return (
         <a className={this._generateClasses()}
-          href="#"
-          onClick={this.logout}>
+          href={this.props.charmstoreLogoutUrl}
+          onClick={this.logout}
+          target="_blank">
           Logout
         </a>
       );

--- a/jujugui/static/gui/src/app/components/logout/logout.js
+++ b/jujugui/static/gui/src/app/components/logout/logout.js
@@ -24,12 +24,15 @@ YUI.add('logout-component', function() {
 
     propTypes: {
       logout: React.PropTypes.func.isRequired,
-      visible: React.PropTypes.bool.isRequired
+      visible: React.PropTypes.bool.isRequired,
+      clearCookie: React.PropTypes.func.isRequired
     },
 
     logout: function(e) {
+      var props = this.props;
       e.preventDefault();
-      this.props.logout();
+      props.clearCookie();
+      props.logout();
     },
 
     /**

--- a/jujugui/static/gui/src/app/components/logout/test-logout.js
+++ b/jujugui/static/gui/src/app/components/logout/test-logout.js
@@ -32,43 +32,95 @@ describe('Logout', () => {
 
   it('renders properly', () => {
     var logout = sinon.stub();
+    var logoutUrl = 'http://logout';
     var output = jsTestUtils.shallowRender(
       <juju.components.Logout
         logout={logout}
-        visible={true} />);
+        visible={true}
+        clearCookie={sinon.stub()}
+        charmstoreLogoutUrl={logoutUrl}
+        getUser={sinon.stub()}
+        clearUser={sinon.stub()}/>);
     var expected = (
       <a className="logout-link"
-        href="#"
-        onClick={output.props.onClick}>Logout</a>
+        href={logoutUrl}
+        onClick={output.props.onClick}
+        target="_blank">Logout</a>
       );
     assert.deepEqual(output, expected);
   });
 
   it('can be hidden', () => {
     var logout = sinon.stub();
+    var logoutUrl = 'http://logout';
     var output = jsTestUtils.shallowRender(
       <juju.components.Logout
         logout={logout}
-        visible={false} />);
+        visible={false}
+        clearCookie={sinon.stub()}
+        charmstoreLogoutUrl={logoutUrl}
+        getUser={sinon.stub()}
+        clearUser={sinon.stub()} />);
     var expected = (
       <a className="logout-link logout-link--hidden"
-        href="#"
-        onClick={output.props.onClick}>Logout</a>
+        href={logoutUrl}
+        onClick={output.props.onClick}
+        target="_blank">Logout</a>
       );
     assert.deepEqual(output, expected);
   });
 
   it('calls the logout prop on click', () => {
     var logout = sinon.stub();
+    var logoutUrl = 'http://logout';
     var prevent = sinon.stub();
+    var clearUser = sinon.stub();
+    var clearCookie = sinon.stub();
     var output = jsTestUtils.shallowRender(
       <juju.components.Logout
         logout={logout}
-        visible={true} />);
+        visible={true}
+        clearCookie={clearCookie}
+        charmstoreLogoutUrl={logoutUrl}
+        getUser={sinon.stub().returns(undefined)}
+        clearUser={clearUser} />);
     assert.equal(logout.callCount, 0);
     output.props.onClick({ preventDefault: prevent });
+    // It should clear the user and the cookie.
+    assert.equal(clearUser.callCount, 1);
+    assert.equal(clearCookie.callCount, 1);
+
     assert.equal(logout.callCount, 1);
+    // preventDefault should only be called if no user is defined. There is no
+    // need to redirect the user if they do not need to log out.
+    // The next test checks to make sure that it does in that case.
     assert.equal(prevent.callCount, 1);
+  });
+
+  it('lets the user navigate if a user exists', () => {
+    var logout = sinon.stub();
+    var logoutUrl = 'http://logout';
+    var prevent = sinon.stub();
+    var clearUser = sinon.stub();
+    var getUser = sinon.stub().returns(true);
+    var clearCookie = sinon.stub();
+    var output = jsTestUtils.shallowRender(
+      <juju.components.Logout
+        logout={logout}
+        visible={true}
+        clearCookie={clearCookie}
+        charmstoreLogoutUrl={logoutUrl}
+        getUser={getUser}
+        clearUser={clearUser} />);
+    assert.equal(logout.callCount, 0);
+    output.props.onClick({ preventDefault: prevent });
+    // It should clear the user and the cookie.
+    assert.equal(clearUser.callCount, 1);
+    assert.equal(clearCookie.callCount, 1);
+
+    assert.equal(logout.callCount, 1);
+    // Unless getUser returns a user it shouldn't call preventDefault.
+    assert.equal(prevent.callCount, 0);
   });
 
 });

--- a/jujugui/static/gui/src/app/store/env/bakery.js
+++ b/jujugui/static/gui/src/app/store/env/bakery.js
@@ -570,6 +570,24 @@ YUI.add('juju-env-bakery', function(Y) {
           }
         }
         return null;
+      },
+
+      /**
+        Clears the cookies saved for macaroons.
+
+        @method clearCookie
+      */
+      clearCookie: function() {
+        var name = this.macaroonName;
+        var pathParts = '/profile'.split('/');
+        var currentPath = ' path=';
+        // Delete the / cookie first
+        document.cookie = `${name}=; expires=Thu, 01-Jan-1970 00:00:01 GMT;`;
+        pathParts.forEach(part => {
+          currentPath += ((currentPath.substr(-1) !== '/') ? '/' : '') + part;
+          document.cookie =
+            `${name}=; expires=Thu, 01-Jan-1970 00:00:01 GMT;${currentPath};`;
+        });
       }
     }
   );

--- a/jujugui/static/gui/src/test/test_app.js
+++ b/jujugui/static/gui/src/test/test_app.js
@@ -1235,6 +1235,59 @@ describe('App', function() {
     });
   });
 
+  describe('getUser', function() {
+    var Y;
+
+    before(function(done) {
+      Y = YUI(GlobalConfig).use(['juju-gui'], function(Y) {
+        done();
+      });
+    });
+
+    it('gets the set user for the supplied service', function() {
+      container = Y.Node.create('<div id="test" class="container"></div>');
+      var app = new Y.juju.App({
+        viewContainer: container,
+        consoleEnabled: true
+      });
+      var charmstoreUser = {
+        name: 'foo'
+      };
+      app.set('users', {
+        'charmstore': charmstoreUser
+      });
+      assert.deepEqual(app.getUser('charmstore'), charmstoreUser);
+    });
+
+  });
+
+  describe('clearUser', function() {
+    var Y;
+
+    before(function(done) {
+      Y = YUI(GlobalConfig).use(['juju-gui'], function(Y) {
+        done();
+      });
+    });
+
+    it('clears the set user for the supplied service', function() {
+      container = Y.Node.create('<div id="test" class="container"></div>');
+      var app = new Y.juju.App({
+        viewContainer: container,
+        consoleEnabled: true
+      });
+      var charmstoreUser = {
+        name: 'foo'
+      };
+      app.set('users', {
+        'charmstore': charmstoreUser
+      });
+      app.clearUser('charmstore');
+      assert.equal(app.getUser('charmstore'), undefined);
+    });
+
+  });
+
   describe('storeUser', function() {
     var Y, app, csStub, jemStub, testUtils;
 


### PR DESCRIPTION
When logging out of the GUI it should clear all the local cookies and redirect the user to log out of the charmstore if they are logged in.