### PR TITLE
Update config.js.go for new staticURL and fix broken paths

### DIFF
--- a/jujugui/static/gui/src/app/components/user-profile/test-user-profile.js
+++ b/jujugui/static/gui/src/app/components/user-profile/test-user-profile.js
@@ -130,13 +130,13 @@ describe('UserProfile', () => {
         showConnectingMask={sinon.stub()}
         interactiveLogin={true}
         changeState={sinon.stub()}
-        staticURL='path/to/assets'
+        staticURL='surl'
         storeUser={sinon.stub()}
         user={users.charmstore} />);
     assert.equal(
       output.props.children.props.children.props
             .children[1].props.children[0].props.src,
-      'path/to/assets/juju-ui/assets/images/non-sprites/empty_profile.png');
+      'surl/static/gui/build/app/assets/images/non-sprites/empty_profile.png');
   });
 
   it('displays loading spinners for charms and bundles', () => {

--- a/jujugui/static/gui/src/app/components/user-profile/user-profile.js
+++ b/jujugui/static/gui/src/app/components/user-profile/user-profile.js
@@ -591,12 +591,15 @@ YUI.add('user-profile', function() {
                     && state.envList.length === 0;
       if (isEmpty) {
         var staticURL = this.props.staticURL || '';
-        /* eslint-disable max-len */
+        var basePath = '/juju-ui';
+        if (staticURL) {
+          basePath = `${staticURL}/static/gui/build/app`;
+        }
         return (
           <div className="user-profile__empty twelve-col no-margin-bottom">
             <img alt="Empty profile"
               className="user-profile__empty-image"
-              src={`${staticURL}/juju-ui/assets/images/non-sprites/empty_profile.png`} />
+              src={`${basePath}/assets/images/non-sprites/empty_profile.png`} />
             <h2 className="user-profile__empty-title">
               Your profile is currently empty
             </h2>
@@ -605,7 +608,6 @@ YUI.add('user-profile', function() {
               them.
             </p>
           </div>);
-        /* eslint-enable max-len */
       }
       return (
         <div>

--- a/jujugui/static/gui/src/app/models/entity-extension.js
+++ b/jujugui/static/gui/src/app/models/entity-extension.js
@@ -72,8 +72,12 @@ YUI.add('entity-extension', function(Y) {
       if (type === 'bundle') {
         var staticURL =
           (window.juju_config && window.juju_config.staticURL) || '';
+        var basePath = '/juju-ui';
+        if (staticURL) {
+          basePath = `${staticURL}/static/gui/build/app`;
+        }
         entity.iconPath =
-          `${staticURL}/juju-ui/assets/images/non-sprites/bundle.svg`;
+          `${basePath}/assets/images/non-sprites/bundle.svg`;
         var srvcs = this.get('services');
         entity.services = this.parseBundleServices(srvcs);
       } else {

--- a/jujugui/static/gui/src/app/views/topology/relation.js
+++ b/jujugui/static/gui/src/app/views/topology/relation.js
@@ -314,10 +314,9 @@ YUI.add('juju-topology-relation', function(Y) {
       var self = this;
       var topo = this.get('component');
       var staticURL = topo.get('staticURL') || '';
+      var basePath = '/juju-ui';
       if (staticURL) {
-        // Add the trailing slash to the staticURL because it's only
-        // needed for the embedded deploy environment.
-        staticURL += '/';
+        basePath = `${staticURL}/static/gui/build/app`;
       }
       var vis = topo.vis;
       var parentId = topo._yuid;
@@ -391,7 +390,7 @@ YUI.add('juju-topology-relation', function(Y) {
         .selectAll('image')
         .attr('xlink:href', function(d) {
           return (
-              staticURL + 'juju-ui/assets/svgs/relation-icon-' +
+              basePath + '/assets/svgs/relation-icon-' +
               d.aggregatedStatus + '.svg');
         });
       return g;

--- a/jujugui/static/gui/src/app/views/topology/relation.js
+++ b/jujugui/static/gui/src/app/views/topology/relation.js
@@ -314,7 +314,7 @@ YUI.add('juju-topology-relation', function(Y) {
       var self = this;
       var topo = this.get('component');
       var staticURL = topo.get('staticURL') || '';
-      var basePath = '/juju-ui';
+      var basePath = 'juju-ui';
       if (staticURL) {
         basePath = `${staticURL}/static/gui/build/app`;
       }

--- a/jujugui/static/gui/src/app/views/topology/service.js
+++ b/jujugui/static/gui/src/app/views/topology/service.js
@@ -1522,7 +1522,7 @@ YUI.add('juju-topology-service', function(Y) {
      */
     createServiceNode: function(node, self) {
       var staticURL = self.get('component').get('staticURL') || '';
-      var basePath = '/juju-ui';
+      var basePath = 'juju-ui';
       if (staticURL) {
         basePath = `${staticURL}/static/gui/build/app`;
       }

--- a/jujugui/static/gui/src/app/views/topology/service.js
+++ b/jujugui/static/gui/src/app/views/topology/service.js
@@ -1522,10 +1522,9 @@ YUI.add('juju-topology-service', function(Y) {
      */
     createServiceNode: function(node, self) {
       var staticURL = self.get('component').get('staticURL') || '';
+      var basePath = '/juju-ui';
       if (staticURL) {
-        // Add the trailing slash to the staticURL because it's only
-        // needed for the embedded deploy environment.
-        staticURL += '/';
+        basePath = `${staticURL}/static/gui/build/app`;
       }
       node.attr({'data-name':  function(d) { return d.name; }});
 
@@ -1576,7 +1575,7 @@ YUI.add('juju-topology-service', function(Y) {
       relationButton.append('image')
         .classed('relation-button__image', true)
         .attr({
-          'xlink:href': `${staticURL}juju-ui/assets/svgs/build-relation_16.svg`,
+          'xlink:href': `${basePath}/assets/svgs/build-relation_16.svg`,
           width: 16,
           height: 16,
           transform: 'translate(-8, -8)'

--- a/jujugui/static/gui/src/app/views/utils.js
+++ b/jujugui/static/gui/src/app/views/utils.js
@@ -1745,7 +1745,11 @@ YUI.add('juju-view-utils', function(Y) {
       if (typeof isBundle === 'boolean' && isBundle) {
         var staticURL =
           (window.juju_config && window.juju_config.staticURL) || '';
-        path = `${staticURL}/juju-ui/assets/images/non-sprites/bundle.svg`;
+        var basePath = '/juju-ui';
+        if (staticURL) {
+          basePath = `${staticURL}/static/gui/build/app`;
+        }
+        path = `${basePath}/assets/images/non-sprites/bundle.svg`;
       } else {
         // Get the charm ID from the service.  In some cases, this will be
         // the charm URL with a protocol, which will need to be removed.

--- a/jujugui/static/gui/src/test/test_entity_extension.js
+++ b/jujugui/static/gui/src/test/test_entity_extension.js
@@ -129,7 +129,7 @@ describe('Entity Extension', function() {
 
   it('uses the staticURL for bundle asset if available', function() {
     window.juju_config = {
-      staticURL: 'staticURLPrefix'
+      staticURL: 'static'
     };
     utils.makeStubMethod(entityModel, 'parseBundleServices', []);
     var attrs = {
@@ -142,6 +142,6 @@ describe('Entity Extension', function() {
     var entity = entityModel.toEntity();
     assert.deepEqual(
       entity.iconPath,
-       'staticURLPrefix/juju-ui/assets/images/non-sprites/bundle.svg');
+       'static/static/gui/build/app/assets/images/non-sprites/bundle.svg');
   });
 });

--- a/jujugui/static/gui/src/test/test_environment_view.js
+++ b/jujugui/static/gui/src/test/test_environment_view.js
@@ -413,7 +413,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       var img = relationIcon.one('image');
       assert.equal(
         img.getAttribute('href'),
-        'staticpath/juju-ui/assets/svgs/build-relation_16.svg');
+        'staticpath/static/gui/build/app/assets/svgs/build-relation_16.svg');
     });
 
     // Ensure the environment view loads properly
@@ -1236,7 +1236,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     });
 
     it('uses staticURL config for the relation status assets', function() {
-      view.set('staticURL', 'staticpath');
+      view.set('staticURL', 'static');
       view.render();
       var reduceImages = function() {
         return view.topo.vis.selectAll('.rel-indicator image')[0]
@@ -1244,10 +1244,9 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
             return d3.select(image).attr('href');
           });
       };
-      console.log(reduceImages());
       assert.deepEqual(reduceImages(), [
-        'staticpath/juju-ui/assets/svgs/relation-icon-subordinate.svg',
-        'staticpath/juju-ui/assets/svgs/relation-icon-healthy.svg'
+        'static/static/gui/build/app/assets/svgs/relation-icon-subordinate.svg',
+        'static/static/gui/build/app/assets/svgs/relation-icon-healthy.svg'
       ]);
 
       var unit = db.services.getById('mysql').get('units').item(0);
@@ -1256,10 +1255,9 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
         hook: 'db-relation'
       };
       view.update();
-      console.log(reduceImages());
       assert.deepEqual(reduceImages(), [
-        'staticpath/juju-ui/assets/svgs/relation-icon-subordinate.svg',
-        'staticpath/juju-ui/assets/svgs/relation-icon-error.svg'
+        'static/static/gui/build/app/assets/svgs/relation-icon-subordinate.svg',
+        'static/static/gui/build/app/assets/svgs/relation-icon-error.svg'
       ]);
     });
 

--- a/jujugui/static/gui/src/test/test_utils.js
+++ b/jujugui/static/gui/src/test/test_utils.js
@@ -945,7 +945,9 @@ describe('utilities', function() {
         staticURL: 'static'
       };
       var path = utils.getIconPath('bundle:elasticsearch', true);
-      assert.equal(path, 'static/juju-ui/assets/images/non-sprites/bundle.svg');
+      assert.equal(
+        path,
+        'static/static/gui/build/app/assets/images/non-sprites/bundle.svg');
     });
 
     it('returns a qualified charmstoreURL icon location', function() {

--- a/jujugui/templates/config.js.go
+++ b/jujugui/templates/config.js.go
@@ -1,5 +1,6 @@
 var juju_config = {
     "baseUrl": "{{.base}}",
+    "staticURL": "{{.staticURL}}",
     "jujuCoreVersion": "{{.version}}",
     "jujuEnvUUID": "{{.uuid}}",
     "apiAddress": "wss://{{.host}}",


### PR DESCRIPTION
The config.js template for Juju 2 was missing the staticURL flag so it wasn't being passed to the GUI. This branch adds that plus updates the parsing of the staticURL ans base url paths for both the charm and the Juju 2 GUI.