### PR TITLE
Fix inspector header & scale up input regressions

### DIFF
--- a/jujugui/static/gui/src/app/assets/css/_generic.scss
+++ b/jujugui/static/gui/src/app/assets/css/_generic.scss
@@ -27,6 +27,7 @@
   input[type="number"],
   input[type="password"] {
         @extend %input;
+        box-sizing: content-box;
   }
 
   input[type=number]::-webkit-inner-spin-button,

--- a/jujugui/static/gui/src/app/assets/css/_generic.scss
+++ b/jujugui/static/gui/src/app/assets/css/_generic.scss
@@ -27,7 +27,6 @@
   input[type="number"],
   input[type="password"] {
         @extend %input;
-        box-sizing: content-box;
   }
 
   input[type=number]::-webkit-inner-spin-button,

--- a/jujugui/static/gui/src/app/components/constraints/_constraints.scss
+++ b/jujugui/static/gui/src/app/components/constraints/_constraints.scss
@@ -9,7 +9,6 @@
     &__input {
         @extend %stagger-fade-in;
         margin: 5px 10px 10px 10px;
-        height: 28px;
-        width: calc(100% - 40px);
+        width: calc(100% - 20px);
     }
 }

--- a/jujugui/static/gui/src/app/components/inspector-header/_inspector-header.scss
+++ b/jujugui/static/gui/src/app/components/inspector-header/_inspector-header.scss
@@ -1,7 +1,8 @@
 .inspector-header {
-    cursor: pointer;
-    padding: 10px 20px;
     border-bottom: 1px solid $mid-grey;
+    cursor: pointer;
+    min-height: 44px;
+    padding: 10px 20px;
 
     &__back {
         vertical-align: middle;

--- a/jujugui/static/gui/src/app/components/inspector/_inspector.scss
+++ b/jujugui/static/gui/src/app/components/inspector/_inspector.scss
@@ -1,4 +1,8 @@
 .inspector-content {
     @extend %scroll-children;
     position: relative;
+
+    .button-row {
+        min-height: 60px;
+    }
 }

--- a/jujugui/static/gui/src/app/components/machine-view/scale-up/_scale-up.scss
+++ b/jujugui/static/gui/src/app/components/machine-view/scale-up/_scale-up.scss
@@ -21,10 +21,10 @@
 
     &-unit-input[type="number"] {
         float: right;
-        width: 35px;
         margin-top: -2px;
-        padding-top: 4px;
         padding-bottom: 4px;
+        padding-top: 4px;
         text-align: right;
+        width: 55px;
     }
 }

--- a/jujugui/static/gui/src/app/components/scale-service/_scale-service.scss
+++ b/jujugui/static/gui/src/app/components/scale-service/_scale-service.scss
@@ -4,8 +4,8 @@
 
         &__input {
             margin: 20px 20px 13px 20px;
-            height: 28px;
-            width: 230px;
+            height: 38px;
+            width: 250px;
             background-color: transparent;
         }
 

--- a/jujugui/static/gui/src/app/components/scale-service/_scale-service.scss
+++ b/jujugui/static/gui/src/app/components/scale-service/_scale-service.scss
@@ -4,8 +4,7 @@
 
         &__input {
             margin: 20px 20px 13px 20px;
-            height: 38px;
-            width: 250px;
+            width: 230px;
             background-color: transparent;
         }
 

--- a/jujugui/static/gui/src/app/components/scale-service/_scale-service.scss
+++ b/jujugui/static/gui/src/app/components/scale-service/_scale-service.scss
@@ -4,7 +4,7 @@
 
         &__input {
             margin: 20px 20px 13px 20px;
-            width: 230px;
+            width: 250px;
             background-color: transparent;
         }
 


### PR DESCRIPTION
Both regressions were caused by the switch to box-sizing: border-box for all elements by default. They needed their heights/widths adjusted to include the padding.
Fixes: https://github.com/juju/juju-gui/issues/1824, Fixes: https://github.com/juju/juju-gui/issues/1834