### PR TITLE
Handle changes in ModelInfo and CreateModel responses.

### DIFF
--- a/jujugui/static/gui/src/app/store/env/api.js
+++ b/jujugui/static/gui/src/app/store/env/api.js
@@ -783,10 +783,13 @@ YUI.add('juju-env-api', function(Y) {
         - series: the model default series, like "trusty" or "xenial";
         - provider: the provider type, like "lxd" or "aws";
         - uuid: the model unique identifier;
-        - ownerTag: the Juju tag of the user owning the model;
+        - ownerTag: the tag of the user owning the model (with "user-" prefix);
+        - owner: the name of the user owning the model;
+        - cloudTag: the model cloud tag (prefixed with "cloud-");
         - cloud: the model cloud;
         - region: the cloud region in which the model is placed;
         - credentialTag: the cloud credential tag (prefixed with "cloudcred-");
+        - credential: the cloud credential name;
         - life: the lifecycle status of the model: "alive", "dying" or "dead";
         - isAlive: whether the model is alive or dying/dead.
      @return {undefined} Nothing.
@@ -809,9 +812,13 @@ YUI.add('juju-env-api', function(Y) {
           provider: response['provider-type'],
           uuid: response.uuid,
           ownerTag: response['owner-tag'],
-          cloud: response.cloud,
+          owner: response['owner-tag'].replace(/^user-/, ''),
+          cloudTag: response['cloud-tag'],
+          cloud: response['cloud-tag'].replace(/^cloud-/, ''),
           region: response['cloud-region'],
           credentialTag: response['cloud-credential-tag'],
+          credential: response['cloud-credential-tag'].replace(
+            /^cloudcred-/, ''),
           life: response.life,
           isAlive: response.life === 'alive'
         });

--- a/jujugui/static/gui/src/app/store/env/controller-api.js
+++ b/jujugui/static/gui/src/app/store/env/controller-api.js
@@ -534,13 +534,16 @@ YUI.add('juju-controller-api', function(Y) {
         following attributes:
         - name: the name of the new model;
         - uuid: the unique identifier of the new model;
-        - ownerTag: the model owner tag;
+        - ownerTag: the model owner tag (prefixed with "user-");
+        - owner: the name of the user owning the model;
         - provider: the model provider type;
         - series: the model default series;
+        - cloudTag: the cloud tag (prefixed with "cloud-");
         - cloud: the name of the cloud;
         - region: the cloud region;
         - credentialTag: the tag of the cloud credential used to create the
-          model.
+          model (prefixed with "cloudcred-");
+        - credential: the name of the credential used to create the model;
       @return {undefined} Sends a message to the server only.
     */
     createModel: function(name, userTag, args, callback) {
@@ -559,11 +562,15 @@ YUI.add('juju-controller-api', function(Y) {
           name: response.name,
           uuid: response.uuid,
           ownerTag: response['owner-tag'],
+          owner: response['owner-tag'].replace(/^user-/, ''),
           provider: response['provider-type'],
           series: response['default-series'],
-          cloud: response.cloud,
+          cloudTag: response['cloud-tag'],
+          cloud: response['cloud-tag'].replace(/^cloud-/, ''),
           region: response['cloud-region'],
-          credentialTag: response['cloud-credential-tag']
+          credentialTag: response['cloud-credential-tag'],
+          credential: response['cloud-credential-tag'].replace(
+            /^cloudcred-/, '')
         });
       }.bind(this, callback);
 

--- a/jujugui/static/gui/src/test/test_controller_api.js
+++ b/jujugui/static/gui/src/test/test_controller_api.js
@@ -967,11 +967,14 @@ describe('Controller API', function() {
         assert.strictEqual(data.name, 'mymodel');
         assert.strictEqual(data.uuid, 'unique-id');
         assert.strictEqual(data.ownerTag, 'user-rose@external');
+        assert.strictEqual(data.owner, 'rose@external');
         assert.strictEqual(data.provider, 'lxd');
         assert.strictEqual(data.series, 'xenial');
+        assert.strictEqual(data.cloudTag, 'cloud-proxima-centauri');
         assert.strictEqual(data.cloud, 'proxima-centauri');
         assert.strictEqual(data.region, 'alpha-quadrant');
         assert.strictEqual(data.credentialTag, 'cloudcred-dalek');
+        assert.strictEqual(data.credential, 'dalek');
         assert.equal(conn.messages.length, 1);
         const msg = conn.last_message();
         assert.deepEqual(msg, {
@@ -999,7 +1002,7 @@ describe('Controller API', function() {
           'owner-tag': 'user-rose@external',
           'provider-type': 'lxd',
           'default-series': 'xenial',
-          cloud: 'proxima-centauri',
+          'cloud-tag': 'cloud-proxima-centauri',
           'cloud-region': 'alpha-quadrant',
           'cloud-credential-tag': 'cloudcred-dalek'
         }
@@ -1034,7 +1037,7 @@ describe('Controller API', function() {
           'owner-tag': 'user-rose@local',
           'provider-type': 'lxd',
           'default-series': 'xenial',
-          cloud: 'proxima-centauri',
+          'cloud-tag': 'cloud-proxima-centauri',
           'cloud-region': 'delta-quadrant',
           'cloud-credential-tag': 'cloudcred-dalek'
         }

--- a/jujugui/static/gui/src/test/test_env_api.js
+++ b/jujugui/static/gui/src/test/test_env_api.js
@@ -645,12 +645,12 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
           'default-series': 'xenial',
           name: 'my-model',
           'provider-type': 'aws',
-          'cloud': 'aws',
+          'cloud-tag': 'cloud-aws',
           'cloud-region': 'us-east-1',
           'cloud-credential-tag': 'cloudcred-aws_admin@local_aws',
           uuid: '5bea955d-7a43-47d3-89dd-tag1',
           life: 'alive',
-          'owner-tag': 'user-admin@local'
+          'owner-tag': 'user-admin@local',
         }
       });
       assert.equal(env.get('defaultSeries'), 'xenial');
@@ -691,7 +691,9 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
           'provider-type': 'maas',
           uuid: '5bea955d-7a43-47d3-89dd-tag1',
           life: 'alive',
-          'owner-tag': 'user-admin@local'
+          'owner-tag': 'user-admin@local',
+          'cloud-tag': 'cloud-maas',
+          'cloud-credential-tag': 'cloudcred-admin'
         }
       });
       conn.msg({'request-id': 2, error: 'bad wolf'});
@@ -711,7 +713,9 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
           'provider-type': 'maas',
           uuid: '5bea955d-7a43-47d3-89dd-tag1',
           life: 'alive',
-          'owner-tag': 'user-admin@local'
+          'owner-tag': 'user-admin@local',
+          'cloud-tag': 'cloud-maas',
+          'cloud-credential-tag': 'cloudcred-admin'
         }
       });
       conn.msg({
@@ -747,7 +751,9 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
           'provider-type': 'maas',
           uuid: '5bea955d-7a43-47d3-89dd-tag1',
           life: 'alive',
-          'owner-tag': 'user-admin@local'
+          'owner-tag': 'user-admin@local',
+          'cloud-tag': 'cloud-maas',
+          'cloud-credential-tag': 'cloudcred-admin'
         }
       });
       assert.lengthOf(conn.messages, 2);
@@ -770,17 +776,15 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       conn.msg({
         'request-id': 1,
         response: {
-          results: [{
-            result: {
-              'default-series': 'xenial',
-              name: 'my-model',
-              'provider-type': 'aws',
-              uuid: '5bea955d-7a43-47d3-89dd-tag1',
-              'controller-uuid': '5bea955d-7a43-47d3-89dd-tag1',
-              life: 'alive',
-              'owner-tag': 'user-admin@local'
-            }
-          }]
+          'default-series': 'xenial',
+          name: 'my-model',
+          'provider-type': 'aws',
+          uuid: '5bea955d-7a43-47d3-89dd-tag1',
+          'controller-uuid': '5bea955d-7a43-47d3-89dd-tag1',
+          life: 'alive',
+          'owner-tag': 'user-admin@local',
+          'cloud-tag': 'cloud-aws',
+          'cloud-credential-tag': 'cloudcred-admin'
         }
       });
       assert.lengthOf(conn.messages, 1);


### PR DESCRIPTION
These calls used to return cloud names, now they return cloud tags.