### PR TITLE
An API connection odyssey

### DIFF
--- a/jujugui/static/gui/src/app/store/env/base.js
+++ b/jujugui/static/gui/src/app/store/env/base.js
@@ -404,6 +404,10 @@ YUI.add('juju-env-base', function(Y) {
         if (credentials.user.indexOf(API_USER_TAG) !== 0) {
           credentials.user = API_USER_TAG + credentials.user;
         }
+        // User names without a "@something" part are local Juju users.
+        if (credentials.user.indexOf('@') === -1) {
+          credentials.user += '@local';
+        }
       } else {
         credentials.user = '';
       }

--- a/jujugui/static/gui/src/app/store/env/fakebackend.js
+++ b/jujugui/static/gui/src/app/store/env/fakebackend.js
@@ -48,8 +48,8 @@ YUI.add('juju-env-fakebackend', function(Y) {
     authenticated: {value: false},
     authorizedUsers: {
       value: {
-        'user-admin': 'password',
-        'user-test': 'test'
+        'user-admin@local': 'password',
+        'user-test@local': 'test'
       }
     },
     defaultSeries: {value: 'trusty'},
@@ -173,8 +173,11 @@ YUI.add('juju-env-fakebackend', function(Y) {
     @return {Bool} True if the authentication was successful.
     */
     login: function(username, submittedPassword) {
-      var password = this.get('authorizedUsers')[username],
-          authenticated = password === submittedPassword;
+      if (username.indexOf('@') === -1) {
+        username += '@local';
+      }
+      const password = this.get('authorizedUsers')[username];
+      const authenticated = password === submittedPassword;
       this.set('authenticated', authenticated);
       return authenticated;
     },

--- a/jujugui/static/gui/src/app/store/env/sandbox.js
+++ b/jujugui/static/gui/src/app/store/env/sandbox.js
@@ -300,16 +300,21 @@ YUI.add('juju-env-sandbox', function(Y) {
     @return {undefined} Side effects only.
     */
     handleAdminLogin: function(data, client, state) {
-      data.error = !state.login(
-        data.params['auth-tag'], data.params.credentials);
-      data.response = {
-        facades: sandboxModule.facades,
-        'user-info': {
-          'controller-access': 'superuser',
-          'model-access': 'admin'
-        }
-      };
-      client.receive(data);
+      const username = data.params['auth-tag'];
+      const password = data.params.credentials;
+      const response = {'request-id': data['request-id']};
+      if (state.login(username, password)) {
+        response.response = {
+          facades: sandboxModule.facades,
+          'user-info': {
+            'controller-access': 'superuser',
+            'model-access': 'admin'
+          }
+        };
+      } else {
+        response.error = 'invalid username or password';
+      }
+      client.receive(response);
     },
 
     /**
@@ -341,7 +346,8 @@ YUI.add('juju-env-sandbox', function(Y) {
           'provider-type': state.get('providerType'),
           'default-series': state.get('defaultSeries'),
           name: 'sandbox',
-          cloud: 'demonstration',
+          'owner-tag': 'user-admin@local',
+          'cloud-tag': 'cloud-demonstration',
           'cloud-credential-tag':
             'cloudcred-demonstration_admin@local_demonstration',
           'cloud-region': 'demo-west'

--- a/jujugui/static/gui/src/app/views/utils.js
+++ b/jujugui/static/gui/src/app/views/utils.js
@@ -1474,7 +1474,7 @@ YUI.add('juju-view-utils', function(Y) {
     // Update the model name. The onEnvironmentNameChange in app.js method will
     // update the name correctly accross components.
     env.set('environmentName', name);
-    this.set('jujuEnvUUID', uuid);
+    this.set('modelUUID', uuid);
     var username, password, address, port;
     if (uuid && modelList) {
       var found = modelList.some((model) => {
@@ -1613,7 +1613,7 @@ YUI.add('juju-view-utils', function(Y) {
       password: model.password
     });
     var socketURL = createSocketURL(model.uuid, pathParts[0], pathParts[1]);
-    appSet('jujuEnvUUID', model.uuid);
+    appSet('modelUUID', model.uuid);
     // Set the socket url in both the app and the env so we don't end
     // up with any confusion later on about which is which.
     appSet('socket_url', socketURL);

--- a/jujugui/static/gui/src/test/test_env.js
+++ b/jujugui/static/gui/src/test/test_env.js
@@ -94,7 +94,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       assert.deepEqual(setItemValue, {credentials: Y.JSON.stringify(value)});
       var creds = env.getCredentials();
       assert.strictEqual(creds.areAvailable, true);
-      assert.strictEqual(creds.user, 'user-foo');
+      assert.strictEqual(creds.user, 'user-foo@local');
       assert.strictEqual(creds.password, 'kumquat');
       assert.deepEqual(creds.macaroons, ['macaroon']);
       // Try with null value.

--- a/jujugui/static/gui/src/test/test_env_legacy_api.js
+++ b/jujugui/static/gui/src/test/test_env_legacy_api.js
@@ -260,7 +260,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
           Type: 'Admin',
           Request: 'Login',
           RequestId: 1,
-          Params: {AuthTag: 'user-user', Password: 'password'},
+          Params: {AuthTag: 'user-user@local', Password: 'password'},
           Version: 0
         };
         assert.deepEqual(expected, lastMessage);
@@ -400,8 +400,8 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
         assert.strictEqual(err, null);
         assert.strictEqual(fromToken, true);
         const credentials = env.getCredentials();
-        assert.strictEqual('user-tokenuser', credentials.user);
-        assert.strictEqual('tokenpasswd', credentials.password);
+        assert.strictEqual(credentials.user, 'user-tokenuser@local');
+        assert.strictEqual(credentials.password, 'tokenpasswd');
       });
 
       it('resets failed markers on successful login', function() {
@@ -680,7 +680,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
       it('uses the stored webHandler to perform requests', function() {
         env.userIsAuthenticated = true;
-        var mockWebHandler = {sendPostRequest: sinon.stub()};
+        const mockWebHandler = {sendPostRequest: sinon.stub()};
         env.set('webHandler', mockWebHandler);
         env.uploadLocalCharm(
             'a zip file', 'trusty',
@@ -689,14 +689,14 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
         // Ensure the web handler's sendPostRequest method has been called with
         // the expected arguments.
         assert.strictEqual(mockWebHandler.sendPostRequest.callCount, 1);
-        var lastArguments = mockWebHandler.sendPostRequest.lastCall.args;
+        const lastArguments = mockWebHandler.sendPostRequest.lastCall.args;
         assert.strictEqual(lastArguments.length, 7);
         assert.strictEqual(
             lastArguments[0], '/juju-core/charms?series=trusty'); // Path.
         assert.deepEqual(
             lastArguments[1], {'Content-Type': 'application/zip'}); // Headers.
         assert.strictEqual(lastArguments[2], 'a zip file'); // Zip file object.
-        assert.strictEqual(lastArguments[3], 'user-user'); // User name.
+        assert.strictEqual(lastArguments[3], 'user-user@local'); // User name.
         assert.strictEqual(lastArguments[4], 'password'); // Password.
         assert.strictEqual(
             lastArguments[5](), 'progress'); // Progress callback.
@@ -709,20 +709,20 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     describe('getLocalCharmFileUrl', function() {
 
       it('uses the stored webHandler to retrieve the file URL', function() {
-        var mockWebHandler = {getUrl: sinon.stub().returns('myurl')};
+        const mockWebHandler = {getUrl: sinon.stub().returns('myurl')};
         env.set('webHandler', mockWebHandler);
-        var url = env.getLocalCharmFileUrl(
+        const url = env.getLocalCharmFileUrl(
             'local:trusty/django-42', 'icon.svg');
         assert.strictEqual(url, 'myurl');
         // Ensure the web handler's getUrl method has been called with the
         // expected arguments.
         assert.strictEqual(mockWebHandler.getUrl.callCount, 1);
-        var lastArguments = mockWebHandler.getUrl.lastCall.args;
+        const lastArguments = mockWebHandler.getUrl.lastCall.args;
         assert.lengthOf(lastArguments, 3);
         assert.strictEqual(
             lastArguments[0],
             '/juju-core/charms?url=local:trusty/django-42&file=icon.svg');
-        assert.strictEqual(lastArguments[1], 'user-user'); // User name.
+        assert.strictEqual(lastArguments[1], 'user-user@local'); // User name.
         assert.strictEqual(lastArguments[2], 'password'); // Password.
       });
 
@@ -731,7 +731,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     describe('listLocalCharmFiles', function() {
 
       it('uses the stored webHandler to retrieve the file list', function() {
-        var mockWebHandler = {sendGetRequest: sinon.stub()};
+        const mockWebHandler = {sendGetRequest: sinon.stub()};
         env.set('webHandler', mockWebHandler);
         env.listLocalCharmFiles(
             'local:trusty/django-42',
@@ -740,12 +740,12 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
         // Ensure the web handler's sendGetRequest method has been called with
         // the expected arguments.
         assert.strictEqual(mockWebHandler.sendGetRequest.callCount, 1);
-        var lastArguments = mockWebHandler.sendGetRequest.lastCall.args;
+        const lastArguments = mockWebHandler.sendGetRequest.lastCall.args;
         assert.lengthOf(lastArguments, 6);
         assert.strictEqual(
             lastArguments[0], '/juju-core/charms?url=local:trusty/django-42');
         assert.deepEqual(lastArguments[1], {}); // Headers.
-        assert.strictEqual(lastArguments[2], 'user-user'); // User name.
+        assert.strictEqual(lastArguments[2], 'user-user@local'); // User name.
         assert.strictEqual(lastArguments[3], 'password'); // Password.
         assert.strictEqual(
             lastArguments[4](), 'progress'); // Progress callback.
@@ -758,7 +758,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     describe('getLocalCharmFileContents', function() {
 
       it('uses the stored webHandler to retrieve the contents', function() {
-        var mockWebHandler = {sendGetRequest: sinon.stub()};
+        const mockWebHandler = {sendGetRequest: sinon.stub()};
         env.set('webHandler', mockWebHandler);
         env.getLocalCharmFileContents(
             'local:trusty/django-42', 'hooks/install',
@@ -767,13 +767,13 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
         // Ensure the web handler's sendGetRequest method has been called with
         // the expected arguments.
         assert.strictEqual(mockWebHandler.sendGetRequest.callCount, 1);
-        var lastArguments = mockWebHandler.sendGetRequest.lastCall.args;
+        const lastArguments = mockWebHandler.sendGetRequest.lastCall.args;
         assert.lengthOf(lastArguments, 6);
         assert.strictEqual(
             lastArguments[0],
             '/juju-core/charms?url=local:trusty/django-42&file=hooks/install');
         assert.deepEqual(lastArguments[1], {}); // Headers.
-        assert.strictEqual(lastArguments[2], 'user-user'); // User name.
+        assert.strictEqual(lastArguments[2], 'user-user@local'); // User name.
         assert.strictEqual(lastArguments[3], 'password'); // Password.
         assert.strictEqual(
             lastArguments[4](), 'progress'); // Progress callback.

--- a/jujugui/static/gui/src/test/test_fakebackend.js
+++ b/jujugui/static/gui/src/test/test_fakebackend.js
@@ -51,8 +51,13 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       assert.equal(fakebackend.get('authenticated'), true);
       fakebackend.logout();
       assert.equal(fakebackend.get('authenticated'), false);
+      assert.equal(fakebackend.login('user-admin@local', 'password'), true);
+      assert.equal(fakebackend.get('authenticated'), true);
+      fakebackend.logout();
+      assert.equal(fakebackend.get('authenticated'), false);
       assert.equal(fakebackend.login('user-test', 'test'), true);
       assert.equal(fakebackend.get('authenticated'), true);
+      fakebackend.logout();
     });
 
     it('refuses to authenticate', function() {
@@ -82,7 +87,8 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       fakebackend = new environmentsModule.FakeBackend();
       assert.equal(fakebackend.get('authenticated'), false);
       assert.deepEqual(
-          fakebackend.tokenlogin('demoToken'), ['user-admin', 'password']);
+          fakebackend.tokenlogin('demoToken'),
+          ['user-admin@local', 'password']);
       assert.equal(fakebackend.get('authenticated'), true);
     });
 

--- a/jujugui/static/gui/src/test/test_login.js
+++ b/jujugui/static/gui/src/test/test_login.js
@@ -74,17 +74,17 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     });
 
     test('credentials passed to the constructor are stored', function() {
-      var user = 'Will Smith';
-      var password = 'I am legend!';
+      const user = 'jean-luc-picard';
+      const password = 'I am the real legend!';
       // Make sure that the session is empty from the 'beforeEach' instantiation
       sessionStorage.setItem('credentials', null);
-      var env = new juju.environments.GoEnvironment({
+      const env = new juju.environments.GoEnvironment({
         user: user,
         password: password,
         conn: conn
       });
-      var credentials = env.getCredentials();
-      assert.equal(credentials.user, 'user-' + user);
+      const credentials = env.getCredentials();
+      assert.equal(credentials.user, 'user-' + user + '@local');
       assert.equal(credentials.password, password);
       assert.equal(JSON.stringify({
         user: 'user-' + user,
@@ -108,7 +108,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       env.login();
       var message = conn.last_message();
       assert.equal(message.request, 'Login');
-      assert.equal(message.params['auth-tag'], 'user-admin');
+      assert.equal(message.params['auth-tag'], 'user-admin@local');
       assert.equal(message.params.credentials, 'password');
     });
 

--- a/jujugui/static/gui/src/test/test_utils.js
+++ b/jujugui/static/gui/src/test/test_utils.js
@@ -1106,7 +1106,7 @@ describe('utilities', function() {
       assert.equal(createSocketURLArgs[2], '80');
       assert.equal(appSet.callCount, 2);
       var appSetArgs = appSet.args;
-      assert.equal(appSetArgs[0][0], 'jujuEnvUUID');
+      assert.equal(appSetArgs[0][0], 'modelUUID');
       assert.equal(appSetArgs[0][1], 'uuid123');
       assert.equal(appSetArgs[1][0], 'socket_url');
       assert.equal(appSetArgs[1][1], 'wss://socket-url');


### PR DESCRIPTION
Connect the controller, get the models, connect the model, in this order.

This fixes #1987 by only establishing the model connection once we have already obtained the list of available models using the ListModels call on the controller connection.

This branch also includes:
- some app.js clean up, especially targeted to further simplification of the authentication logic;
- a fix to how the selected model is picked;
- fixes to the authentication process in sandbox mode;
- updates to ModelInfo responses as simulated by the fake backend;
- improved handling of credentials: the `@local` part is automatically added when retrieving credentials from the storage when required.
