### PR TITLE
Load when no models

### DIFF
--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -1389,8 +1389,14 @@ YUI.add('juju-gui', function(Y) {
           this.storeUser('jem', null, true);
         }
 
-        var modelData = this._pickModel(modelList);
         this.set('environmentList', modelList);
+        if (modelList.length === 0) {
+          var socketUrl = this.createSocketURL(this.get('jujuEnvUUID'));
+          callback.call(
+            this, socketUrl, this.get('user'), this.get('password'));
+          return;
+        }
+        var modelData = this._pickModel(modelList);
 
         // XXX frankban: we should try to connect to all the addresses in
         // parallel instead of assuming private addresses must be excluded.


### PR DESCRIPTION
Don't try and connect to the first model if JEM doesn't return any. Fixes #1657.