### PR TITLE
Fix model switching and remove duplicate code

### DIFF
--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -740,13 +740,13 @@ YUI.add('juju-gui', function(Y) {
           jem={this.jem}
           listEnvs={this.env.listEnvs.bind(this.env)}
           changeState={this.changeState.bind(this)}
-          switchEnv={this.switchEnv.bind(this)}
           dbEnvironmentSet={this.db.environment.set.bind(this.db.environment)}
-          createSocketURL={this.createSocketURL.bind(this)}
           showConnectingMask={this.showConnectingMask.bind(this)}
           getDiagramURL={charmstore.getDiagramURL.bind(charmstore)}
           interactiveLogin={this.get('interactiveLogin')}
           storeUser={this.storeUser.bind(this)}
+          switchModel={views.utils.switchModel.bind(
+            this, this.createSocketURL.bind(this), this.switchEnv.bind(this))}
           username={username}
           charmstore={this.get('charmstore')} />,
         document.getElementById('charmbrowser-container'));
@@ -1079,7 +1079,6 @@ YUI.add('juju-gui', function(Y) {
       var state = this.state;
       ReactDOM.render(
         <components.HeaderBreadcrumb
-          app={this}
           env={this.env}
           envName={envName}
           dbEnvironmentSet={this.db.environment.set.bind(this.db.environment)}
@@ -1089,7 +1088,10 @@ YUI.add('juju-gui', function(Y) {
           getAppState={state.getState.bind(state)}
           showConnectingMask={this.showConnectingMask.bind(this)}
           authDetails={auth}
-          showEnvSwitcher={showEnvSwitcher}/>,
+          showEnvSwitcher={showEnvSwitcher}
+          switchModel={views.utils.switchModel.bind(
+            this, this.createSocketURL.bind(this),
+            this.switchEnv.bind(this))} />,
         document.getElementById('header-breadcrumb'));
     },
 
@@ -1780,15 +1782,7 @@ YUI.add('juju-gui', function(Y) {
     switchEnv: function(socketUrl, username, password) {
       console.log('switching to new socket URL:', socketUrl);
       if (this.get('sandbox')) {
-        console.log('switching environments is not supported in sandbox');
-        // In the sandbox we need to close the profile page to simulate loading
-        // a model.
-        this.changeState({
-          sectionC: {
-            component: null,
-            metadata: null
-          }
-        });
+        console.log('switching models is not supported in sandbox');
       }
       if (username && password) {
         // We don't always get a new username and password when switching

--- a/jujugui/static/gui/src/app/components/env-switcher/env-switcher.js
+++ b/jujugui/static/gui/src/app/components/env-switcher/env-switcher.js
@@ -25,9 +25,9 @@ YUI.add('env-switcher', function() {
       jem: React.PropTypes.object,
       env: React.PropTypes.object,
       environmentName: React.PropTypes.string,
-      app: React.PropTypes.object,
       showConnectingMask: React.PropTypes.func.isRequired,
-      dbEnvironmentSet: React.PropTypes.func.isRequired
+      dbEnvironmentSet: React.PropTypes.func.isRequired,
+      switchModel: React.PropTypes.func.isRequired
     },
 
     getInitialState: function() {
@@ -122,8 +122,8 @@ YUI.add('env-switcher', function() {
     },
 
     /**
-      Hides the env list and calls the switchEnv method based on the data-id of
-      the currentTarget passed to this click handler.
+      Hides the env list and calls the switchModel method based on the data-id
+      of the currentTarget passed to this click handler.
 
       @method handleEnvClick
       @param {Object} e The click event.
@@ -134,7 +134,8 @@ YUI.add('env-switcher', function() {
       props.showConnectingMask();
       this.setState({showEnvList: false});
       props.dbEnvironmentSet('name', currentTarget.getAttribute('data-name'));
-      this.switchEnv(currentTarget.getAttribute('data-id'));
+      props.switchModel(
+        currentTarget.getAttribute('data-id'), this.state.envList);
     },
 
     /**
@@ -199,35 +200,8 @@ YUI.add('env-switcher', function() {
         return;
       }
       this.props.dbEnvironmentSet('name', data.name || data.path);
-      this.updateEnvList(this.switchEnv.bind(this, data.uuid));
-    },
-
-    /**
-      Take the supplied UUID, fetch the username and password then call the
-      passed in switchEnv method.
-
-      @method switchEnv
-      @param {String} uuid The env UUID.
-    */
-    switchEnv: function(uuid) {
-      var username, password, address, port;
-      var found = this.state.envList.some((env) => {
-        if (env.uuid === uuid) {
-          username = env.user;
-          password = env.password;
-          if (env['host-ports']) {
-            var hostport = env['host-ports'][0].split(':');
-            address = hostport[0];
-            port = hostport[1];
-          }
-          return true;
-        }
-      });
-      if (!found) {
-        console.log('No user credentials for env: ', uuid);
-      }
-      var socketUrl = this.props.app.createSocketURL(address, port, uuid);
-      this.props.app.switchEnv(socketUrl, username, password);
+      this.updateEnvList(this.props.switchModel.bind(
+        this, data.uuid, this.state.envList));
     },
 
     /**

--- a/jujugui/static/gui/src/app/components/env-switcher/test-env-switcher.js
+++ b/jujugui/static/gui/src/app/components/env-switcher/test-env-switcher.js
@@ -37,7 +37,8 @@ describe('EnvSwitcher', function() {
       <juju.components.EnvSwitcher.prototype.wrappedComponent
         showConnectingMask={sinon.stub()}
         dbEnvironmentSet={sinon.stub()}
-        environmentName="MyEnv" />, true);
+        environmentName="MyEnv"
+        switchModel={sinon.stub()} />, true);
 
     var instance = renderer.getMountedInstance();
     var output = renderer.getRenderOutput();
@@ -75,7 +76,8 @@ describe('EnvSwitcher', function() {
       <juju.components.EnvSwitcher.prototype.wrappedComponent
         showConnectingMask={sinon.stub()}
         dbEnvironmentSet={sinon.stub()}
-        env={env} />, true);
+        env={env}
+        switchModel={sinon.stub()} />, true);
     var output = renderer.getRenderOutput();
     // Click the toggler
     output.props.children[0].props.onClick({
@@ -86,7 +88,8 @@ describe('EnvSwitcher', function() {
       <juju.components.EnvSwitcher.prototype.wrappedComponent
         showConnectingMask={sinon.stub()}
         dbEnvironmentSet={sinon.stub()}
-        env={env} />);
+        env={env}
+        switchModel={sinon.stub()} />);
 
     var instance = renderer.getMountedInstance();
     output = renderer.getRenderOutput();
@@ -108,7 +111,8 @@ describe('EnvSwitcher', function() {
       <juju.components.EnvSwitcher.prototype.wrappedComponent
         showConnectingMask={sinon.stub()}
         dbEnvironmentSet={sinon.stub()}
-        jem={jem} />, true);
+        jem={jem}
+        switchModel={sinon.stub()} />, true);
     var instance = renderer.getMountedInstance();
     instance.componentDidMount();
     assert.equal(listEnvs.callCount, 1);
@@ -128,7 +132,8 @@ describe('EnvSwitcher', function() {
       <juju.components.EnvSwitcher.prototype.wrappedComponent
         showConnectingMask={sinon.stub()}
         dbEnvironmentSet={sinon.stub()}
-        env={env} />, true);
+        env={env}
+        switchModel={sinon.stub()} />, true);
     var instance = renderer.getMountedInstance();
     instance.componentDidMount();
     assert.equal(listEnvs.callCount, 1);
@@ -147,7 +152,8 @@ describe('EnvSwitcher', function() {
       <juju.components.EnvSwitcher.prototype.wrappedComponent
         showConnectingMask={sinon.stub()}
         dbEnvironmentSet={sinon.stub()}
-        env={env} />, true);
+        env={env}
+        switchModel={sinon.stub()} />, true);
     var output = renderer.getRenderOutput();
     var instance = renderer.getMountedInstance();
     // Click the toggler
@@ -172,24 +178,18 @@ describe('EnvSwitcher', function() {
       user: 'The Dr.',
       password: 'buffalo'
     }];
-    var socketURL = '/a/socket/url/abc123';
-    var createSocketURL = sinon.stub().returns(socketURL);
     var listEnvs = sinon.stub();
-    var switchEnv = sinon.stub();
+    var switchModel = sinon.stub();
     var mask = sinon.stub();
     var jem = {
       listEnvironments: listEnvs
-    };
-    var app = {
-      createSocketURL: createSocketURL,
-      switchEnv: switchEnv
     };
     var renderer = jsTestUtils.shallowRender(
       <juju.components.EnvSwitcher.prototype.wrappedComponent
         dbEnvironmentSet={sinon.stub()}
         showConnectingMask={mask}
         jem={jem}
-        app={app} />, true);
+        switchModel={switchModel} />, true);
     var instance = renderer.getMountedInstance();
     instance.componentDidMount();
     listEnvs.args[0][0](null, envs);
@@ -199,14 +199,12 @@ describe('EnvSwitcher', function() {
       }
     });
     assert.equal(mask.callCount, 1);
-    assert.equal(switchEnv.callCount, 1);
+    assert.equal(switchModel.callCount, 1);
     assert.deepEqual(instance.state, {
       showEnvList: false,
       envList: envs
     });
-    assert.deepEqual(switchEnv.args[0], [
-      socketURL, envs[0].user, envs[0].password
-    ]);
+    assert.deepEqual(switchModel.args[0], ['abc123', envs]);
   });
 
   // To fully test the new env creation it has to be tested accepting a custom
@@ -232,20 +230,14 @@ describe('EnvSwitcher', function() {
       listServers: listSrv,
       newEnvironment: newEnv
     };
-    var socketURL = '/a/socket/url/abc123';
-    var createSocketURL = sinon.stub().returns(socketURL);
-    var switchEnv = sinon.stub();
-    var app = {
-      createSocketURL: createSocketURL,
-      switchEnv: switchEnv
-    };
+    var switchModel = sinon.stub();
     var dbset = sinon.stub();
     var renderer = jsTestUtils.shallowRender(
       <juju.components.EnvSwitcher.prototype.wrappedComponent
         showConnectingMask={sinon.stub()}
         dbEnvironmentSet={dbset}
         jem={jem}
-        app={app} />, true);
+        switchModel={switchModel} />, true);
     var instance = renderer.getMountedInstance();
     instance.componentDidMount();
     listEnvs.args[0][0](null, envs);
@@ -272,7 +264,7 @@ describe('EnvSwitcher', function() {
     // Then switch to the new one.
     envs.push(createdEnv);
     listEnvs.args[1][0](null, envs);
-    assert.equal(switchEnv.callCount, 1);
+    assert.equal(switchModel.callCount, 1);
     // After creating a new env it should call to update the environment name
     // in the db.
     assert.equal(dbset.callCount, 1);
@@ -306,7 +298,8 @@ describe('EnvSwitcher', function() {
       <juju.components.EnvSwitcher.prototype.wrappedComponent
         showConnectingMask={sinon.stub()}
         dbEnvironmentSet={sinon.stub()}
-        env={env} />, true);
+        env={env}
+        switchModel={sinon.stub()} />, true);
     var instance = renderer.getMountedInstance();
     instance.componentDidMount();
     listEnvs.args[0][1](envs);
@@ -328,7 +321,8 @@ describe('EnvSwitcher', function() {
       <juju.components.EnvSwitcher.prototype.wrappedComponent
         showConnectingMask={sinon.stub()}
         dbEnvironmentSet={sinon.stub()}
-        changeState={changeState} />, true);
+        changeState={changeState}
+        switchModel={sinon.stub()} />, true);
     var instance = renderer.getMountedInstance();
     instance.showUserProfile();
     assert.equal(changeState.callCount, 1);

--- a/jujugui/static/gui/src/app/components/header-breadcrumb/header-breadcrumb.js
+++ b/jujugui/static/gui/src/app/components/header-breadcrumb/header-breadcrumb.js
@@ -22,7 +22,6 @@ YUI.add('header-breadcrumb', function() {
 
   juju.components.HeaderBreadcrumb = React.createClass({
     propTypes: {
-      app: React.PropTypes.object.isRequired,
       env: React.PropTypes.object,
       envName: React.PropTypes.string.isRequired,
       dbEnvironmentSet: React.PropTypes.func.isRequired,
@@ -33,6 +32,7 @@ YUI.add('header-breadcrumb', function() {
       showConnectingMask: React.PropTypes.func.isRequired,
       authDetails: React.PropTypes.object,
       showEnvSwitcher: React.PropTypes.bool.isRequired,
+      switchModel: React.PropTypes.func.isRequired,
       userName: React.PropTypes.string
     },
 
@@ -49,7 +49,6 @@ YUI.add('header-breadcrumb', function() {
         return (
           <li className="header-breadcrumb__list-item">
             <window.juju.components.EnvSwitcher
-              app={this.props.app}
               env={this.props.env}
               environmentName={this.props.envName}
               dbEnvironmentSet={this.props.dbEnvironmentSet}
@@ -57,6 +56,7 @@ YUI.add('header-breadcrumb', function() {
               envList={this.props.envList}
               changeState={this.props.changeState}
               showConnectingMask={this.props.showConnectingMask}
+              switchModel={this.props.switchModel}
               authDetails={this.props.authDetails} />
           </li>);
       }

--- a/jujugui/static/gui/src/app/components/header-breadcrumb/test-header-breadcrumb.js
+++ b/jujugui/static/gui/src/app/components/header-breadcrumb/test-header-breadcrumb.js
@@ -31,7 +31,7 @@ describe('HeaderBreadcrumb', () => {
   });
 
   it('Renders properly', () => {
-    var app = {app:'app'};
+    var switchModel = sinon.stub();
     var env = {env: 'env'};
     var envName = 'bar';
     var dbEnvironmentSet = sinon.stub();
@@ -43,7 +43,6 @@ describe('HeaderBreadcrumb', () => {
     var authDetails = {user: 'foo'};
     var output = jsTestUtils.shallowRender(
       <juju.components.HeaderBreadcrumb
-        app={app}
         env={env}
         envName={envName}
         dbEnvironmentSet={dbEnvironmentSet}
@@ -53,7 +52,8 @@ describe('HeaderBreadcrumb', () => {
         getAppState={getAppState}
         showConnectingMask={showConnectingMask}
         authDetails={authDetails}
-        showEnvSwitcher={true} />);
+        showEnvSwitcher={true}
+        switchModel={switchModel} />);
 
     var expected = (
       <ul className="header-breadcrumb">
@@ -64,7 +64,6 @@ describe('HeaderBreadcrumb', () => {
         </li>
         <li className="header-breadcrumb__list-item">
           <window.juju.components.EnvSwitcher
-            app={app}
             env={env}
             environmentName={envName}
             dbEnvironmentSet={dbEnvironmentSet}
@@ -72,7 +71,8 @@ describe('HeaderBreadcrumb', () => {
             envList={envList}
             changeState={changeState}
             showConnectingMask={showConnectingMask}
-            authDetails={authDetails} />
+            authDetails={authDetails}
+            switchModel={switchModel} />
         </li>
       </ul>
     );
@@ -100,7 +100,8 @@ describe('HeaderBreadcrumb', () => {
         changeState={changeState}
         getAppState={getAppState}
         showConnectingMask={showConnectingMask}
-        showEnvSwitcher={true} />);
+        showEnvSwitcher={true}
+        switchModel={sinon.stub()} />);
     assert.equal(
       output.props.children[0].props.children.props.children, 'anonymous');
   });
@@ -126,7 +127,8 @@ describe('HeaderBreadcrumb', () => {
         changeState={changeState}
         getAppState={getAppState}
         showConnectingMask={showConnectingMask}
-        showEnvSwitcher={false} />);
+        showEnvSwitcher={false}
+        switchModel={sinon.stub()} />);
     // There will be no third child if the envSwitcher is rendered
     assert.equal(output.props.children[1], undefined);
   });
@@ -154,7 +156,8 @@ describe('HeaderBreadcrumb', () => {
         showConnectingMask={showConnectingMask}
         // Even though showEnvSwitcher is true, because the profile is visibile
         // it shouldn't render the env switcher.
-        showEnvSwitcher={true} />);
+        showEnvSwitcher={true}
+        switchModel={sinon.stub()} />);
     // There will be no third child if the envSwitcher is rendered
     assert.equal(output.props.children[1], undefined);
   });

--- a/jujugui/static/gui/src/app/components/user-profile/entity/entity.js
+++ b/jujugui/static/gui/src/app/components/user-profile/entity/entity.js
@@ -27,7 +27,7 @@ YUI.add('user-profile-entity', function() {
       entity: React.PropTypes.object.isRequired,
       expanded: React.PropTypes.bool,
       getDiagramURL: React.PropTypes.func,
-      switchEnv: React.PropTypes.func,
+      switchModel: React.PropTypes.func,
       type: React.PropTypes.string.isRequired
     },
 
@@ -84,7 +84,7 @@ YUI.add('user-profile-entity', function() {
       @param {Object} e The click event.
     */
     _switchEnv: function(uuid, name, e) {
-      this.props.switchEnv(uuid, name);
+      this.props.switchModel(uuid, name);
     },
 
     /**

--- a/jujugui/static/gui/src/app/components/user-profile/entity/test-entity.js
+++ b/jujugui/static/gui/src/app/components/user-profile/entity/test-entity.js
@@ -41,7 +41,7 @@ describe('UserProfileEntity', () => {
     var renderer = jsTestUtils.shallowRender(
       <juju.components.UserProfileEntity
         entity={model}
-        switchEnv={sinon.stub()}
+        switchModel={sinon.stub()}
         type="model">
         <span>Summary details</span>
       </juju.components.UserProfileEntity>, true);
@@ -262,20 +262,20 @@ describe('UserProfileEntity', () => {
   });
 
   it('can switch envs for a model', () => {
-    var switchEnv = sinon.stub();
+    var switchModel = sinon.stub();
     var renderer = jsTestUtils.shallowRender(
       <juju.components.UserProfileEntity
         entity={model}
-        switchEnv={switchEnv}
+        switchModel={switchModel}
         type="model">
         <span>Summary details</span>
       </juju.components.UserProfileEntity>, true);
     var output = renderer.getRenderOutput();
     output.props.children[1].props.children.props.children[0].props.children[1]
       .props.children.props.action();
-    assert.equal(switchEnv.callCount, 1);
-    assert.equal(switchEnv.args[0][0], 'env1');
-    assert.equal(switchEnv.args[0][1], 'sandbox');
+    assert.equal(switchModel.callCount, 1);
+    assert.equal(switchModel.args[0][0], 'env1');
+    assert.equal(switchModel.args[0][1], 'sandbox');
   });
 
   it('can navigate to view a charm or bundle', () => {
@@ -337,7 +337,7 @@ describe('UserProfileEntity', () => {
     var renderer = jsTestUtils.shallowRender(
       <juju.components.UserProfileEntity
         entity={model}
-        switchEnv={sinon.stub()}
+        switchModel={sinon.stub()}
         type="model" />, true);
     var instance = renderer.getMountedInstance();
     var output = renderer.getRenderOutput();

--- a/jujugui/static/gui/src/app/components/user-profile/test-user-profile.js
+++ b/jujugui/static/gui/src/app/components/user-profile/test-user-profile.js
@@ -61,11 +61,10 @@ describe('UserProfile', () => {
       <juju.components.UserProfile
         authenticated={true}
         charmstore={{}}
-        createSocketURL={sinon.stub()}
         dbEnvironmentSet={sinon.stub()}
         getDiagramURL={sinon.stub()}
         jem={jem}
-        switchEnv={sinon.stub()}
+        switchModel={sinon.stub()}
         showConnectingMask={sinon.stub()}
         interactiveLogin={true}
         changeState={sinon.stub()}
@@ -115,11 +114,10 @@ describe('UserProfile', () => {
       <juju.components.UserProfile
         authenticated={true}
         charmstore={charmstore}
-        createSocketURL={sinon.stub()}
         dbEnvironmentSet={sinon.stub()}
         getDiagramURL={sinon.stub()}
         jem={jem}
-        switchEnv={sinon.stub()}
+        switchModel={sinon.stub()}
         showConnectingMask={sinon.stub()}
         interactiveLogin={true}
         changeState={sinon.stub()}
@@ -150,11 +148,10 @@ describe('UserProfile', () => {
       <juju.components.UserProfile
         authenticated={true}
         charmstore={charmstore}
-        createSocketURL={sinon.stub()}
         dbEnvironmentSet={sinon.stub()}
         getDiagramURL={sinon.stub()}
         jem={jem}
-        switchEnv={sinon.stub()}
+        switchModel={sinon.stub()}
         showConnectingMask={sinon.stub()}
         interactiveLogin={true}
         changeState={sinon.stub()}
@@ -176,16 +173,15 @@ describe('UserProfile', () => {
     };
     var changeState = sinon.stub();
     var getDiagramURL = sinon.stub();
-    var switchEnv = sinon.stub();
+    var switchModel = sinon.stub();
     var component = jsTestUtils.shallowRender(
       <juju.components.UserProfile
         authenticated={true}
         charmstore={charmstore}
-        createSocketURL={sinon.stub()}
         dbEnvironmentSet={sinon.stub()}
         getDiagramURL={getDiagramURL}
         jem={jem}
-        switchEnv={switchEnv}
+        switchModel={switchModel}
         showConnectingMask={sinon.stub()}
         interactiveLogin={true}
         changeState={changeState}
@@ -234,7 +230,7 @@ describe('UserProfile', () => {
                 entity={models[0]}
                 expanded={false}
                 key="env1"
-                switchEnv={switchEnv}
+                switchModel={instance.switchEnv}
                 type="model">
                 <span className="user-profile__list-col three-col">
                   sandbox
@@ -379,11 +375,10 @@ describe('UserProfile', () => {
       <juju.components.UserProfile
         authenticated={true}
         charmstore={{}}
-        switchEnv={sinon.stub()}
+        switchModel={sinon.stub()}
         listEnvs={sinon.stub()}
         showConnectingMask={sinon.stub()}
         changeState={sinon.stub()}
-        createSocketURL={sinon.stub()}
         dbEnvironmentSet={sinon.stub()}
         getDiagramURL={sinon.stub()}
         interactiveLogin={false}
@@ -414,11 +409,10 @@ describe('UserProfile', () => {
     var renderer = jsTestUtils.shallowRender(
       <juju.components.UserProfile
         authenticated={true}
-        switchEnv={sinon.stub()}
+        switchModel={sinon.stub()}
         listEnvs={sinon.stub()}
         showConnectingMask={sinon.stub()}
         changeState={sinon.stub()}
-        createSocketURL={sinon.stub()}
         charmstore={charmstore}
         dbEnvironmentSet={sinon.stub()}
         getDiagramURL={sinon.stub()}
@@ -437,11 +431,10 @@ describe('UserProfile', () => {
     jsTestUtils.shallowRender(
       <juju.components.UserProfile
         authenticated={false}
-        switchEnv={sinon.stub()}
+        switchModel={sinon.stub()}
         listEnvs={sinon.stub()}
         showConnectingMask={sinon.stub()}
         changeState={sinon.stub()}
-        createSocketURL={sinon.stub()}
         charmstore={charmstore}
         dbEnvironmentSet={sinon.stub()}
         getDiagramURL={sinon.stub()}
@@ -452,11 +445,10 @@ describe('UserProfile', () => {
     jsTestUtils.shallowRender(
       <juju.components.UserProfile
         authenticated={true}
-        switchEnv={sinon.stub()}
+        switchModel={sinon.stub()}
         listEnvs={sinon.stub()}
         showConnectingMask={sinon.stub()}
         changeState={sinon.stub()}
-        createSocketURL={sinon.stub()}
         charmstore={charmstore}
         dbEnvironmentSet={sinon.stub()}
         getDiagramURL={sinon.stub()}
@@ -473,10 +465,9 @@ describe('UserProfile', () => {
     var component = jsTestUtils.shallowRender(
       <juju.components.UserProfile
         authenticated={true}
-        switchEnv={sinon.stub()}
+        switchModel={sinon.stub()}
         changeState={sinon.stub()}
         charmstore={{}}
-        createSocketURL={sinon.stub()}
         dbEnvironmentSet={sinon.stub()}
         getDiagramURL={sinon.stub()}
         showConnectingMask={sinon.stub()}
@@ -494,10 +485,9 @@ describe('UserProfile', () => {
     var component = jsTestUtils.shallowRender(
       <juju.components.UserProfile
         authenticated={true}
-        switchEnv={sinon.stub()}
+        switchModel={sinon.stub()}
         changeState={sinon.stub()}
         charmstore={{}}
-        createSocketURL={sinon.stub()}
         dbEnvironmentSet={sinon.stub()}
         getDiagramURL={sinon.stub()}
         showConnectingMask={sinon.stub()}
@@ -510,14 +500,13 @@ describe('UserProfile', () => {
     assert.deepEqual(instance.state.envList, models);
   });
 
-  it('switches env when calling switchEnv method passed to list', () => {
+  it('switches env when calling switchModel method passed to list', () => {
     // This method is passed down to child components and called from there.
     // We are just calling it directly here to unit test the method.
-    var switchEnv = sinon.stub();
+    var switchModel = sinon.stub();
     var changeState = sinon.stub();
     var listEnvs = sinon.stub();
     var showMask = sinon.stub();
-    var createSocketURL = sinon.stub().returns('gensocketurl');
     var dbset = sinon.stub();
     var envs = [{
       uuid: 'abc123',
@@ -527,8 +516,7 @@ describe('UserProfile', () => {
     var component = jsTestUtils.shallowRender(
       <juju.components.UserProfile
         authenticated={true}
-        switchEnv={switchEnv}
-        createSocketURL={createSocketURL}
+        switchModel={switchModel}
         changeState={changeState}
         charmstore={{}}
         getDiagramURL={sinon.stub()}
@@ -546,10 +534,10 @@ describe('UserProfile', () => {
     // Make sure we show the canvas loading mask when switching models.
     assert.equal(showMask.callCount, 1);
     // We need to call to generate the proper socket URL.
-    assert.equal(createSocketURL.callCount, 1);
-    // Check that switchEnv is called with the proper values.
-    assert.equal(switchEnv.callCount, 1, 'switchEnv not called');
-    assert.deepEqual(switchEnv.args[0], ['gensocketurl', 'foo', 'bar']);
+    // Check that switchModel is called with the proper values.
+    assert.equal(switchModel.callCount, 1, 'switchEnv not called');
+    assert.deepEqual(switchModel.args[0], ['abc123', [{
+      uuid: 'abc123', user: 'foo', password: 'bar'}]]);
     // The database needs to be updated with the new model name.
     assert.equal(dbset.callCount, 1);
     assert.deepEqual(dbset.args[0], ['name', 'modelname']);
@@ -571,14 +559,13 @@ describe('UserProfile', () => {
         authenticated={true}
         changeState={sinon.stub()}
         charmstore={charmstore}
-        createSocketURL={sinon.stub()}
         dbEnvironmentSet={sinon.stub()}
         getDiagramURL={sinon.stub()}
         interactiveLogin={true}
         listEnvs={sinon.stub()}
         showConnectingMask={sinon.stub()}
         storeUser={sinon.stub()}
-        switchEnv={sinon.stub()}
+        switchModel={sinon.stub()}
         username={username} />, true);
     var instance = component.getMountedInstance();
     assert.equal(charmstore.list.callCount, 2,

--- a/jujugui/static/gui/src/app/components/user-profile/user-profile.js
+++ b/jujugui/static/gui/src/app/components/user-profile/user-profile.js
@@ -26,7 +26,6 @@ YUI.add('user-profile', function() {
       authenticated: React.PropTypes.bool.isRequired,
       changeState: React.PropTypes.func.isRequired,
       charmstore: React.PropTypes.object.isRequired,
-      createSocketURL: React.PropTypes.func.isRequired,
       currentModel: React.PropTypes.string,
       dbEnvironmentSet: React.PropTypes.func.isRequired,
       getDiagramURL: React.PropTypes.func.isRequired,
@@ -35,7 +34,7 @@ YUI.add('user-profile', function() {
       listEnvs: React.PropTypes.func,
       showConnectingMask: React.PropTypes.func.isRequired,
       storeUser: React.PropTypes.func.isRequired,
-      switchEnv: React.PropTypes.func.isRequired,
+      switchModel: React.PropTypes.func.isRequired,
       username: React.PropTypes.string
     },
 
@@ -166,35 +165,16 @@ YUI.add('user-profile', function() {
 
     /**
       Take the supplied UUID, fetch the username and password then call the
-      passed in switchEnv method.
+      passed in switchModel method.
 
       @method switchEnv
       @param {String} uuid The env UUID.
       @param {String} name The env name.
     */
     switchEnv: function(uuid, name) {
-      var username = '';
-      var password = '';
-      var address, port;
       var props = this.props;
       props.showConnectingMask();
-      var found = this.state.envList.some((env) => {
-        if (env.uuid === uuid) {
-          username = env.user;
-          password = env.password;
-          if (env['host-ports']) {
-            var hostport = env['host-ports'][0].split(':');
-            address = hostport[0];
-            port = hostport[1];
-          }
-          return true;
-        }
-      });
-      if (!found) {
-        console.log('No user credentials for env: ', uuid);
-      }
-      var socketUrl = props.createSocketURL(address, port, uuid);
-      props.switchEnv(socketUrl, username, password);
+      props.switchModel(uuid, this.state.envList);
       props.dbEnvironmentSet('name', name);
       this.close();
     },
@@ -247,7 +227,7 @@ YUI.add('user-profile', function() {
           entity={model}
           expanded={model.name === this.props.currentModel}
           key={uuid}
-          switchEnv={this.props.switchEnv}
+          switchModel={this.switchEnv}
           type="model">
           <span className="user-profile__list-col three-col">
             {model.name}

--- a/jujugui/static/gui/src/app/store/env/sandbox.js
+++ b/jujugui/static/gui/src/app/store/env/sandbox.js
@@ -367,6 +367,18 @@ YUI.add('juju-env-sandbox', function(Y) {
     },
 
     /**
+      Handle CreateModel messages.
+
+      @method handleModelManagerCreateModel
+      @param {Object} data The contents of the API arguments.
+      @param {Object} client The active ClientConnection.
+      @param {Object} state An instance of FakeBackend.
+    */
+    handleModelManagerCreateModel: function(data, client, state) {
+      console.log('Creating models is not supported in the sandbox.');
+    },
+
+    /**
     Handle ListModels.
 
     @method handleModelManagerListModels

--- a/jujugui/static/gui/src/app/views/utils.js
+++ b/jujugui/static/gui/src/app/views/utils.js
@@ -1899,6 +1899,36 @@ YUI.add('juju-view-utils', function(Y) {
     return 0;
   };
 
+  /**
+    Switch models using the correct username and password.
+
+    @method switchModel
+    @param {Function} createSocketURL The function to create a socket URL.
+    @param {Function} switchEnv The function to switch models.
+    @param {String} uuid A model UUID.
+    @param {Array} modelList A list of models.
+  */
+  utils.switchModel = function(createSocketURL, switchEnv, uuid, modelList) {
+    var username, password, address, port;
+    var found = modelList.some((model) => {
+      if (model.uuid === uuid) {
+        username = model.user;
+        password = model.password;
+        if (model['host-ports']) {
+          var hostport = model['host-ports'][0].split(':');
+          address = hostport[0];
+          port = hostport[1];
+        }
+        return true;
+      }
+    });
+    if (!found) {
+      console.log('No user credentials for model: ', uuid);
+    }
+    var socketUrl = createSocketURL(address, port, uuid);
+    switchEnv(socketUrl, username, password);
+  };
+
 }, '0.1.0', {
   requires: [
     'base-build',

--- a/jujugui/static/gui/src/test/test_utils.js
+++ b/jujugui/static/gui/src/test/test_utils.js
@@ -1324,4 +1324,42 @@ describe('utilities', function() {
     });
   });
 
+  describe('switchModel', function() {
+    var utils, testUtils;
+
+    before(function(done) {
+      YUI(GlobalConfig).use('juju-view-utils', 'juju-tests-utils', function(Y) {
+        utils = Y.namespace('juju.views.utils');
+        testUtils = Y.namespace('juju-tests.utils');
+        done();
+      });
+    });
+
+    it('can switch models', function() {
+      var createSocketURL = testUtils.makeStubFunction('newaddress:80');
+      var switchEnv = testUtils.makeStubFunction();
+      var models = [{
+        uuid: 'uuid1',
+        user: 'spinach',
+        password: 'hasselhoff',
+        'host-ports': [
+          'localhost:80',
+          'localhost:443'
+        ]
+      }];
+      utils.switchModel(createSocketURL, switchEnv, 'uuid1', models);
+      assert.deepEqual(createSocketURL.callCount(), 1);
+      var socketArgs = createSocketURL.allArguments();
+      assert.deepEqual(socketArgs[0][0], 'localhost');
+      assert.deepEqual(socketArgs[0][1], '80');
+      assert.deepEqual(socketArgs[0][2], models[0].uuid);
+      assert.deepEqual(switchEnv.callCount(), 1);
+      var switchEnvArgs = switchEnv.allArguments();
+      assert.deepEqual(switchEnvArgs[0][0], 'newaddress:80');
+      assert.deepEqual(switchEnvArgs[0][1], models[0].user);
+      assert.deepEqual(switchEnvArgs[0][2], models[0].password);
+    });
+
+  });
+
 })();


### PR DESCRIPTION
Switching models from the user profile was not working as it was calling the wrong env switching code. As part of fixing this I also removed the duplicate switching methods. Fixes #1421.