### PR TITLE
Create Section load watcher component

### DIFF
--- a/jujugui/static/gui/src/app/components/section-load-watcher/section-load-watcher.js
+++ b/jujugui/static/gui/src/app/components/section-load-watcher/section-load-watcher.js
@@ -35,6 +35,8 @@ YUI.add('section-load-watcher', function(Y) {
     },
 
     getInitialState: function() {
+      this._childrenStatuses = new Map();
+
       return {
         renderEmpty: false,
         renderError: false
@@ -42,8 +44,6 @@ YUI.add('section-load-watcher', function(Y) {
     },
 
     _validStatuses: ['starting', 'ok', 'empty', 'error'],
-
-    _childrenStatuses: new Map(),
 
     /**
       When a child status has been updated we need to loop through all of
@@ -69,6 +69,14 @@ YUI.add('section-load-watcher', function(Y) {
       }
     },
 
+    /**
+      Sets the child status in the component and then checks all the statuses
+      to see if we should be rendering an error or empty component.
+
+      @method _setChildStatus
+      @param {String} ref The ref of the child.
+      @param {String} status The status of the child.
+    */
     _setChildStatus: function(ref, status) {
       if (this._validStatuses.indexOf(status) === -1) {
         throw `Invalid status: "${status}" from ref: ${ref}`;
@@ -77,6 +85,12 @@ YUI.add('section-load-watcher', function(Y) {
       this._checkChildrenStatuses();
     },
 
+    /**
+      Checks the state of the component to determine whether it should
+      render the empty, error, or children components.
+
+      @method _renderContent
+    */
     _renderContent: function() {
       if (this.state.renderEmpty) {
         return <this.props.EmptyComponent />;

--- a/jujugui/static/gui/src/app/components/section-load-watcher/section-load-watcher.js
+++ b/jujugui/static/gui/src/app/components/section-load-watcher/section-load-watcher.js
@@ -1,0 +1,68 @@
+/*
+This file is part of the Juju GUI, which lets users view and manage Juju
+environments within a graphical interface (https://launchpad.net/juju-gui).
+Copyright (C) 2012-2013 Canonical Ltd.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU Affero General Public License version 3, as published by
+the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero
+General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along
+with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+'use strict';
+
+YUI.add('section-load-watcher', function(Y) {
+
+  juju.components.SectionLoadWatcher = React.createClass({
+
+    propTypes: {
+      children: React.PropTypes.func,
+      EmptyComponent: React.PropTypes.func,
+      ErrorComponent: React.PropTypes.func,
+      timeout: React.PropTypes.number
+    },
+
+    _validStatuses: ['starting', 'ok', 'empty', 'error'],
+
+    _childrenStatuses: {},
+
+    _setChildStatus: function(ref, status) {
+      if (this._validStatuses.indexOf(status) === -1) {
+        throw `Invalid status: ${status} from ref: ${ref}`;
+      }
+      this._childrenStatuses[ref] = status;
+    },
+
+    render: function() {
+      // Augment the children with the broadcastStatus method
+      const children = React.Children.map(this.props.children, child => {
+        const ref = child.ref;
+        if (!ref) {
+          throw `ref required but not supplied for component: ${child.type}`;
+        }
+        // Set the status for the child as null if it is new.
+        if (!this._childrenStatuses[ref]) {
+          this._childrenStatuses[ref] = null;
+        }
+        // Clone the child adding in the broadcastStatus prop.
+        return React.cloneElement(child, {
+          broadcastStatus: this._setChildStatus.bind(this, ref)
+        });
+      });
+
+      return (
+        <div>
+          {children}
+        </div>);
+    }
+
+  });
+
+}, '0.1.0', {requires: []});

--- a/jujugui/static/gui/src/app/components/section-load-watcher/test-section-load-watcher.js
+++ b/jujugui/static/gui/src/app/components/section-load-watcher/test-section-load-watcher.js
@@ -1,0 +1,154 @@
+/*
+This file is part of the Juju GUI, which lets users view and manage Juju
+environments within a graphical interface (https://launchpad.net/juju-gui).
+Copyright (C) 2015 Canonical Ltd.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU Affero General Public License version 3, as published by
+the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero
+General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along
+with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+'use strict';
+
+var juju = {components: {}}; // eslint-disable-line no-unused-vars
+
+chai.config.includeStack = true;
+chai.config.truncateThreshold = 0;
+
+describe('SectionLoadWatcher', () => {
+  let SectionLoadWatcher; // eslint-disable-line no-unused-vars
+  let EmptyComponent, ErrorComponent, TestComponent;
+
+  beforeAll(done => YUI().use('section-load-watcher', () => { done(); }));
+
+  beforeEach(() => {
+    SectionLoadWatcher = juju.components.SectionLoadWatcher;
+    TestComponent = React.createClass({
+      render: function() { return <div className="test"></div>; }
+    });
+    EmptyComponent = React.createClass({
+      render: function() { return <div className="empty"></div>; }
+    });
+    ErrorComponent = React.createClass({
+      render: function() { return <div className="error"></div>; }
+    });
+  });
+
+  it('augments a child component', () => {
+    const renderer = jsTestUtils.shallowRender(
+      <SectionLoadWatcher>
+        <TestComponent ref="test1"/>
+      </SectionLoadWatcher>, true);
+    const instance = renderer.getMountedInstance();
+    const output = renderer.getRenderOutput();
+    output.props.children[0].props.broadcastStatus('starting');
+    assert.equal(instance._childrenStatuses.get('test1'), 'starting');
+  });
+
+  it('renders all child components', () => {
+    const output = jsTestUtils.shallowRender(
+      <SectionLoadWatcher>
+        <TestComponent ref="test1"/>
+        <TestComponent ref="test2"/>
+      </SectionLoadWatcher>);
+    assert.equal(output.props.children.length, 2);
+    assert.equal(output.props.children[0].type, TestComponent);
+    assert.equal(output.props.children[0].ref, 'test1');
+    assert.equal(output.props.children[1].type, TestComponent);
+    assert.equal(output.props.children[1].ref, 'test2');
+  });
+
+  it('renders the empty component when all children report empty', () => {
+    const renderer = jsTestUtils.shallowRender(
+      <SectionLoadWatcher
+        EmptyComponent={EmptyComponent}>
+        <TestComponent ref="test1"/>
+        <TestComponent ref="test2"/>
+      </SectionLoadWatcher>, true);
+    let output = renderer.getRenderOutput();
+    output.props.children[0].props.broadcastStatus('empty');
+    output.props.children[1].props.broadcastStatus('empty');
+    // Trigger the render again
+    output = renderer.getRenderOutput();
+    assert.equal(output.props.children.type, EmptyComponent);
+  });
+
+  it('renders the error component when all children report an error', () => {
+    const renderer = jsTestUtils.shallowRender(
+      <SectionLoadWatcher
+        ErrorComponent={ErrorComponent}>
+        <TestComponent ref="test1"/>
+        <TestComponent ref="test2"/>
+      </SectionLoadWatcher>, true);
+    let output = renderer.getRenderOutput();
+    output.props.children[0].props.broadcastStatus('error');
+    output.props.children[1].props.broadcastStatus('error');
+    // Trigger the render again
+    output = renderer.getRenderOutput();
+    assert.equal(output.props.children.type, ErrorComponent);
+  });
+
+  it('renders the children if not all report empty', () => {
+    const renderer = jsTestUtils.shallowRender(
+      <SectionLoadWatcher>
+        <TestComponent ref="test1"/>
+        <TestComponent ref="test2"/>
+      </SectionLoadWatcher>, true);
+    let output = renderer.getRenderOutput();
+    output.props.children[0].props.broadcastStatus('empty');
+    // Trigger the render again
+    output = renderer.getRenderOutput();
+    assert.equal(output.props.children.length, 2);
+    assert.equal(output.props.children[0].type, TestComponent);
+    assert.equal(output.props.children[0].ref, 'test1');
+    assert.equal(output.props.children[1].type, TestComponent);
+    assert.equal(output.props.children[1].ref, 'test2');
+  });
+
+  it('renders the children if not all report error', () => {
+    const renderer = jsTestUtils.shallowRender(
+      <SectionLoadWatcher>
+        <TestComponent ref="test1"/>
+        <TestComponent ref="test2"/>
+      </SectionLoadWatcher>, true);
+    let output = renderer.getRenderOutput();
+    output.props.children[0].props.broadcastStatus('error');
+    // Trigger the render again
+    output = renderer.getRenderOutput();
+    assert.equal(output.props.children.length, 2);
+    assert.equal(output.props.children[0].type, TestComponent);
+    assert.equal(output.props.children[0].ref, 'test1');
+    assert.equal(output.props.children[1].type, TestComponent);
+    assert.equal(output.props.children[1].ref, 'test2');
+  });
+
+  it('throws if a child tries to set an invalid status', () => {
+    const renderer = jsTestUtils.shallowRender(
+      <SectionLoadWatcher>
+        <TestComponent ref="test1"/>
+      </SectionLoadWatcher>, true);
+    const instance = renderer.getMountedInstance();
+    const output = renderer.getRenderOutput();
+    assert.throws(
+      output.props.children[0].props.broadcastStatus.bind(instance, 'invalid'),
+      'Invalid status: "invalid" from ref: test1');
+  });
+
+  it('throws if a child is missing a ref', () => {
+    assert.throws(
+      jsTestUtils.shallowRender.bind(this,
+        <SectionLoadWatcher>
+          <TestComponent />
+        </SectionLoadWatcher>),
+      'ref required but not supplied for component');
+  });
+
+});


### PR DESCRIPTION
When we have a number of components that are individually making requests we want to know if all of them return no data, or return an error. This component allows you to easily show an error or empty component if all of the children return an error or empty status via the `broadcastStatus` prop which is augmented onto all of the children.