### PR TITLE
Replace calls to listEnvs with listModelsWithInfo.

### DIFF
--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -753,7 +753,7 @@ YUI.add('juju-gui', function(Y) {
           env={this.env}
           jem={this.jem}
           gisf={this.get('gisf')}
-          listEnvs={this.env.listEnvs.bind(this.env)}
+          listModels={this.env.listModelsWithInfo.bind(this.env)}
           changeState={this.changeState.bind(this)}
           dbEnvironmentSet={this.db.environment.set.bind(this.db.environment)}
           showConnectingMask={this.showConnectingMask.bind(this)}

--- a/jujugui/static/gui/src/app/components/env-switcher/test-env-switcher.js
+++ b/jujugui/static/gui/src/app/components/env-switcher/test-env-switcher.js
@@ -71,7 +71,7 @@ describe('EnvSwitcher', function() {
 
   it('open the list on click', function() {
     var env = {
-      listEnvs: sinon.stub()
+      listModelsWithInfo: sinon.stub()
     };
     var renderer = jsTestUtils.shallowRender(
       <juju.components.EnvSwitcher.prototype.wrappedComponent
@@ -107,9 +107,9 @@ describe('EnvSwitcher', function() {
   });
 
   it('fetches a list of environments on mount (JEM)', function() {
-    var listEnvs = sinon.stub();
+    var listEnvironments = sinon.stub();
     var jem = {
-      listEnvironments: listEnvs
+      listEnvironments: listEnvironments
     };
     var renderer = jsTestUtils.shallowRender(
       <juju.components.EnvSwitcher.prototype.wrappedComponent
@@ -120,18 +120,18 @@ describe('EnvSwitcher', function() {
         uncommittedChanges={false} />, true);
     var instance = renderer.getMountedInstance();
     instance.componentDidMount();
-    assert.equal(listEnvs.callCount, 1);
+    assert.equal(listEnvironments.callCount, 1);
     var envData = {
       env: 'env'
     };
-    listEnvs.args[0][0](null, envData);
+    listEnvironments.args[0][0](null, envData);
     assert.deepEqual(instance.state.envList, envData);
   });
 
-  it('fetches a list of environments on mount (JES)', function() {
-    var listEnvs = sinon.stub();
+  it('fetches a list of environments on mount (controller)', function() {
+    var listModelsWithInfo = sinon.stub();
     var env = {
-      listEnvs: listEnvs
+      listModelsWithInfo: listModelsWithInfo
     };
     var renderer = jsTestUtils.shallowRender(
       <juju.components.EnvSwitcher.prototype.wrappedComponent
@@ -142,17 +142,16 @@ describe('EnvSwitcher', function() {
         uncommittedChanges={false} />, true);
     var instance = renderer.getMountedInstance();
     instance.componentDidMount();
-    assert.equal(listEnvs.callCount, 1);
-    var envData = {
-      envs: {env: 'env'}
-    };
-    listEnvs.args[0][1](envData);
-    assert.deepEqual(instance.state.envList, envData.envs);
+    assert.equal(listModelsWithInfo.callCount, 1);
+    listModelsWithInfo.args[0][0]({
+      models: [{name: 'm1', isAlive: true}, {name: 'm2', isAlive: false}]
+    });
+    assert.deepEqual(instance.state.envList, [{name: 'm1', isAlive: true}]);
   });
 
   it('fetches the env list when opening', function() {
     var env = {
-      listEnvs: sinon.stub()
+      listModelsWithInfo: sinon.stub()
     };
     var renderer = jsTestUtils.shallowRender(
       <juju.components.EnvSwitcher.prototype.wrappedComponent
@@ -167,12 +166,12 @@ describe('EnvSwitcher', function() {
     output.props.children[0].props.onClick({
       preventDefault: () => null
     });
-    assert.equal(env.listEnvs.callCount, 1);
+    assert.equal(env.listModelsWithInfo.callCount, 1);
     var envData = {
-      envs: [{env: 'env'}]
+      models: [{name: 'm1', isAlive: true}]
     };
-    env.listEnvs.args[0][1](envData);
-    assert.deepEqual(instance.state.envList, envData.envs);
+    env.listModelsWithInfo.args[0][0](envData);
+    assert.deepEqual(instance.state.envList, envData.models);
   });
 
   it('can call to switch environments', function() {
@@ -185,11 +184,11 @@ describe('EnvSwitcher', function() {
       user: 'The Dr.',
       password: 'buffalo'
     }];
-    var listEnvs = sinon.stub();
+    var listEnvironments = sinon.stub();
     var switchModel = sinon.stub();
     var mask = sinon.stub();
     var jem = {
-      listEnvironments: listEnvs
+      listEnvironments: listEnvironments
     };
     var renderer = jsTestUtils.shallowRender(
       <juju.components.EnvSwitcher.prototype.wrappedComponent
@@ -200,7 +199,7 @@ describe('EnvSwitcher', function() {
         uncommittedChanges={false} />, true);
     var instance = renderer.getMountedInstance();
     instance.componentDidMount();
-    listEnvs.args[0][0](null, envs);
+    listEnvironments.args[0][0](null, envs);
     instance.handleEnvClick({
       name: 'abc123',
       id: 'abc123'
@@ -226,14 +225,14 @@ describe('EnvSwitcher', function() {
       user: 'The Dr.',
       password: 'buffalo'
     }];
-    var listEnvs = sinon.stub();
+    var listEnvironments = sinon.stub();
     var listSrv = sinon.stub();
     var newEnv = sinon.stub();
 
     listSrv.callsArgWith(0, null, [{path: 'admin/foo'}]);
 
     var jem = {
-      listEnvironments: listEnvs,
+      listEnvironments: listEnvironments,
       listServers: listSrv,
       newEnvironment: newEnv
     };
@@ -248,7 +247,7 @@ describe('EnvSwitcher', function() {
         uncommittedChanges={false} />, true);
     var instance = renderer.getMountedInstance();
     instance.componentDidMount();
-    listEnvs.args[0][0](null, envs);
+    listEnvironments.args[0][0](null, envs);
     // Previous code is to set up the state of the component.
     instance.createNewEnv(envName);
     assert.equal(newEnv.callCount, 1);
@@ -268,10 +267,10 @@ describe('EnvSwitcher', function() {
     };
     newEnv.args[0][5](null, createdEnv);
     // After creating an env it should re-list them.
-    assert.equal(listEnvs.callCount, 2);
+    assert.equal(listEnvironments.callCount, 2);
     // Then switch to the new one.
     envs.push(createdEnv);
-    listEnvs.args[1][0](null, envs);
+    listEnvironments.args[1][0](null, envs);
     assert.equal(switchModel.callCount, 1);
     // After creating a new env it should call to update the environment name
     // in the db.
@@ -287,7 +286,7 @@ describe('EnvSwitcher', function() {
     createNewJEMEnvTest('custom-env-name');
   });
 
-  it('can call to create a new env (JES)', function() {
+  it('can call to create a new env (controller)', function() {
     // To create a new environment you click a button in a sub component. This
     // excersizes the method that gets passed down.
     var envs = [{
@@ -296,11 +295,11 @@ describe('EnvSwitcher', function() {
       user: 'The Dr.',
       password: 'buffalo'
     }];
-    var listEnvs = sinon.stub();
-    var createEnv = sinon.stub();
+    var listModelsWithInfo = sinon.stub();
+    var createModel = sinon.stub();
     var env = {
-      createEnv: createEnv,
-      listEnvs: listEnvs
+      createModel: createModel,
+      listModelsWithInfo: listModelsWithInfo
     };
     var renderer = jsTestUtils.shallowRender(
       <juju.components.EnvSwitcher.prototype.wrappedComponent
@@ -311,12 +310,12 @@ describe('EnvSwitcher', function() {
         uncommittedChanges={false} />, true);
     var instance = renderer.getMountedInstance();
     instance.componentDidMount();
-    listEnvs.args[0][1](envs);
+    listModelsWithInfo.args[0][0](envs);
     // Previous code is to set up the state of the component.
     instance.createNewEnv();
-    assert.equal(createEnv.callCount, 1);
-    assert.equal(createEnv.args[0][0], 'new-env-1');
-    assert.equal(createEnv.args[0][1], 'user-admin');
+    assert.equal(createModel.callCount, 1);
+    assert.equal(createModel.args[0][0], 'new-env-1');
+    assert.equal(createModel.args[0][1], 'user-admin');
     // Because the callbacks are identical for JEM and JES we do not need
     // to test that it switches envs past this point as long as the previous
     // test passes.

--- a/jujugui/static/gui/src/app/components/user-profile/entity/entity.js
+++ b/jujugui/static/gui/src/app/components/user-profile/entity/entity.js
@@ -262,6 +262,13 @@ YUI.add('user-profile-entity', function() {
         'user-profile__entity': true,
         'user-profile__list-row': true
       };
+      var isZombieModel = isModel && !entity.isAlive;
+      // XXX frankban: add UX for zombie models in place of undefined below.
+      var button = isZombieModel ? undefined : (
+        <juju.components.GenericButton
+          action={buttonAction}
+          type='inline-neutral'
+          title={isModel ? 'Manage' : 'View'} />);
       return (
         <juju.components.ExpandingRow classes={classes}
           expanded={this.props.expanded}>
@@ -273,10 +280,7 @@ YUI.add('user-profile-entity', function() {
               </div>
               <div className={'expanding-row__expanded-header-action ' +
                 'two-col last-col no-margin-bottom'}>
-                <juju.components.GenericButton
-                  action={buttonAction}
-                  type='inline-neutral'
-                  title={isModel ? 'Manage' : 'View'} />
+                {button}
               </div>
             </div>
             <div className={'expanding-row__expanded-content twelve-col ' +

--- a/jujugui/static/gui/src/app/components/user-profile/entity/test-entity.js
+++ b/jujugui/static/gui/src/app/components/user-profile/entity/test-entity.js
@@ -33,7 +33,8 @@ describe('UserProfileEntity', () => {
       uuid: 'env1',
       name: 'sandbox',
       lastConnection: 'today',
-      owner: 'test-owner'
+      owner: 'test-owner',
+      isAlive: true
     };
   });
 
@@ -65,6 +66,49 @@ describe('UserProfileEntity', () => {
                 action={button.props.action}
                 type="inline-neutral"
                 title="Manage" />
+            </div>
+          </div>
+          <div className={'expanding-row__expanded-content twelve-col ' +
+            'no-margin-bottom'}>
+            {undefined}
+            {undefined}
+            <div className="three-col last-col">
+              Owner: {"test-owner"}
+            </div>
+            {undefined}
+            {undefined}
+            {undefined}
+            {undefined}
+          </div>
+        </div>
+      </juju.components.ExpandingRow>);
+    assert.deepEqual(output, expected);
+  });
+
+  it('does not render manage button for zombie models', () => {
+    model.isAlive = false;
+    var renderer = jsTestUtils.shallowRender(
+      <juju.components.UserProfileEntity
+        entity={model}
+        expanded={false}
+        switchModel={sinon.stub()}
+        type="model">
+        <span>Summary details</span>
+      </juju.components.UserProfileEntity>, true);
+    var output = renderer.getRenderOutput();
+    var expected = (
+      <juju.components.ExpandingRow classes={{
+        'user-profile__entity': true, 'user-profile__list-row': true}}
+        expanded={false}>
+        <span>Summary details</span>
+        <div>
+          <div className="expanding-row__expanded-header twelve-col">
+            <div className="ten-col no-margin-bottom">
+              {undefined}{"sandbox"}
+            </div>
+            <div className={'expanding-row__expanded-header-action ' +
+              'two-col last-col no-margin-bottom'}>
+              {undefined}
             </div>
           </div>
           <div className={'expanding-row__expanded-content twelve-col ' +

--- a/jujugui/static/gui/src/test/test_env_go.js
+++ b/jujugui/static/gui/src/test/test_env_go.js
@@ -3810,9 +3810,9 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       });
     });
 
-    it('successfully creates a local environment', function(done) {
+    it('successfully creates a local model', function(done) {
       env.set('providerType', 'local');
-      env.createEnv('myenv', 'user-who', function(data) {
+      env.createModel('myenv', 'user-who', function(data) {
         assert.strictEqual(data.err, undefined);
         assert.strictEqual(data.name, 'myenv');
         assert.strictEqual(data.owner, 'user-rose');
@@ -3871,10 +3871,10 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       });
     });
 
-    it('successfully creates a local environment (legacy)', function(done) {
+    it('successfully creates a local model (legacy)', function(done) {
       env.set('providerType', 'local');
       env.set('facades', {'EnvironmentManager': [1]});
-      env.createEnv('myenv', 'user-who', function(data) {
+      env.createModel('myenv', 'user-who', function(data) {
         assert.strictEqual(data.err, undefined);
         assert.strictEqual(data.name, 'myenv');
         assert.strictEqual(data.owner, 'user-rose');
@@ -3933,9 +3933,9 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       });
     });
 
-    it('successfully creates an ec2 environment', function(done) {
+    it('successfully creates an ec2 model', function(done) {
       env.set('providerType', 'ec2');
-      env.createEnv('myenv', 'user-who', function(data) {
+      env.createModel('myenv', 'user-who', function(data) {
         assert.strictEqual(data.err, undefined);
         assert.strictEqual(data.name, 'my-ec2-env');
         assert.equal(conn.messages.length, 3);
@@ -3979,9 +3979,9 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       });
     });
 
-    it('successfully creates an openstack environment', function(done) {
+    it('successfully creates an openstack model', function(done) {
       env.set('providerType', 'openstack');
-      env.createEnv('myenv', 'user-who', function(data) {
+      env.createModel('myenv', 'user-who', function(data) {
         assert.strictEqual(data.err, undefined);
         assert.strictEqual(data.name, 'my-openstack-env');
         assert.equal(conn.messages.length, 3);
@@ -4030,9 +4030,9 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       });
     });
 
-    it('successfully creates a MAAS environment', function(done) {
+    it('successfully creates a MAAS model', function(done) {
       env.set('providerType', 'maas');
-      env.createEnv('myenv', 'user-who', function(data) {
+      env.createModel('myenv', 'user-who', function(data) {
         assert.strictEqual(data.err, undefined);
         assert.strictEqual(data.name, 'my-maas-env');
         assert.equal(conn.messages.length, 3);
@@ -4081,8 +4081,8 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       });
     });
 
-    it('handles failures while retrieving env skeleton', function(done) {
-      env.createEnv('bad-env', 'user-dalek', function(data) {
+    it('handles failures while retrieving model skeleton', function(done) {
+      env.createModel('bad-env', 'user-dalek', function(data) {
         assert.strictEqual(
           data.err, 'cannot get configuration skeleton: bad wolf');
         done();
@@ -4091,8 +4091,8 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       conn.msg({RequestId: 1, Error: 'bad wolf'});
     });
 
-    it('handles failures while retrieving env config', function(done) {
-      env.createEnv('bad-env', 'user-dalek', function(data) {
+    it('handles failures while retrieving model config', function(done) {
+      env.createModel('bad-env', 'user-dalek', function(data) {
         assert.strictEqual(
           data.err, 'cannot get model configuration: bad wolf');
         done();
@@ -4106,9 +4106,9 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       conn.msg({RequestId: 2, Error: 'bad wolf'});
     });
 
-    it('handles failures while creating environments', function(done) {
+    it('handles failures while creating models', function(done) {
       env.set('providerType', 'local');
-      env.createEnv('bad-env', 'user-dalek', function(data) {
+      env.createModel('bad-env', 'user-dalek', function(data) {
         assert.strictEqual(data.err, 'bad wolf');
         done();
       });
@@ -4126,8 +4126,8 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       conn.msg({RequestId: 3, Error: 'bad wolf'});
     });
 
-    it('lists environments for a specific owner', function(done) {
-      env.listEnvs('user-who', function(data) {
+    it('lists models for a specific owner', function(done) {
+      env.listModels('user-who', function(data) {
         assert.strictEqual(data.err, undefined);
         assert.deepEqual([
           {
@@ -4177,9 +4177,9 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       });
     });
 
-    it('lists environments for a specific owner (legacy)', function(done) {
+    it('lists models for a specific owner (legacy)', function(done) {
       env.set('facades', {'EnvironmentManager': [1]});
-      env.listEnvs('user-who', function(data) {
+      env.listModels('user-who', function(data) {
         assert.strictEqual(data.err, undefined);
         assert.deepEqual([
           {
@@ -4229,8 +4229,8 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       });
     });
 
-    it('handles failures while listing environments', function(done) {
-      env.listEnvs('user-dalek', function(data) {
+    it('handles failures while listing models', function(done) {
+      env.listModels('user-dalek', function(data) {
         assert.strictEqual(data.err, 'bad wolf');
         done();
       });


### PR DESCRIPTION
So that we have access to more details about existing models
and also we stop using hardcoded 'user-admin' tag.
More details about models means this branch can also provide the ability to:
- show/hide models in the model switcher based on the model lifecycle;
- hide the profile page manage button for zombie models,
  so that switching to them is not allowed.

Also rename env methods to call models "models" more consistently.

This must be QAed in real models, both GIJoe (for the controller story)
and JEM enabled. Create a new model, switch to it, deploy something, then 
call `app.env.destroyModel()`: the model switcher no longer shows the model,
the profile page shows it without the manage button.

Fixes #1582