### PR TITLE
Do not require a model name to be specified when deploying

### DIFF
--- a/jujugui/static/gui/src/app/components/deployment-flow/deployment-flow.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/deployment-flow.js
@@ -466,8 +466,12 @@ YUI.add('deployment-flow', function() {
       @method _handleDeploy
     */
     _handleDeploy: function() {
+      let modelName = '';
+      if (this.refs.modelName) {
+        modelName = this.refs.modelName.getValue();
+      }
       this.props.deploy(
-        this._handleClose, true, this.refs.modelName.getValue(),
+        this._handleClose, true, modelName,
         this.state.credential, this.state.cloud.id, this.state.region);
     },
 

--- a/jujugui/static/gui/src/app/components/deployment-flow/test-deployment-flow.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/test-deployment-flow.js
@@ -670,4 +670,46 @@ describe('DeploymentFlow', function() {
     assert.equal(deploy.args[0][5], 'north');
     assert.equal(changeState.callCount, 1);
   });
+
+  it('can deploy without a model name', function() {
+    var deploy = sinon.stub().callsArg(0);
+    var changeState = sinon.stub();
+    var renderer = jsTestUtils.shallowRender(
+      <juju.components.DeploymentFlow
+        acl={acl}
+        changes={{}}
+        changesFilterByParent={sinon.stub()}
+        changeState={changeState}
+        deploy={deploy}
+        generateAllChangeDescriptions={sinon.stub()}
+        generateCloudCredentialTag={sinon.stub()}
+        getCloudCredentials={sinon.stub()}
+        getTagsForCloudCredentials={sinon.stub()}
+        groupedChanges={groupedChanges}
+        listBudgets={sinon.stub()}
+        listClouds={sinon.stub()}
+        listPlansForCharm={sinon.stub()}
+        modelCommitted={true}
+        modelName="Pavlova"
+        servicesGetById={sinon.stub()}
+        updateCloudCredential={sinon.stub()}
+        user="user-admin">
+        <span>content</span>
+      </juju.components.DeploymentFlow>, true);
+    var instance = renderer.getMountedInstance();
+    instance.refs = {};
+    instance._setCloud({id: 'cloud'});
+    instance._setCredential('cred');
+    instance._setRegion('north');
+    var output = renderer.getRenderOutput();
+    output.props.children.props.children[1].props.children.props.children
+      .props.children[7].props.children.props.children[1].props.children
+      .props.action();
+    assert.equal(deploy.callCount, 1);
+    assert.equal(deploy.args[0][2], '');
+    assert.equal(deploy.args[0][3], 'cred');
+    assert.equal(deploy.args[0][4], 'cloud');
+    assert.equal(deploy.args[0][5], 'north');
+    assert.equal(changeState.callCount, 1);
+  });
 });


### PR DESCRIPTION
It was impossible to deploy anything without this modification to the new DF.