### PR TITLE
Fix entity file links.

### DIFF
--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -1168,10 +1168,9 @@ YUI.add('juju-gui', function(Y) {
           }
         }
       });
-      var apiUrl = `${charmstore.url}${charmstore.version}`;
       ReactDOM.render(
         <components.Charmbrowser
-          apiUrl={apiUrl}
+          apiUrl={charmstore.url}
           charmstoreSearch={charmstore.search.bind(charmstore)}
           series={utils.getSeriesList()}
           importBundleYAML={this.bundleImporter.importBundleYAML.bind(


### PR DESCRIPTION
No need to concat the charmstore URL and version anymore as the URL now contains the version. Fixes https://github.com/juju/juju-gui/issues/1641.