### PR TITLE
Set the focus on panels when they open

### DIFF
--- a/jujugui/static/gui/src/app/components/entity-details/entity-details.js
+++ b/jujugui/static/gui/src/app/components/entity-details/entity-details.js
@@ -149,6 +149,9 @@ YUI.add('entity-details', function() {
     },
 
     componentDidMount: function() {
+      // Set the keyboard focus on the component so it can be scrolled with the
+      // keyboard. Requires tabIndex to be set on the element.
+      this.refs.content.focus();
       this.detailsXhr = this.props.getEntity(
           this.props.id, this.fetchCallback);
     },
@@ -202,10 +205,12 @@ YUI.add('entity-details', function() {
 
     render: function() {
       return (
-        <div className={this._generateClasses()}>
+        <div className={this._generateClasses()}
+          ref="content"
+          tabIndex="0">
           {this._generateContent()}
         </div>
-      );;
+      );
     }
   });
 

--- a/jujugui/static/gui/src/app/components/entity-details/test-entity-details.js
+++ b/jujugui/static/gui/src/app/components/entity-details/test-entity-details.js
@@ -87,14 +87,18 @@ describe('EntityDetails', function() {
           pluralize={pluralize}
           addNotification={addNotification}
           makeEntityModel={makeEntityModel} />, true);
-    shallowRenderer.getMountedInstance().componentDidMount();
+    var instance = shallowRenderer.getMountedInstance();
+    instance.refs = {content: {focus: sinon.stub()}};
+    instance.componentDidMount();
     var output = shallowRenderer.getRenderOutput();
     assert.isTrue(getEntity.calledOnce,
                   'getEntity function not called');
     assert.equal(getEntity.args[0][0], id,
                  'getEntity not called with the entity ID');
     var expected = (
-      <div className={'entity-details charm'}>
+      <div className={'entity-details charm'}
+        ref="content"
+        tabIndex="0">
         <div>
           <juju.components.EntityHeader
             entityModel={mockEntity}
@@ -145,10 +149,13 @@ describe('EntityDetails', function() {
           pluralize={pluralize}
           scrollPosition={0} />, true);
     var instance = shallowRenderer.getMountedInstance();
+    instance.refs = {content: {focus: sinon.stub()}};
     instance.componentDidMount();
     var output = shallowRenderer.getRenderOutput();
     var expected = (
-      <div className="entity-details">
+      <div className="entity-details"
+        ref="content"
+        tabIndex="0">
         <p className="error">
           There was a problem while loading the entity details.
           You could try searching for another charm or bundle or go{' '}
@@ -192,14 +199,18 @@ describe('EntityDetails', function() {
           pluralize={pluralize}
           addNotification={addNotification}
           makeEntityModel={makeEntityModel} />, true);
-    shallowRenderer.getMountedInstance().componentDidMount();
+    var instance = shallowRenderer.getMountedInstance();
+    instance.refs = {content: {focus: sinon.stub()}};
+    instance.componentDidMount();
     var output = shallowRenderer.getRenderOutput();
     assert.isTrue(getEntity.calledOnce,
                   'getEntity function not called');
     assert.equal(getEntity.args[0][0], id,
                  'getEntity not called with the entity ID');
     var expected = (
-      <div className={'entity-details bundle'}>
+      <div className={'entity-details bundle'}
+        ref="content"
+        tabIndex="0">
         <div>
           <juju.components.EntityHeader
             entityModel={mockEntity}
@@ -251,8 +262,33 @@ describe('EntityDetails', function() {
           id={id}
           pluralize={pluralize}
           scrollPosition={0} />, true);
-    shallowRenderer.getMountedInstance().componentDidMount();
-    shallowRenderer.unmount();
+    var instance = shallowRenderer.getMountedInstance();
+    instance.refs = {content: {focus: sinon.stub()}};
+    instance.componentDidMount();
+    instance.componentWillUnmount();
     assert.equal(abort.callCount, 1);
+  });
+
+  it('sets the focus when rendered', function() {
+    var focus = sinon.stub();
+    var shallowRenderer = jsTestUtils.shallowRender(
+      <juju.components.EntityDetails
+        addNotification={sinon.stub()}
+        apiUrl="http://example.com/"
+        id="test"
+        deployService={sinon.spy()}
+        changeState={sinon.spy()}
+        getDiagramURL={sinon.stub()}
+        getEntity={sinon.spy()}
+        getFile={sinon.stub()}
+        importBundleYAML={sinon.stub()}
+        makeEntityModel={sinon.spy()}
+        pluralize={sinon.spy()}
+        renderMarkdown={sinon.stub()}
+        scrollPosition={0} />, true);
+    var instance = shallowRenderer.getMountedInstance();
+    instance.refs = {content: {focus: focus}};
+    instance.componentDidMount();
+    assert.equal(focus.callCount, 1);
   });
 });

--- a/jujugui/static/gui/src/app/components/panel/panel.js
+++ b/jujugui/static/gui/src/app/components/panel/panel.js
@@ -22,6 +22,12 @@ YUI.add('panel-component', function() {
 
   juju.components.Panel = React.createClass({
 
+    componentDidMount: function() {
+      // Set the keyboard focus on the component so it can be scrolled with the
+      // keyboard. Requires tabIndex to be set on the element.
+      this.refs.content.focus();
+    },
+
     /**
       Returns the supplied classes with the 'active' class applied if the
       component is the one which is active.
@@ -68,7 +74,9 @@ YUI.add('panel-component', function() {
     render: function() {
       return (
         <div className={this._genClasses()}
-          onClick={this._handleClick}>
+          onClick={this._handleClick}
+          ref="content"
+          tabIndex="0">
           <div className="panel-component__inner"
             onClick={this._stopBubble}>
             {this.props.children}

--- a/jujugui/static/gui/src/app/components/panel/test-panel.js
+++ b/jujugui/static/gui/src/app/components/panel/test-panel.js
@@ -40,7 +40,9 @@ describe('PanelComponent', function() {
     var output = renderer.getRenderOutput();
     var expected = (
       <div className="panel-component custom-instance-name"
-        onClick={instance._handleClick}>
+        onClick={instance._handleClick}
+        ref="content"
+        tabIndex="0">
         <div className="panel-component__inner"
           onClick={instance._stopBubble}>
           {undefined}
@@ -58,7 +60,9 @@ describe('PanelComponent', function() {
     var output = renderer.getRenderOutput();
     var expected = (
       <div className="panel-component custom-instance-name hidden"
-        onClick={instance._handleClick}>
+        onClick={instance._handleClick}
+        ref="content"
+        tabIndex="0">
         <div className="panel-component__inner"
           onClick={instance._stopBubble}>
           {undefined}
@@ -79,7 +83,9 @@ describe('PanelComponent', function() {
     var output = renderer.getRenderOutput();
     assert.deepEqual(output,
       <div className="panel-component custom-instance-name"
-        onClick={instance._handleClick}>
+        onClick={instance._handleClick}
+        ref="content"
+        tabIndex="0">
         <div className="panel-component__inner"
           onClick={instance._stopBubble}>
           <div>child</div>
@@ -113,5 +119,16 @@ describe('PanelComponent', function() {
     output.props.children.props.onClick({stopPropagation: stopPropagation});
     assert.equal(stopPropagation.callCount, 1);
     assert.equal(clickAction.callCount, 0);
+  });
+
+  it('sets the keyboard focus when it loads', function() {
+    var focus = sinon.stub();
+    var renderer = jsTestUtils.shallowRender(
+        <juju.components.Panel
+          visible={true} />, true);
+    var instance = renderer.getMountedInstance();
+    instance.refs = {content: {focus: focus}};
+    instance.componentDidMount();
+    assert.equal(focus.callCount, 1);
   });
 });


### PR DESCRIPTION
When panels are displayed then set the keyboard focus on the content so they can be navigated with the keyboard. Fixes #1524.