### PR TITLE
Remove the nested YUI node_modules folder that bloats the dist since the npm3 update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,6 +171,9 @@ $(REACT_ASSETS): $(NODE_MODULES)
 
 $(BUILT_YUI): $(YUI) $(BUILT_JS_ASSETS)
 	cp -r $(YUI) $(BUILT_YUI)
+	# With the update to npm3 YUI now has nested dependencies which bloats the
+	# dist. Because we do not run YUI in node we can safely delete this folder.
+	rm -rf $(BUILT_YUI)/node_modules
 
 $(STATIC_CSS_FILES):
 	mkdir -p $(GUIBUILD)/app/assets/stylesheets


### PR DESCRIPTION
Because of changes to how npm structures the node modules our old dist process was copying in even more unnecessary YUI files. This subsequently removes them so that the dist returns back to it's original size. There are still improvements to be made by removing even more of the unnecessary YUI deps that are rolled up.