### PR TITLE
Fix create-new-model for for Controllers

### DIFF
--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -793,6 +793,7 @@ YUI.add('juju-gui', function(Y) {
             this, this.createSocketURL.bind(this), this.switchEnv.bind(this),
             this.env)}
           showConnectingMask={this.showConnectingMask.bind(this)}
+          hideConnectingMask={this.hideConnectingMask.bind(this)}
           user={user}
           users={Y.clone(this.get('users'), true)}
           charmstore={this.get('charmstore')} />,
@@ -2077,6 +2078,18 @@ YUI.add('juju-gui', function(Y) {
       var msg = document.getElementById('loading-message');
       if (msg) {
         msg.style.display = 'block';
+      }
+    },
+
+    /**
+      Hides the connecting to Juju model mask.
+      @method hideConnectingMask
+    */
+    hideConnectingMask: function() {
+      this.maskVisibility(false);
+      var msg = document.getElementById('loading-message');
+      if (msg) {
+        msg.style.display = 'none';
       }
     },
 

--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -786,6 +786,7 @@ YUI.add('juju-gui', function(Y) {
           changeState={this.changeState.bind(this)}
           getDiagramURL={charmstore.getDiagramURL.bind(charmstore)}
           interactiveLogin={this.get('interactiveLogin')}
+          jem={this.jem}
           pluralize={utils.pluralize.bind(this)}
           staticURL={window.juju_config.staticURL}
           storeUser={this.storeUser.bind(this)}

--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -792,6 +792,7 @@ YUI.add('juju-gui', function(Y) {
           switchModel={utils.switchModel.bind(
             this, this.createSocketURL.bind(this), this.switchEnv.bind(this),
             this.env)}
+          showConnectingMask={this.showConnectingMask.bind(this)}
           user={user}
           users={Y.clone(this.get('users'), true)}
           charmstore={this.get('charmstore')} />,

--- a/jujugui/static/gui/src/app/components/deployment/input/_input.scss
+++ b/jujugui/static/gui/src/app/components/deployment/input/_input.scss
@@ -12,8 +12,6 @@
         width: calc(100% - 20px);
         height: 20px;
         margin-bottom: 20px;
-        padding-top: 25px;
-        padding-bottom: 7px;
     }
 
     &__errors {

--- a/jujugui/static/gui/src/app/components/deployment/input/_input.scss
+++ b/jujugui/static/gui/src/app/components/deployment/input/_input.scss
@@ -12,6 +12,8 @@
         width: calc(100% - 20px);
         height: 20px;
         margin-bottom: 20px;
+        padding-top: 25px;
+        padding-bottom: 7px;
     }
 
     &__errors {

--- a/jujugui/static/gui/src/app/components/deployment/input/input.js
+++ b/jujugui/static/gui/src/app/components/deployment/input/input.js
@@ -106,8 +106,13 @@ YUI.add('deployment-input', function() {
 
     render: function() {
       var {labelElement, id} = this._generateLabel();
+      var classes = classNames(
+        'deployment-input', {
+          error: !!this.state.errors
+        }
+      );
       return (
-        <div className="deployment-input">
+        <div className={classes}>
           {labelElement}
           <input className="deployment-input__field"
             defaultValue={this.props.value}

--- a/jujugui/static/gui/src/app/components/deployment/input/input.js
+++ b/jujugui/static/gui/src/app/components/deployment/input/input.js
@@ -24,7 +24,7 @@ YUI.add('deployment-input', function() {
 
     propTypes: {
       disabled: React.PropTypes.bool,
-      label: React.PropTypes.string.isRequired,
+      label: React.PropTypes.string,
       placeholder: React.PropTypes.string.isRequired,
       required: React.PropTypes.bool,
       validate: React.PropTypes.array,
@@ -82,16 +82,33 @@ YUI.add('deployment-input', function() {
       return this.refs.field.value;
     },
 
-
-    render: function() {
+    /**
+      Generates a label for the input if the prop is provided.
+      @method _generateLabel
+    */
+    _generateLabel: function() {
       var label = this.props.label;
-      var id = label.replace(' ', '-');
-      return (
-        <div className="deployment-input">
+      var element, id;
+      if (label) {
+        id = label.replace(' ', '-');
+        element =
           <label className="deployment-input__label"
             htmlFor={id}>
             {label}
-          </label>
+          </label>;
+      }
+      return {
+        labelElement: element,
+        id: id
+      };
+    },
+
+
+    render: function() {
+      var {labelElement, id} = this._generateLabel();
+      return (
+        <div className="deployment-input">
+          {labelElement}
           <input className="deployment-input__field"
             defaultValue={this.props.value}
             disabled={this.props.disabled}

--- a/jujugui/static/gui/src/app/components/deployment/input/test-input.js
+++ b/jujugui/static/gui/src/app/components/deployment/input/test-input.js
@@ -138,4 +138,55 @@ describe('DeploymentInput', function() {
     );
     assert.deepEqual(output.props.children[2], expected);
   });
+
+  it('allows the label to be optional', () => {
+    var renderer = jsTestUtils.shallowRender(
+      <juju.components.DeploymentInput
+        disabled={false}
+        placeholder="us-central-1"
+        required={true}
+        ref="templateRegion"
+        validate={[{
+          regex: /\S+/,
+          error: 'This field is required.'
+        }]}
+        value="default" />, true);
+    var instance = renderer.getMountedInstance();
+    var output = renderer.getRenderOutput();
+    var expected = (
+      <div className="deployment-input">
+        {undefined}
+        <input className="deployment-input__field"
+          defaultValue="default"
+          disabled={false}
+          id={undefined}
+          placeholder="us-central-1"
+          required={true}
+          onChange={instance.validate}
+          ref="field"
+          type="text" />
+        {null}
+      </div>
+    );
+    assert.deepEqual(output, expected);
+  });
+
+  it('adds a class to the wrapper element on error', () => {
+    var renderer = jsTestUtils.shallowRender(
+      <juju.components.DeploymentInput
+        disabled={false}
+        placeholder="us-central-1"
+        required={true}
+        ref="templateRegion"
+        validate={[{
+          regex: /\S+/,
+          error: 'This field is required.'
+        }]} />, true);
+    var instance = renderer.getMountedInstance();
+    instance.refs = {field: {value: ''}};
+    var output = renderer.getRenderOutput();
+    output.props.children[1].props.onChange();
+    output = renderer.getRenderOutput();
+    assert.deepEqual(output.props.className, 'deployment-input error');
+  });
 });

--- a/jujugui/static/gui/src/app/components/user-profile/_user-profile.scss
+++ b/jujugui/static/gui/src/app/components/user-profile/_user-profile.scss
@@ -13,7 +13,7 @@
                 border-width: 0;
             }
             .deployment-input__field {
-              padding: 0;
+                padding: 0;
             }
             .button--inline-neutral.first {
                 width: 150px;
@@ -31,9 +31,9 @@
             white-space: nowrap;
             transition: all 0.5s ease-in;
             width: 150px;
-            outline: none;
-            padding: 10px 0;
             display: inline-block;
+            padding-right: 0;
+            padding-left: 0;
         }
 
         .deployment-input {
@@ -41,14 +41,14 @@
 
             &.error {
                 .deployment-input__field {
-                    border: 1px solid #df382c;
+                    border: 1px solid $error;
                 }
             }
         }
 
         .deployment-input__errors {
             position: absolute;
-            z-index: 600;
+            z-index: index($z-indexed-elements, more-menu);
             top: 60px;
             width: 350px;
             text-align: left;
@@ -60,7 +60,7 @@
             transition: all 0.5s ease-in;
             margin-bottom: 0;
             box-sizing: border-box;
-            height: 38px;
+            height: 40px;
         }
     }
 
@@ -84,8 +84,12 @@
     &__empty {
         text-align: center;
 
+        .clearfix {
+            clear: both;
+        }
+
         &-image {
-            margin: 40px 0;
+            margin: 0 0 40px 0;
         }
 
         &-title {
@@ -96,10 +100,6 @@
             max-width: 360px;
             margin: 0 auto;
             color: $warm-grey;
-        }
-
-        &-button {
-            margin-top: 40px;
         }
     }
 

--- a/jujugui/static/gui/src/app/components/user-profile/_user-profile.scss
+++ b/jujugui/static/gui/src/app/components/user-profile/_user-profile.scss
@@ -29,7 +29,7 @@
         .button--inline-neutral {
             overflow: hidden;
             white-space: nowrap;
-            transition: all 0.5s ease-in;
+            transition: width 0.5s ease-in, padding 0.5s ease-in;
             width: 150px;
             display: inline-block;
             padding-right: 0;

--- a/jujugui/static/gui/src/app/components/user-profile/_user-profile.scss
+++ b/jujugui/static/gui/src/app/components/user-profile/_user-profile.scss
@@ -1,7 +1,53 @@
 .user-profile {
+
     &__create-new {
         float: right;
         font-size: 1rem;
+        width: 400px;
+        text-align: right;
+
+        &.collapsed {
+            .deployment-input__field,
+            .button--inline-neutral.second {
+                width: 0;
+                border-width: 0;
+            }
+            .deployment-input__field {
+              padding: 0;
+            }
+            .button--inline-neutral.first {
+                width: 150px;
+                border-width: 1px;
+            }
+        }
+
+        .button--inline-neutral.first {
+            width: 0;
+            border-width: 0;
+        }
+
+        .button--inline-neutral {
+            overflow: hidden;
+            white-space: nowrap;
+            transition: all 0.5s ease-in;
+            width: 150px;
+            outline: none;
+            padding: 10px 0;
+            display: inline-block;
+        }
+
+        .deployment-input {
+            display: inline-block;
+        }
+
+        .deployment-input__field {
+            padding: 8px;
+            width: 200px;
+            transition: all 0.5s ease-in;
+            margin-bottom: 0;
+            box-sizing: border-box;
+            height: 38px;
+        }
     }
 
     &__close {

--- a/jujugui/static/gui/src/app/components/user-profile/_user-profile.scss
+++ b/jujugui/static/gui/src/app/components/user-profile/_user-profile.scss
@@ -38,6 +38,20 @@
 
         .deployment-input {
             display: inline-block;
+
+            &.error {
+                .deployment-input__field {
+                    border: 1px solid #df382c;
+                }
+            }
+        }
+
+        .deployment-input__errors {
+            position: absolute;
+            z-index: 600;
+            top: 60px;
+            width: 350px;
+            text-align: left;
         }
 
         .deployment-input__field {

--- a/jujugui/static/gui/src/app/components/user-profile/test-user-profile.js
+++ b/jujugui/static/gui/src/app/components/user-profile/test-user-profile.js
@@ -58,7 +58,17 @@ describe('UserProfile', () => {
     env = {
       destroyModel: sinon.stub().callsArg(0),
       findFacadeVersion: sinon.stub(),
-      get: sinon.stub().returns('default')
+      get: sinon.stub().returns('default'),
+      createModel: (modelName, userName, callback) => {
+        assert.equal(modelName, 'newmodelname', 'model name not set properly');
+        assert.equal(userName, 'test-owner', 'user name not set properly');
+        // Simulate the model being created.
+        callback({
+          err: null,
+          uuid: 'abc123',
+          name: modelName
+        });
+      }
     };
   });
 
@@ -87,6 +97,7 @@ describe('UserProfile', () => {
         interactiveLogin={true}
         changeState={sinon.stub()}
         pluralize={pluralize}
+        showConnectingMask={sinon.stub()}
         storeUser={sinon.stub()}
         user={users.charmstore} />, true);
     var instance = component.getMountedInstance();
@@ -115,12 +126,31 @@ describe('UserProfile', () => {
                 Your models, bundles and charms will appear here when you create
                 them.
               </p>
-              <p className="user-profile__empty-button">
-                <juju.components.GenericButton
-                  action={instance.switchModel}
-                  type='inline-neutral'
-                  title='Create new model' />
-              </p>
+              <div className="user-profile__create-new user-profile__empty-button collapsed">
+                <form onSubmit={instance.createAndSwitch}>
+                  <juju.components.GenericButton
+                    action={instance._toggleNameInput}
+                    type='inline-neutral first'
+                    title='Create new' />
+                  <juju.components.DeploymentInput
+                    placeholder="untitled_model"
+                    required={true}
+                    ref="modelName"
+                    validate={[{
+                      regex: /\S+/,
+                      error: 'This field is required.'
+                    }, {
+                      regex: /^[a-zA-Z0-9]([a-zA-Z0-9.-]*[a-zA-Z0-9])?$/,
+                      error: 'This field must only contain upper and lowercase ' +
+                        'letters, numbers, and hyphens. It must not start or ' +
+                        'end with a hyphen.'
+                    }]} />
+                  <juju.components.GenericButton
+                    action={instance.createAndSwitch}
+                    type='inline-neutral second'
+                    title='Submit' />
+                </form>
+              </div>
             </div>
           </div>
         </div>
@@ -145,6 +175,7 @@ describe('UserProfile', () => {
         changeState={sinon.stub()}
         pluralize={sinon.stub()}
         staticURL='surl'
+        showConnectingMask={sinon.stub()}
         storeUser={sinon.stub()}
         user={users.charmstore} />);
     assert.equal(
@@ -168,6 +199,7 @@ describe('UserProfile', () => {
         interactiveLogin={true}
         changeState={sinon.stub()}
         pluralize={sinon.stub()}
+        showConnectingMask={sinon.stub()}
         storeUser={sinon.stub()}
         user={users.charmstore} />, true);
     var output = component.getRenderOutput();
@@ -201,6 +233,7 @@ describe('UserProfile', () => {
         interactiveLogin={true}
         changeState={sinon.stub()}
         pluralize={sinon.stub()}
+        showConnectingMask={sinon.stub()}
         storeUser={sinon.stub()}
         user={users.charmstore} />, true);
     var output = component.getRenderOutput();
@@ -241,6 +274,7 @@ describe('UserProfile', () => {
         interactiveLogin={true}
         changeState={changeState}
         pluralize={pluralize}
+        showConnectingMask={sinon.stub()}
         storeUser={sinon.stub()}
         user={users.charmstore} />, true);
     var instance = component.getMountedInstance();
@@ -261,11 +295,30 @@ describe('UserProfile', () => {
               <span className="user-profile__size">
                 ({1})
               </span>
-              <div className='user-profile__create-new'>
-                <juju.components.GenericButton
-                  action={instance.switchModel}
-                  type='inline-neutral'
-                  title='Create new' />
+              <div className="user-profile__create-new collapsed">
+                <form onSubmit={instance.createAndSwitch}>
+                  <juju.components.GenericButton
+                    action={instance._toggleNameInput}
+                    type='inline-neutral first'
+                    title='Create new' />
+                  <juju.components.DeploymentInput
+                    placeholder="untitled_model"
+                    required={true}
+                    ref="modelName"
+                    validate={[{
+                      regex: /\S+/,
+                      error: 'This field is required.'
+                    }, {
+                      regex: /^[a-zA-Z0-9]([a-zA-Z0-9.-]*[a-zA-Z0-9])?$/,
+                      error: 'This field must only contain upper and lowercase ' +
+                        'letters, numbers, and hyphens. It must not start or ' +
+                        'end with a hyphen.'
+                    }]} />
+                  <juju.components.GenericButton
+                    action={instance.createAndSwitch}
+                    type='inline-neutral second'
+                    title='Submit' />
+                </form>
               </div>
             </div>
             <ul className="user-profile__list twelve-col">
@@ -448,6 +501,7 @@ describe('UserProfile', () => {
         interactiveLogin={true}
         changeState={sinon.stub()}
         pluralize={sinon.stub()}
+        showConnectingMask={sinon.stub()}
         storeUser={sinon.stub()}
         user={users.charmstore} />, true);
     var output = component.getRenderOutput();
@@ -486,6 +540,7 @@ describe('UserProfile', () => {
         getDiagramURL={sinon.stub()}
         interactiveLogin={false}
         pluralize={pluralize}
+        showConnectingMask={sinon.stub()}
         storeUser={sinon.stub()}
         user={users.charmstore} />);
     var expected = (
@@ -521,6 +576,7 @@ describe('UserProfile', () => {
         getDiagramURL={sinon.stub()}
         interactiveLogin={true}
         pluralize={sinon.stub()}
+        showConnectingMask={sinon.stub()}
         storeUser={storeUser}
         user={users.charmstore} />, true);
     var instance = renderer.getMountedInstance();
@@ -545,6 +601,7 @@ describe('UserProfile', () => {
         getDiagramURL={sinon.stub()}
         interactiveLogin={true}
         pluralize={sinon.stub()}
+        showConnectingMask={sinon.stub()}
         storeUser={sinon.stub()}
         user={users.charmstore} />, true);
     assert.equal(list.callCount, 0);
@@ -561,6 +618,7 @@ describe('UserProfile', () => {
         getDiagramURL={sinon.stub()}
         interactiveLogin={true}
         pluralize={sinon.stub()}
+        showConnectingMask={sinon.stub()}
         storeUser={sinon.stub()}
         user={users.charmstore} />);
     assert.equal(list.callCount, 2);
@@ -581,6 +639,7 @@ describe('UserProfile', () => {
         charmstore={{}}
         env={env}
         getDiagramURL={sinon.stub()}
+        showConnectingMask={sinon.stub()}
         pluralize={sinon.stub()}
         storeUser={sinon.stub()}
         user={users.charmstore}
@@ -615,6 +674,7 @@ describe('UserProfile', () => {
         interactiveLogin={true}
         listModels={sinon.stub()}
         pluralize={sinon.stub()}
+        showConnectingMask={sinon.stub()}
         storeUser={sinon.stub()}
         switchModel={sinon.stub()}
         user={users.charmstore} />, true);
@@ -646,6 +706,7 @@ describe('UserProfile', () => {
         interactiveLogin={true}
         listModels={listModels}
         pluralize={sinon.stub()}
+        showConnectingMask={sinon.stub()}
         storeUser={sinon.stub()}
         switchModel={sinon.stub()}
         user={users.charmstore} />, true);
@@ -672,6 +733,7 @@ describe('UserProfile', () => {
         env={env}
         getDiagramURL={sinon.stub()}
         interactiveLogin={true}
+        showConnectingMask={sinon.stub()}
         storeUser={sinon.stub()}
         pluralize={pluralize}
         user={users.charmstore} />, true);
@@ -696,11 +758,94 @@ describe('UserProfile', () => {
         getDiagramURL={sinon.stub()}
         listModels={sinon.stub().callsArgWith(0, null, {models: models})}
         pluralize={sinon.stub()}
+        showConnectingMask={sinon.stub()}
         storeUser={sinon.stub()}
         switchModel={sinon.stub()}
         user={users.charmstore} />, true);
     var output = component.getRenderOutput();
     assert.isUndefined(output.props.children.props.children.props.children[1]
       .props.children[0].props.children[0].props.children[2]);
+  });
+
+  it('creates then switches to newly created models', () => {
+    // This test doesn't check the user interactions and animations, that
+    // will need to be done with the uitest suite.
+    var showConnectingMask = sinon.stub();
+    var switchModel = sinon.stub();
+    var component = jsTestUtils.shallowRender(
+      <juju.components.UserProfile
+        addNotification={sinon.stub()}
+        users={users}
+        canCreateNew={true}
+        changeState={sinon.stub()}
+        charmstore={charmstore}
+        env={env}
+        getDiagramURL={sinon.stub()}
+        listModels={sinon.stub().callsArgWith(0, null, {models: models})}
+        pluralize={sinon.stub()}
+        showConnectingMask={showConnectingMask}
+        storeUser={sinon.stub()}
+        switchModel={switchModel}
+        user={users.charmstore} />, true);
+    var output = component.getRenderOutput();
+    var instance = component.getMountedInstance();
+    // Set up the component to simulate user action.
+    instance.refs = {
+      modelName: {
+        validate: _ => true,
+        getValue: _ => 'newmodelname'
+      }
+    };
+    var preventable = { preventDefault: sinon.stub() };
+    // Call the action method in the proper element.
+    output.props.children.props.children.props.children[1].props.children[0]
+      .props.children[0].props.children[2].props.children.props.children[2]
+      .props.action(preventable);
+    assert.equal(preventable.preventDefault.callCount, 1, 'default not prevented');
+    assert.equal(showConnectingMask.callCount, 1, 'mask not shown');
+    // Make sure that it switches to the model after it's created.
+    assert.equal(switchModel.callCount, 1, 'model not switched to');
+    assert.equal(switchModel.args[0][0], 'abc123', 'uuid not passed through');
+    assert.equal(switchModel.args[0][2], 'newmodelname', 'model name not set');
+  });
+
+  it('does not submit to create new if name does not validate', () => {
+    // This test doesn't check the user interactions and animations, that
+    // will need to be done with the uitest suite.
+    var showConnectingMask = sinon.stub();
+    var switchModel = sinon.stub();
+    var component = jsTestUtils.shallowRender(
+      <juju.components.UserProfile
+        addNotification={sinon.stub()}
+        users={users}
+        canCreateNew={true}
+        changeState={sinon.stub()}
+        charmstore={charmstore}
+        env={env}
+        getDiagramURL={sinon.stub()}
+        listModels={sinon.stub().callsArgWith(0, null, {models: models})}
+        pluralize={sinon.stub()}
+        showConnectingMask={showConnectingMask}
+        storeUser={sinon.stub()}
+        switchModel={switchModel}
+        user={users.charmstore} />, true);
+    var output = component.getRenderOutput();
+    var instance = component.getMountedInstance();
+    // Set up the component to simulate user action.
+    instance.refs = {
+      modelName: {
+        validate: _ => false
+      }
+    };
+    var preventable = { preventDefault: sinon.stub() };
+    // Call the action method in the proper element.
+    output.props.children.props.children.props.children[1].props.children[0]
+      .props.children[0].props.children[2].props.children.props.children[2]
+      .props.action(preventable);
+    assert.equal(
+      preventable.preventDefault.callCount, 1, 'default not prevented');
+    assert.equal(showConnectingMask.callCount, 0, 'mask shown');
+    // Make sure that it switches to the model after it's created.
+    assert.equal(switchModel.callCount, 0, 'model should not be switched to');
   });
 });

--- a/jujugui/static/gui/src/app/components/user-profile/test-user-profile.js
+++ b/jujugui/static/gui/src/app/components/user-profile/test-user-profile.js
@@ -120,7 +120,7 @@ describe('UserProfile', () => {
               <div className="user-profile__create-new user-profile__empty-button collapsed">
                 <form onSubmit={instance.createAndSwitch}>
                   <juju.components.GenericButton
-                    action={instance._toggleNameInput}
+                    action={instance._nextCreateStep}
                     type='inline-neutral first'
                     title='Create new' />
                   <juju.components.DeploymentInput
@@ -305,7 +305,7 @@ describe('UserProfile', () => {
               <div className="user-profile__create-new collapsed">
                 <form onSubmit={instance.createAndSwitch}>
                   <juju.components.GenericButton
-                    action={instance._toggleNameInput}
+                    action={instance._nextCreateStep}
                     type='inline-neutral first'
                     title='Create new' />
                   <juju.components.DeploymentInput
@@ -922,5 +922,52 @@ describe('UserProfile', () => {
       message: 'this is an error',
       level: 'error'
     });
+  });
+
+  it('swtches models by switching to disconnected with JIMM', () => {
+    var switchModel = sinon.stub();
+    var showConnectingMask = sinon.stub();
+    env.createModel = sinon.stub();
+    var component = jsTestUtils.shallowRender(
+      <juju.components.UserProfile
+        addNotification={sinon.stub()}
+        users={users}
+        canCreateNew={true}
+        changeState={sinon.stub()}
+        charmstore={charmstore}
+        env={env}
+        getDiagramURL={sinon.stub()}
+        listModels={sinon.stub().callsArgWith(0, null, {models: models})}
+        jem={{}}
+        pluralize={sinon.stub()}
+        hideConnectingMask={sinon.stub()}
+        showConnectingMask={showConnectingMask}
+        storeUser={sinon.stub()}
+        switchModel={switchModel}
+        user={users.charmstore} />, true);
+    var output = component.getRenderOutput();
+    // Click the button.
+    output.props.children.props.children.props.children[1].props.children[0]
+      .props.children[0].props.children[2].props.children.props.children[0]
+      .props.action();
+    // It should not try to create a model.
+    assert.equal(showConnectingMask.callCount, 0, 'should not show mask');
+    assert.equal(env.createModel.callCount, 0, 'it should not create model');
+    // Switching models.
+    assert.equal(switchModel.callCount, 1, 'it should have called switchModel');
+    assert.deepEqual(
+      switchModel.args[0], [
+        undefined,
+        [{
+          uuid: 'env1',
+          name: 'spinach/sandbox',
+          lastConnection: 'today',
+          ownerTag: 'test-owner',
+          isAlive: true,
+          owner: 'test-owner'
+        }],
+        undefined,
+        undefined
+      ]);
   });
 });

--- a/jujugui/static/gui/src/app/components/user-profile/test-user-profile.js
+++ b/jujugui/static/gui/src/app/components/user-profile/test-user-profile.js
@@ -97,6 +97,7 @@ describe('UserProfile', () => {
         interactiveLogin={true}
         changeState={sinon.stub()}
         pluralize={pluralize}
+        hideConnectingMask={sinon.stub()}
         showConnectingMask={sinon.stub()}
         storeUser={sinon.stub()}
         user={users.charmstore} />, true);
@@ -177,6 +178,7 @@ describe('UserProfile', () => {
         changeState={sinon.stub()}
         pluralize={sinon.stub()}
         staticURL='surl'
+        hideConnectingMask={sinon.stub()}
         showConnectingMask={sinon.stub()}
         storeUser={sinon.stub()}
         user={users.charmstore} />);
@@ -201,6 +203,7 @@ describe('UserProfile', () => {
         interactiveLogin={true}
         changeState={sinon.stub()}
         pluralize={sinon.stub()}
+        hideConnectingMask={sinon.stub()}
         showConnectingMask={sinon.stub()}
         storeUser={sinon.stub()}
         user={users.charmstore} />, true);
@@ -235,6 +238,7 @@ describe('UserProfile', () => {
         interactiveLogin={true}
         changeState={sinon.stub()}
         pluralize={sinon.stub()}
+        hideConnectingMask={sinon.stub()}
         showConnectingMask={sinon.stub()}
         storeUser={sinon.stub()}
         user={users.charmstore} />, true);
@@ -276,6 +280,7 @@ describe('UserProfile', () => {
         interactiveLogin={true}
         changeState={changeState}
         pluralize={pluralize}
+        hideConnectingMask={sinon.stub()}
         showConnectingMask={sinon.stub()}
         storeUser={sinon.stub()}
         user={users.charmstore} />, true);
@@ -503,6 +508,7 @@ describe('UserProfile', () => {
         interactiveLogin={true}
         changeState={sinon.stub()}
         pluralize={sinon.stub()}
+        hideConnectingMask={sinon.stub()}
         showConnectingMask={sinon.stub()}
         storeUser={sinon.stub()}
         user={users.charmstore} />, true);
@@ -542,6 +548,7 @@ describe('UserProfile', () => {
         getDiagramURL={sinon.stub()}
         interactiveLogin={false}
         pluralize={pluralize}
+        hideConnectingMask={sinon.stub()}
         showConnectingMask={sinon.stub()}
         storeUser={sinon.stub()}
         user={users.charmstore} />);
@@ -578,6 +585,7 @@ describe('UserProfile', () => {
         getDiagramURL={sinon.stub()}
         interactiveLogin={true}
         pluralize={sinon.stub()}
+        hideConnectingMask={sinon.stub()}
         showConnectingMask={sinon.stub()}
         storeUser={storeUser}
         user={users.charmstore} />, true);
@@ -603,6 +611,7 @@ describe('UserProfile', () => {
         getDiagramURL={sinon.stub()}
         interactiveLogin={true}
         pluralize={sinon.stub()}
+        hideConnectingMask={sinon.stub()}
         showConnectingMask={sinon.stub()}
         storeUser={sinon.stub()}
         user={users.charmstore} />, true);
@@ -620,6 +629,7 @@ describe('UserProfile', () => {
         getDiagramURL={sinon.stub()}
         interactiveLogin={true}
         pluralize={sinon.stub()}
+        hideConnectingMask={sinon.stub()}
         showConnectingMask={sinon.stub()}
         storeUser={sinon.stub()}
         user={users.charmstore} />);
@@ -641,6 +651,7 @@ describe('UserProfile', () => {
         charmstore={{}}
         env={env}
         getDiagramURL={sinon.stub()}
+        hideConnectingMask={sinon.stub()}
         showConnectingMask={sinon.stub()}
         pluralize={sinon.stub()}
         storeUser={sinon.stub()}
@@ -676,6 +687,7 @@ describe('UserProfile', () => {
         interactiveLogin={true}
         listModels={sinon.stub()}
         pluralize={sinon.stub()}
+        hideConnectingMask={sinon.stub()}
         showConnectingMask={sinon.stub()}
         storeUser={sinon.stub()}
         switchModel={sinon.stub()}
@@ -708,6 +720,7 @@ describe('UserProfile', () => {
         interactiveLogin={true}
         listModels={listModels}
         pluralize={sinon.stub()}
+        hideConnectingMask={sinon.stub()}
         showConnectingMask={sinon.stub()}
         storeUser={sinon.stub()}
         switchModel={sinon.stub()}
@@ -735,6 +748,7 @@ describe('UserProfile', () => {
         env={env}
         getDiagramURL={sinon.stub()}
         interactiveLogin={true}
+        hideConnectingMask={sinon.stub()}
         showConnectingMask={sinon.stub()}
         storeUser={sinon.stub()}
         pluralize={pluralize}
@@ -760,6 +774,7 @@ describe('UserProfile', () => {
         getDiagramURL={sinon.stub()}
         listModels={sinon.stub().callsArgWith(0, null, {models: models})}
         pluralize={sinon.stub()}
+        hideConnectingMask={sinon.stub()}
         showConnectingMask={sinon.stub()}
         storeUser={sinon.stub()}
         switchModel={sinon.stub()}
@@ -785,6 +800,7 @@ describe('UserProfile', () => {
         getDiagramURL={sinon.stub()}
         listModels={sinon.stub().callsArgWith(0, null, {models: models})}
         pluralize={sinon.stub()}
+        hideConnectingMask={sinon.stub()}
         showConnectingMask={showConnectingMask}
         storeUser={sinon.stub()}
         switchModel={switchModel}
@@ -827,6 +843,7 @@ describe('UserProfile', () => {
         getDiagramURL={sinon.stub()}
         listModels={sinon.stub().callsArgWith(0, null, {models: models})}
         pluralize={sinon.stub()}
+        hideConnectingMask={sinon.stub()}
         showConnectingMask={showConnectingMask}
         storeUser={sinon.stub()}
         switchModel={switchModel}
@@ -849,5 +866,61 @@ describe('UserProfile', () => {
     assert.equal(showConnectingMask.callCount, 0, 'mask shown');
     // Make sure that it switches to the model after it's created.
     assert.equal(switchModel.callCount, 0, 'model should not be switched to');
+  });
+
+  it('gracefully handles errors when creating new model', () => {
+    // This test doesn't check the user interactions and animations, that
+    // will need to be done with the uitest suite.
+    env.createModel = (modelName, userName, callback) => {
+      assert.equal(modelName, 'newmodelname', 'model name not set properly');
+      assert.equal(userName, 'test-owner', 'user name not set properly');
+      // Simulate the model being created.
+      callback({
+        err: 'this is an error',
+        uuid: 'abc123',
+        name: modelName
+      });
+    };
+    var hideConnectingMask = sinon.stub();
+    var addNotification = sinon.stub();
+    var component = jsTestUtils.shallowRender(
+      <juju.components.UserProfile
+        addNotification={addNotification}
+        users={users}
+        canCreateNew={true}
+        changeState={sinon.stub()}
+        charmstore={charmstore}
+        env={env}
+        getDiagramURL={sinon.stub()}
+        listModels={sinon.stub().callsArgWith(0, null, {models: models})}
+        pluralize={sinon.stub()}
+        hideConnectingMask={hideConnectingMask}
+        showConnectingMask={sinon.stub()}
+        storeUser={sinon.stub()}
+        switchModel={sinon.stub()}
+        user={users.charmstore} />, true);
+    var output = component.getRenderOutput();
+    var instance = component.getMountedInstance();
+    // Set up the component to simulate user action.
+    instance.refs = {
+      modelName: {
+        validate: _ => true,
+        getValue: _ => 'newmodelname'
+      }
+    };
+    var preventable = { preventDefault: sinon.stub() };
+    // Call the action method in the proper element.
+    output.props.children.props.children.props.children[1].props.children[0]
+      .props.children[0].props.children[2].props.children.props.children[2]
+      .props.action(preventable);
+    // Make sure that the mask is hidden and that a notification was added
+    // with the error message.
+    assert.equal(hideConnectingMask.callCount, 1, 'mask not hidden');
+    assert.equal(addNotification.callCount, 1, 'notification not added');
+    assert.deepEqual(addNotification.args[0][0], {
+      title: 'Failed to create new Model',
+      message: 'this is an error',
+      level: 'error'
+    });
   });
 });

--- a/jujugui/static/gui/src/app/components/user-profile/test-user-profile.js
+++ b/jujugui/static/gui/src/app/components/user-profile/test-user-profile.js
@@ -116,16 +116,6 @@ describe('UserProfile', () => {
               links={links}
               username={users.charmstore.usernameDisplay} />
             <div className="user-profile__empty twelve-col no-margin-bottom">
-              <img alt="Empty profile"
-                className="user-profile__empty-image"
-                src="/static/gui/build/app/assets/images/non-sprites/empty_profile.png" />
-              <h2 className="user-profile__empty-title">
-                Your profile is currently empty
-              </h2>
-              <p className="user-profile__empty-text">
-                Your models, bundles and charms will appear here when you create
-                them.
-              </p>
               <div className="user-profile__create-new user-profile__empty-button collapsed">
                 <form onSubmit={instance.createAndSwitch}>
                   <juju.components.GenericButton
@@ -150,6 +140,18 @@ describe('UserProfile', () => {
                     type='inline-neutral second'
                     title='Submit' />
                 </form>
+              </div>
+              <div className="clearfix">
+                <img alt="Empty profile"
+                  className="user-profile__empty-image"
+                  src="/static/gui/build/app/assets/images/non-sprites/empty_profile.png" />
+                <h2 className="user-profile__empty-title">
+                  Your profile is currently empty
+                </h2>
+                <p className="user-profile__empty-text">
+                  Your models, bundles and charms will appear here when you create
+                  them.
+                </p>
               </div>
             </div>
           </div>
@@ -179,8 +181,8 @@ describe('UserProfile', () => {
         storeUser={sinon.stub()}
         user={users.charmstore} />);
     assert.equal(
-      output.props.children.props.children.props
-            .children[1].props.children[0].props.src,
+      output.props.children.props.children.props.children[1].props
+        .children[1].props.children[0].props.src,
       'surl/static/gui/build/app/assets/images/non-sprites/empty_profile.png');
   });
 

--- a/jujugui/static/gui/src/app/components/user-profile/user-profile.js
+++ b/jujugui/static/gui/src/app/components/user-profile/user-profile.js
@@ -38,6 +38,7 @@ YUI.add('user-profile', function() {
       storeUser: React.PropTypes.func.isRequired,
       switchModel: React.PropTypes.func.isRequired,
       showConnectingMask: React.PropTypes.func.isRequired,
+      hideConnectingMask: React.PropTypes.func.isRequired,
       user: React.PropTypes.object,
       users: React.PropTypes.object.isRequired
     },
@@ -234,9 +235,15 @@ YUI.add('user-profile', function() {
         modelName.getValue(),
         this.props.user.user,
         data => {
-          if (data.err) {
-            // XXX Throw notification
+          var err = data.err;
+          if (err) {
+            this.props.addNotification({
+              title: 'Failed to create new Model',
+              message: err,
+              level: 'error'
+            });
             console.error(err);
+            this.props.hideConnectingMask(false);
             return;
           }
           this.switchModel(data.uuid, data.name);

--- a/jujugui/static/gui/src/app/components/user-profile/user-profile.js
+++ b/jujugui/static/gui/src/app/components/user-profile/user-profile.js
@@ -213,14 +213,21 @@ YUI.add('user-profile', function() {
       Fetches the model name from the modelName ref and then creates a model
       then switches to it.
       @method createAndSwitch
+      @param {Object} e The event handler from a form submission.
     */
-    createAndSwitch: function() {
+    createAndSwitch: function(e) {
+      if (e && e.preventDefault) {
+        e.preventDefault();
+      }
       // The supplied new model name needs to be valid.
       var modelName = this.refs.modelName;
       if (!modelName.validate()) {
         // Only continue if the validation passes.
         return;
       }
+      // Because this will automatically connect to the model lets show
+      // the connecting mask right now.
+      this.props.showConnectingMask();
       // XXX This is only for the JIMM flow.
       this.props.env.createModel(
         modelName.getValue(),
@@ -421,27 +428,29 @@ YUI.add('user-profile', function() {
         });
       return (
         <div className={classes}>
-          <juju.components.GenericButton
-            action={this._toggleNameInput}
-            type='inline-neutral first'
-            title='Create new' />
-          <juju.components.DeploymentInput
-            placeholder="untitled_model"
-            required={true}
-            ref="modelName"
-            validate={[{
-              regex: /\S+/,
-              error: 'This field is required.'
-            }, {
-              regex: /^[a-zA-Z0-9]([a-zA-Z0-9.-]*[a-zA-Z0-9])?$/,
-              error: 'This field must only contain upper and lowercase ' +
-                'letters, numbers, and hyphens. It must not start or ' +
-                'end with a hyphen.'
-            }]} />
-          <juju.components.GenericButton
-            action={this.createAndSwitch}
-            type='inline-neutral second'
-            title='Submit' />
+          <form onSubmit={this.createAndSwitch}>
+            <juju.components.GenericButton
+              action={this._toggleNameInput}
+              type='inline-neutral first'
+              title='Create new' />
+            <juju.components.DeploymentInput
+              placeholder="untitled_model"
+              required={true}
+              ref="modelName"
+              validate={[{
+                regex: /\S+/,
+                error: 'This field is required.'
+              }, {
+                regex: /^[a-zA-Z0-9]([a-zA-Z0-9.-]*[a-zA-Z0-9])?$/,
+                error: 'This field must only contain upper and lowercase ' +
+                  'letters, numbers, and hyphens. It must not start or ' +
+                  'end with a hyphen.'
+              }]} />
+            <juju.components.GenericButton
+              action={this.createAndSwitch}
+              type='inline-neutral second'
+              title='Submit' />
+          </form>
         </div>
       );
     },

--- a/jujugui/static/gui/src/app/components/user-profile/user-profile.js
+++ b/jujugui/static/gui/src/app/components/user-profile/user-profile.js
@@ -236,7 +236,7 @@ YUI.add('user-profile', function() {
         data => {
           if (data.err) {
             // XXX Throw notification
-            console.log(err);
+            console.error(err);
             return;
           }
           this.switchModel(data.uuid, data.name);
@@ -433,8 +433,8 @@ YUI.add('user-profile', function() {
           <form onSubmit={this.createAndSwitch}>
             <juju.components.GenericButton
               action={this._toggleNameInput}
-              type='inline-neutral first'
-              title='Create new' />
+              type="inline-neutral first"
+              title="Create new" />
             <juju.components.DeploymentInput
               placeholder="untitled_model"
               required={true}
@@ -450,8 +450,8 @@ YUI.add('user-profile', function() {
               }]} />
             <juju.components.GenericButton
               action={this.createAndSwitch}
-              type='inline-neutral second'
-              title='Submit' />
+              type="inline-neutral second"
+              title="Submit" />
           </form>
         </div>
       );
@@ -668,17 +668,20 @@ YUI.add('user-profile', function() {
         var basePath = `${staticURL}/static/gui/build/app`;
         return (
           <div className="user-profile__empty twelve-col no-margin-bottom">
-            <img alt="Empty profile"
-              className="user-profile__empty-image"
-              src={`${basePath}/assets/images/non-sprites/empty_profile.png`} />
-            <h2 className="user-profile__empty-title">
-              Your profile is currently empty
-            </h2>
-            <p className="user-profile__empty-text">
-              Your models, bundles and charms will appear here when you create
-              them.
-            </p>
             {this._generateCreateNew('user-profile__empty-button')}
+            <div className="clearfix">
+              <img alt="Empty profile"
+                className="user-profile__empty-image"
+                src=
+                  {`${basePath}/assets/images/non-sprites/empty_profile.png`} />
+              <h2 className="user-profile__empty-title">
+                Your profile is currently empty
+              </h2>
+              <p className="user-profile__empty-text">
+                Your models, bundles and charms will appear here when you create
+                them.
+              </p>
+            </div>
           </div>);
       }
       return (

--- a/jujugui/static/gui/src/app/components/user-profile/user-profile.js
+++ b/jujugui/static/gui/src/app/components/user-profile/user-profile.js
@@ -206,17 +206,33 @@ YUI.add('user-profile', function() {
     */
     switchModel: function(uuid, name, callback) {
       var props = this.props;
-      // If no uuid is specified then this is switching to create a new model
-      // and we need to grab the new name and validate it.
-      if (!uuid) {
-        var modelName = this.refs.modelName;
-        if (!modelName.validate()) {
-          // Only continue if the validation passes.
-          return;
-        }
-        name = modelName.getValue();
-      }
       props.switchModel(uuid, this.state.envList, name, callback);
+    },
+
+    /**
+      Fetches the model name from the modelName ref and then creates a model
+      then switches to it.
+      @method createAndSwitch
+    */
+    createAndSwitch: function() {
+      // The supplied new model name needs to be valid.
+      var modelName = this.refs.modelName;
+      if (!modelName.validate()) {
+        // Only continue if the validation passes.
+        return;
+      }
+      // XXX This is only for the JIMM flow.
+      this.props.env.createModel(
+        modelName.getValue(),
+        this.props.user.user,
+        data => {
+          if (data.err) {
+            // XXX Throw notification
+            console.log(err);
+            return;
+          }
+          this.switchModel(data.uuid, data.name);
+        });
     },
 
     /**
@@ -386,7 +402,9 @@ YUI.add('user-profile', function() {
       @method _toggleNameInput
     */
     _toggleNameInput: function() {
-      this.setState({ createNewModelActive: true });
+      this.setState({ createNewModelActive: true }, _ => {
+        this.refs.modelName.refs.field.focus();
+      });
     },
 
     /**
@@ -421,7 +439,7 @@ YUI.add('user-profile', function() {
                 'end with a hyphen.'
             }]} />
           <juju.components.GenericButton
-            action={this.switchModel}
+            action={this.createAndSwitch}
             type='inline-neutral second'
             title='Submit' />
         </div>

--- a/jujugui/static/gui/src/app/components/user-profile/user-profile.js
+++ b/jujugui/static/gui/src/app/components/user-profile/user-profile.js
@@ -209,12 +209,12 @@ YUI.add('user-profile', function() {
       // If no uuid is specified then this is switching to create a new model
       // and we need to grab the new name and validate it.
       if (!uuid) {
-        var modelname = this.refs.modelname;
+        var modelName = this.refs.modelName;
         if (!modelName.validate()) {
           // Only continue if the validation passes.
           return;
         }
-        name = modelname.getValue();
+        name = modelName.getValue();
       }
       props.switchModel(uuid, this.state.envList, name, callback);
     },
@@ -405,7 +405,6 @@ YUI.add('user-profile', function() {
         <div className={classes}>
           <juju.components.GenericButton
             action={this._toggleNameInput}
-            ref="createNewFirstBtn"
             type='inline-neutral first'
             title='Create new' />
           <juju.components.DeploymentInput
@@ -423,7 +422,6 @@ YUI.add('user-profile', function() {
             }]} />
           <juju.components.GenericButton
             action={this.switchModel}
-            ref="createNewSecondBtn"
             type='inline-neutral second'
             title='Submit' />
         </div>

--- a/jujugui/static/gui/src/app/components/user-profile/user-profile.js
+++ b/jujugui/static/gui/src/app/components/user-profile/user-profile.js
@@ -37,6 +37,7 @@ YUI.add('user-profile', function() {
       staticURL: React.PropTypes.string,
       storeUser: React.PropTypes.func.isRequired,
       switchModel: React.PropTypes.func.isRequired,
+      showConnectingMask: React.PropTypes.func.isRequired,
       user: React.PropTypes.object,
       users: React.PropTypes.object.isRequired
     },
@@ -422,8 +423,9 @@ YUI.add('user-profile', function() {
     */
     _generateCreateNew: function(className) {
       var classes = classNames(
-        'user-profile__create-new', {
-          className: !!className,
+        'user-profile__create-new',
+        className,
+        {
           collapsed: !this.state.createNewModelActive
         });
       return (

--- a/jujugui/static/gui/src/app/components/user-profile/user-profile.js
+++ b/jujugui/static/gui/src/app/components/user-profile/user-profile.js
@@ -32,6 +32,7 @@ YUI.add('user-profile', function() {
       env: React.PropTypes.object.isRequired,
       getDiagramURL: React.PropTypes.func.isRequired,
       interactiveLogin: React.PropTypes.bool,
+      jem: React.PropTypes.object,
       listModels: React.PropTypes.func.isRequired,
       pluralize: React.PropTypes.func.isRequired,
       staticURL: React.PropTypes.string,
@@ -413,13 +414,21 @@ YUI.add('user-profile', function() {
     },
 
     /**
-      Toggles the class on the necessary elements for the create new interaction
-      @method _toggleNameInput
+      Depending on the existance of jem this will either switch to a
+      disconnected model or open up the UI to allow the user to create a
+      new model.
+      @method _nextCreateStep
     */
-    _toggleNameInput: function() {
-      this.setState({ createNewModelActive: true }, _ => {
-        this.refs.modelName.refs.field.focus();
-      });
+    _nextCreateStep: function() {
+      if (this.props.jem) {
+        // Switch to a disconnected model
+        this.switchModel();
+      } else {
+        // Open up the UI to specify a model name for the Controller.
+        this.setState({ createNewModelActive: true }, _ => {
+          this.refs.modelName.refs.field.focus();
+        });
+      }
     },
 
     /**
@@ -439,7 +448,7 @@ YUI.add('user-profile', function() {
         <div className={classes}>
           <form onSubmit={this.createAndSwitch}>
             <juju.components.GenericButton
-              action={this._toggleNameInput}
+              action={this._nextCreateStep}
               type="inline-neutral first"
               title="Create new" />
             <juju.components.DeploymentInput


### PR DESCRIPTION
Now that the only place you can create a model is in the user profile view this adds the ability to specify the model name at time of creation and then connects you to that model.