### PR TITLE
Consolidate bundle icon generation

### DIFF
--- a/jujugui/static/gui/src/app/models/entity-extension.js
+++ b/jujugui/static/gui/src/app/models/entity-extension.js
@@ -71,10 +71,10 @@ YUI.add('entity-extension', function(Y) {
         url: attrs.url
       };
       if (type === 'bundle') {
-        entity.iconPath = utils.getIconPath(null, true);
+        entity.iconPath = utils.getIconPath(entity.id, true);
         entity.services = this.parseBundleServices(this.get('services'));
       } else {
-        entity.iconPath = utils.getIconPath(attrs.id, false);
+        entity.iconPath = utils.getIconPath(entity.id, false);
         entity.series = attrs.series;
         entity.tags = attrs.tags || [];
       }

--- a/jujugui/static/gui/src/app/models/entity-extension.js
+++ b/jujugui/static/gui/src/app/models/entity-extension.js
@@ -71,13 +71,8 @@ YUI.add('entity-extension', function(Y) {
         url: attrs.url
       };
       if (type === 'bundle') {
-        var staticURL =
-          (window.juju_config && window.juju_config.staticURL) || '';
-        var basePath = `${staticURL}/static/gui/build/app`;
-        entity.iconPath =
-          `${basePath}/assets/images/non-sprites/bundle.svg`;
-        var srvcs = this.get('services');
-        entity.services = this.parseBundleServices(srvcs);
+        entity.iconPath = utils.getIconPath(null, true);
+        entity.services = this.parseBundleServices(this.get('services'));
       } else {
         entity.iconPath = utils.getIconPath(attrs.id, false);
         entity.series = attrs.series;

--- a/jujugui/static/gui/src/app/views/utils.js
+++ b/jujugui/static/gui/src/app/views/utils.js
@@ -1742,8 +1742,7 @@ YUI.add('juju-view-utils', function(Y) {
   utils.getIconPath = function(charmId, isBundle, env) {
     var cfg = window.juju_config,
         charmstoreURL = (cfg && cfg.charmstoreURL) || '',
-        // charmId won't necessarily be provided if it is a bundle.
-        localIndex = (charmId && charmId.indexOf('local:')) || -1,
+        localIndex = charmId.indexOf('local:'),
         path;
     if (localIndex > -1 && env) {
       path = env.getLocalCharmFileUrl(charmId, 'icon.svg');

--- a/jujugui/static/gui/src/app/views/utils.js
+++ b/jujugui/static/gui/src/app/views/utils.js
@@ -1742,15 +1742,20 @@ YUI.add('juju-view-utils', function(Y) {
   utils.getIconPath = function(charmId, isBundle, env) {
     var cfg = window.juju_config,
         charmstoreURL = (cfg && cfg.charmstoreURL) || '',
-        localIndex = charmId.indexOf('local:'),
+        // charmId won't necessarily be provided if it is a bundle.
+        localIndex = (charmId && charmId.indexOf('local:')) || -1,
         path;
     if (localIndex > -1 && env) {
       path = env.getLocalCharmFileUrl(charmId, 'icon.svg');
     } else if (localIndex === -1) {
       if (typeof isBundle === 'boolean' && isBundle) {
-        var staticURL =
-          (window.juju_config && window.juju_config.staticURL) || '';
-        var basePath = `${staticURL}/static/gui/build/app`;
+        var staticURL = '';
+        if (window.juju_config && window.juju_config.staticURL) {
+          // The missing slash is important because we need to use an
+          // associated path for GISF but a root path for GiJoe.
+          staticURL = window.juju_config.staticURL + '/';
+        }
+        var basePath = `${staticURL}static/gui/build/app`;
         path = `${basePath}/assets/images/non-sprites/bundle.svg`;
       } else {
         // Get the charm ID from the service.  In some cases, this will be

--- a/jujugui/static/gui/src/test/test_entity_extension.js
+++ b/jujugui/static/gui/src/test/test_entity_extension.js
@@ -123,7 +123,7 @@ describe('Entity Extension', function() {
       url: 'http://example.com/',
       // no staticURL is defined on window.juju_config.staticURL so this
       // path should not include a staticURL prefix.
-      iconPath: '/static/gui/build/app/assets/images/non-sprites/bundle.svg',
+      iconPath: 'static/gui/build/app/assets/images/non-sprites/bundle.svg',
       services: []
     };
     assert.deepEqual(expected, entity,

--- a/jujugui/static/gui/src/test/test_utils.js
+++ b/jujugui/static/gui/src/test/test_utils.js
@@ -941,7 +941,7 @@ describe('utilities', function() {
       var path = utils.getIconPath('bundle:elasticsearch', true);
       assert.equal(
         path,
-        '/static/gui/build/app/assets/images/non-sprites/bundle.svg');
+        'static/gui/build/app/assets/images/non-sprites/bundle.svg');
     });
 
     it('uses staticURL if provided for bundle icon location', function() {


### PR DESCRIPTION
The bundle icon was being generated in two places. This consolidates it into one and updates the util method to properly handle the lack of `staticURL`