### PR TITLE
Update the charmstore version

### DIFF
--- a/jujugui/static/gui/src/app/assets/javascripts/jujulib/juju.js
+++ b/jujugui/static/gui/src/app/assets/javascripts/jujulib/juju.js
@@ -402,7 +402,7 @@ var module = module;
      Provides access to the charmstore API.
    */
 
-  var charmstoreAPIVersion = 'v4';
+  var charmstoreAPIVersion = 'v5';
 
   /**
      Initializer

--- a/jujugui/static/gui/src/app/assets/javascripts/jujulib/test-jujulib-charmstore.js
+++ b/jujugui/static/gui/src/app/assets/javascripts/jujulib/test-jujulib-charmstore.js
@@ -17,27 +17,27 @@ describe('jujulib charmstore', function() {
   });
 
   it('can be instantiated with the proper config values', function() {
-    assert.strictEqual(charmstore.url, 'local/v4');
+    assert.strictEqual(charmstore.url, 'local/v5');
   });
 
   it('is smart enough to handle missing trailing slash in URL', function() {
     var bakery = {};
     charmstore = new window.jujulib.charmstore('http://example.com', bakery);
-    assert.strictEqual(charmstore.url, 'http://example.com/v4');
+    assert.strictEqual(charmstore.url, 'http://example.com/v5');
   });
 
   describe('_generatePath', function() {
 
     it('generates a valid url using provided args', function() {
       var path = charmstore._generatePath('search/', 'text=foo');
-      assert.equal(path, 'local/v4/search/?text=foo');
+      assert.equal(path, 'local/v5/search/?text=foo');
     });
   });
 
   describe('getLogoutUrl', function() {
     it('returns a valid logout url', function() {
       var path = charmstore.getLogoutUrl();
-      assert.equal(path, 'local/v4/logout');
+      assert.equal(path, 'local/v5/logout');
     });
   });
 
@@ -112,7 +112,7 @@ describe('jujulib charmstore', function() {
 
   describe('_processEntityQueryData', function() {
 
-    it('can properly transform v4 charm data to v3', function() {
+    it('can properly transform v5 charm data to v3', function() {
       var data = {
         Id: 'cs:trusty/mongodb-9',
         Meta: {
@@ -220,7 +220,7 @@ describe('jujulib charmstore', function() {
       assert.deepEqual(processed.revisions, []);
     });
 
-    it('can properly transform v4 bundle data to v3', function() {
+    it('can properly transform v5 bundle data to v3', function() {
       var data = {
         Id: 'cs:~charmers/bundle/mongodb-cluster-4',
         Meta: {
@@ -245,7 +245,7 @@ describe('jujulib charmstore', function() {
         code_source: {
           location: 'lp:~charmers/charms/bundles/mongodb-cluster/bundle'
         },
-        deployerFileUrl: 'local/v4/~charmers/bundle/mongodb-cluster-4/' +
+        deployerFileUrl: 'local/v5/~charmers/bundle/mongodb-cluster-4/' +
             'archive/bundle.yaml',
         downloads: 10,
         entityType: 'bundle',
@@ -359,7 +359,7 @@ describe('jujulib charmstore', function() {
   describe('getDiagramURL', function() {
     it('can generate a URL for a bundle diagram', function() {
       assert.equal(charmstore.getDiagramURL('apache2'),
-          'local/v4/apache2/diagram.svg');
+          'local/v5/apache2/diagram.svg');
     });
   });
 
@@ -419,7 +419,7 @@ describe('jujulib charmstore', function() {
       charmstore.getAvailableVersions('cs:precise/ghost-5', cb);
       var requestArgs = charmstore.bakery.sendGetRequest.lastCall.args;
       // The path should not have cs: in it.
-      assert.equal(requestArgs[0], 'local/v4/precise/ghost-5/expand-id');
+      assert.equal(requestArgs[0], 'local/v5/precise/ghost-5/expand-id');
       // Call the makeRequest success handler simulating a response object;
       requestArgs[1](
           {target: { responseText: '[{"Id": "cs:precise/ghost-4"}]'}});
@@ -457,7 +457,7 @@ describe('jujulib charmstore', function() {
       };
       charmstore.whoami(cb);
       var requestArgs = charmstore.bakery.sendGetRequest.lastCall.args;
-      assert.equal(requestArgs[0], 'local/v4/whoami');
+      assert.equal(requestArgs[0], 'local/v5/whoami');
       // Make sure that we have disabled redirect on 401
       assert.strictEqual(requestArgs[3], false);
       // Call the makeRequest success handler simulating a response object;

--- a/jujugui/static/gui/src/test/factory.js
+++ b/jujugui/static/gui/src/test/factory.js
@@ -49,7 +49,7 @@ YUI(GlobalConfig).add('juju-tests-factory', function(Y) {
       var fakeBakery = {
         sendGetRequest: function(path, success, failure) {
           // Remove the includes and the charmstore path.
-          path = path.split('/meta/any')[0].replace('local/v4/', '');
+          path = path.split('/meta/any')[0].replace('local/v5/', '');
           // Get just the charm name
           path = path.split('/')[1].split('-');
           if (path.length > 1) {

--- a/jujugui/static/gui/src/test/test_app.js
+++ b/jujugui/static/gui/src/test/test_app.js
@@ -357,11 +357,11 @@ describe('App', function() {
         }, this);
         // The charmstore attribute is undefined by default
         assert.equal(typeof app.get('charmstore'), 'object');
-        assert.equal(app.get('charmstore').url, 'http://1.2.3.4/v4');
+        assert.equal(app.get('charmstore').url, 'http://1.2.3.4/v5');
         window.juju_config.charmstoreURL = 'it broke';
         assert.equal(
             app.get('charmstore').url,
-            'http://1.2.3.4/v4',
+            'http://1.2.3.4/v5',
             'It should only ever create a single instance of the charmstore');
       });
 

--- a/jujugui/static/gui/src/test/test_entity_extension.js
+++ b/jujugui/static/gui/src/test/test_entity_extension.js
@@ -73,7 +73,7 @@ describe('Entity Extension', function() {
       series: 'trusty',
       tags: ['database', 'application'],
     };
-    var iconPath = 'v4/' + entityModel.get('id') + '/icon.svg';
+    var iconPath = 'v5/' + entityModel.get('id') + '/icon.svg';
     utils.makeStubMethod(utils, 'getIconPath', iconPath);
     entityModel.setAttrs(attrs);
     var entity = entityModel.toEntity();

--- a/jujugui/static/gui/src/test/test_environment_view.js
+++ b/jujugui/static/gui/src/test/test_environment_view.js
@@ -486,7 +486,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
           view.render();
           var service = container.one('.service');
           assert.equal(service.one('.service-icon').getAttribute('href'),
-            'v4/precise/wordpress-6/icon.svg');
+            'v5/precise/wordpress-6/icon.svg');
 
           done();
         }
@@ -1740,7 +1740,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       assert.equal(boxes['local:ceph-1'].icon, 'local charm icon');
 
       // The mysql charm has an icon from on the server.
-      assert.equal(boxes['cs:mysql-1'].icon, 'v4/mysql-1/icon.svg');
+      assert.equal(boxes['cs:mysql-1'].icon, 'v5/mysql-1/icon.svg');
     });
   });
 })();

--- a/jujugui/static/gui/src/test/test_utils.js
+++ b/jujugui/static/gui/src/test/test_utils.js
@@ -1154,7 +1154,7 @@ describe('utilities', function() {
       var path = utils.getIconPath('~paulgear/precise/quassel-core-2');
       assert.equal(
           path,
-          'local/v4/~paulgear/precise/quassel-core-2/icon.svg');
+          'local/v5/~paulgear/precise/quassel-core-2/icon.svg');
     });
 
     after(function() {


### PR DESCRIPTION
Updating the charmstore version allows calls like 'whoami' to work again. Fixes #1723.