### PR TITLE
Add version.js to a jujugui dist.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,9 @@ LSB_RELEASE = $(shell lsb_release -cs)
 SYSDEPS = coreutils g++ git inotify-tools nodejs \
 	python-virtualenv realpath xvfb chromium-browser
 
+CURRENT_VERSION = $(shell sed -n -e '/current_version =/ s/.*\= *// p' .bumpversion.cfg)
+CURRENT_COMMIT = $(shell git rev-parse HEAD)
+
 .PHONY: help
 help:
 	@echo "bumpversion - bump version."
@@ -329,17 +332,15 @@ ci-check: clean-downloadcache deps fast-babel check
 bumpversion: deps
 	bin/bumpversion $(VPART)
 
-CURRENT_VERSION = $(shell sed -n -e '/current_version =/ s/.*\= *// p' .bumpversion.cfg)
-CURRENT_COMMIT = $(shell git rev-parse HEAD)
 .PHONY: version
 version:
-	echo '{ "version": "$(CURRENT_VERSION)", "commit": "$(CURRENT_COMMIT)" }' > $(GUIBUILD)/app/version.json
+	echo "'version: $(CURRENT_VERSION)';\n'commit: $(CURRENT_COMMIT)';" > $(GUIBUILD)/app/version.js
 
 .PHONY: dist
 dist: clean-all fast-dist
 
 .PHONY: fast-dist
-fast-dist: deps fast-babel gui test-deps collect-requirements
+fast-dist: deps fast-babel gui test-deps collect-requirements version
 	python setup.py sdist --formats=bztar\
 
 #######

--- a/Makefile
+++ b/Makefile
@@ -329,9 +329,11 @@ ci-check: clean-downloadcache deps fast-babel check
 bumpversion: deps
 	bin/bumpversion $(VPART)
 
+CURRENT_VERSION = $(shell sed -n -e '/current_version =/ s/.*\= *// p' .bumpversion.cfg)
+CURRENT_COMMIT = $(shell git rev-parse HEAD)
 .PHONY: version
 version:
-	python setup.py --version | sed -e "s/.*/'&'/" > $(GUIBUILD)/app/version.js
+	echo '{ "version": "$(CURRENT_VERSION)", "commit": "$(CURRENT_COMMIT)" }' > $(GUIBUILD)/app/version.json
 
 .PHONY: dist
 dist: clean-all fast-dist

--- a/Makefile
+++ b/Makefile
@@ -329,6 +329,10 @@ ci-check: clean-downloadcache deps fast-babel check
 bumpversion: deps
 	bin/bumpversion $(VPART)
 
+.PHONY: version
+version:
+	python setup.py --version | sed -e "s/.*/'&'/" > $(GUIBUILD)/app/version.js
+
 .PHONY: dist
 dist: clean-all fast-dist
 

--- a/Makefile
+++ b/Makefile
@@ -334,7 +334,7 @@ bumpversion: deps
 
 .PHONY: version
 version:
-	echo "'version: $(CURRENT_VERSION)';\n'commit: $(CURRENT_COMMIT)';" > $(GUIBUILD)/app/version.js
+	echo '{"version": "$(CURRENT_VERSION)", "commit": "$(CURRENT_COMMIT)"}' > $(GUIBUILD)/app/version.json
 
 .PHONY: dist
 dist: clean-all fast-dist


### PR DESCRIPTION
Adds a version.js asset to the tree which constains the GUI version and the git sha. It can be fetched by visiting: `/gui/[CONTROLLER UUID]/[MODEL UUID]/static/gui/build/app/version.json`

Fixes #1986.