### PR TITLE
Do not re-open deployment flow after initial commit

### DIFF
--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -1834,7 +1834,6 @@ YUI.add('juju-gui', function(Y) {
         // The login was a success.
         this.maskVisibility(false);
         this._emptySectionApp();
-        var redirectPath = this.popLoginRedirectPath();
         this.set('loggedIn', true);
         // Handle token authentication.
         if (e.data.fromToken) {
@@ -1869,16 +1868,13 @@ YUI.add('juju-gui', function(Y) {
           // Try to create a bundle uncommitted state using the token.
           this.bundleImporter.importChangesToken(changesToken);
         }
-        this.navigate(redirectPath, {overrideAllNamespaces: true});
-        // If the redirectPath has a hash then it will not dispatch after log in
-        // because navigateOnHash is set to false so that we can use hash's to
-        // show the correct tab in the charm details pages. This issue only
-        // presents itself until the next delta comes in and the application
-        // hits it's double dispatch and dispatches the url again. As a
-        // workaround we check if there is a hash in the url and then dispatch
-        // manually.
-        if (redirectPath.indexOf('#') > -1) {
-          this.dispatch();
+        // If we are in GISF mode then we do not want to store and redirect
+        // on login because the user has already logged into their models
+        // and will frequently be switching between models and logging in to
+        // them. We rely exclusively on the state system to update the paths.
+        if (!this.get('gisf')) {
+          var redirectPath = this.popLoginRedirectPath();
+          this.navigate(redirectPath, {overrideAllNamespaces: true});
         }
       } else {
         this._renderLogin(true);

--- a/jujugui/static/gui/src/test/test_app.js
+++ b/jujugui/static/gui/src/test/test_app.js
@@ -831,28 +831,19 @@ describe('App', function() {
       assert.equal(app.dispatch.calledOnce(), false);
     });
 
-    it('navigates to requested url with hash on login', function() {
-      // In order to support bookmarking the current tab in the charm details
-      // we have navigateOnHash http://yuilibrary.com/yui/docs/api/classes/
-      // PjaxBase.html#attr_navigateOnHash set to false. This causes issues
-      // if the user is not yet logged in and requests a url with a hash in it
-      // becaause the router will then refuse to navigate to it. By navigating
-      // then manually dispatching it forces the application to render the
-      // proper view.
+    it('does not navigate to requested url on login with gisf', function() {
       var stubit = utils.makeStubMethod;
       var popup = utils.makeStubMethod(
-          Y.juju.App.prototype, 'popLoginRedirectPath', '/foo/bar#baz');
+          Y.juju.App.prototype, 'popLoginRedirectPath', '/foo/bar');
       this._cleanups.push(popup.reset);
       var app = makeApp(true, this);
+      app.set('gisf', true);
       stubit(app, 'maskVisibility');
       stubit(app, 'navigate');
       stubit(app, 'dispatch');
       app.onLogin({ data: { result: true } });
-      assert.equal(app.navigate.calledOnce(), true);
-      assert.deepEqual(app.navigate.lastArguments(), [
-        '/foo/bar#baz',
-        { overrideAllNamespaces: true }]);
-      assert.equal(app.dispatch.calledOnce(), true);
+      assert.equal(app.navigate.calledOnce(), false,
+        'navigate should not be called in gisf mode here');
     });
 
     // XXX This test causes intermittent cascading failures when run in CI.


### PR DESCRIPTION
On the first deploy to a new model in the deployment flow the onLogin method is called because the user has logged into a new model. This preserves the old URL because of legacy login functionality. This fix disables that functionality when under gisf mode. Fixes #1567 