### PR TITLE
Fix shortcuts panel

### DIFF
--- a/jujugui/static/gui/src/app/components/shortcuts/shortcuts.js
+++ b/jujugui/static/gui/src/app/components/shortcuts/shortcuts.js
@@ -81,11 +81,6 @@ YUI.add('shortcuts', function() {
                 Enable container control for this provider.
               </label>
             </div>
-            <div className="three-col last-col">
-              <label htmlFor="environment-name">
-                Change the name of this Model in the GUI.
-              </label>
-            </div>
             <div className="two-col">
               <input type="checkbox" name="disable-auto-place"
                 id="disable-auto-place"


### PR DESCRIPTION
Remove the unused model name label to fix the shortcuts screen layout.