### PR TITLE
Fix bundle import/export

### DIFF
--- a/jujugui/static/gui/src/app/models/models.js
+++ b/jujugui/static/gui/src/app/models/models.js
@@ -2713,16 +2713,15 @@ YUI.add('juju-models', function(Y) {
     _collapseMachineConstraints: function(constraints) {
       var constraint = '';
       var constraintMap = {
-        arch: 'arch',
         cpuCores: 'cpu-cores',
         cpuPower: 'cpu-power',
-        mem: 'mem',
         disk: 'root-disk'
       };
       Object.keys(constraints).forEach(function(key) {
         var value = constraints[key];
         if (value) {
-          constraint += constraintMap[key] + '=' + value + ' ';
+          var property = constraintMap[key] || key;
+          constraint += property + '=' + value + ' ';
         }
       });
       return constraint.trim();

--- a/jujugui/static/gui/src/app/models/models.js
+++ b/jujugui/static/gui/src/app/models/models.js
@@ -2713,6 +2713,7 @@ YUI.add('juju-models', function(Y) {
     _collapseMachineConstraints: function(constraints) {
       var constraint = '';
       var constraintMap = {
+        availabilityZone: 'availability-zone',
         cpuCores: 'cpu-cores',
         cpuPower: 'cpu-power',
         disk: 'root-disk'

--- a/jujugui/static/gui/src/app/utils/bundle-importer.js
+++ b/jujugui/static/gui/src/app/utils/bundle-importer.js
@@ -104,7 +104,8 @@ YUI.add('bundle-importer', function(Y) {
     _ensureV4Format: function(bundleYAML) {
       try {
         var bundle = jsyaml.safeLoad(bundleYAML);
-        if (bundle.services && !bundle.services.services) {
+        if (bundle.services && !bundle.services.services ||
+          bundle.applications) {
           return bundleYAML;
         } else {
           // Fetch the first bundle in the v3 bundle basket.

--- a/jujugui/static/gui/src/test/test_bundle_importer.js
+++ b/jujugui/static/gui/src/test/test_bundle_importer.js
@@ -219,6 +219,19 @@ describe('Bundle Importer', function() {
         assert.strictEqual(args[1], null);
       });
 
+      it('can import v4 bundles with applications key', function() {
+        var yaml = '{"applications":{}}';
+        var getBundleChanges = utils.makeStubMethod(
+            bundleImporter.env, 'getBundleChanges');
+        this._cleanups.push(getBundleChanges.reset);
+        bundleImporter.fetchDryRun(yaml, null);
+        assert.equal(getBundleChanges.callCount(), 1);
+        var args = getBundleChanges.lastArguments();
+        assert.equal(args.length, 3);
+        assert.equal(args[0], '{"applications":{}}');
+        assert.strictEqual(args[1], null);
+      });
+
       it('calls to the env to get bundle changes from a token', function() {
         var token = 'foo';
         var getBundleChanges = utils.makeStubMethod(


### PR DESCRIPTION
There are two issues addressed here. Firstly fixes importing bundles files using the new yaml format using 'applications' instead of 'services' and also resolves exporting bundles with availability-zone constraints. Fixes #1937.