### PR TITLE
Handle new ACLs introduced by beta18.

### DIFF
--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -418,7 +418,6 @@ YUI.add('juju-gui', function(Y) {
         ecs: ecs,
         user: this.get('user'),
         password: this.get('password'),
-        readOnly: this.get('readOnly'),
         conn: this.get('conn'),
         jujuCoreVersion: this.get('jujuCoreVersion')
       };
@@ -510,7 +509,7 @@ YUI.add('juju-gui', function(Y) {
       });
 
       // Create the ACL object.
-      this.acl = new Y.juju.generateAcl(this.env);
+      this.acl = new Y.juju.generateAcl(this.controllerAPI, this.env);
 
       this.changesUtils = window.juju.utils.ChangesUtils;
       this.relationUtils = window.juju.utils.RelationUtils;

--- a/jujugui/static/gui/src/app/store/env/api.js
+++ b/jujugui/static/gui/src/app/store/env/api.js
@@ -491,7 +491,8 @@ YUI.add('juju-env-api', function(Y) {
         }, {});
         this.set('facades', facades);
         var userInfo = response['user-info'];
-        this.set('readOnly', !!userInfo['read-only']);
+        this.set('modelAccess', userInfo['model-access']);
+        this.set('controllerAccess', userInfo['controller-access']);
         this.set('modelTag', response['model-tag']);
         this.currentModelInfo(this._handleCurrentModelInfo.bind(this));
         this._watchAll();

--- a/jujugui/static/gui/src/app/store/env/base.js
+++ b/jujugui/static/gui/src/app/store/env/base.js
@@ -152,12 +152,19 @@ YUI.add('juju-env-base', function(Y) {
     */
     'debug': {value: false},
     /**
-      Whether or not to run in read-only mode
+      The controller access level (see "app/store/env/acl.js").
 
-      @attribute readOnly
-      @type {boolean}
+      @attribute controllerAccess
+      @type {String}
     */
-    'readOnly': {value: false},
+    'controllerAccess': {value: ''},
+    /**
+      The model access level (see "app/store/env/acl.js").
+
+      @attribute modelAccess
+      @type {String}
+    */
+    'modelAccess': {value: ''},
     /**
       The default series (e.g.: precise) as provided by juju.
 

--- a/jujugui/static/gui/src/app/store/env/controller-api.js
+++ b/jujugui/static/gui/src/app/store/env/controller-api.js
@@ -142,7 +142,7 @@ YUI.add('juju-controller-api', function(Y) {
         }, {});
         this.set('facades', facades);
         var userInfo = response['user-info'];
-        this.set('readOnly', !!userInfo['read-only']);
+        this.set('controllerAccess', userInfo['controller-access']);
         this.set('serverTag', response['server-tag']);
         // Start pinging the server.
         // XXX frankban: this is only required as a temporary workaround to

--- a/jujugui/static/gui/src/app/store/env/sandbox.js
+++ b/jujugui/static/gui/src/app/store/env/sandbox.js
@@ -304,7 +304,10 @@ YUI.add('juju-env-sandbox', function(Y) {
         data.params['auth-tag'], data.params.credentials);
       data.response = {
         facades: sandboxModule.facades,
-        'user-info': {'read-only': false}
+        'user-info': {
+          'controller-access': 'superuser',
+          'model-access': 'admin'
+        }
       };
       client.receive(data);
     },

--- a/jujugui/static/gui/src/test/test_app.js
+++ b/jujugui/static/gui/src/test/test_app.js
@@ -157,18 +157,6 @@ describe('App', function() {
           });
         });
 
-    it('propagates the readOnly option from the configuration', function() {
-      app = new Y.juju.App({
-        container: container,
-        readOnly: true,
-        viewContainer: container,
-        conn: {close: function() {}},
-        jujuCoreVersion: '1.21.1.1-trusty-amd64',
-        ecs: new juju.EnvironmentChangeSet()
-      });
-      assert.isTrue(app.env.get('readOnly'));
-    });
-
     it('should produce a valid index', function() {
       constructAppInstance({
         env: new juju.environments.GoEnvironment({

--- a/jujugui/static/gui/src/test/test_controller_api.js
+++ b/jujugui/static/gui/src/test/test_controller_api.js
@@ -189,9 +189,9 @@ describe('Controller API', function() {
           {name: 'Client', versions: [0]},
           {name: 'ModelManager', versions: [2]}
         ],
-        'user-info': {'read-only': true}
+        'user-info': {'controller-access': 'addmodel', 'model-access': ''}
       }});
-      assert.strictEqual(controllerAPI.get('readOnly'), true);
+      assert.strictEqual(controllerAPI.get('controllerAccess'), 'addmodel');
     });
   });
 

--- a/jujugui/static/gui/src/test/test_env_api.js
+++ b/jujugui/static/gui/src/test/test_env_api.js
@@ -389,9 +389,10 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
             {name: 'Client', versions: [0]},
             {name: 'ModelManager', versions: [2]}
           ],
-          'user-info': {'read-only': true}
+          'user-info': {'controller-access': 'login', 'model-access': 'read'}
         }});
-        assert.strictEqual(env.get('readOnly'), true);
+        assert.strictEqual(env.get('controllerAccess'), 'login');
+        assert.strictEqual(env.get('modelAccess'), 'read');
       });
 
     });

--- a/jujugui/static/gui/src/test/test_sandbox_go.js
+++ b/jujugui/static/gui/src/test/test_sandbox_go.js
@@ -142,7 +142,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     it('can log in.', function(done) {
       // See FakeBackend's authorizedUsers for these default authentication
       // values.
-      var data = {
+      const data = {
         type: 'Admin',
         request: 'Login',
         params: {
@@ -157,7 +157,10 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
         data.error = false;
         data.response = {
           facades: sandboxModule.facades,
-          'user-info': {'read-only': false}
+          'user-info': {
+            'controller-access': 'superuser',
+            'model-access': 'admin'
+          }
         };
         assert.deepEqual(JSON.parse(received.data), data);
         assert.isTrue(state.get('authenticated'));
@@ -173,7 +176,8 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       state.logout();
       env.after('login', function() {
         assert.deepEqual(env.userIsAuthenticated, true);
-        assert.deepEqual(env.get('readOnly'), false);
+        assert.strictEqual(env.get('controllerAccess'), 'superuser');
+        assert.strictEqual(env.get('modelAccess'), 'admin');
         done();
       });
       env.connect();


### PR DESCRIPTION
Also extend the ACL interface so that it can be used in
the future when it will be required to do more fine grained
permission checks, like "can the current user create models?"
or "can they share this model?".

**Warning: do not land this branch before GUI 2.1.11 is released.**