### PR TITLE
Fix logout when disconnected

### DIFF
--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -594,7 +594,7 @@ YUI.add('juju-gui', function(Y) {
               // Try a token login.
               this.env.tokenLogin(authtoken);
             } else {
-              this.checkUserCredentials();
+              this._displayLogin();
             }
           }
         }
@@ -1715,6 +1715,26 @@ YUI.add('juju-gui', function(Y) {
       this._renderComponents();
     },
 
+    /**
+      Display the login page.
+
+      @method _displayLogin
+    */
+    _displayLogin: function() {
+      this.set('loggedIn', false);
+      var component = this.state.getState('current', 'app', 'component');
+      if (!component && component !== 'login') {
+        this.state.dispatch({
+          app: {
+            component: 'login',
+            metadata: {
+              redirectPath: this.get('currentUrl')
+            }
+          }
+        });
+      }
+    },
+
     // Route handlers
 
     /**
@@ -1782,19 +1802,8 @@ YUI.add('juju-gui', function(Y) {
       // form was never shown - this handles that edge case.
       var noCredentials = !(credentials && credentials.areAvailable);
       if (noCredentials) {
-        this.set('loggedIn', false);
-        // If there are no stored credentials redirect to the login page
-        var component = this.state.getState('current', 'app', 'component');
-        if (!component && component !== 'login') {
-          this.state.dispatch({
-            app: {
-              component: 'login',
-              metadata: {
-                redirectPath: this.get('currentUrl')
-              }
-            }
-          });
-        }
+        // If there are no stored credentials redirect to the login page.
+        this._displayLogin();
         return;
       } else if (!this.get('loggedIn')) {
         return;

--- a/jujugui/static/gui/src/app/store/env/base.js
+++ b/jujugui/static/gui/src/app/store/env/base.js
@@ -281,7 +281,7 @@ YUI.add('juju-env-base', function(Y) {
         this.beforeClose(this.ws.close.bind(this.ws));
       }
       if (cb) {
-        cb(); 
+        cb();
       }
     },
 
@@ -404,7 +404,9 @@ YUI.add('juju-env-base', function(Y) {
     logout: function() {
       this.userIsAuthenticated = false;
       this.setCredentials(null);
-      this.ws.close();
+      if (this.ws) {
+        this.ws.close();
+      }
       this.connect();
     }
 


### PR DESCRIPTION
The logout was not working when in a disconnected model state due to the websocket and credentials not existing. Fixes #1555.