### PR TITLE
Convert Juju2 API to lower-case dash-separated fields.

### DIFF
--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -472,7 +472,9 @@ YUI.add('juju-gui', function(Y) {
           envOptions.webHandler = new webModule.WebHandler();
         }
         var environment = environments.GoEnvironment;
-        if (this.isLegacyJuju()) {
+        // TODO frankban: switch to using the new GoEnvironment when sandbox
+        // is ready to do so.
+        if (this.isLegacyJuju() || this.get('sandbox')) {
           environment = environments.GoLegacyEnvironment;
         }
         this._init(cfg, new environment(envOptions), state);

--- a/jujugui/static/gui/src/app/models/model-controller.js
+++ b/jujugui/static/gui/src/app/models/model-controller.js
@@ -115,7 +115,6 @@ YUI.add('model-controller', function(Y) {
               resolve(service);
               return;
             }
-
             if (!service || !service.get('loaded')) {
               env.getApplicationConfig(serviceId, function(result) {
                 if (result.err) {

--- a/jujugui/static/gui/src/test/test_bundle_import_notifications.js
+++ b/jujugui/static/gui/src/test/test_bundle_import_notifications.js
@@ -127,7 +127,8 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
   describe('bundle helpers watchAll', function() {
     var bundleNotifications, conn, db, env, juju, testUtils;
     var requirements = [
-      'bundle-import-notifications', 'juju-tests-utils'];
+      'bundle-import-notifications', 'juju-env-legacy-api', 'juju-tests-utils'
+    ];
 
     before(function(done) {
       YUI(GlobalConfig).use(requirements, function(Y) {
@@ -140,9 +141,9 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
     beforeEach(function() {
       conn = new testUtils.SocketStub();
-      env = new juju.environments.GoEnvironment({
+      env = new juju.environments.GoLegacyEnvironment({
         conn: conn, user: 'user', password: 'password'
-      }, 'go');
+      });
       env.connect();
       env.set('facades', {Deployer: [0]});
       this._cleanups.push(env.close.bind(env));

--- a/jujugui/static/gui/src/test/test_endpoints.js
+++ b/jujugui/static/gui/src/test/test_endpoints.js
@@ -528,7 +528,7 @@ describe('Endpoints map handlers', function() {
 });
 
 
-describe('Service config handlers', function() {
+describe('Application config handlers', function() {
   var Y, juju, utils, app, conn, env, controller, destroyMe;
 
   before(function(done) {
@@ -558,6 +558,7 @@ describe('Service config handlers', function() {
       password: 'password'
     });
     env.connect();
+    env.set('facades', {Application: [1]});
     this._cleanups.push(env.close.bind(env));
     app = new Y.juju.App({env: env, consoleEnabled: true });
     destroyMe.push(app);
@@ -575,10 +576,12 @@ describe('Service config handlers', function() {
   // Ensure the last message in the connection is a ServiceGet request.
   var assertServiceGetCalled = function() {
     assert.equal(1, conn.messages.length);
-    assert.equal('ServiceGet', conn.last_message().Request);
+    var msg = conn.last_message();
+    assert.strictEqual(msg.type, 'Application');
+    assert.strictEqual(msg.request, 'Get');
   };
 
-  it('should not call ServiceGet when a pending service is added',
+  it('should not call Application.Get when a pending service is added',
      function() {
        var charmUrl = 'cs:precise/wordpress-2';
        app.db.services.add({
@@ -588,7 +591,7 @@ describe('Service config handlers', function() {
        assert.equal(0, conn.messages.length);
      });
 
-  it('should call ServiceGet when non-pending services are added',
+  it('should call Application.Get when non-pending services are added',
      function() {
        var applicationName = 'wordpress';
        var charmUrl = 'cs:precise/wordpress-2';
@@ -602,7 +605,7 @@ describe('Service config handlers', function() {
        assertServiceGetCalled();
      });
 
-  it('should call ServiceGet when a service\'s charm changes', function() {
+  it('should call Application.Get when a charm changes', function() {
     var applicationName = 'wordpress';
     var charmUrl = 'cs:precise/wordpress-2';
     var charm = app.db.charms.add({id: charmUrl});

--- a/jujugui/static/gui/src/test/test_login.js
+++ b/jujugui/static/gui/src/test/test_login.js
@@ -52,19 +52,19 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     });
 
     test('successful login event marks user as authenticated', function() {
-      var data = {Response: {}};
+      var data = {response: {facades: []}};
       env.handleLogin(data);
       assert.isTrue(env.userIsAuthenticated);
     });
 
     test('unsuccessful login event keeps user unauthenticated', function() {
-      var data = {Error: 'who are you?'};
+      var data = {error: 'who are you?'};
       env.handleLogin(data);
       assert.isFalse(env.userIsAuthenticated);
     });
 
     test('bad credentials are removed', function() {
-      var data = {Error: 'who are you?'};
+      var data = {error: 'who are you?'};
       env.handleLogin(data);
       assert.deepEqual(
         env.getCredentials(), {user: '', password: '', macaroons: null});
@@ -101,12 +101,12 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     });
 
     test('with credentials set, login() sends an RPC message', function() {
-      env.setCredentials({user: 'user', password: 'password'});
+      env.setCredentials({user: 'admin', password: 'password'});
       env.login();
       var message = conn.last_message();
-      assert.equal('Login', message.Request);
-      assert.equal('user-user', message.Params.AuthTag);
-      assert.equal('password', message.Params.Password);
+      assert.equal(message.request, 'Login');
+      assert.equal(message.params['auth-tag'], 'user-admin');
+      assert.equal(message.params.credentials, 'password');
     });
 
   });

--- a/jujugui/static/gui/src/test/test_model.js
+++ b/jujugui/static/gui/src/test/test_model.js
@@ -1542,6 +1542,7 @@ describe('test_model.js', function() {
       conn = new (Y.namespace('juju-tests.utils')).SocketStub();
       env = new juju.environments.GoEnvironment({conn: conn});
       env.connect();
+      env.set('facades', {Client: [0]});
       conn.open();
       container = Y.Node.create('<div id="test" class="container"></div>');
     });
@@ -1596,7 +1597,7 @@ describe('test_model.js', function() {
     it('must send request to juju environment for local charms', function() {
       var charm = new models.Charm({id: 'local:precise/foo-4'}).load(env);
       assert(!charm.loaded);
-      assert.equal('CharmInfo', conn.last_message().Request);
+      assert.equal(conn.last_message().request, 'CharmInfo');
     });
 
     it('must handle success from local charm request', function(done) {
@@ -1609,8 +1610,8 @@ describe('test_model.js', function() {
             done();
           });
       var response = {
-        RequestId: conn.last_message().RequestId,
-        Response: {Meta: {Summary: 'wowza'}, Config: {}}
+        'request-id': conn.last_message()['request-id'],
+        response: {Meta: {Summary: 'wowza'}, Config: {}}
       };
       env.dispatch_result(response);
       // The test in the callback above should run.
@@ -1629,8 +1630,8 @@ describe('test_model.js', function() {
             done();
           });
       var response = {
-        RequestId: conn.last_message().RequestId,
-        Response: {
+        'request-id': conn.last_message()['request-id'],
+        response: {
           Meta: {},
           Config: {
             Options: {
@@ -1657,8 +1658,8 @@ describe('test_model.js', function() {
             done();
           });
       var response = {
-        RequestId: conn.last_message().RequestId,
-        Error: 'error'
+        'request-id': conn.last_message()['request-id'],
+        error: 'error'
       };
       env.dispatch_result(response);
       // The test in the callback above should run.

--- a/jujugui/static/gui/src/test/test_sandbox_go.js
+++ b/jujugui/static/gui/src/test/test_sandbox_go.js
@@ -23,7 +23,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
   describe('sandbox.GoJujuAPI', function() {
     var requires = [
       'jsyaml', 'juju-env-sandbox', 'juju-tests-utils',
-      'environment-change-set', 'juju-tests-factory', 'juju-env-api',
+      'environment-change-set', 'juju-tests-factory', 'juju-env-legacy-api',
       'juju-models', 'promise'
     ];
     var client, env, ecs, environmentsModule, factory, juju,
@@ -48,7 +48,10 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       });
       client = new sandboxModule.ClientConnection({juju: juju});
       ecs = new ns.EnvironmentChangeSet({db: state.db});
-      env = new environmentsModule.GoEnvironment({conn: client, ecs: ecs});
+      // TODO frankban: use the proper GoEnvironment here.
+      env = new environmentsModule.GoLegacyEnvironment({
+        conn: client, ecs: ecs
+      });
       var facades = sandboxModule.Facades.reduce(function(collected, facade) {
         collected[facade.Name] = facade.Versions;
         return collected;


### PR DESCRIPTION
This branch is huge but mostly mechanical.
It includes:
- converting all API fields to lower-case-dash-separated, excluding the internal response of CharmInfo, still not implemented in core;
- removing support to legacy API and facades from api.js, resulting in lots of code simplifications;
- removing support for token login in the new non-legacy API: it's only used by quickstart, which is deprecated in Juju 2;
- removing support to legacy bundle changes (making use of the GUI server) in the new non-legacy API: in Juju 2 controllers are always capable to return bundle changes natively;
- removing supoort for GUI server Deployer facade, only used in Juju1 as Juju2 has native bundle deployment supoort and the deployment from the GUI is managed by ECS.

Sandbox mode now temporarily use the legacy API file so that its tests still pass and we can defer updating it. This will be changed in follow up branches, this one is already huge.

QA is impossible.