### PR TITLE
Disable plan info and display machines

### DIFF
--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -1163,7 +1163,8 @@ YUI.add('juju-gui', function(Y) {
           servicesGetById={services.getById.bind(services)}
           updateCloudCredential={
             controllerAPI.updateCloudCredential.bind(controllerAPI)}
-          user={this.controllerAPI.get('user')} />,
+          user={`user-${this.controllerAPI.get('user')}`}
+          withPlans={false} />,
         document.getElementById('deployment-container'));
     },
 

--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -1136,6 +1136,9 @@ YUI.add('juju-gui', function(Y) {
         });
         return;
       }
+      // Auto place the units. This is probably not be best UX, but is required
+      // to display the machines in the deployment flow.
+      autoPlaceUnits();
       ReactDOM.render(
         <window.juju.components.DeploymentFlow
           acl={this.acl}

--- a/jujugui/static/gui/src/app/components/budget-table/budget-table.js
+++ b/jujugui/static/gui/src/app/components/budget-table/budget-table.js
@@ -28,7 +28,8 @@ YUI.add('budget-table', function() {
       listPlansForCharm: React.PropTypes.func,
       plansEditable: React.PropTypes.bool,
       services: React.PropTypes.array.isRequired,
-      showExtra: React.PropTypes.bool
+      showExtra: React.PropTypes.bool,
+      withPlans: React.PropTypes.bool
     },
 
     /**
@@ -49,12 +50,41 @@ YUI.add('budget-table', function() {
             listPlansForCharm={this.props.listPlansForCharm}
             plansEditable={this.props.plansEditable}
             service={service}
-            showExtra={this.props.showExtra} />);
+            showExtra={this.props.showExtra}
+            withPlans={this.props.withPlans} />);
       });
     },
 
+    /**
+      Generate plan headers.
+
+      @method _generatePlanHeaders
+      @returns {Object} The plan headers markup.
+    */
+    _generatePlanHeaders: function() {
+      if (!this.props.withPlans) {
+        return;
+      }
+      const plansEditable = this.props.plansEditable;
+      return (
+        <div>
+          <div className="three-col">
+            Details
+          </div>
+          <div className={plansEditable ? 'one-col' : 'two-col'}>
+            Usage
+          </div>
+          <div className={plansEditable ? 'one-col' : 'two-col'}>
+            Allocation
+          </div>
+          <div className="one-col last-col">
+            Spend
+          </div>
+        </div>
+      );
+    },
+
     render: function() {
-      var plansEditable = this.props.plansEditable;
       return (
         <div className="budget-table">
           <div className="budget-table__row-header twelve-col">
@@ -64,18 +94,7 @@ YUI.add('budget-table', function() {
             <div className="one-col">
               Units
             </div>
-            <div className="three-col">
-              Details
-            </div>
-            <div className={plansEditable ? 'one-col' : 'two-col'}>
-              Usage
-            </div>
-            <div className={plansEditable ? 'one-col' : 'two-col'}>
-              Allocation
-            </div>
-            <div className="one-col last-col">
-              Spend
-            </div>
+            {this._generatePlanHeaders()}
           </div>
           {this._generateServices()}
         </div>

--- a/jujugui/static/gui/src/app/components/budget-table/row/row.js
+++ b/jujugui/static/gui/src/app/components/budget-table/row/row.js
@@ -28,7 +28,8 @@ YUI.add('budget-table-row', function() {
       listPlansForCharm: React.PropTypes.func,
       plansEditable: React.PropTypes.bool,
       service: React.PropTypes.object.isRequired,
-      showExtra: React.PropTypes.bool
+      showExtra: React.PropTypes.bool,
+      withPlans: React.PropTypes.bool
     },
 
     plansXHR: null,
@@ -268,14 +269,43 @@ YUI.add('budget-table-row', function() {
         </div>);
     },
 
+    /**
+      Generate plan cols.
+
+      @method _generatePlanCols
+      @returns {Object} The plan cols markup.
+    */
+    _generatePlanCols: function() {
+      if (!this.props.withPlans) {
+        return;
+      }
+      const plansEditable = this.props.plansEditable;
+      const editableWidth = !plansEditable ? 'two-col' : 'one-col';
+      return (
+        <div>
+          <div className="three-col no-margin-bottom">
+            {this._generateSelectedPlan()}
+          </div>
+          <div className={editableWidth + ' no-margin-bottom'}>
+            $1
+          </div>
+          <div className={editableWidth + ' no-margin-bottom'}>
+            {this._generateAllocation()}
+          </div>
+          <div className={
+            'one-col no-margin-bottom' + (plansEditable ? '' : ' last-col')}>
+            $1
+          </div>
+          {this._generateEdit()}
+        </div>
+      );
+    },
+
     render: function() {
-      var plansEditable = this.props.plansEditable;
       var classes = {
         'budget-table-row': true,
         'twelve-col': true
       };
-      var editableWidth = !plansEditable ?
-        'two-col' : 'one-col';
       return (
         <juju.components.ExpandingRow
           classes={classes}
@@ -283,20 +313,7 @@ YUI.add('budget-table-row', function() {
           expanded={this.state.expanded}>
           <div>
             {this._generateSharedFields()}
-            <div className="three-col no-margin-bottom">
-              {this._generateSelectedPlan()}
-            </div>
-            <div className={editableWidth + ' no-margin-bottom'}>
-              $1
-            </div>
-            <div className={editableWidth + ' no-margin-bottom'}>
-              {this._generateAllocation()}
-            </div>
-            <div className={
-              'one-col no-margin-bottom' + (plansEditable ? '' : ' last-col')}>
-              $1
-            </div>
-            {this._generateEdit()}
+            {this._generatePlanCols()}
             {this._generateExtra()}
           </div>
           <div>

--- a/jujugui/static/gui/src/app/components/budget-table/row/test-row.js
+++ b/jujugui/static/gui/src/app/components/budget-table/row/test-row.js
@@ -66,7 +66,8 @@ describe('BudgetTableRow', function() {
         allocationEditable={false}
         listPlansForCharm={listPlansForCharm}
         plansEditable={false}
-        service={service} />, true);
+        service={service}
+        withPlans={true} />, true);
     var output = renderer.getRenderOutput();
     var expected = (
       <juju.components.ExpandingRow
@@ -87,17 +88,58 @@ describe('BudgetTableRow', function() {
               {4}
             </div>
           </div>
-          <div className="three-col no-margin-bottom">
-            <span>You need to select a plan</span>
+          <div>
+            <div className="three-col no-margin-bottom">
+              <span>You need to select a plan</span>
+            </div>
+            <div className="two-col no-margin-bottom">
+              $1
+            </div>
+            <div className="two-col no-margin-bottom">
+              <span onClick={undefined}>$1</span>
+            </div>
+            <div className="one-col no-margin-bottom last-col">
+              $1
+            </div>
+            {undefined}
           </div>
-          <div className="two-col no-margin-bottom">
-            $1
-          </div>
-          <div className="two-col no-margin-bottom">
-            <span onClick={undefined}>$1</span>
-          </div>
-          <div className="one-col no-margin-bottom last-col">
-            $1
+          {undefined}
+        </div>
+        <div>
+          {undefined}
+        </div>
+      </juju.components.ExpandingRow>);
+    assert.deepEqual(output, expected);
+  });
+
+  it('can render without plans', function() {
+    var renderer = jsTestUtils.shallowRender(
+      <juju.components.BudgetTableRow
+        acl={acl}
+        allocationEditable={false}
+        listPlansForCharm={listPlansForCharm}
+        plansEditable={false}
+        service={service}
+        withPlans={false} />, true);
+    var output = renderer.getRenderOutput();
+    var expected = (
+      <juju.components.ExpandingRow
+        classes={{
+          'budget-table-row': true,
+          'twelve-col': true
+        }}
+        clickable={false}
+        expanded={false}>
+        <div>
+          <div>
+            <div className="three-col no-margin-bottom">
+              <img className="budget-table__charm-icon"
+                src="landscape.svg" />
+              Landscape
+            </div>
+            <div className="one-col no-margin-bottom">
+              {4}
+            </div>
           </div>
           {undefined}
           {undefined}
@@ -118,7 +160,8 @@ describe('BudgetTableRow', function() {
         listPlansForCharm={listPlansForCharm}
         plansEditable={false}
         service={service}
-        showExtra={true} />, true);
+        showExtra={true}
+        withPlans={true} />, true);
     var output = renderer.getRenderOutput();
     var expected = (
       <juju.components.ExpandingRow
@@ -139,19 +182,21 @@ describe('BudgetTableRow', function() {
               {4}
             </div>
           </div>
-          <div className="three-col no-margin-bottom">
-            <span>You need to select a plan</span>
+          <div>
+            <div className="three-col no-margin-bottom">
+              <span>You need to select a plan</span>
+            </div>
+            <div className="two-col no-margin-bottom">
+              $1
+            </div>
+            <div className="two-col no-margin-bottom">
+              <span onClick={undefined}>$1</span>
+            </div>
+            <div className="one-col no-margin-bottom last-col">
+              $1
+            </div>
+            {undefined}
           </div>
-          <div className="two-col no-margin-bottom">
-            $1
-          </div>
-          <div className="two-col no-margin-bottom">
-            <span onClick={undefined}>$1</span>
-          </div>
-          <div className="one-col no-margin-bottom last-col">
-            $1
-          </div>
-          {undefined}
           <div className="twelve-col no-margin-bottom">
             <span>extra</span>
           </div>
@@ -192,7 +237,8 @@ describe('BudgetTableRow', function() {
         allocationEditable={false}
         listPlansForCharm={listPlansForCharm}
         plansEditable={false}
-        service={service} />, true);
+        service={service}
+        withPlans={true} />, true);
     var output = renderer.getRenderOutput();
     var expected = (
       <juju.components.ExpandingRow
@@ -213,19 +259,21 @@ describe('BudgetTableRow', function() {
               {4}
             </div>
           </div>
-          <div className="three-col no-margin-bottom">
-            <span>{'plan 1'} ({'$5'})</span>
+          <div>
+            <div className="three-col no-margin-bottom">
+              <span>{'plan 1'} ({'$5'})</span>
+            </div>
+            <div className="two-col no-margin-bottom">
+              $1
+            </div>
+            <div className="two-col no-margin-bottom">
+              <span onClick={undefined}>$1</span>
+            </div>
+            <div className="one-col no-margin-bottom last-col">
+              $1
+            </div>
+            {undefined}
           </div>
-          <div className="two-col no-margin-bottom">
-            $1
-          </div>
-          <div className="two-col no-margin-bottom">
-            <span onClick={undefined}>$1</span>
-          </div>
-          <div className="one-col no-margin-bottom last-col">
-            $1
-          </div>
-          {undefined}
           {undefined}
         </div>
         <div>
@@ -243,7 +291,8 @@ describe('BudgetTableRow', function() {
         allocationEditable={false}
         listPlansForCharm={listPlansForCharm}
         plansEditable={true}
-        service={service} />, true);
+        service={service}
+        withPlans={true} />, true);
     var output = renderer.getRenderOutput();
     var expected = (
       <juju.components.ExpandingRow
@@ -264,19 +313,21 @@ describe('BudgetTableRow', function() {
               {4}
             </div>
           </div>
-          <div className="three-col no-margin-bottom">
-            <span>-</span>
+          <div>
+            <div className="three-col no-margin-bottom">
+              <span>-</span>
+            </div>
+            <div className="one-col no-margin-bottom">
+              $1
+            </div>
+            <div className="one-col no-margin-bottom">
+              <span onClick={undefined}>$1</span>
+            </div>
+            <div className="one-col no-margin-bottom">
+              $1
+            </div>
+            {undefined}
           </div>
-          <div className="one-col no-margin-bottom">
-            $1
-          </div>
-          <div className="one-col no-margin-bottom">
-            <span onClick={undefined}>$1</span>
-          </div>
-          <div className="one-col no-margin-bottom">
-            $1
-          </div>
-          {undefined}
           {undefined}
         </div>
         <div>
@@ -293,7 +344,8 @@ describe('BudgetTableRow', function() {
         allocationEditable={false}
         listPlansForCharm={listPlansForCharm}
         plansEditable={true}
-        service={service} />, true);
+        service={service}
+        withPlans={true} />, true);
     var instance = renderer.getMountedInstance();
     var output = renderer.getRenderOutput();
     var expected = (
@@ -315,25 +367,27 @@ describe('BudgetTableRow', function() {
               {4}
             </div>
           </div>
-          <div className="three-col no-margin-bottom">
-            <span>You need to select a plan</span>
-          </div>
-          <div className="one-col no-margin-bottom">
-            $1
-          </div>
-          <div className="one-col no-margin-bottom">
-            <span onClick={undefined}>$1</span>
-          </div>
-          <div className="one-col no-margin-bottom">
-            $1
-          </div>
-          <div className="two-col last-col no-margin-bottom">
-            <div className="budget-table__edit">
-              <juju.components.GenericButton
-                action={instance._toggle}
-                disabled={false}
-                type="neutral"
-                title="Change plan" />
+          <div>
+            <div className="three-col no-margin-bottom">
+              <span>You need to select a plan</span>
+            </div>
+            <div className="one-col no-margin-bottom">
+              $1
+            </div>
+            <div className="one-col no-margin-bottom">
+              <span onClick={undefined}>$1</span>
+            </div>
+            <div className="one-col no-margin-bottom">
+              $1
+            </div>
+            <div className="two-col last-col no-margin-bottom">
+              <div className="budget-table__edit">
+                <juju.components.GenericButton
+                  action={instance._toggle}
+                  disabled={false}
+                  type="neutral"
+                  title="Change plan" />
+              </div>
             </div>
           </div>
           {undefined}
@@ -412,7 +466,8 @@ describe('BudgetTableRow', function() {
         allocationEditable={false}
         listPlansForCharm={listPlansForCharm}
         plansEditable={true}
-        service={service} />, true);
+        service={service}
+        withPlans={true} />, true);
     var instance = renderer.getMountedInstance();
     var output = renderer.getRenderOutput();
     var expected = (
@@ -434,25 +489,27 @@ describe('BudgetTableRow', function() {
               {4}
             </div>
           </div>
-          <div className="three-col no-margin-bottom">
-            <span>You need to select a plan</span>
-          </div>
-          <div className="one-col no-margin-bottom">
-            $1
-          </div>
-          <div className="one-col no-margin-bottom">
-            <span onClick={undefined}>$1</span>
-          </div>
-          <div className="one-col no-margin-bottom">
-            $1
-          </div>
-          <div className="two-col last-col no-margin-bottom">
-            <div className="budget-table__edit">
-              <juju.components.GenericButton
-                action={instance._toggle}
-                disabled={true}
-                type="neutral"
-                title="Change plan" />
+          <div>
+            <div className="three-col no-margin-bottom">
+              <span>You need to select a plan</span>
+            </div>
+            <div className="one-col no-margin-bottom">
+              $1
+            </div>
+            <div className="one-col no-margin-bottom">
+              <span onClick={undefined}>$1</span>
+            </div>
+            <div className="one-col no-margin-bottom">
+              $1
+            </div>
+            <div className="two-col last-col no-margin-bottom">
+              <div className="budget-table__edit">
+                <juju.components.GenericButton
+                  action={instance._toggle}
+                  disabled={true}
+                  type="neutral"
+                  title="Change plan" />
+              </div>
             </div>
           </div>
           {undefined}
@@ -532,7 +589,8 @@ describe('BudgetTableRow', function() {
         allocationEditable={false}
         listPlansForCharm={listPlansForCharm}
         plansEditable={false}
-        service={service} />, true);
+        service={service}
+        withPlans={true} />, true);
     renderer.unmount();
     assert.equal(abort.callCount, 1);
   });

--- a/jujugui/static/gui/src/app/components/budget-table/test-budget-table.js
+++ b/jujugui/static/gui/src/app/components/budget-table/test-budget-table.js
@@ -43,7 +43,8 @@ describe('BudgetTable', function() {
         allocationEditable={false}
         listPlansForCharm={listPlansForCharm}
         plansEditable={false}
-        services={[{}, {}]} />, true);
+        services={[{}, {}]}
+        withPlans={true} />, true);
     var output = renderer.getRenderOutput();
     var expected = (
       <div className="budget-table">
@@ -54,17 +55,19 @@ describe('BudgetTable', function() {
           <div className="one-col">
             Units
           </div>
-          <div className="three-col">
-            Details
-          </div>
-          <div className="two-col">
-            Usage
-          </div>
-          <div className="two-col">
-            Allocation
-          </div>
-          <div className="one-col last-col">
-            Spend
+          <div>
+            <div className="three-col">
+              Details
+            </div>
+            <div className="two-col">
+              Usage
+            </div>
+            <div className="two-col">
+              Allocation
+            </div>
+            <div className="one-col last-col">
+              Spend
+            </div>
           </div>
         </div>
         {[<juju.components.BudgetTableRow
@@ -75,7 +78,8 @@ describe('BudgetTable', function() {
             listPlansForCharm={listPlansForCharm}
             plansEditable={false}
             service={{}}
-            showExtra={undefined} />,
+            showExtra={undefined}
+            withPlans={true} />,
           <juju.components.BudgetTableRow
             acl={acl}
             key={1}
@@ -84,7 +88,54 @@ describe('BudgetTable', function() {
             listPlansForCharm={listPlansForCharm}
             plansEditable={false}
             service={{}}
-            showExtra={undefined} />]}
+            showExtra={undefined}
+            withPlans={true} />]}
+      </div>);
+    assert.deepEqual(output, expected);
+  });
+
+  it('can render without plans', function() {
+    var listPlansForCharm = sinon.stub();
+    var renderer = jsTestUtils.shallowRender(
+      <juju.components.BudgetTable
+        acl={acl}
+        allocationEditable={false}
+        listPlansForCharm={listPlansForCharm}
+        plansEditable={false}
+        services={[{}, {}]}
+        withPlans={false} />, true);
+    var output = renderer.getRenderOutput();
+    var expected = (
+      <div className="budget-table">
+        <div className="budget-table__row-header twelve-col">
+          <div className="three-col">
+            Name
+          </div>
+          <div className="one-col">
+            Units
+          </div>
+          {undefined}
+        </div>
+        {[<juju.components.BudgetTableRow
+            acl={acl}
+            key={0}
+            allocationEditable={false}
+            extraInfo={undefined}
+            listPlansForCharm={listPlansForCharm}
+            plansEditable={false}
+            service={{}}
+            showExtra={undefined}
+            withPlans={false} />,
+          <juju.components.BudgetTableRow
+            acl={acl}
+            key={1}
+            allocationEditable={false}
+            extraInfo={undefined}
+            listPlansForCharm={listPlansForCharm}
+            plansEditable={false}
+            service={{}}
+            showExtra={undefined}
+            withPlans={false} />]}
       </div>);
     assert.deepEqual(output, expected);
   });
@@ -97,7 +148,8 @@ describe('BudgetTable', function() {
         allocationEditable={false}
         listPlansForCharm={listPlansForCharm}
         plansEditable={true}
-        services={[{}, {}]} />, true);
+        services={[{}, {}]}
+        withPlans={true} />, true);
     var output = renderer.getRenderOutput();
     var expected = (
       <div className="budget-table">
@@ -108,17 +160,19 @@ describe('BudgetTable', function() {
           <div className="one-col">
             Units
           </div>
-          <div className="three-col">
-            Details
-          </div>
-          <div className="one-col">
-            Usage
-          </div>
-          <div className="one-col">
-            Allocation
-          </div>
-          <div className="one-col last-col">
-            Spend
+          <div>
+            <div className="three-col">
+              Details
+            </div>
+            <div className="one-col">
+              Usage
+            </div>
+            <div className="one-col">
+              Allocation
+            </div>
+            <div className="one-col last-col">
+              Spend
+            </div>
           </div>
         </div>
         {[<juju.components.BudgetTableRow
@@ -129,7 +183,8 @@ describe('BudgetTable', function() {
             listPlansForCharm={listPlansForCharm}
             plansEditable={true}
             service={{}}
-            showExtra={undefined} />,
+            showExtra={undefined}
+            withPlans={true} />,
           <juju.components.BudgetTableRow
             acl={acl}
             key={1}
@@ -138,7 +193,8 @@ describe('BudgetTable', function() {
             listPlansForCharm={listPlansForCharm}
             plansEditable={true}
             service={{}}
-            showExtra={undefined} />]}
+            showExtra={undefined}
+            withPlans={true} />]}
       </div>);
     assert.deepEqual(output, expected);
   });

--- a/jujugui/static/gui/src/app/components/deployment-flow/deployment-flow.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/deployment-flow.js
@@ -100,6 +100,7 @@ YUI.add('deployment-flow', function() {
       var hasCredential = !!this.state.credential;
       var mode = this.props.modelCommitted ? 'commit' : 'deploy';
       var includesPlans = this.props.withPlans;
+      const groupedChanges = this.props.groupedChanges;
       switch (section) {
         case 'cloud':
           completed = hasCloud && hasCredential;
@@ -112,14 +113,16 @@ YUI.add('deployment-flow', function() {
           visible = true;
           break;
         case 'machines':
+          const addMachines = groupedChanges._addMachines;
           completed = false;
           disabled = !hasCloud || !hasCredential;
-          visible = true;
+          visible = addMachines && Object.keys(addMachines).length > 0;
           break;
         case 'services':
+          const deploys = groupedChanges._deploy;
           completed = false;
           disabled = !hasCloud || !hasCredential;
-          visible = true;
+          visible = deploys && Object.keys(deploys).length > 0;
           break;
         case 'budget':
           completed = false;

--- a/jujugui/static/gui/src/app/components/deployment-flow/deployment-flow.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/deployment-flow.js
@@ -38,6 +38,7 @@ YUI.add('deployment-flow', function() {
       servicesGetById: React.PropTypes.func.isRequired,
       updateCloudCredential: React.PropTypes.func.isRequired,
       user: React.PropTypes.string,
+      withPlans: React.PropTypes.bool
     },
 
     CLOUDS: {
@@ -98,9 +99,7 @@ YUI.add('deployment-flow', function() {
       var hasCloud = !!this.state.cloud;
       var hasCredential = !!this.state.credential;
       var mode = this.props.modelCommitted ? 'commit' : 'deploy';
-      // XXX: Need to find a way to check if any newly added applications have
-      // plans.
-      var includesPlans = true;
+      var includesPlans = this.props.withPlans;
       switch (section) {
         case 'cloud':
           completed = hasCloud && hasCredential;
@@ -396,7 +395,7 @@ YUI.add('deployment-flow', function() {
           title="Machines to be deployed">
           <juju.components.DeploymentMachines
             acl={this.props.acl}
-            cloud={cloud && this.CLOUDS[cloud]} />
+            cloud={cloud} />
         </juju.components.DeploymentSection>);
     },
 
@@ -426,7 +425,8 @@ YUI.add('deployment-flow', function() {
             groupedChanges={this.props.groupedChanges}
             listPlansForCharm={this.props.listPlansForCharm}
             servicesGetById={this.props.servicesGetById}
-            showChangelogs={this.state.showChangelogs} />
+            showChangelogs={this.state.showChangelogs}
+            withPlans={this.props.withPlans} />
         </juju.components.DeploymentSection>);
     },
 

--- a/jujugui/static/gui/src/app/components/deployment-flow/deployment-flow.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/deployment-flow.js
@@ -395,7 +395,8 @@ YUI.add('deployment-flow', function() {
           title="Machines to be deployed">
           <juju.components.DeploymentMachines
             acl={this.props.acl}
-            cloud={cloud} />
+            cloud={cloud}
+            machines={this.props.groupedChanges._addMachines} />
         </juju.components.DeploymentSection>);
     },
 

--- a/jujugui/static/gui/src/app/components/deployment-flow/machines/machines.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/machines/machines.js
@@ -79,7 +79,7 @@ YUI.add('deployment-machines', function() {
         <div>
           <p className="deployment-machines__message">
             These machines will be provisioned on&nbsp;
-            {this.props.cloud && this.props.cloud.title}.
+            {this.props.cloud && this.props.cloud.name}.
             {chargeMessage}
           </p>
           {this._generateMachines()}

--- a/jujugui/static/gui/src/app/components/deployment-flow/machines/machines.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/machines/machines.js
@@ -23,7 +23,8 @@ YUI.add('deployment-machines', function() {
   juju.components.DeploymentMachines = React.createClass({
     propTypes: {
       acl: React.PropTypes.object.isRequired,
-      cloud: React.PropTypes.object
+      cloud: React.PropTypes.object,
+      machines: React.PropTypes.object
     },
 
     /**
@@ -33,23 +34,52 @@ YUI.add('deployment-machines', function() {
       @returns {Object} The list of machines.
     */
     _generateMachines: function() {
-      // Create a fake list of machines until we can get the correct data.
-      var machines = [1, 2];
-      if (!machines || machines.length === 0) {
+      const machines = this.props.machines;
+      if (!machines || Object.keys(machines).length === 0) {
         return;
       }
-      var machineList = machines.map((machine, i) => {
+      let machineDetails = {};
+      Object.keys(machines).forEach(key => {
+        const machine = machines[key];
+        let constraintsDetails;
+        let seriesDetails = '';
+        const args = machine.command.args[0][0];
+        const series = args.series;
+        const constraints = args.constraints;
+        const cpu = constraints.cpu;
+        const disk = constraints.disk;
+        const mem = constraints.mem;
+        const cores = constraints.cores;
+        if (cores && cpu && disk && mem) {
+          cpu = cpu / 100;
+          disk = disk / 1024;
+          mem = mem / 1024;
+          constraintsDetails = `${cores}x${cpu}GHz, ${mem.toFixed(2)}GB, ` +
+            `${disk.toFixed(2)}GB`;
+        } else {
+          constraintsDetails = '(constraints not set)';
+        }
+        if (series) {
+          seriesDetails = `${series}, `;
+        }
+        const info = seriesDetails + constraintsDetails;
+        const current = machineDetails[info] || 0;
+        machineDetails[info] = current + 1;
+      });
+      const cloud = this.props.cloud && this.props.cloud.name;
+      const machineList = Object.keys(machineDetails).map(machine => {
+        const count = machineDetails[machine];
         return (
           <li className="deployment-flow__row twelve-col"
-            key={i}>
+            key={machine}>
             <div className="eight-col">
-              Trusty, 1x1GHz, 1.70GB, 8.00GB
+              {machine}
             </div>
             <div className="three-col">
-              Google
+              {cloud}
             </div>
             <div className="one-col last-col">
-              4
+              {count}
             </div>
           </li>);
       });

--- a/jujugui/static/gui/src/app/components/deployment-flow/machines/test-machines.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/machines/test-machines.js
@@ -39,7 +39,7 @@ describe('DeploymentMachines', function() {
     var renderer = jsTestUtils.shallowRender(
       <juju.components.DeploymentMachines
         acl={acl}
-        cloud={{title: 'My cloud', id: 'azure'}} />, true);
+        cloud={{name: 'My cloud', id: 'azure'}} />, true);
     var output = renderer.getRenderOutput();
     var expected = (
       <div>
@@ -93,7 +93,7 @@ describe('DeploymentMachines', function() {
     var renderer = jsTestUtils.shallowRender(
       <juju.components.DeploymentMachines
         acl={acl}
-        cloud={{title: 'Local', id: 'local'}} />, true);
+        cloud={{name: 'Local', id: 'local'}} />, true);
     var output = renderer.getRenderOutput();
     var expected = (
       <div>

--- a/jujugui/static/gui/src/app/components/deployment-flow/machines/test-machines.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/machines/test-machines.js
@@ -24,7 +24,7 @@ chai.config.includeStack = true;
 chai.config.truncateThreshold = 0;
 
 describe('DeploymentMachines', function() {
-  var acl;
+  var acl, machines;
 
   beforeAll(function(done) {
     // By loading this file it adds the component to the juju components.
@@ -33,13 +33,49 @@ describe('DeploymentMachines', function() {
 
   beforeEach(() => {
     acl = {isReadOnly: sinon.stub().returns(false)};
+    machines = {
+      machine1: {
+        command: {
+          args: [[{
+            constraints: {},
+            series: 'xenial'
+          }]]
+        }
+      },
+      machine2: {
+        command: {
+          args: [[{
+            constraints: {
+              cores: 2,
+              cpu: 3,
+              disk: 4096,
+              mem: 1024
+            },
+            series: null
+          }]]
+        }
+      },
+      machine3: {
+        command: {
+          args: [[{
+            constraints: {
+              cores: 2,
+              cpu: 3,
+              disk: 4096,
+              mem: 1024
+            }
+          }]]
+        }
+      }
+    };
   });
 
   it('can render', function() {
     var renderer = jsTestUtils.shallowRender(
       <juju.components.DeploymentMachines
         acl={acl}
-        cloud={{name: 'My cloud', id: 'azure'}} />, true);
+        cloud={{name: 'My cloud', id: 'azure'}}
+        machines={machines} />, true);
     var output = renderer.getRenderOutput();
     var expected = (
       <div>
@@ -61,27 +97,27 @@ describe('DeploymentMachines', function() {
             </div>
           </li>
           {[<li className="deployment-flow__row twelve-col"
-            key={0}>
+            key="xenial, (constraints not set)">
             <div className="eight-col">
-              Trusty, 1x1GHz, 1.70GB, 8.00GB
+              xenial, (constraints not set)
             </div>
             <div className="three-col">
-              Google
+              My cloud
             </div>
             <div className="one-col last-col">
-              4
+              {1}
             </div>
           </li>,
           <li className="deployment-flow__row twelve-col"
-            key={1}>
+            key="2x0.03GHz, 1.00GB, 4.00GB">
             <div className="eight-col">
-              Trusty, 1x1GHz, 1.70GB, 8.00GB
+              2x0.03GHz, 1.00GB, 4.00GB
             </div>
             <div className="three-col">
-              Google
+              My cloud
             </div>
             <div className="one-col last-col">
-              4
+              {2}
             </div>
           </li>]}
         </ul>
@@ -93,53 +129,15 @@ describe('DeploymentMachines', function() {
     var renderer = jsTestUtils.shallowRender(
       <juju.components.DeploymentMachines
         acl={acl}
-        cloud={{name: 'Local', id: 'local'}} />, true);
+        cloud={{name: 'Local', id: 'local'}}
+        machines={machines} />, true);
     var output = renderer.getRenderOutput();
     var expected = (
-      <div>
-        <p className="deployment-machines__message">
-          These machines will be provisioned on&nbsp;
-          {'Local'}.
-          {''}
-        </p>
-        <ul className="deployment-machines__list">
-          <li className="deployment-flow__row-header twelve-col">
-            <div className="eight-col">
-              Type
-            </div>
-            <div className="three-col">
-              Provider
-            </div>
-            <div className="one-col last-col">
-              Quantity
-            </div>
-          </li>
-          {[<li className="deployment-flow__row twelve-col"
-            key={0}>
-            <div className="eight-col">
-              Trusty, 1x1GHz, 1.70GB, 8.00GB
-            </div>
-            <div className="three-col">
-              Google
-            </div>
-            <div className="one-col last-col">
-              4
-            </div>
-          </li>,
-          <li className="deployment-flow__row twelve-col"
-            key={1}>
-            <div className="eight-col">
-              Trusty, 1x1GHz, 1.70GB, 8.00GB
-            </div>
-            <div className="three-col">
-              Google
-            </div>
-            <div className="one-col last-col">
-              4
-            </div>
-          </li>]}
-        </ul>
-      </div>);
-    assert.deepEqual(output, expected);
+      <p className="deployment-machines__message">
+        These machines will be provisioned on&nbsp;
+        {'Local'}.
+        {''}
+      </p>);
+    assert.deepEqual(output.props.children[0], expected);
   });
 });

--- a/jujugui/static/gui/src/app/components/deployment-flow/services/services.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/services/services.js
@@ -28,7 +28,8 @@ YUI.add('deployment-services', function() {
       groupedChanges: React.PropTypes.object.isRequired,
       listPlansForCharm: React.PropTypes.func.isRequired,
       servicesGetById: React.PropTypes.func.isRequired,
-      showChangelogs: React.PropTypes.bool
+      showChangelogs: React.PropTypes.bool,
+      withPlans: React.PropTypes.bool
     },
 
     /**
@@ -77,6 +78,26 @@ YUI.add('deployment-services', function() {
       return infos;
     },
 
+    /**
+      Generate spend summary.
+
+      @method _generateSpend
+      @returns {Object} The spend markup.
+    */
+    _generateSpend: function() {
+      if (!this.props.withPlans) {
+        return;
+      }
+      return (
+        <div className="prepend-seven">
+          Maximum monthly spend:&nbsp;
+          <span className="deployment-services__max">
+            $100
+          </span>
+        </div>
+      );
+    },
+
     render: function() {
       return (
         <div>
@@ -87,13 +108,9 @@ YUI.add('deployment-services', function() {
             listPlansForCharm={this.props.listPlansForCharm}
             plansEditable={true}
             services={this._getServices()}
-            showExtra={this.props.showChangelogs} />
-          <div className="prepend-seven">
-            Maximum monthly spend:&nbsp;
-            <span className="deployment-services__max">
-              $100
-            </span>
-          </div>
+            showExtra={this.props.showChangelogs}
+            withPlans={this.props.withPlans} />
+          {this._generateSpend()}
         </div>
       );
     }

--- a/jujugui/static/gui/src/app/components/deployment-flow/services/test-services.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/services/test-services.js
@@ -54,7 +54,8 @@ describe('DeploymentServices', function() {
         groupedChanges={groupedChanges}
         listPlansForCharm={listPlansForCharm}
         servicesGetById={servicesGetById}
-        showChangelogs={false} />, true);
+        showChangelogs={false}
+        withPlans={true} />, true);
     var output = renderer.getRenderOutput();
     var expected = (
       <div>
@@ -80,13 +81,58 @@ describe('DeploymentServices', function() {
           listPlansForCharm={listPlansForCharm}
           plansEditable={true}
           services={[{service: 'apache2'}, {service: 'mysql'}]}
-          showExtra={false} />
+          showExtra={false}
+          withPlans={true} />
         <div className="prepend-seven">
           Maximum monthly spend:&nbsp;
           <span className="deployment-services__max">
             $100
           </span>
         </div>
+      </div>);
+    assert.deepEqual(output, expected);
+  });
+
+  it('can render without plans', function() {
+    var listPlansForCharm = sinon.stub();
+    var renderer = jsTestUtils.shallowRender(
+      <juju.components.DeploymentServices
+        acl={acl}
+        changesFilterByParent={sinon.stub()}
+        generateAllChangeDescriptions={sinon.stub().returns([{id: 'change1'}])}
+        groupedChanges={groupedChanges}
+        listPlansForCharm={listPlansForCharm}
+        servicesGetById={servicesGetById}
+        showChangelogs={false}
+        withPlans={false} />, true);
+    var output = renderer.getRenderOutput();
+    var expected = (
+      <div>
+        <juju.components.BudgetTable
+          acl={acl}
+          allocationEditable={true}
+          extraInfo={{
+            'apache2': (
+              <ul className="deployment-services__changes">
+                {[<juju.components.DeploymentChangeItem
+                  change={{id: 'change1'}}
+                  key="change1"
+                  showTime={false} />]}
+              </ul>),
+            'mysql': (
+              <ul className="deployment-services__changes">
+                {[<juju.components.DeploymentChangeItem
+                  change={{id: 'change1'}}
+                  key="change1"
+                  showTime={false} />]}
+              </ul>)
+          }}
+          listPlansForCharm={listPlansForCharm}
+          plansEditable={true}
+          services={[{service: 'apache2'}, {service: 'mysql'}]}
+          showExtra={false}
+          withPlans={false} />
+        {undefined}
       </div>);
     assert.deepEqual(output, expected);
   });

--- a/jujugui/static/gui/src/app/components/deployment-flow/test-deployment-flow.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/test-deployment-flow.js
@@ -24,7 +24,7 @@ chai.config.includeStack = true;
 chai.config.truncateThreshold = 0;
 
 describe('DeploymentFlow', function() {
-  var acl;
+  var acl, groupedChanges;
 
   beforeAll(function(done) {
     // By loading this file it adds the component to the juju components.
@@ -33,6 +33,10 @@ describe('DeploymentFlow', function() {
 
   beforeEach(() => {
     acl = {isReadOnly: sinon.stub().returns(false)};
+    groupedChanges = {
+      _deploy: {service: 'service1'},
+      _addMachines: {machine: 'machine1'}
+    };
   });
 
   it('can render', function() {
@@ -56,7 +60,7 @@ describe('DeploymentFlow', function() {
         generateAllChangeDescriptions={generateAllChangeDescriptions}
         getCloudCredentials={getCloudCredentials}
         getTagsForCloudCredentials={getTagsForCloudCredentials}
-        groupedChanges={{}}
+        groupedChanges={groupedChanges}
         listBudgets={listBudgets}
         listClouds={listClouds}
         listPlansForCharm={listPlansForCharm}
@@ -131,7 +135,7 @@ describe('DeploymentFlow', function() {
                   <juju.components.DeploymentMachines
                     acl={acl}
                     cloud={null}
-                    machines={undefined} />
+                    machines={groupedChanges._addMachines} />
                 </juju.components.DeploymentSection>
                 <juju.components.DeploymentSection
                   completed={false}
@@ -151,7 +155,7 @@ describe('DeploymentFlow', function() {
                     changesFilterByParent={changesFilterByParent}
                     generateAllChangeDescriptions={
                       generateAllChangeDescriptions}
-                    groupedChanges={{}}
+                    groupedChanges={groupedChanges}
                     listPlansForCharm={listPlansForCharm}
                     servicesGetById={servicesGetById}
                     showChangelogs={false}
@@ -219,18 +223,19 @@ describe('DeploymentFlow', function() {
     var output = jsTestUtils.shallowRender(
       <juju.components.DeploymentFlow
         acl={acl}
-        updateCloudCredential={sinon.stub()}
         changesFilterByParent={sinon.stub()}
         changeState={changeState}
         deploy={sinon.stub()}
         generateAllChangeDescriptions={sinon.stub()}
         getCloudCredentials={sinon.stub()}
-        groupedChanges={{}}
+        getTagsForCloudCredentials={sinon.stub()}
+        groupedChanges={groupedChanges}
         listBudgets={sinon.stub()}
         listClouds={sinon.stub()}
         listPlansForCharm={sinon.stub()}
         modelName="Pavlova"
         servicesGetById={sinon.stub()}
+        updateCloudCredential={sinon.stub()}
         user="user-admin">
         <span>content</span>
       </juju.components.DeploymentFlow>);
@@ -249,17 +254,20 @@ describe('DeploymentFlow', function() {
     var renderer = jsTestUtils.shallowRender(
       <juju.components.DeploymentFlow
         acl={acl}
-        updateCloudCredential={sinon.stub()}
         changes={{}}
+        changesFilterByParent={sinon.stub()}
         changeState={sinon.stub()}
         deploy={sinon.stub()}
+        generateAllChangeDescriptions={sinon.stub()}
         getCloudCredentials={sinon.stub()}
-        groupedChanges={{}}
+        getTagsForCloudCredentials={sinon.stub()}
+        groupedChanges={groupedChanges}
         listBudgets={sinon.stub()}
         listClouds={sinon.stub()}
         listPlansForCharm={sinon.stub()}
         modelName="Pavlova"
         servicesGetById={sinon.stub()}
+        updateCloudCredential={sinon.stub()}
         user="user-admin">
         <span>content</span>
       </juju.components.DeploymentFlow>, true);
@@ -276,17 +284,20 @@ describe('DeploymentFlow', function() {
     var renderer = jsTestUtils.shallowRender(
       <juju.components.DeploymentFlow
         acl={acl}
-        updateCloudCredential={sinon.stub()}
         changes={{}}
+        changesFilterByParent={sinon.stub()}
         changeState={sinon.stub()}
         deploy={sinon.stub()}
+        generateAllChangeDescriptions={sinon.stub()}
         getCloudCredentials={sinon.stub()}
-        groupedChanges={{}}
+        getTagsForCloudCredentials={sinon.stub()}
+        groupedChanges={groupedChanges}
         listBudgets={sinon.stub()}
         listClouds={sinon.stub()}
         listPlansForCharm={sinon.stub()}
         modelName="Pavlova"
         servicesGetById={sinon.stub()}
+        updateCloudCredential={sinon.stub()}
         user="user-admin">
         <span>content</span>
       </juju.components.DeploymentFlow>, true);
@@ -300,22 +311,25 @@ describe('DeploymentFlow', function() {
     var renderer = jsTestUtils.shallowRender(
       <juju.components.DeploymentFlow
         acl={acl}
-        updateCloudCredential={sinon.stub()}
         changes={{}}
+        changesFilterByParent={sinon.stub()}
         changeState={sinon.stub()}
         deploy={sinon.stub()}
+        generateAllChangeDescriptions={sinon.stub()}
         getCloudCredentials={sinon.stub()}
-        groupedChanges={{}}
+        getTagsForCloudCredentials={sinon.stub()}
+        groupedChanges={groupedChanges}
         listBudgets={sinon.stub()}
         listClouds={sinon.stub()}
         listPlansForCharm={sinon.stub()}
         modelName="Pavlova"
         servicesGetById={sinon.stub()}
+        updateCloudCredential={sinon.stub()}
         user="user-admin">
         <span>content</span>
       </juju.components.DeploymentFlow>, true);
     var instance = renderer.getMountedInstance();
-    instance._setCloud('azure');
+    instance._setCloud({id: 'azure'});
     var output = renderer.getRenderOutput();
     var sections = output.props.children.props.children[1].props.children
       .props.children.props.children;
@@ -326,17 +340,20 @@ describe('DeploymentFlow', function() {
     var renderer = jsTestUtils.shallowRender(
       <juju.components.DeploymentFlow
         acl={acl}
-        updateCloudCredential={sinon.stub()}
         changes={{}}
+        changesFilterByParent={sinon.stub()}
         changeState={sinon.stub()}
         deploy={sinon.stub()}
+        generateAllChangeDescriptions={sinon.stub()}
         getCloudCredentials={sinon.stub()}
-        groupedChanges={{}}
+        getTagsForCloudCredentials={sinon.stub()}
+        groupedChanges={groupedChanges}
         listBudgets={sinon.stub()}
         listClouds={sinon.stub()}
         listPlansForCharm={sinon.stub()}
         modelName="Pavlova"
         servicesGetById={sinon.stub()}
+        updateCloudCredential={sinon.stub()}
         user="user-admin">
         <span>content</span>
       </juju.components.DeploymentFlow>, true);
@@ -352,22 +369,25 @@ describe('DeploymentFlow', function() {
     var renderer = jsTestUtils.shallowRender(
       <juju.components.DeploymentFlow
         acl={acl}
-        updateCloudCredential={sinon.stub()}
         changes={{}}
+        changesFilterByParent={sinon.stub()}
         changeState={sinon.stub()}
         deploy={sinon.stub()}
+        generateAllChangeDescriptions={sinon.stub()}
         getCloudCredentials={sinon.stub()}
-        groupedChanges={{}}
+        getTagsForCloudCredentials={sinon.stub()}
+        groupedChanges={groupedChanges}
         listBudgets={sinon.stub()}
         listClouds={sinon.stub()}
         listPlansForCharm={sinon.stub()}
         modelName="Pavlova"
         servicesGetById={sinon.stub()}
+        updateCloudCredential={sinon.stub()}
         user="user-admin">
         <span>content</span>
       </juju.components.DeploymentFlow>, true);
     var instance = renderer.getMountedInstance();
-    instance._setCloud('local');
+    instance._setCloud({id: 'local'});
     instance._setCredential('local');
     var output = renderer.getRenderOutput();
     var sections = output.props.children.props.children[1].props.children
@@ -383,17 +403,20 @@ describe('DeploymentFlow', function() {
     var renderer = jsTestUtils.shallowRender(
       <juju.components.DeploymentFlow
         acl={acl}
-        updateCloudCredential={sinon.stub()}
         changes={{}}
+        changesFilterByParent={sinon.stub()}
         changeState={sinon.stub()}
         deploy={sinon.stub()}
+        generateAllChangeDescriptions={sinon.stub()}
         getCloudCredentials={sinon.stub()}
-        groupedChanges={{}}
+        getTagsForCloudCredentials={sinon.stub()}
+        groupedChanges={groupedChanges}
         listBudgets={sinon.stub()}
         listClouds={sinon.stub()}
         listPlansForCharm={sinon.stub()}
         modelName="Pavlova"
         servicesGetById={sinon.stub()}
+        updateCloudCredential={sinon.stub()}
         user="user-admin">
         <span>content</span>
       </juju.components.DeploymentFlow>, true);
@@ -409,17 +432,20 @@ describe('DeploymentFlow', function() {
     var renderer = jsTestUtils.shallowRender(
       <juju.components.DeploymentFlow
         acl={acl}
-        updateCloudCredential={sinon.stub()}
         changes={{}}
+        changesFilterByParent={sinon.stub()}
         changeState={sinon.stub()}
         deploy={sinon.stub()}
+        generateAllChangeDescriptions={sinon.stub()}
         getCloudCredentials={sinon.stub()}
-        groupedChanges={{}}
+        getTagsForCloudCredentials={sinon.stub()}
+        groupedChanges={groupedChanges}
         listBudgets={sinon.stub()}
         listClouds={sinon.stub()}
         listPlansForCharm={sinon.stub()}
         modelName="Pavlova"
         servicesGetById={sinon.stub()}
+        updateCloudCredential={sinon.stub()}
         user="user-admin">
         <span>content</span>
       </juju.components.DeploymentFlow>, true);
@@ -436,17 +462,20 @@ describe('DeploymentFlow', function() {
     var renderer = jsTestUtils.shallowRender(
       <juju.components.DeploymentFlow
         acl={acl}
-        updateCloudCredential={sinon.stub()}
         changes={{}}
+        changesFilterByParent={sinon.stub()}
         changeState={sinon.stub()}
         deploy={sinon.stub()}
+        generateAllChangeDescriptions={sinon.stub()}
         getCloudCredentials={sinon.stub()}
-        groupedChanges={{}}
+        getTagsForCloudCredentials={sinon.stub()}
+        groupedChanges={groupedChanges}
         listBudgets={sinon.stub()}
         listClouds={sinon.stub()}
         listPlansForCharm={sinon.stub()}
         modelName="Pavlova"
         servicesGetById={sinon.stub()}
+        updateCloudCredential={sinon.stub()}
         user="user-admin">
         <span>content</span>
       </juju.components.DeploymentFlow>, true);
@@ -463,17 +492,20 @@ describe('DeploymentFlow', function() {
     var renderer = jsTestUtils.shallowRender(
       <juju.components.DeploymentFlow
         acl={acl}
-        updateCloudCredential={sinon.stub()}
         changes={{}}
+        changesFilterByParent={sinon.stub()}
         changeState={sinon.stub()}
         deploy={sinon.stub()}
+        generateAllChangeDescriptions={sinon.stub()}
         getCloudCredentials={sinon.stub()}
-        groupedChanges={{}}
+        getTagsForCloudCredentials={sinon.stub()}
+        groupedChanges={groupedChanges}
         listBudgets={sinon.stub()}
         listClouds={sinon.stub()}
         listPlansForCharm={sinon.stub()}
         modelName="Pavlova"
         servicesGetById={sinon.stub()}
+        updateCloudCredential={sinon.stub()}
         user="user-admin"
         withPlans={true}>
         <span>content</span>
@@ -491,18 +523,21 @@ describe('DeploymentFlow', function() {
     var renderer = jsTestUtils.shallowRender(
       <juju.components.DeploymentFlow
         acl={acl}
-        updateCloudCredential={sinon.stub()}
         changes={{}}
+        changesFilterByParent={sinon.stub()}
         changeState={sinon.stub()}
         deploy={sinon.stub()}
+        generateAllChangeDescriptions={sinon.stub()}
         getCloudCredentials={sinon.stub()}
-        groupedChanges={{}}
+        getTagsForCloudCredentials={sinon.stub()}
+        groupedChanges={groupedChanges}
         listBudgets={sinon.stub()}
         listClouds={sinon.stub()}
         listPlansForCharm={sinon.stub()}
         modelCommitted={true}
         modelName="Pavlova"
         servicesGetById={sinon.stub()}
+        updateCloudCredential={sinon.stub()}
         user="user-admin">
         <span>content</span>
       </juju.components.DeploymentFlow>, true);
@@ -521,18 +556,21 @@ describe('DeploymentFlow', function() {
     var renderer = jsTestUtils.shallowRender(
       <juju.components.DeploymentFlow
         acl={acl}
-        updateCloudCredential={sinon.stub()}
         changes={{}}
+        changesFilterByParent={sinon.stub()}
         changeState={changeState}
         deploy={deploy}
+        generateAllChangeDescriptions={sinon.stub()}
         getCloudCredentials={sinon.stub()}
-        groupedChanges={{}}
+        getTagsForCloudCredentials={sinon.stub()}
+        groupedChanges={groupedChanges}
         listBudgets={sinon.stub()}
         listClouds={sinon.stub()}
         listPlansForCharm={sinon.stub()}
         modelCommitted={true}
         modelName="Pavlova"
         servicesGetById={sinon.stub()}
+        updateCloudCredential={sinon.stub()}
         user="user-admin">
         <span>content</span>
       </juju.components.DeploymentFlow>, true);

--- a/jujugui/static/gui/src/app/components/deployment-flow/test-deployment-flow.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/test-deployment-flow.js
@@ -130,7 +130,8 @@ describe('DeploymentFlow', function() {
                   title="Machines to be deployed">
                   <juju.components.DeploymentMachines
                     acl={acl}
-                    cloud={null} />
+                    cloud={null}
+                    machines={undefined} />
                 </juju.components.DeploymentSection>
                 <juju.components.DeploymentSection
                   completed={false}
@@ -253,6 +254,7 @@ describe('DeploymentFlow', function() {
         changeState={sinon.stub()}
         deploy={sinon.stub()}
         getCloudCredentials={sinon.stub()}
+        groupedChanges={{}}
         listBudgets={sinon.stub()}
         listClouds={sinon.stub()}
         listPlansForCharm={sinon.stub()}
@@ -279,6 +281,7 @@ describe('DeploymentFlow', function() {
         changeState={sinon.stub()}
         deploy={sinon.stub()}
         getCloudCredentials={sinon.stub()}
+        groupedChanges={{}}
         listBudgets={sinon.stub()}
         listClouds={sinon.stub()}
         listPlansForCharm={sinon.stub()}
@@ -302,6 +305,7 @@ describe('DeploymentFlow', function() {
         changeState={sinon.stub()}
         deploy={sinon.stub()}
         getCloudCredentials={sinon.stub()}
+        groupedChanges={{}}
         listBudgets={sinon.stub()}
         listClouds={sinon.stub()}
         listPlansForCharm={sinon.stub()}
@@ -327,6 +331,7 @@ describe('DeploymentFlow', function() {
         changeState={sinon.stub()}
         deploy={sinon.stub()}
         getCloudCredentials={sinon.stub()}
+        groupedChanges={{}}
         listBudgets={sinon.stub()}
         listClouds={sinon.stub()}
         listPlansForCharm={sinon.stub()}
@@ -352,6 +357,7 @@ describe('DeploymentFlow', function() {
         changeState={sinon.stub()}
         deploy={sinon.stub()}
         getCloudCredentials={sinon.stub()}
+        groupedChanges={{}}
         listBudgets={sinon.stub()}
         listClouds={sinon.stub()}
         listPlansForCharm={sinon.stub()}
@@ -382,6 +388,7 @@ describe('DeploymentFlow', function() {
         changeState={sinon.stub()}
         deploy={sinon.stub()}
         getCloudCredentials={sinon.stub()}
+        groupedChanges={{}}
         listBudgets={sinon.stub()}
         listClouds={sinon.stub()}
         listPlansForCharm={sinon.stub()}
@@ -407,6 +414,7 @@ describe('DeploymentFlow', function() {
         changeState={sinon.stub()}
         deploy={sinon.stub()}
         getCloudCredentials={sinon.stub()}
+        groupedChanges={{}}
         listBudgets={sinon.stub()}
         listClouds={sinon.stub()}
         listPlansForCharm={sinon.stub()}
@@ -433,6 +441,7 @@ describe('DeploymentFlow', function() {
         changeState={sinon.stub()}
         deploy={sinon.stub()}
         getCloudCredentials={sinon.stub()}
+        groupedChanges={{}}
         listBudgets={sinon.stub()}
         listClouds={sinon.stub()}
         listPlansForCharm={sinon.stub()}
@@ -459,6 +468,7 @@ describe('DeploymentFlow', function() {
         changeState={sinon.stub()}
         deploy={sinon.stub()}
         getCloudCredentials={sinon.stub()}
+        groupedChanges={{}}
         listBudgets={sinon.stub()}
         listClouds={sinon.stub()}
         listPlansForCharm={sinon.stub()}
@@ -486,6 +496,7 @@ describe('DeploymentFlow', function() {
         changeState={sinon.stub()}
         deploy={sinon.stub()}
         getCloudCredentials={sinon.stub()}
+        groupedChanges={{}}
         listBudgets={sinon.stub()}
         listClouds={sinon.stub()}
         listPlansForCharm={sinon.stub()}
@@ -515,6 +526,7 @@ describe('DeploymentFlow', function() {
         changeState={changeState}
         deploy={deploy}
         getCloudCredentials={sinon.stub()}
+        groupedChanges={{}}
         listBudgets={sinon.stub()}
         listClouds={sinon.stub()}
         listPlansForCharm={sinon.stub()}

--- a/jujugui/static/gui/src/app/components/deployment-flow/test-deployment-flow.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/test-deployment-flow.js
@@ -62,7 +62,8 @@ describe('DeploymentFlow', function() {
         listPlansForCharm={listPlansForCharm}
         modelName="Pavlova"
         servicesGetById={servicesGetById}
-        user="user-admin">
+        user="user-admin"
+        withPlans={true}>
         <span>content</span>
       </juju.components.DeploymentFlow>, true);
     var instance = renderer.getMountedInstance();
@@ -152,7 +153,8 @@ describe('DeploymentFlow', function() {
                     groupedChanges={{}}
                     listPlansForCharm={listPlansForCharm}
                     servicesGetById={servicesGetById}
-                    showChangelogs={false} />
+                    showChangelogs={false}
+                    withPlans={true} />
                 </juju.components.DeploymentSection>
                 <juju.components.DeploymentSection
                   completed={false}
@@ -462,7 +464,8 @@ describe('DeploymentFlow', function() {
         listPlansForCharm={sinon.stub()}
         modelName="Pavlova"
         servicesGetById={sinon.stub()}
-        user="user-admin">
+        user="user-admin"
+        withPlans={true}>
         <span>content</span>
       </juju.components.DeploymentFlow>, true);
     var instance = renderer.getMountedInstance();


### PR DESCRIPTION
Update the deployment flow to hide the plan info for now. Display the real machine info.