### PR TITLE
Destroy confirmation position

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ pip-selfcheck.json
 *.pyc
 python-shelltoolbox
 releases
+share
 Session.vim
 .*.swp
 tags

--- a/jujugui/static/gui/src/app/components/deployment/choose-cloud/choose-cloud.js
+++ b/jujugui/static/gui/src/app/components/deployment/choose-cloud/choose-cloud.js
@@ -147,10 +147,12 @@ YUI.add('deployment-choose-cloud', function() {
     _generateCloudOnboarding: function() {
       return (
         <div className="deployment-panel__notice twelve-col">
-          <juju.components.SvgIcon
-            name="general-action-blue"
-            size="16" />
-          Fetching available clouds...
+          <p className="deployment-panel__notice-content">
+            <juju.components.SvgIcon
+              name="general-action-blue"
+              size="16" />
+            Fetching available clouds...
+          </p>
         </div>);
     },
 
@@ -196,11 +198,13 @@ YUI.add('deployment-choose-cloud', function() {
     _generateCredentialsOnboarding: function() {
       return (
         <div className="deployment-panel__notice twelve-col">
-          <juju.components.SvgIcon
-            name="general-action-blue"
-            size="16" />
-          Add a public cloud credential, and we can save it as an option
-          for later use
+          <p className="deployment-panel__notice-content">
+            <juju.components.SvgIcon
+              name="general-action-blue"
+              size="16" />
+            Add a public cloud credential, and we can save it as an option
+            for later use
+          </p>
         </div>);
     },
 

--- a/jujugui/static/gui/src/app/components/deployment/choose-cloud/test-choose-cloud.js
+++ b/jujugui/static/gui/src/app/components/deployment/choose-cloud/test-choose-cloud.js
@@ -88,17 +88,21 @@ describe('DeploymentChooseCloud', function() {
         <juju.components.DeploymentPanelContent
           title="Choose cloud">
           <div className="deployment-panel__notice twelve-col">
-            <juju.components.SvgIcon
-              name="general-action-blue"
-              size="16" />
-            Add a public cloud credential, and we can save it as an option
-            for later use
+            <p className="deployment-panel__notice-content">
+              <juju.components.SvgIcon
+                name="general-action-blue"
+                size="16" />
+              Add a public cloud credential, and we can save it as an option
+              for later use
+            </p>
           </div>
           <div className="deployment-panel__notice twelve-col">
-            <juju.components.SvgIcon
-              name="general-action-blue"
-              size="16" />
-            Fetching available clouds...
+            <p className="deployment-panel__notice-content">
+              <juju.components.SvgIcon
+                name="general-action-blue"
+                size="16" />
+              Fetching available clouds...
+            </p>
           </div>
           <div className="deployment-choose-cloud__download twelve-col">
             <juju.components.SvgIcon
@@ -160,10 +164,12 @@ describe('DeploymentChooseCloud', function() {
             </h3>
           </div>
           <div className="deployment-panel__notice twelve-col">
-            <juju.components.SvgIcon
-              name="general-action-blue"
-              size="16" />
-            Fetching available clouds...
+            <p className="deployment-panel__notice-content">
+              <juju.components.SvgIcon
+                name="general-action-blue"
+                size="16" />
+              Fetching available clouds...
+              </p>
           </div>
           <div className="deployment-choose-cloud__download twelve-col">
             <juju.components.SvgIcon
@@ -205,11 +211,13 @@ describe('DeploymentChooseCloud', function() {
         <juju.components.DeploymentPanelContent
           title="Choose cloud">
           <div className="deployment-panel__notice twelve-col">
-            <juju.components.SvgIcon
-              name="general-action-blue"
-              size="16" />
-            Add a public cloud credential, and we can save it as an option
-            for later use
+            <p className="deployment-panel__notice-content">
+              <juju.components.SvgIcon
+                name="general-action-blue"
+                size="16" />
+              Add a public cloud credential, and we can save it as an option
+              for later use
+            </p>
           </div>
           <ul className="deployment-choose-cloud__list twelve-col">
             {[<li className="deployment-choose-cloud__cloud-option four-col "

--- a/jujugui/static/gui/src/app/components/panel/_panel.scss
+++ b/jujugui/static/gui/src/app/components/panel/_panel.scss
@@ -72,6 +72,7 @@
 }
 
 .panel-component.confirmation-popup {
+    position: fixed;
     z-index: index($z-indexed-elements, confirmation-popup);
     top: 0;
     bottom: 0;


### PR DESCRIPTION
Fix the position of the model destroy confirmation popup to always be centred on the screen. Fixes #1643.
Fix the styling of the notifications on the choose-cloud screen. Fixes #1651.