### PR TITLE
Fix search focus

### DIFF
--- a/jujugui/static/gui/src/app/components/charmbrowser/charmbrowser.js
+++ b/jujugui/static/gui/src/app/components/charmbrowser/charmbrowser.js
@@ -181,10 +181,14 @@ YUI.add('charmbrowser-component', function() {
     },
 
     render: function() {
+      // Do not focus on the panel when the midpoint is opened so that the focus
+      // remains on the search box.
+      var focus = this.state.activeComponent !== 'mid-point';
       return (
         <juju.components.Panel
           clickAction={this._close}
           instanceName="white-box"
+          focus={focus}
           visible={true}>
           <div className="charmbrowser"
             ref="charmbrowser">

--- a/jujugui/static/gui/src/app/components/charmbrowser/test-charmbrowser.js
+++ b/jujugui/static/gui/src/app/components/charmbrowser/test-charmbrowser.js
@@ -76,6 +76,7 @@ describe('Charmbrowser', function() {
         <juju.components.Panel
           instanceName="white-box"
           clickAction={instance._close}
+          focus={true}
           visible={true}>
           <div className="charmbrowser"
             ref="charmbrowser">
@@ -129,6 +130,7 @@ describe('Charmbrowser', function() {
         <juju.components.Panel
           instanceName="white-box"
           clickAction={instance._close}
+          focus={false}
           visible={true}>
           <div className="charmbrowser"
             ref="charmbrowser">
@@ -175,6 +177,7 @@ describe('Charmbrowser', function() {
         <juju.components.Panel
           instanceName="white-box"
           clickAction={instance._close}
+          focus={true}
           visible={true}>
           <div className="charmbrowser"
             ref="charmbrowser">
@@ -235,6 +238,7 @@ describe('Charmbrowser', function() {
         <juju.components.Panel
           instanceName="white-box"
           clickAction={instance._close}
+          focus={true}
           visible={true}>
           <div className="charmbrowser"
             ref="charmbrowser">

--- a/jujugui/static/gui/src/app/components/panel/panel.js
+++ b/jujugui/static/gui/src/app/components/panel/panel.js
@@ -21,11 +21,23 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 YUI.add('panel-component', function() {
 
   juju.components.Panel = React.createClass({
+    propTypes: {
+      clickAction: React.PropTypes.func,
+      focus: React.PropTypes.bool,
+      instanceName: React.PropTypes.string.isRequired,
+      visible: React.PropTypes.bool.isRequired
+    },
+
+    getDefaultProps: function() {
+      return {focus: true};
+    },
 
     componentDidMount: function() {
       // Set the keyboard focus on the component so it can be scrolled with the
       // keyboard. Requires tabIndex to be set on the element.
-      this.refs.content.focus();
+      if (this.props.focus) {
+        this.refs.content.focus();
+      }
     },
 
     /**

--- a/jujugui/static/gui/src/app/components/panel/test-panel.js
+++ b/jujugui/static/gui/src/app/components/panel/test-panel.js
@@ -131,4 +131,16 @@ describe('PanelComponent', function() {
     instance.componentDidMount();
     assert.equal(focus.callCount, 1);
   });
+
+  it('can not set the keyboard focus on load', function() {
+    var focus = sinon.stub();
+    var renderer = jsTestUtils.shallowRender(
+        <juju.components.Panel
+          focus={false}
+          visible={true} />, true);
+    var instance = renderer.getMountedInstance();
+    instance.refs = {content: {focus: focus}};
+    instance.componentDidMount();
+    assert.equal(focus.callCount, 0);
+  });
 });


### PR DESCRIPTION
Correctly set the focus on the header search when the mid-point opens. Fixes #1703.