### PR TITLE
API mega-watcher handlers: more cleanup in preparation for big change.

### DIFF
--- a/jujugui/static/gui/src/test/test_environment_view.js
+++ b/jujugui/static/gui/src/test/test_environment_view.js
@@ -26,22 +26,22 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
     var environment_delta = {
       'result': [
-        ['serviceInfo', 'add', {
+        ['applicationInfo', 'add', {
           'CharmURL': 'cs:precise/wordpress-6',
           'Name': 'wordpress',
           'exposed': false,
           'Annotations': {'gui-x': 100, 'gui-y': 200}
         }],
-        ['serviceInfo', 'add', {
+        ['applicationInfo', 'add', {
           'CharmURL': 'cs:precise/mediawiki-3',
           'Name': 'mediawiki',
           'exposed': false
         }],
-        ['serviceInfo', 'add', {
+        ['applicationInfo', 'add', {
           'CharmURL': 'cs:precise/mysql-26',
           'Name': 'mysql'
         }],
-        ['serviceInfo', 'add', {
+        ['applicationInfo', 'add', {
           'Subordinate': true,
           'CharmURL': 'cs:precise/puppet-2',
           'Name': 'puppet'
@@ -124,19 +124,22 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
         }],
         ['unitInfo', 'add', {
           'MachineId': 0,
-          'Status': 'started',
+          'JujuStatus': {Current: '', Message: '', Data: {}},
+          'WorkloadStatus': {Current: '', Message: '', Data: {}},
           'PublicAddress': '192.168.122.113',
           'Name': 'wordpress/0'
         }],
         ['unitInfo', 'add', {
           'MachineId': 0,
-          'Status': 'started',
+          'JujuStatus': {Current: '', Message: '', Data: {}},
+          'WorkloadStatus': {Current: '', Message: '', Data: {}},
           'PublicAddress': '192.168.122.113',
           'Name': 'mediawiki/0'
         }],
         ['unitInfo', 'add', {
           'MachineId': 0,
-          'Status': 'started',
+          'JujuStatus': {Current: '', Message: '', Data: {}},
+          'WorkloadStatus': {Current: '', Message: '', Data: {}},
           'PublicAddress': '192.168.122.222',
           'Name': 'mysql/0'
         }], [
@@ -515,7 +518,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       });
       var addSubordinate = {
         result: [
-          ['serviceInfo', 'add', {
+          ['applicationInfo', 'add', {
             'Subordinate': true,
             'CharmURL': 'cs:precise/puppet-2',
             'Name': 'puppet2'
@@ -774,14 +777,14 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
           tmp_data = {
             result: [
               [
-                'serviceInfo',
+                'applicationInfo',
                 'add', {
                   Subordinate: true,
                   CharmURL: 'cs:precise/puppet-2',
                   Name: 'puppet2'
                 }
               ], [
-                'serviceInfo',
+                'applicationInfo',
                 'add', {
                   CharmURL: 'cs:precise/mysql-26',
                   Name: 'mysql2'
@@ -790,7 +793,8 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
                 'unitInfo',
                 'add', {
                   MachineId: 0,
-                  Status: 'started',
+                  'JujuStatus': {Current: '', Message: '', Data: {}},
+                  'WorkloadStatus': {Current: '', Message: '', Data: {}},
                   PublicAddress: '192.168.122.222',
                   Name: 'mysql2/0'
                 }
@@ -826,7 +830,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       var tmp_data = {
         result: [
           [
-            'serviceInfo',
+            'applicationInfo',
             'add', {
               Subordinate: false,
               CharmURL: 'cs:precise/wordpress-6',
@@ -897,7 +901,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       tmp_data = {
         result: [
           [
-            'serviceInfo',
+            'applicationInfo',
             'add',
             {
               Subordinate: true,

--- a/jujugui/static/gui/src/test/test_model.js
+++ b/jujugui/static/gui/src/test/test_model.js
@@ -555,7 +555,7 @@ describe('test_model.js', function() {
       it('should handle messages from legacy Juju versions', function() {
         var db = new models.Database();
         db.onDelta({data: {result: [
-          ['serviceInfo', 'add', {Name: 'django'}]
+          ['serviceLegacyInfo', 'add', {Name: 'django'}]
         ]}});
         assert.strictEqual(db.services.size(), 1);
         assert.strictEqual(db.services.item(0).get('id'), 'django');
@@ -642,7 +642,7 @@ describe('test_model.js', function() {
            var my0 = new models.Service({id: 'mysql', exposed: true});
            db.services.add([my0]);
            db.onDelta({data: {result: [
-             ['serviceInfo', 'add', {
+             ['applicationInfo', 'add', {
                Name: 'mysql',
                CharmURL: 'cs:precise/mysql',
                Exposed: false
@@ -656,12 +656,12 @@ describe('test_model.js', function() {
          function() {
            var db = new models.Database();
            db.services.add({id: 'mysql'});
-           var my0 = {id: 'mysql/0', agent_state: 'pending'};
+           var my0 = {id: 'mysql/0', public_address: '1.2.3.4'};
            db.addUnits([my0]);
            db.onDelta({data: {result: [
-             ['unitInfo', 'add', {Name: 'mysql/0', Status: 'another'}]
+             ['unitInfo', 'add', {Name: 'mysql/0', PublicAddress: '5.6.7.8'}]
            ]}});
-           my0.agent_state.should.equal('another');
+           my0.public_address.should.equal('5.6.7.8');
          });
 
       it('uses default handler for unknown deltas', function() {


### PR DESCRIPTION
With this the legacy mega-watcher handlers should be ready to go and we "only" need to change the fields in the Juju 2 handlers.js file. All the legacy handler functions have been renamed to *LegacyInfo so that the legacy API can refer to them without clashes with the new API.