### PR TITLE
Use https instead of ssh to check out project dependency.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -275,7 +275,7 @@ watch:
 # Download cache
 ################
 $(CACHE):
-	git clone --depth=1 "git@github.com:juju/juju-gui-downloadcache.git" $(CACHE)
+	git clone --depth=1 "https://github.com/juju/juju-gui-downloadcache.git" $(CACHE)
 
 downloadcache: $(CACHE)
 


### PR DESCRIPTION
This allows building from scratch without having to have an SSH key registered with Github.
