### PR TITLE
Refactor mega-watcher handler utilities.

### DIFF
--- a/jujugui/static/gui/src/app/models/handlers.js
+++ b/jujugui/static/gui/src/app/models/handlers.js
@@ -50,8 +50,7 @@ YUI.add('juju-delta-handlers', function(Y) {
       @return {String} The tag without the prefix.
     */
     cleanUpEntityTags: function(tag) {
-      var result = tag.replace(
-        /^(application|service|unit|machine|model|environment)-/, '');
+      var result = tag.replace(/^(application|unit|machine|model)-/, '');
       if (!result) {
         return tag;
       }
@@ -76,7 +75,7 @@ YUI.add('juju-delta-handlers', function(Y) {
         return [];
       }
       return ports.map(port => {
-        return port.Number + '/' + port.Protocol;
+        return port.number + '/' + port.protocol;
       });
     },
 
@@ -90,10 +89,9 @@ YUI.add('juju-delta-handlers', function(Y) {
     */
     createEndpoints: function(endpoints) {
       return endpoints.map(endpoint => {
-        var relation = endpoint.Relation;
-        var data = {role: relation.Role, name: relation.Name};
-        var applicationName = endpoint.ApplicationName || endpoint.ServiceName;
-        return [applicationName, data];
+        var relation = endpoint.relation;
+        var data = {role: relation.role, name: relation.name};
+        return [endpoint['application-name'], data];
       });
     },
 
@@ -373,12 +371,12 @@ YUI.add('juju-delta-handlers', function(Y) {
     relationInfo: function(db, action, change) {
       var endpoints = change.Endpoints;
       var firstEp = endpoints[0];
-      var firstRelation = firstEp.Relation;
+      var firstRelation = firstEp.relation;
       var data = {
         id: change.Key,
         // The interface and scope attrs should be the same in both relations.
-        'interface': firstRelation.Interface,
-        scope: firstRelation.Scope,
+        'interface': firstRelation.interface,
+        scope: firstRelation.scope,
         endpoints: utils.createEndpoints(endpoints)
       };
 
@@ -386,7 +384,7 @@ YUI.add('juju-delta-handlers', function(Y) {
         db.relations.process_delta(action, data, db);
       };
 
-      var applicationName = firstEp.ApplicationName || firstEp.ServiceName;
+      var applicationName = firstEp['application-name'];
       if (!db.services.getById(applicationName)) {
         // Sometimes (e.g. when a peer relation is immediately created on
         // application deploy) a relation delta is sent by juju-core before the

--- a/jujugui/static/gui/src/test/data/large_stream.json
+++ b/jujugui/static/gui/src/test/data/large_stream.json
@@ -72,13 +72,13 @@
             "Key": "wordpress:loadbalancer wordpress:loadbalancer",
             "Endpoints": [
                 {
-                    "Relation": {
-                        "Name": "loadbalancer",
-                        "Role": "peer",
-                        "Interface": "reversenginx",
-                        "Scope": "container"
+                    "relation": {
+                        "name": "loadbalancer",
+                        "role": "peer",
+                        "interface": "reversenginx",
+                        "scope": "container"
                     },
-                    "ApplicationName": "wordpress"
+                    "application-name": "wordpress"
                 }
             ]
         }
@@ -90,22 +90,22 @@
             "Key": "puppet:juju-info mediawiki:juju-info",
             "Endpoints": [
                 {
-                    "Relation": {
-                        "Name": "juju-info",
-                        "Role": "client",
-                        "Interface": "juju-info",
-                        "Scope": "container"
+                    "relation": {
+                        "name": "juju-info",
+                        "role": "client",
+                        "interface": "juju-info",
+                        "scope": "container"
                     },
-                    "ApplicationName": "puppet"
+                    "application-name": "puppet"
                 },
                 {
-                    "Relation": {
-                        "Name": "juju-info",
-                        "Role": "server",
-                        "Interface": "juju-info",
-                        "Scope": "container"
+                    "relation": {
+                        "name": "juju-info",
+                        "role": "server",
+                        "interface": "juju-info",
+                        "scope": "container"
                     },
-                    "ApplicationName": "mediawiki"
+                    "application-name": "mediawiki"
                 }
             ]
         }
@@ -117,22 +117,22 @@
             "Key": "puppet:puppetmaster puppetmaster:puppetmaster",
             "Endpoints": [
                 {
-                    "Relation": {
-                        "Name": "puppetmaster",
-                        "Role": "client",
-                        "Interface": "puppet",
-                        "Scope": "global"
+                    "relation": {
+                        "name": "puppetmaster",
+                        "role": "client",
+                        "interface": "puppet",
+                        "scope": "global"
                     },
-                    "ApplicationName": "puppet"
+                    "application-name": "puppet"
                 },
                 {
-                    "Relation": {
-                        "Name": "puppetmaster",
-                        "Role": "server",
-                        "Interface": "puppet",
-                        "Scope": "global"
+                    "relation": {
+                        "name": "puppetmaster",
+                        "role": "server",
+                        "interface": "puppet",
+                        "scope": "global"
                     },
-                    "ApplicationName": "puppetmaster"
+                    "application-name": "puppetmaster"
                 }
             ]
         }
@@ -144,22 +144,22 @@
             "Key": "rsyslog-forwarder-ha:juju-info mysql:juju-info",
             "Endpoints": [
                 {
-                    "Relation": {
-                        "Name": "juju-info",
-                        "Role": "client",
-                        "Interface": "juju-info",
-                        "Scope": "container"
+                    "relation": {
+                        "name": "juju-info",
+                        "role": "client",
+                        "interface": "juju-info",
+                        "scope": "container"
                     },
-                    "ApplicationName": "rsyslog-forwarder-ha"
+                    "application-name": "rsyslog-forwarder-ha"
                 },
                 {
-                    "Relation": {
-                        "Name": "juju-info",
-                        "Role": "server",
-                        "Interface": "juju-info",
-                        "Scope": "container"
+                    "relation": {
+                        "name": "juju-info",
+                        "role": "server",
+                        "interface": "juju-info",
+                        "scope": "container"
                     },
-                    "ApplicationName": "mysql"
+                    "application-name": "mysql"
                 }
             ]
         }
@@ -171,22 +171,22 @@
             "Key": "puppet:juju-info wordpress:juju-info",
             "Endpoints": [
                 {
-                    "Relation": {
-                        "Name": "juju-info",
-                        "Role": "client",
-                        "Interface": "juju-info",
-                        "Scope": "container"
+                    "relation": {
+                        "name": "juju-info",
+                        "role": "client",
+                        "interface": "juju-info",
+                        "scope": "container"
                     },
-                    "ApplicationName": "puppet"
+                    "application-name": "puppet"
                 },
                 {
-                    "Relation": {
-                        "Name": "juju-info",
-                        "Role": "server",
-                        "Interface": "juju-info",
-                        "Scope": "container"
+                    "relation": {
+                        "name": "juju-info",
+                        "role": "server",
+                        "interface": "juju-info",
+                        "scope": "container"
                     },
-                    "ApplicationName": "wordpress"
+                    "application-name": "wordpress"
                 }
             ]
         }
@@ -198,22 +198,22 @@
             "Key": "rsyslog-forwarder-ha:syslog rsyslog:aggregator",
             "Endpoints": [
                 {
-                    "Relation": {
-                        "Name": "syslog",
-                        "Role": "client",
-                        "Interface": "syslog",
-                        "Scope": "global"
+                    "relation": {
+                        "name": "syslog",
+                        "role": "client",
+                        "interface": "syslog",
+                        "scope": "global"
                     },
-                    "ApplicationName": "rsyslog-forwarder-ha"
+                    "application-name": "rsyslog-forwarder-ha"
                 },
                 {
-                    "Relation": {
-                        "Name": "aggregator",
-                        "Role": "server",
-                        "Interface": "syslog",
-                        "Scope": "global"
+                    "relation": {
+                        "name": "aggregator",
+                        "role": "server",
+                        "interface": "syslog",
+                        "scope": "global"
                     },
-                    "ApplicationName": "rsyslog"
+                    "application-name": "rsyslog"
                 }
             ]
         }
@@ -225,22 +225,22 @@
             "Key": "rsyslog-forwarder-ha:juju-info mediawiki:juju-info",
             "Endpoints": [
                 {
-                    "Relation": {
-                        "Name": "juju-info",
-                        "Role": "client",
-                        "Interface": "juju-info",
-                        "Scope": "container"
+                    "relation": {
+                        "name": "juju-info",
+                        "role": "client",
+                        "interface": "juju-info",
+                        "scope": "container"
                     },
-                    "ApplicationName": "rsyslog-forwarder-ha"
+                    "application-name": "rsyslog-forwarder-ha"
                 },
                 {
-                    "Relation": {
-                        "Name": "juju-info",
-                        "Role": "server",
-                        "Interface": "juju-info",
-                        "Scope": "container"
+                    "relation": {
+                        "name": "juju-info",
+                        "role": "server",
+                        "interface": "juju-info",
+                        "scope": "container"
                     },
-                    "ApplicationName": "mediawiki"
+                    "application-name": "mediawiki"
                 }
             ]
         }
@@ -252,22 +252,22 @@
             "Key": "mediawiki:cache memcached:cache",
             "Endpoints": [
                 {
-                    "Relation": {
-                        "Name": "cache",
-                        "Role": "client",
-                        "Interface": "memcache",
-                        "Scope": "global"
+                    "relation": {
+                        "name": "cache",
+                        "role": "client",
+                        "interface": "memcache",
+                        "scope": "global"
                     },
-                    "ApplicationName": "mediawiki"
+                    "application-name": "mediawiki"
                 },
                 {
-                    "Relation": {
-                        "Name": "cache",
-                        "Role": "server",
-                        "Interface": "memcache",
-                        "Scope": "global"
+                    "relation": {
+                        "name": "cache",
+                        "role": "server",
+                        "interface": "memcache",
+                        "scope": "global"
                     },
-                    "ApplicationName": "memcached"
+                    "application-name": "memcached"
                 }
             ]
         }
@@ -279,22 +279,22 @@
             "Key": "wordpress:db mysql:db",
             "Endpoints": [
                 {
-                    "Relation": {
-                        "Name": "db",
-                        "Role": "client",
-                        "Interface": "mysql",
-                        "Scope": "global"
+                    "relation": {
+                        "name": "db",
+                        "role": "client",
+                        "interface": "mysql",
+                        "scope": "global"
                     },
-                    "ApplicationName": "wordpress"
+                    "application-name": "wordpress"
                 },
                 {
-                    "Relation": {
-                        "Name": "db",
-                        "Role": "server",
-                        "Interface": "mysql",
-                        "Scope": "global"
+                    "relation": {
+                        "name": "db",
+                        "role": "server",
+                        "interface": "mysql",
+                        "scope": "global"
                     },
-                    "ApplicationName": "mysql"
+                    "application-name": "mysql"
                 }
             ]
         }
@@ -306,22 +306,22 @@
             "Key": "puppet:juju-info mysql:juju-info",
             "Endpoints": [
                 {
-                    "Relation": {
-                        "Name": "juju-info",
-                        "Role": "client",
-                        "Interface": "juju-info",
-                        "Scope": "container"
+                    "relation": {
+                        "name": "juju-info",
+                        "role": "client",
+                        "interface": "juju-info",
+                        "scope": "container"
                     },
-                    "ApplicationName": "puppet"
+                    "application-name": "puppet"
                 },
                 {
-                    "Relation": {
-                        "Name": "juju-info",
-                        "Role": "server",
-                        "Interface": "juju-info",
-                        "Scope": "container"
+                    "relation": {
+                        "name": "juju-info",
+                        "role": "server",
+                        "interface": "juju-info",
+                        "scope": "container"
                     },
-                    "ApplicationName": "mysql"
+                    "application-name": "mysql"
                 }
             ]
         }

--- a/jujugui/static/gui/src/test/test_environment_view.js
+++ b/jujugui/static/gui/src/test/test_environment_view.js
@@ -52,12 +52,12 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
             Id: 0,
             Endpoints: [
               {
-                ServiceName: 'wordpress',
-                Relation: {
-                  Name: 'loadbalancer',
-                  Role: 'peer',
-                  Interface: 'reversenginx',
-                  Scope: 'global'
+                'application-name': 'wordpress',
+                relation: {
+                  name: 'loadbalancer',
+                  role: 'peer',
+                  interface: 'reversenginx',
+                  scope: 'global'
                 }
               }
             ]
@@ -69,21 +69,21 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
             Id: 1,
             Endpoints: [
               {
-                ServiceName: 'puppet',
-                Relation: {
-                  Name: 'juju-info',
-                  Role: 'requirer',
-                  Interface: 'juju-info',
-                  Scope: 'container'
+                'application-name': 'puppet',
+                relation: {
+                  name: 'juju-info',
+                  role: 'requirer',
+                  interface: 'juju-info',
+                  scope: 'container'
                 }
               },
               {
-                ServiceName: 'wordpress',
-                Relation: {
-                  Name: 'juju-info',
-                  Role: 'provider',
-                  Interface: 'juju-info',
-                  Scope: 'container'
+                'application-name': 'wordpress',
+                relation: {
+                  name: 'juju-info',
+                  role: 'provider',
+                  interface: 'juju-info',
+                  scope: 'container'
                 }
               }
             ]
@@ -95,20 +95,20 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
             Id: 2,
             Endpoints: [
               {
-                ServiceName: 'mysql',
-                Relation: {
-                  Name: 'db',
-                  Role: 'server',
-                  Interface: 'mysql',
-                  Scope: 'global'
+                'application-name': 'mysql',
+                relation: {
+                  name: 'db',
+                  role: 'server',
+                  interface: 'mysql',
+                  scope: 'global'
                 }
               }, {
-                ServiceName: 'wordpress',
-                Relation: {
-                  Name: 'db',
-                  Role: 'client',
-                  Interface: 'mysql',
-                  Scope: 'global'
+                'application-name': 'wordpress',
+                relation: {
+                  name: 'db',
+                  role: 'client',
+                  interface: 'mysql',
+                  scope: 'global'
                 }
               }
             ]
@@ -142,7 +142,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
         }], [
           'annotationInfo',
           'change', {
-            Tag: 'service-wordpress',
+            Tag: 'application-wordpress',
             Annotations: {
               'gui-x': 100,
               'gui-y': 200
@@ -163,20 +163,20 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
           Id: 5,
           Endpoints: [
             {
-              ServiceName: 'mysql',
-              Relation: {
-                Name: 'db',
-                Role: 'server',
-                Interface: 'mysql',
-                Scope: 'global'
+              'application-name': 'mysql',
+              relation: {
+                name: 'db',
+                role: 'server',
+                interface: 'mysql',
+                scope: 'global'
               }
             }, {
-              ServiceName: 'mediawiki',
-              Relation: {
-                Name: 'db',
-                Role: 'client',
-                Interface: 'mysql',
-                Scope: 'global'
+              'application-name': 'mediawiki',
+              relation: {
+                name: 'db',
+                role: 'client',
+                interface: 'mysql',
+                scope: 'global'
               }
             }
           ]
@@ -188,20 +188,20 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
           Id: 6,
           Endpoints: [
             {
-              ServiceName: 'mysql',
-              Relation: {
-                Name: 'db-slave',
-                Role: 'server',
-                Interface: 'mysql',
-                Scope: 'global'
+              'application-name': 'mysql',
+              relation: {
+                name: 'db-slave',
+                role: 'server',
+                interface: 'mysql',
+                scope: 'global'
               }
             }, {
-              ServiceName: 'mediawiki',
-              Relation: {
-                Name: 'db-slave',
-                Role: 'client',
-                Interface: 'mysql',
-                Scope: 'global'
+              'application-name': 'mediawiki',
+              relation: {
+                name: 'db-slave',
+                role: 'client',
+                interface: 'mysql',
+                scope: 'global'
               }
             }
           ]
@@ -527,16 +527,16 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
               Id: 7,
               Endpoints: [
                 {
-                  ServiceName: 'puppet2',
-                  Relation: {
-                    Name: 'juju-info', Role: 'requirer',
-                    Interface: 'juju-info', Scope: 'container'
+                  'application-name': 'puppet2',
+                  relation: {
+                    name: 'juju-info', role: 'requirer',
+                    interface: 'juju-info', scope: 'container'
                   }
                 }, {
-                  ServiceName: 'wordpress',
-                  Relation: {
-                    Name: 'juju-info', Role: 'provider',
-                    Interface: 'juju-info', Scope: 'container'
+                  'application-name': 'wordpress',
+                  relation: {
+                    name: 'juju-info', role: 'provider',
+                    interface: 'juju-info', scope: 'container'
                   }
                 }
               ]
@@ -553,16 +553,16 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
               Id: 8,
               Endpoints: [
                 {
-                  ServiceName: 'mediawiki',
-                  Relation: {
-                    Name: 'juju-info', Role: 'provider',
-                    Interface: 'juju-info', Scope: 'container'
+                  'application-name': 'mediawiki',
+                  relation: {
+                    name: 'juju-info', role: 'provider',
+                    Interface: 'juju-info', scope: 'container'
                   }
                 }, {
-                  ServiceName: 'puppet',
-                  Relation: {
-                    Name: 'juju-info', Role: 'requirer',
-                    Interface: 'juju-info', Scope: 'container'
+                  'application-name': 'puppet',
+                  relation: {
+                    name: 'juju-info', role: 'requirer',
+                    interface: 'juju-info', scope: 'container'
                   }
                 }
               ]
@@ -858,7 +858,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
           [
             'annotationInfo',
             'change', {
-              'Tag': 'service-wordpress',
+              'Tag': 'application-wordpress',
               'Annotations': {
                 'gui-x': 374.1,
                 'gui-y': 211.2

--- a/jujugui/static/gui/src/test/test_model_handlers.js
+++ b/jujugui/static/gui/src/test/test_model_handlers.js
@@ -55,7 +55,7 @@ describe('Juju delta handlers', function() {
           PublicAddress: 'example.com',
           PrivateAddress: '10.0.0.1',
           Subordinate: false,
-          Ports: [{Number: 80, Protocol: 'tcp'}, {Number: 42, Protocol: 'udp'}]
+          Ports: [{number: 80, protocol: 'tcp'}, {number: 42, protocol: 'udp'}]
         };
         unitInfo(db, 'add', change);
         // Retrieve the unit from the list.
@@ -191,7 +191,7 @@ describe('Juju delta handlers', function() {
           PublicAddress: 'example.com',
           PrivateAddress: '10.0.0.1',
           Subordinate: false,
-          Ports: [{Number: 80, Protocol: 'tcp'}, {Number: 42, Protocol: 'udp'}]
+          Ports: [{number: 80, protocol: 'tcp'}, {number: 42, protocol: 'udp'}]
         };
         unitInfo(db, 'add', change);
         // Retrieve the unit from the list.
@@ -678,26 +678,26 @@ describe('Juju delta handlers', function() {
       ];
       deltaEndpoints = [
         {
-          Relation: {
-            Interface: 'http',
-            Limit: 1,
-            Name: 'reverseproxy',
-            Optional: false,
-            Role: 'requirer',
-            Scope: 'global'
+          relation: {
+            interface: 'http',
+            limit: 1,
+            name: 'reverseproxy',
+            optional: false,
+            role: 'requirer',
+            scope: 'global'
           },
-          ApplicationName: 'haproxy'
+          'application-name': 'haproxy'
         },
         {
-          Relation: {
-            Interface: 'http',
-            Limit: 0,
-            Name: 'website',
-            Optional: false,
-            Role: 'provider',
-            Scope: 'global'
+          relation: {
+            interface: 'http',
+            limit: 0,
+            name: 'website',
+            optional: false,
+            role: 'provider',
+            scope: 'global'
           },
-          ApplicationName: 'wordpress'
+          'application-name': 'wordpress'
         }
       ];
     });
@@ -706,44 +706,6 @@ describe('Juju delta handlers', function() {
       var change = {
         Key: relationKey,
         Endpoints: deltaEndpoints
-      };
-      relationInfo(db, 'add', change);
-      assert.strictEqual(1, db.relations.size());
-      // Retrieve the relation from the database.
-      var relation = db.relations.getById(relationKey);
-      assert.isNotNull(relation);
-      assert.strictEqual('http', relation.get('interface'));
-      assert.strictEqual('global', relation.get('scope'));
-      assert.deepEqual(dbEndpoints, relation.get('endpoints'));
-    });
-
-    it('creates a relation in the database (legacy API)', function() {
-      var change = {
-        Key: relationKey,
-        Endpoints: [
-          {
-            Relation: {
-              Interface: 'http',
-              Limit: 1,
-              Name: 'reverseproxy',
-              Optional: false,
-              Role: 'requirer',
-              Scope: 'global'
-            },
-            ServiceName: 'haproxy'
-          },
-          {
-            Relation: {
-              Interface: 'http',
-              Limit: 0,
-              Name: 'website',
-              Optional: false,
-              Role: 'provider',
-              Scope: 'global'
-            },
-            ServiceName: 'wordpress'
-          }
-        ]
       };
       relationInfo(db, 'add', change);
       assert.strictEqual(1, db.relations.size());
@@ -764,11 +726,11 @@ describe('Juju delta handlers', function() {
         endpoints: dbEndpoints
       });
       var firstEndpoint = deltaEndpoints[0],
-          firstRelation = firstEndpoint.Relation;
-      firstEndpoint.ApplicationName = 'mysql';
-      firstRelation.Name = 'db';
-      firstRelation.Interface = 'mysql';
-      firstRelation.Scope = 'local';
+          firstRelation = firstEndpoint.relation;
+      firstEndpoint['application-name'] = 'mysql';
+      firstRelation.name = 'db';
+      firstRelation.interface = 'mysql';
+      firstRelation.scope = 'local';
       var change = {
         Key: relationKey,
         Endpoints: deltaEndpoints
@@ -807,15 +769,15 @@ describe('Juju delta handlers', function() {
       var change = {
         Key: 'haproxy:peer',
         Endpoints: [{
-          Relation: {
-            Interface: 'haproxy-peer',
-            Limit: 1,
-            Name: 'peer',
-            Optional: false,
-            Role: 'peer',
-            Scope: 'global'
+          relation: {
+            interface: 'haproxy-peer',
+            limit: 1,
+            name: 'peer',
+            optional: false,
+            role: 'peer',
+            scope: 'global'
           },
-          ApplicationName: 'haproxy'
+          'application-name': 'haproxy'
         }]
       };
       relationInfo(db, 'change', change);
@@ -1024,19 +986,6 @@ describe('Juju delta handlers', function() {
       assert.deepEqual(annotations, application.get('annotations'));
     });
 
-    it('stores annotations on an application (legacy)', function() {
-      db.services.add({id: 'django'});
-      var annotations = {'gui-x': '42', 'gui-y': '47'};
-      var change = {
-        Tag: 'service-django',
-        Annotations: annotations
-      };
-      annotationInfo(db, 'add', change);
-      // Retrieve the annotations from the database.
-      var application = db.services.getById('django');
-      assert.deepEqual(annotations, application.get('annotations'));
-    });
-
     it('stores annotations on a unit', function() {
       var django = db.services.add({id: 'django'});
       var djangoUnits = django.get('units');
@@ -1170,9 +1119,6 @@ describe('Juju delta handlers utilities', function() {
       assert.equal('mysql', cleanUpEntityTags('application-mysql'));
       assert.equal(
           'buildbot-master', cleanUpEntityTags('application-buildbot-master'));
-      assert.equal('mysql', cleanUpEntityTags('service-mysql'));
-      assert.equal(
-          'buildbot-master', cleanUpEntityTags('service-buildbot-master'));
       // Clean up unit tags.
       assert.equal('mysql/47', cleanUpEntityTags('unit-mysql-47'));
       assert.equal(
@@ -1180,11 +1126,9 @@ describe('Juju delta handlers utilities', function() {
       // Clean up machine tags.
       assert.equal('0', cleanUpEntityTags('machine-0'));
       assert.equal('42', cleanUpEntityTags('machine-42'));
-      // Clean up model and environment tags.
+      // Clean up model tags.
       assert.equal('aws', cleanUpEntityTags('model-aws'));
       assert.equal('my-env', cleanUpEntityTags('model-my-env'));
-      assert.equal('aws', cleanUpEntityTags('environment-aws'));
-      assert.equal('my-env', cleanUpEntityTags('environment-my-env'));
     });
 
     it('ignores bad values', function() {
@@ -1205,8 +1149,8 @@ describe('Juju delta handlers utilities', function() {
 
     it('correctly returns a list of ports', function() {
       var ports = [
-        {Number: 80, Protocol: 'tcp'},
-        {Number: 42, Protocol: 'udp'}
+        {number: 80, protocol: 'tcp'},
+        {number: 42, protocol: 'udp'}
       ];
       assert.deepEqual(['80/tcp', '42/udp'], convertOpenPorts(ports));
     });
@@ -1229,65 +1173,32 @@ describe('Juju delta handlers utilities', function() {
     it('correctly returns a list of endpoints', function() {
       var endpoints = [
         {
-          Relation: {
-            Interface: 'http',
-            Limit: 1,
-            Name: 'reverseproxy',
-            Optional: false,
-            Role: 'requirer',
-            Scope: 'global'
+          relation: {
+            interface: 'http',
+            limit: 1,
+            name: 'reverseproxy',
+            optional: false,
+            role: 'requirer',
+            scope: 'global'
           },
-          ApplicationName: 'haproxy'
+          'application-name': 'haproxy'
         },
         {
-          Relation: {
-            Interface: 'http',
-            Limit: 0,
-            Name: 'website',
-            Optional: false,
-            Role: 'provider',
-            Scope: 'global'
+          relation: {
+            interface: 'http',
+            limit: 0,
+            name: 'website',
+            optional: false,
+            role: 'provider',
+            scope: 'global'
           },
-          ApplicationName: 'wordpress'
+          'application-name': 'wordpress'
         }
       ];
       var expected = [
         ['haproxy', {role: 'requirer', name: 'reverseproxy'}],
         ['wordpress', {role: 'provider', name: 'website'}]
       ];
-      assert.deepEqual(expected, createEndpoints(endpoints));
-    });
-
-    it('correctly returns a list of endpoints (legacy API)', function() {
-      var endpoints = [
-        {
-          Relation: {
-            Interface: 'http',
-            Limit: 1,
-            Name: 'reverseproxy',
-            Optional: false,
-            Role: 'requirer',
-            Scope: 'global'
-          },
-          ServiceName: 'haproxy'
-        },
-        {
-          Relation: {
-            Interface: 'http',
-            Limit: 0,
-            Name: 'website',
-            Optional: false,
-            Role: 'provider',
-            Scope: 'global'
-          },
-          ServiceName: 'wordpress'
-        }
-      ];
-      var expected = [
-        ['haproxy', {role: 'requirer', name: 'reverseproxy'}],
-        ['wordpress', {role: 'provider', name: 'website'}]
-      ];
-      console.log(createEndpoints(endpoints));
       assert.deepEqual(expected, createEndpoints(endpoints));
     });
 

--- a/jujugui/static/gui/src/test/test_model_legacy_handlers.js
+++ b/jujugui/static/gui/src/test/test_model_legacy_handlers.js
@@ -686,7 +686,7 @@ describe('Juju legacy delta handlers', function() {
             Role: 'requirer',
             Scope: 'global'
           },
-          ApplicationName: 'haproxy'
+          ServiceName: 'haproxy'
         },
         {
           Relation: {
@@ -697,7 +697,7 @@ describe('Juju legacy delta handlers', function() {
             Role: 'provider',
             Scope: 'global'
           },
-          ApplicationName: 'wordpress'
+          ServiceName: 'wordpress'
         }
       ];
     });
@@ -706,44 +706,6 @@ describe('Juju legacy delta handlers', function() {
       var change = {
         Key: relationKey,
         Endpoints: deltaEndpoints
-      };
-      relationInfo(db, 'add', change);
-      assert.strictEqual(1, db.relations.size());
-      // Retrieve the relation from the database.
-      var relation = db.relations.getById(relationKey);
-      assert.isNotNull(relation);
-      assert.strictEqual('http', relation.get('interface'));
-      assert.strictEqual('global', relation.get('scope'));
-      assert.deepEqual(dbEndpoints, relation.get('endpoints'));
-    });
-
-    it('creates a relation in the database (legacy API)', function() {
-      var change = {
-        Key: relationKey,
-        Endpoints: [
-          {
-            Relation: {
-              Interface: 'http',
-              Limit: 1,
-              Name: 'reverseproxy',
-              Optional: false,
-              Role: 'requirer',
-              Scope: 'global'
-            },
-            ServiceName: 'haproxy'
-          },
-          {
-            Relation: {
-              Interface: 'http',
-              Limit: 0,
-              Name: 'website',
-              Optional: false,
-              Role: 'provider',
-              Scope: 'global'
-            },
-            ServiceName: 'wordpress'
-          }
-        ]
       };
       relationInfo(db, 'add', change);
       assert.strictEqual(1, db.relations.size());
@@ -765,7 +727,7 @@ describe('Juju legacy delta handlers', function() {
       });
       var firstEndpoint = deltaEndpoints[0],
           firstRelation = firstEndpoint.Relation;
-      firstEndpoint.ApplicationName = 'mysql';
+      firstEndpoint.ServiceName = 'mysql';
       firstRelation.Name = 'db';
       firstRelation.Interface = 'mysql';
       firstRelation.Scope = 'local';
@@ -1015,19 +977,6 @@ describe('Juju legacy delta handlers', function() {
       db.services.add({id: 'django'});
       var annotations = {'gui-x': '42', 'gui-y': '47'};
       var change = {
-        Tag: 'application-django',
-        Annotations: annotations
-      };
-      annotationInfo(db, 'add', change);
-      // Retrieve the annotations from the database.
-      var application = db.services.getById('django');
-      assert.deepEqual(annotations, application.get('annotations'));
-    });
-
-    it('stores annotations on an application (legacy)', function() {
-      db.services.add({id: 'django'});
-      var annotations = {'gui-x': '42', 'gui-y': '47'};
-      var change = {
         Tag: 'service-django',
         Annotations: annotations
       };
@@ -1087,7 +1036,7 @@ describe('Juju legacy delta handlers', function() {
           expected = {'gui-x': '42', 'gui-y': '47', 'gui-z': 'Now in 3D!'};
       db.services.add({id: 'django', annotations: initial});
       var change = {
-        Tag: 'application-django',
+        Tag: 'service-django',
         Annotations: next
       };
       annotationInfo(db, 'change', change);
@@ -1101,7 +1050,7 @@ describe('Juju legacy delta handlers', function() {
       db.services.add({id: 'django', exposed: true});
       var annotations = {'gui-x': '42', 'gui-y': '47'};
       var change = {
-        Tag: 'application-django',
+        Tag: 'service-django',
         Annotations: annotations
       };
       annotationInfo(db, 'add', change);
@@ -1137,7 +1086,7 @@ describe('Juju legacy delta handlers', function() {
     it('does not create new model instances', function() {
       var annotations = {'gui-x': '42', 'gui-y': '47'};
       var change = {
-        Tag: 'application-django',
+        Tag: 'service-django',
         Annotations: annotations
       };
       annotationInfo(db, 'add', change);


### PR DESCRIPTION
Specialise utilities for Juju 2 API and put the old logic in the legacy handlers, so that we don;t have to maintain the logic for both new and legacy API.