### PR TITLE
Test that plans are set when no plan is selected

### DIFF
--- a/jujugui/static/gui/src/app/components/entity-header/test-entity-header.js
+++ b/jujugui/static/gui/src/app/components/entity-header/test-entity-header.js
@@ -295,6 +295,33 @@ describe('EntityHeader', function() {
     assert.deepEqual(deployService.args[0][3], plans[0]);
   });
 
+  it('can set the plans when deploying a charm without selecing one', () => {
+    var deployService = sinon.stub();
+    var changeState = sinon.stub();
+    var importBundleYAML = sinon.stub();
+    var getBundleYAML = sinon.stub();
+    var plans = [{url: 'test-plan'}];
+    var output = testUtils.renderIntoDocument(
+      <juju.components.EntityHeader
+        addNotification={sinon.stub()}
+        importBundleYAML={importBundleYAML}
+        getBundleYAML={getBundleYAML}
+        hasPlans={true}
+        deployService={deployService}
+        changeState={changeState}
+        entityModel={mockEntity}
+        plans={plans}
+        pluralize={sinon.stub()}
+        scrollPosition={0}/>);
+    var refs = output.refs;
+    var deployAction = refs.deployAction;
+    // Simulate a click.
+    deployAction.props.action();
+    assert.equal(deployService.callCount, 1);
+    assert.deepEqual(deployService.args[0][2], plans);
+    assert.isUndefined(deployService.args[0][3]);
+  });
+
   it('adds a bundle when the add button is clicked', function() {
     var deployService = sinon.stub();
     var changeState = sinon.stub();

--- a/jujugui/static/gui/src/test/test_ghost_deployer_extension.js
+++ b/jujugui/static/gui/src/test/test_ghost_deployer_extension.js
@@ -104,6 +104,15 @@ describe('Ghost Deployer Extension', function() {
     assert.deepEqual(service.get('plans'), plans);
   });
 
+  it('sets the plans on the charm when not setting an active plan', function() {
+    var charm = makeCharm();
+    var plans = ['plan1', 'plan2'];
+    ghostDeployer.db.charms = new Y.juju.models.ServiceList();
+    ghostDeployer.deployService(charm, undefined, plans);
+    var service = ghostDeployer.db.charms.item(0);
+    assert.deepEqual(service.get('plans'), plans);
+  });
+
   it('calls the env deploy method with default charm data', function() {
     var charm = makeCharm();
     ghostDeployer.deployService(charm);


### PR DESCRIPTION
I think we thought there was an issue adding the list of plans when the user adds an application without selecting a plan. I've added tests and it seems we do not.