### PR TITLE
Do not include subordinates in the filterByMachine call

### DIFF
--- a/jujugui/static/gui/src/app/models/models.js
+++ b/jujugui/static/gui/src/app/models/models.js
@@ -1176,7 +1176,7 @@ YUI.add('juju-models', function(Y) {
       } else {
         // Return the unplaced units.
         predicate = function(unit) {
-          return !unit.machine;
+          return !unit.machine && !unit.subordinate;
         };
       }
       machine = machine || null;

--- a/jujugui/static/gui/src/test/test_model.js
+++ b/jujugui/static/gui/src/test/test_model.js
@@ -1049,7 +1049,8 @@ describe('test_model.js', function() {
           {id: 'rails/2', machine: '1/lxc/1'},
           {id: 'postgres/2'},
           {id: 'mysql/47', machine: '1/kvm/0/lxc/1'},
-          {id: 'mysql/12', machine: '15/lxc/6'}
+          {id: 'mysql/12', machine: '15/lxc/6'},
+          {id: 'ghost/1', machine: '', subordinate: true}
         ]);
       });
 


### PR DESCRIPTION
Filter out the subordinate units when trying to grab the unit list which don't have any machines because subordinates have a machine defined as "" instead of `undefined` or `null`.
 
Fixes: #1432 Fixes: #1428 