### PR TITLE
Set UUID on model create

### DIFF
--- a/jujugui/static/gui/src/app/components/deployment/summary/summary.js
+++ b/jujugui/static/gui/src/app/components/deployment/summary/summary.js
@@ -140,6 +140,7 @@ YUI.add('deployment-summary', function() {
             pathParts[1], // port
             data.uuid
           );
+          this.props.appSet('jujuEnvUUID', data.uuid);
           // Set the socket url in both the app and the env so we don't end
           // up with any confusion later on about which is which.
           this.props.appSet('socket_url', socketURL);

--- a/jujugui/static/gui/src/app/components/deployment/summary/test-summary.js
+++ b/jujugui/static/gui/src/app/components/deployment/summary/test-summary.js
@@ -441,8 +441,9 @@ describe('DeploymentSummary', function() {
     assert.deepEqual(createSocketURL.args[0], [
       '1.1.1.1', '1234', '1qaz2wsx3edc'
     ]);
-    assert.equal(appSet.callCount, 1);
-    assert.deepEqual(appSet.args[0], ['socket_url', 'newurl']);
+    assert.equal(appSet.callCount, 2);
+    assert.deepEqual(appSet.args[0], ['jujuEnvUUID', '1qaz2wsx3edc']);
+    assert.deepEqual(appSet.args[1], ['socket_url', 'newurl']);
     assert.equal(env.set.callCount, 1);
     assert.deepEqual(env.set.args[0], ['socket_url', 'newurl']);
     assert.equal(env.connect.callCount, 1);


### PR DESCRIPTION
Correctly set the current model UUID for newly created models. Fixes the first part of #1619.