### PR TITLE
Skip connecting to a model on load

### DIFF
--- a/development.ini
+++ b/development.ini
@@ -15,7 +15,7 @@ jujugui.combine = true
 jujugui.gzip = true
 jujugui.cachebuster = dev
 jujugui.socketTemplate = /environment/$uuid/api
-
+jujugui.gisf = false
 
 # API config
 

--- a/jujugui/options.py
+++ b/jujugui/options.py
@@ -36,6 +36,7 @@ def update(settings):
     _update_bool(settings, 'jujugui.combine', default=True)
     _update_bool(settings, 'jujugui.gzip', default=True)
     _update_bool(settings, 'jujugui.insecure', default=False)
+    _update_bool(settings, 'jujugui.gisf', default=False)
 
 
 def _update(settings, name, default=None, convert=lambda value: value):

--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -892,6 +892,8 @@ YUI.add('juju-gui', function(Y) {
           getUnplacedUnitCount={
             utils.getUnplacedUnitCount.bind(this, db.units)}
           jem={this.jem}
+          env={this.env}
+          appSet={this.set.bind(this)}
           createSocketURL={this.createSocketURL.bind(this)}
           modelCommitted={modelCommitted}
           numberOfChanges={Object.keys(ecs.getCurrentChangeSet()).length}

--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -892,6 +892,7 @@ YUI.add('juju-gui', function(Y) {
           getUnplacedUnitCount={
             utils.getUnplacedUnitCount.bind(this, db.units)}
           jem={this.jem}
+          createSocketURL={this.createSocketURL.bind(this)}
           modelCommitted={modelCommitted}
           numberOfChanges={Object.keys(ecs.getCurrentChangeSet()).length}
           users={Y.clone(this.get('users'), true)} />,

--- a/jujugui/static/gui/src/app/components/deployment/add-credentials/add-credentials.js
+++ b/jujugui/static/gui/src/app/components/deployment/add-credentials/add-credentials.js
@@ -43,12 +43,15 @@ YUI.add('deployment-add-credentials', function() {
             // controller with work to come to generate a controller name.  Also
             // this key will change from 'state-server' to 'controller'.
             // Makyo 2016-03-30
-            'state-server': 'yellow/aws-eu-central-1',
+            'state-server': 'yellow/aws-eu-central',
             //'state-server': 'yellow/aws-' + this.refs.templateRegion.value,
             // XXX This applies only to AWS (for first release).
             'config': {
               'access-key': this.refs.templateAccessKey.value,
-              'secret-key': this.refs.templateSecretKey.value
+              'secret-key': this.refs.templateSecretKey.value,
+              // XXX This is a 'hack' to make Juju not complain about being
+              // able to find ssh keys.
+              'authorized-keys': 'fake'
             }
           };
       this.props.jem.addTemplate(

--- a/jujugui/static/gui/src/app/components/deployment/choose-cloud/choose-cloud.js
+++ b/jujugui/static/gui/src/app/components/deployment/choose-cloud/choose-cloud.js
@@ -24,6 +24,7 @@ YUI.add('deployment-choose-cloud', function() {
 
     propTypes: {
       changeState: React.PropTypes.func.isRequired,
+      setDeploymentInfo: React.PropTypes.func.isRequired,
       jem: React.PropTypes.object.isRequired
     },
 
@@ -134,6 +135,7 @@ YUI.add('deployment-choose-cloud', function() {
       @method _handleCredentialClick
     */
     _handleCredentialClick: function(id) {
+      this.props.setDeploymentInfo('templateName', id);
       this.props.changeState({
         sectionC: {
           component: 'deploy',

--- a/jujugui/static/gui/src/app/components/deployment/choose-cloud/test-choose-cloud.js
+++ b/jujugui/static/gui/src/app/components/deployment/choose-cloud/test-choose-cloud.js
@@ -50,6 +50,7 @@ describe('DeploymentChooseCloud', function() {
     var renderer = jsTestUtils.shallowRender(
       <juju.components.DeploymentChooseCloud
         changeState={sinon.stub()}
+        setDeploymentInfo={sinon.stub()}
         jem={jem} />, true);
     var output = renderer.getRenderOutput();
     var expected = (
@@ -111,6 +112,7 @@ describe('DeploymentChooseCloud', function() {
     var renderer = jsTestUtils.shallowRender(
       <juju.components.DeploymentChooseCloud
         changeState={sinon.stub()}
+        setDeploymentInfo={sinon.stub()}
         jem={jem} />, true);
     var output = renderer.getRenderOutput();
     var expected = (
@@ -179,14 +181,21 @@ describe('DeploymentChooseCloud', function() {
 
   it('can navigate from a credential', function() {
     var changeState = sinon.stub();
+    var setDeploymentInfo = sinon.stub();
     var renderer = jsTestUtils.shallowRender(
       <juju.components.DeploymentChooseCloud
         changeState={changeState}
+        setDeploymentInfo={setDeploymentInfo}
         jem={jem} />, true);
     var output = renderer.getRenderOutput();
     output.props.children.props.children[0].props.children[1].props.children[0]
       .props.onClick();
     assert.equal(changeState.callCount, 1);
+    // It should store the template name in the parentId
+    assert.equal(setDeploymentInfo.callCount, 1);
+    assert.deepEqual(
+      setDeploymentInfo.args[0],
+      ['templateName', 'test-owner/test']);
     assert.deepEqual(changeState.args[0][0], {
       sectionC: {
         component: 'deploy',
@@ -202,6 +211,7 @@ describe('DeploymentChooseCloud', function() {
     var renderer = jsTestUtils.shallowRender(
       <juju.components.DeploymentChooseCloud
         changeState={changeState}
+        setDeploymentInfo={sinon.stub()}
         jem={jem} />, true);
     var output = renderer.getRenderOutput();
     output.props.children.props.children[3].props.children[0].props.onClick();
@@ -223,6 +233,7 @@ describe('DeploymentChooseCloud', function() {
     var renderer = jsTestUtils.shallowRender(
       <juju.components.DeploymentChooseCloud
         changeState={sinon.stub()}
+        setDeploymentInfo={sinon.stub()}
         jem={jem} />, true);
     var output = renderer.getRenderOutput();
     var credentials = output.props.children.props.children[0];

--- a/jujugui/static/gui/src/app/components/deployment/deployment.js
+++ b/jujugui/static/gui/src/app/components/deployment/deployment.js
@@ -30,6 +30,8 @@ YUI.add('deployment-component', function() {
       ecsCommit: React.PropTypes.func.isRequired,
       getUnplacedUnitCount: React.PropTypes.func.isRequired,
       jem: React.PropTypes.object.isRequired,
+      env: React.PropTypes.object.isRequired,
+      appSet: React.PropTypes.func.isRequired,
       createSocketURL: React.PropTypes.func.isRequired,
       numberOfChanges: React.PropTypes.number.isRequired,
       users: React.PropTypes.object.isRequired
@@ -61,6 +63,8 @@ YUI.add('deployment-component', function() {
           return (
             <juju.components.DeploymentSummary
               jem={this.props.jem}
+              env={this.props.env}
+              appSet={this.props.appSet}
               createSocketURL={this.props.createSocketURL}
               deploymentStorage={this._deploymentStorage}
               users={this.props.users}

--- a/jujugui/static/gui/src/app/components/deployment/deployment.js
+++ b/jujugui/static/gui/src/app/components/deployment/deployment.js
@@ -30,9 +30,12 @@ YUI.add('deployment-component', function() {
       ecsCommit: React.PropTypes.func.isRequired,
       getUnplacedUnitCount: React.PropTypes.func.isRequired,
       jem: React.PropTypes.object.isRequired,
+      createSocketURL: React.PropTypes.func.isRequired,
       numberOfChanges: React.PropTypes.number.isRequired,
       users: React.PropTypes.object.isRequired
     },
+
+    _deploymentStorage: {},
 
     /**
       Store information from portions of the deployment for use later down the
@@ -43,17 +46,7 @@ YUI.add('deployment-component', function() {
       @param value The data to store.
     */
     setDeploymentInfo: function(key, value) {
-      this.deploymentStorage[key] = value;
-    },
-
-    /**
-      Retrieve stored deployment info.
-
-      @method getDeploymentInfo
-      @param key The key to retrieve.
-    */
-    getDeploymentInfo: function(key) {
-      return this.deploymentStorage[key];
+      this._deploymentStorage[key] = value;
     },
 
     /**
@@ -67,6 +60,10 @@ YUI.add('deployment-component', function() {
         case 'summary':
           return (
             <juju.components.DeploymentSummary
+              jem={this.props.jem}
+              createSocketURL={this.props.createSocketURL}
+              deploymentStorage={this._deploymentStorage}
+              users={this.props.users}
               autoPlaceUnits={this.props.autoPlaceUnits}
               changeDescriptions={this.props.changeDescriptions}
               changeState={this.props.changeState}
@@ -79,19 +76,19 @@ YUI.add('deployment-component', function() {
           return (
             <juju.components.DeploymentChooseCloud
               jem={this.props.jem}
+              setDeploymentInfo={this.setDeploymentInfo.bind(this)}
               changeState={this.props.changeState} />);
         case 'add-credentials':
           return (
             <juju.components.DeploymentAddCredentials
               changeState={this.props.changeState}
-              setDeploymentInfo={this.setDeploymentInfo}
+              setDeploymentInfo={this.setDeploymentInfo.bind(this)}
               jem={this.props.jem}
               users={this.props.users} />);
       }
     },
 
     render: function() {
-      this.deploymentStorage = this.deploymentStorage || {};
       var activeComponent = this.props.activeComponent;
       var activeChild = this._generateActivePanel();
       var steps = [{

--- a/jujugui/static/gui/src/app/components/deployment/summary/summary.js
+++ b/jujugui/static/gui/src/app/components/deployment/summary/summary.js
@@ -23,6 +23,11 @@ YUI.add('deployment-summary', function() {
   juju.components.DeploymentSummary = React.createClass({
 
     propTypes: {
+      jem: React.PropTypes.object.isRequired,
+      env: React.PropTypes.object.isRequired,
+      createSocketURL: React.PropTypes.func.isRequired,
+      deploymentStorage: React.PropTypes.object.isRequired,
+      users: React.PropTypes.object.isRequired,
       autoPlaceUnits: React.PropTypes.func.isRequired,
       changeDescriptions: React.PropTypes.array.isRequired,
       changeState: React.PropTypes.func.isRequired,
@@ -82,10 +87,41 @@ YUI.add('deployment-summary', function() {
     _handleDeploy: function() {
       this.props.autoPlaceUnits();
       // The env is already bound to ecsCommit in app.js.
-      this.props.ecsCommit();
-      this.setState({hasCommits: true}, () => {
-        this._close();
-      });
+      // Generates an alphanumeric string
+      var randomString = () => Math.random().toString(36).slice(2);
+      var password = randomString() + randomString();
+      this.props.jem.newEnvironment(
+        this.props.users.jem.user,
+        // XXX Hardcoding the model name because we don't yet have a field
+        // for it to be inputted.
+        'my-test-model',
+        this.props.deploymentStorage.templateName,
+        // XXX Hardcoding the controller for now but it will be provided on load
+        'yellow/aws-eu-central',
+        password,
+        (error, data) => {
+          if (error) throw error;
+          var pathParts = data['host-ports'][0].split(':');
+          // Set the credentials to the new model.
+          this.props.env.setCredentials({
+            user: 'user-' + data.user,
+            password: data.password
+          });
+          var socketURL = this.props.createSocketURL(
+            pathParts[0], // server
+            pathParts[1], // port
+            data.uuid
+          );
+          appSet('socket_url', socketURL);
+          this.props.env.set('socket_url', socketURL);
+          this.props.env.connect();
+          this.props.env.on('login', (data) => {
+            this.props.ecsCommit();
+            this.setState({hasCommits: true}, () => {
+              this._close();
+            });
+          });
+        });
     },
 
     /**

--- a/jujugui/static/gui/src/app/components/deployment/test-deployment.js
+++ b/jujugui/static/gui/src/app/components/deployment/test-deployment.js
@@ -38,6 +38,9 @@ describe('Deployment', function() {
     var ecsCommit = sinon.stub();
     var changeDescriptions = [];
     var jem = {};
+    var env = {};
+    var appSet = sinon.stub();
+    var createSocketURL = sinon.stub();
     var users = {
       jem: {
         user: 'foo'
@@ -53,12 +56,22 @@ describe('Deployment', function() {
         ecsCommit={ecsCommit}
         getUnplacedUnitCount={getUnplacedUnitCount}
         jem={jem}
+        env={env}
+        appSet={appSet}
+        createSocketURL={createSocketURL}
         modelCommitted={false}
         numberOfChanges={6}
         users={users} />, true);
     var output = renderer.getRenderOutput();
+    var instance = renderer.getMountedInstance();
     var expected = (
       <juju.components.DeploymentSummary
+        jem={jem}
+        env={env}
+        appSet={appSet}
+        createSocketURL={createSocketURL}
+        deploymentStorage={instance._deploymentStorage}
+        users={users}
         autoPlaceUnits={autoPlaceUnits}
         changeDescriptions={changeDescriptions}
         changeState={changeState}
@@ -78,6 +91,9 @@ describe('Deployment', function() {
     var ecsCommit = sinon.stub();
     var jem = {};
     var changeDescriptions = [];
+    var env = {};
+    var appSet = sinon.stub();
+    var createSocketURL = sinon.stub();
     var renderer = jsTestUtils.shallowRender(
       <juju.components.Deployment
         activeComponent="choose-cloud"
@@ -88,12 +104,17 @@ describe('Deployment', function() {
         ecsCommit={ecsCommit}
         getUnplacedUnitCount={getUnplacedUnitCount}
         jem={jem}
+        env={env}
+        appSet={appSet}
+        createSocketURL={createSocketURL}
         modelCommitted={false}
         numberOfChanges={6} />, true);
     var output = renderer.getRenderOutput();
+    var instance = renderer.getMountedInstance();
     var expected = (
       <juju.components.DeploymentChooseCloud
         jem={jem}
+        setDeploymentInfo={instance.setDeploymentInfo}
         changeState={changeState} />);
     assert.deepEqual(output.props.children, expected);
   });

--- a/jujugui/tests/test_options.py
+++ b/jujugui/tests/test_options.py
@@ -26,6 +26,7 @@ class TestUpdate(unittest.TestCase):
         'jujugui.socketTemplate': '/environment/$uuid/api',
         'jujugui.user': None,
         'jujugui.insecure': False,
+        'jujugui.gisf': False,
     }
 
     def test_default_values(self):
@@ -52,6 +53,7 @@ class TestUpdate(unittest.TestCase):
             'jujugui.socketTemplate': '/juju/api/$host/$port/$uuid',
             'jujugui.user': 'who',
             'jujugui.insecure': True,
+            'jujugui.gisf': True,
         }
         settings = {
             'jujugui.charmstore_api_path': 'v4',
@@ -70,6 +72,7 @@ class TestUpdate(unittest.TestCase):
             'jujugui.socketTemplate': '/juju/api/$host/$port/$uuid',
             'jujugui.user': 'who',
             'jujugui.insecure': True,
+            'jujugui.gisf': True,
         }
         options.update(settings)
         self.assertEqual(expected_settings, settings)

--- a/jujugui/views.py
+++ b/jujugui/views.py
@@ -125,6 +125,7 @@ def config(request):
         'jujuCoreVersion': settings.get('jujugui.jujuCoreVersion', ''),
         'apiAddress': settings.get('jujugui.apiAddress', ''),
         'socketTemplate': settings['jujugui.socketTemplate'],
+        'gisf': settings['jujugui.gisf'],
     }
     return 'var juju_config = {};'.format(json.dumps(options))
 


### PR DESCRIPTION
Depending on how the GUI is being run we may not want to connect to a model on load. This branch prevents that until you provide a socket url to the gui's env and then manually connect it using `app.env.connect()`