### PR TITLE
Add the --compact flag to fast-babel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ modules-js: $(MODULESMIN)
 .PHONY: fast-babel
 fast-babel: $(NODE_MODULES)
 	$(NODE_MODULES)/.bin/babel $(GUISRC)/app --out-dir $(GUIBUILD)/app \
-		--ignore /assets/javascripts/
+		--ignore /assets/javascripts/ --compact
 
 $(GUIBUILD)/app/%-min.js: $(GUIBUILD)/app/%.js $(NODE_MODULES)
 	$(NODE_MODULES)/.bin/uglifyjs --screw-ie8 $(GUIBUILD)/app/$*.js -o $@


### PR DESCRIPTION
Adding the `--compact` flag to the fast-babel target speeds up the processing time from 26s to 17s on my machine. The `--compact` flag doesn't add in whitespace and newlines to make the output look pretty. 

This flag has been left off of the individual target because it is dwarfed by the slow start-up time of babel. And it gives us the ability to generate a 'whitespace full' version if necessary by simply executing make target for a built js file.

 