### PR TITLE
Clean the charm/bundle ids for the profile links

### DIFF
--- a/jujugui/static/gui/src/app/components/user-profile/entity/entity.js
+++ b/jujugui/static/gui/src/app/components/user-profile/entity/entity.js
@@ -100,7 +100,7 @@ YUI.add('user-profile-entity', function() {
           component: 'charmbrowser',
           metadata: {
             activeComponent: 'entity-details',
-            id: id
+            id: id.replace('cs:', '')
           }
         }
       });

--- a/jujugui/static/gui/src/app/components/user-profile/entity/test-entity.js
+++ b/jujugui/static/gui/src/app/components/user-profile/entity/test-entity.js
@@ -280,6 +280,7 @@ describe('UserProfileEntity', () => {
 
   it('can navigate to view a charm or bundle', () => {
     var bundle = jsTestUtils.makeEntity(true).toEntity();
+    bundle.id = 'cs:django-cluster';
     var getDiagramURL = sinon.stub().returns('bundle.svg');
     var changeState = sinon.stub();
     var renderer = jsTestUtils.shallowRender(


### PR DESCRIPTION
Remove the "cs:" from the charm/bundle ids. Fixes #1444.