### PR TITLE
Pop up for GUI persistance of uncommitted state

### DIFF
--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -514,6 +514,9 @@ YUI.add('juju-gui', function(Y) {
       this.changesUtils = window.juju.utils.ChangesUtils;
       this.relationUtils = window.juju.utils.RelationUtils;
 
+      // Listen for window unloads and trigger the unloadWindow function.
+      window.onbeforeunload = views.utils.unloadWindow.bind(this);
+
       this.on('*:navigateTo', function(e) {
         this.navigate(e.url);
       }, this);

--- a/jujugui/static/gui/src/app/views/utils.js
+++ b/jujugui/static/gui/src/app/views/utils.js
@@ -1223,6 +1223,21 @@ YUI.add('juju-view-utils', function(Y) {
     return path;
   };
 
+  /**
+    Displays a confirmation when closing window if there are uncommitted
+    changes
+
+    @method unloadWindow
+    @param {Object} env Reference to the app env.
+  */
+  utils.unloadWindow = function() {
+    var currentChangeSet = this.env.get('ecs').getCurrentChangeSet();
+    if (Object.keys(currentChangeSet).length > 0) {
+      return 'You have uncommitted changes to your model. You will ' +
+        'lose these changes if you continue.';
+    }
+  };
+
   // Modified for Javascript from https://gist.github.com/gruber/8891611 - I
   // escaped the forward slashes and removed the negative-lookbehind, which JS
   // does not support. See line 46 in Gruber's gist; that's the line/feature

--- a/jujugui/static/gui/src/test/test_utils.js
+++ b/jujugui/static/gui/src/test/test_utils.js
@@ -721,6 +721,41 @@ describe('utilities', function() {
 
   });
 
+  describe('unloadWindow', function() {
+    var utils;
+
+    before(function(done) {
+      YUI(GlobalConfig).use(['juju-view-utils'], function(Y) {
+        utils = Y.namespace('juju.views.utils');
+        done();
+      });
+    });
+
+    it('does not block when no uncommitted changes', function() {
+      var context = {env: {
+        get: sinon.stub().returns({
+          getCurrentChangeSet: sinon.stub().returns({})
+        })
+      }};
+
+      var result = utils.unloadWindow.call(context);
+      assert.strictEqual(result, undefined);
+    });
+
+    it('does block when has uncommitted changes', function() {
+      var context = {env: {
+        get: sinon.stub().returns({
+          getCurrentChangeSet: sinon.stub().returns({foo: 'bar'})
+        })
+      }};
+
+      var expected = 'You have uncommitted changes to your model. You will ' +
+        'lose these changes if you continue.';
+      var result = utils.unloadWindow.call(context);
+      assert.strictEqual(result, expected);
+    });
+  });
+
   describe('linkify', function() {
     var utils;
 


### PR DESCRIPTION
Displays a browser pop up when closing or refreshing the window with uncommitted changes.