### PR TITLE
Improve testing around search result IDs.

### DIFF
--- a/jujugui/static/gui/src/app/components/search-results/search-results.js
+++ b/jujugui/static/gui/src/app/components/search-results/search-results.js
@@ -136,11 +136,15 @@ YUI.add('search-results', function(Y) {
         // Pass in a full id including the owner to allow looking up the entity.
         var ownerPath = `~${obj.owner}`,
             storeId = obj.storeId;
+        // If the store ID is not set, or if it does not already have the owner...
         if (!storeId || storeId.indexOf(ownerPath) < 0) {
+          // And if the ID does not also have an owner...
           if (obj.id.indexOf(ownerPath) < 0) {
+            // Construct a new store ID that has the owner.
             var strippedId = obj.id.replace('cs:', '');
             obj.storeId = `cs:${ownerPath}/${strippedId}`;
           } else {
+            // Else use the existing ID (with owner) as the store ID.
             obj.storeId = obj.id;
           }
         }

--- a/jujugui/static/gui/src/app/components/search-results/search-results.js
+++ b/jujugui/static/gui/src/app/components/search-results/search-results.js
@@ -136,7 +136,8 @@ YUI.add('search-results', function(Y) {
         // Pass in a full id including the owner to allow looking up the entity.
         var ownerPath = `~${obj.owner}`,
             storeId = obj.storeId;
-        // If the store ID is not set, or if it does not already have the owner...
+        // If the store ID is not set, or if it does not already have the
+        // owner...
         if (!storeId || storeId.indexOf(ownerPath) < 0) {
           // And if the ID does not also have an owner...
           if (obj.id.indexOf(ownerPath) < 0) {

--- a/jujugui/static/gui/src/app/components/search-results/search-results.js
+++ b/jujugui/static/gui/src/app/components/search-results/search-results.js
@@ -138,7 +138,8 @@ YUI.add('search-results', function(Y) {
             storeId = obj.storeId;
         if (!storeId || storeId.indexOf(ownerPath) < 0) {
           if (obj.id.indexOf(ownerPath) < 0) {
-            obj.storeId = `${ownerPath}/${obj.id}`;
+            var strippedId = obj.id.replace('cs:', '');
+            obj.storeId = `cs:${ownerPath}/${strippedId}`;
           } else {
             obj.storeId = obj.id;
           }

--- a/jujugui/static/gui/src/app/components/search-results/test-search-results.js
+++ b/jujugui/static/gui/src/app/components/search-results/test-search-results.js
@@ -663,10 +663,14 @@ describe('SearchResults', function() {
       searchResults.setState = setState;
       searchResults.searchCallback(null, rawResults);
       var actualResults = setState.getCall(1).args[0].data.promulgatedResults;
-      assert.deepEqual(actualResults[0].storeId, 'cs:~charmers/trusty/mysql-38');
-      assert.deepEqual(actualResults[1].storeId, 'cs:~stub/precise/postgresql-psql-9');
-      assert.deepEqual(actualResults[2].storeId, 'cs:~charmers/precise/nova-volume-6');
-      assert.deepEqual(actualResults[3].storeId, 'cs:~cloudbaseit/win2012r2/mssql-express-1');
+      assert.deepEqual(actualResults[0].storeId,
+                       'cs:~charmers/trusty/mysql-38');
+      assert.deepEqual(actualResults[1].storeId,
+                       'cs:~stub/precise/postgresql-psql-9');
+      assert.deepEqual(actualResults[2].storeId,
+                       'cs:~charmers/precise/nova-volume-6');
+      assert.deepEqual(actualResults[3].storeId,
+                       'cs:~cloudbaseit/win2012r2/mssql-express-1');
       searchResults._changeActiveComponent = _changeActiveComponent;
     });
   });

--- a/jujugui/static/gui/src/app/components/search-results/test-search-results.js
+++ b/jujugui/static/gui/src/app/components/search-results/test-search-results.js
@@ -621,37 +621,37 @@ describe('SearchResults', function() {
         downloads: 1000,
         owner: 'charmers',
         promulgated: true,
-        id: 'mysql',
+        id: 'cs:trusty/mysql-38',
         type: 'charm'
       }, {
-        name: 'wordpress',
-        displayName: 'wordpress',
-        url: 'http://example.com/wordpress',
-        downloads: 1000,
-        owner: 'charmers',
-        promulgated: true,
-        id: '~charmers/wordpress',
-        type: 'charm'
-      }, {
-        name: 'apache',
-        displayName: 'apache',
-        url: 'http://example.com/apache',
-        downloads: 1000,
-        owner: 'charmers',
-        promulgated: true,
-        id: 'apache',
-        type: 'charm',
-        storeId: 'apache'
-      }, {
-        name: 'postgresql',
-        displayName: 'postgresql',
+        name: 'postgresql-psql',
+        displayName: 'postgresql-psql',
         url: 'http://example.com/postgresql',
         downloads: 1000,
+        owner: 'stub',
+        promulgated: true,
+        id: 'cs:~stub/precise/postgresql-psql-9',
+        type: 'charm'
+      }, {
+        name: 'nova-volume',
+        displayName: 'nova-volume',
+        url: 'http://example.com/nova-volume',
+        downloads: 1000,
         owner: 'charmers',
         promulgated: true,
-        id: 'postgresql',
+        id: 'cs:precise/nova-volume-6',
         type: 'charm',
-        storeId: '~charmers/postgresql'
+        storeId: 'cs:precise/nova-volume-6'
+      }, {
+        name: 'mssql-express',
+        displayName: 'mssql-express',
+        url: 'http://example.com/mssql-express',
+        downloads: 1000,
+        owner: 'cloudbaseit',
+        promulgated: true,
+        id: 'cs:~cloudbaseit/win2012r2/mssql-express-1',
+        type: 'charm',
+        storeId: 'cs:~cloudbaseit/win2012r2/mssql-express-1'
       }];
       var rawResults = results.map(function(obj) {
         var m = {};
@@ -663,10 +663,10 @@ describe('SearchResults', function() {
       searchResults.setState = setState;
       searchResults.searchCallback(null, rawResults);
       var actualResults = setState.getCall(1).args[0].data.promulgatedResults;
-      assert.deepEqual(actualResults[0].storeId, '~charmers/mysql');
-      assert.deepEqual(actualResults[1].storeId, '~charmers/wordpress');
-      assert.deepEqual(actualResults[2].storeId, '~charmers/apache');
-      assert.deepEqual(actualResults[3].storeId, '~charmers/postgresql');
+      assert.deepEqual(actualResults[0].storeId, 'cs:~charmers/trusty/mysql-38');
+      assert.deepEqual(actualResults[1].storeId, 'cs:~stub/precise/postgresql-psql-9');
+      assert.deepEqual(actualResults[2].storeId, 'cs:~charmers/precise/nova-volume-6');
+      assert.deepEqual(actualResults[3].storeId, 'cs:~cloudbaseit/win2012r2/mssql-express-1');
       searchResults._changeActiveComponent = _changeActiveComponent;
     });
   });


### PR DESCRIPTION
The change came about because we had a bug (fixed in https://github.com/juju/juju-gui/pull/1658) that the tests missed because they didn't use particularly realistic IDs. Consequently code for parsing the IDs was never being exercised.

In the course of improving the tests, I found another bug and fixed that as well.