### PR TITLE
Improve login/logout handling.

### DIFF
--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -1842,6 +1842,9 @@ YUI.add('juju-gui', function(Y) {
     @method destructor
     */
     destructor: function() {
+      // Clear the database handler timer. Without this, the application could
+      // dispatch after it is destroyed, resulting in a dirty state and bugs
+      // difficult to debug, so please do not remove this code.
       if (this.dbChangedTimer) {
         clearTimeout(this.dbChangedTimer);
       }

--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -582,9 +582,13 @@ YUI.add('juju-gui', function(Y) {
           // Try a token login.
           this.env.tokenLogin(authtoken);
         }
-        // There are no credentials. Do nothing in this case as the controller
-        // login check will have kicked the user to the login prompt already
-        // and we can wait until they have provided the credentials there.
+        // There are no credentials. Do nothing in this case if we are on Juju
+        // >= 2 as the controller login check will have kicked the user to the
+        // login prompt already and we can wait until they have provided the
+        // credentials there. In Juju 1 though we need to display the login.
+        if (!this.controllerAPI) {
+          this._displayLogin();
+        }
       });
 
       // If the database updates, redraw the view (distinct from model updates).
@@ -764,7 +768,12 @@ YUI.add('juju-gui', function(Y) {
         });
       });
 
-      controllerAPI.after('connectedChange', e => {
+      controllerAPI.after('connectedChange', evt => {
+        if (!evt.newVal) {
+          // The controller is not connected, do nothing waiting for a
+          // reconnection.
+          return;
+        }
         const credentials = this.controllerAPI.getCredentials();
         if (!credentials.areAvailable && !this.get('gisf')) {
           this._displayLogin();
@@ -848,10 +857,15 @@ YUI.add('juju-gui', function(Y) {
       }
       apis.forEach(api => {
         // The api may be unset if the current Juju does not support it.
-        if (api && api.get('connected')) {
-          if (credentials) {
-            api.setCredentials(credentials);
-          }
+        if (!api) {
+          return;
+        }
+        if (credentials) {
+          // We set credentials even if the API is not connected: they will be
+          // used when the connection is eventually established.
+          api.setCredentials(credentials);
+        }
+        if (api.get('connected')) {
           console.log(`logging into ${api.name} with user and password`);
           api.login();
         }
@@ -1828,21 +1842,27 @@ YUI.add('juju-gui', function(Y) {
     @method destructor
     */
     destructor: function() {
+      if (this.dbChangedTimer) {
+        clearTimeout(this.dbChangedTimer);
+      }
       if (this.zoomMessageHandler) {
         this.zoomMessageHandler.detach();
       }
       if (this._keybindings) {
         this._keybindings.detach();
       }
-      Y.each(
-          [this.env, this.db, this.endpointsController, this.controllerAPI],
-          function(o) {
-            if (o && o.destroy) {
-              o.detachAll();
-              o.destroy();
-            }
-          }
-      );
+      const toBeDestroyed = [
+        this.env,
+        this.controllerAPI,
+        this.db,
+        this.endpointsController
+      ];
+      toBeDestroyed.forEach(obj => {
+        if (obj && obj.destroy) {
+          obj.detachAll();
+          obj.destroy();
+        }
+      });
       ['dragenter', 'dragover', 'dragleave'].forEach((eventName) => {
         document.removeEventListener(eventName, this._boundAppDragOverHandler);
       });
@@ -1867,11 +1887,12 @@ YUI.add('juju-gui', function(Y) {
      */
     on_database_changed: function(evt) {
       // This timeout helps to reduce the number of needless dispatches from
-      // upwards of 8 to 2. At least until we can move to the model bound views.
+      // upwards of 8 to 2. At least until we can move to the model bound
+      // views.
       if (this.dbChangedTimer) {
-        this.dbChangedTimer.cancel();
+        clearTimeout(this.dbChangedTimer);
       }
-      this.dbChangedTimer = Y.later(100, this, this._dbChangedHandler);
+      this.dbChangedTimer = setTimeout(this._dbChangedHandler.bind(this), 100);
       return;
     },
 
@@ -1931,12 +1952,31 @@ YUI.add('juju-gui', function(Y) {
       if (environmentInstance) {
         environmentInstance.topo.update();
       }
+      this.set('modelUUID', '');
       this.set('loggedIn', false);
-      this.env.logout();
-      this.controllerAPI.logout();
-      this.maskVisibility(true);
-      this._renderLogin(null);
-      return;
+      // Close both controller and model API connections.
+      let closeController = callback => {
+        callback();
+      };
+      const controllerAPI = this.controllerAPI;
+      if (controllerAPI) {
+        closeController = controllerAPI.close.bind(controllerAPI);
+      }
+      this.env.close(() => {
+        closeController(() => {
+          if (controllerAPI) {
+            // Juju 2 connects to the controller and gets models from there.
+            controllerAPI.connect();
+          } else {
+            // Juju 1 is just connected to a model.
+            this.env.connect();
+          }
+          this.maskVisibility(true);
+          this.db.reset();
+          this.db.fire('update');
+          this._renderLogin(null);
+        });
+      });
     },
 
     // Persistent Views
@@ -2136,11 +2176,14 @@ YUI.add('juju-gui', function(Y) {
       @param {Boolean} clearDB Whether to clear the database and ecs.
     */
     switchEnv: function(
+      // TODO frankban: make the function defaults saner, for instance
+      // clearDB=true should really be preserveDB=false by default.
       socketUrl, username, password, callback, reconnect=!!socketUrl,
       clearDB=true) {
       if (this.get('sandbox')) {
         console.log('switching models is not supported in sandbox');
       }
+      console.log('switching model connection');
       if (username && password) {
         // We don't always get a new username and password when switching
         // environments; only set new credentials if we've actually gotten them.
@@ -2150,34 +2193,41 @@ YUI.add('juju-gui', function(Y) {
           password: password
         });
       };
+      const credentials = this.env.getCredentials();
       if (callback) {
-        var onLogin = function(callback) {
+        const onLogin = function(callback) {
           callback(this.env);
         };
         // Delay the callback until after the env login as everything should be
         // set up by then.
         this.env.onceAfter('login', onLogin.bind(this, callback), this);
       }
-      // Tell the environment to use the new socket URL when reconnecting.
-      this.env.set('socket_url', socketUrl);
       if (clearDB) {
         // Clear uncommitted state.
         this.env.get('ecs').clear();
       }
-      // Disconnect and reconnect the model.
-      var onclose = function() {
-        this.on_close();
+      const setUpModel = model => {
+        // Tell the model to use the new socket URL when reconnecting.
+        model.set('socket_url', socketUrl);
+        // Store the existing credentials so that they can be possibly reused.
+        model.setCredentials(credentials);
+        // Reconnect the model if required.
         if (reconnect) {
-          this.connect();
+          model.connect();
         }
+      };
+      // Disconnect and reconnect the model.
+      const onclose = function() {
+        this.on_close();
+        setUpModel(this);
       }.bind(this.env);
       if (this.env.ws) {
         this.env.ws.onclose = onclose;
         this.env.close();
         this.hideConnectingMask();
         // If we are already disconnected then connect if we're supposed to.
-        if (!this.env.get('connected') && reconnect) {
-          this.env.connect();
+        if (!this.env.get('connected')) {
+          setUpModel(this.env);
         }
       } else {
         this.env.close(onclose);

--- a/jujugui/static/gui/src/app/models/models.js
+++ b/jujugui/static/gui/src/app/models/models.js
@@ -2280,6 +2280,11 @@ YUI.add('juju-models', function(Y) {
       return this.resolveModelByName(model_id);
     },
 
+    /**
+      Reset all database collections.
+
+      @method reset
+    */
     reset: function() {
       this.services.reset();
       this.remoteServices.reset();
@@ -2288,6 +2293,7 @@ YUI.add('juju-models', function(Y) {
       this.relations.reset();
       this.notifications.reset();
       this.units.reset();
+      this.environment.reset();
     },
 
     /**

--- a/jujugui/static/gui/src/app/store/env/base.js
+++ b/jujugui/static/gui/src/app/store/env/base.js
@@ -275,9 +275,9 @@ YUI.add('juju-env-base', function(Y) {
         this._txn_callbacks = {};
       }
       this.ws.debug = this.get('debug');
-      this.ws.onmessage = Y.bind(this.on_message, this);
-      this.ws.onopen = Y.bind(this.on_open, this);
-      this.ws.onclose = Y.bind(this.on_close, this);
+      this.ws.onmessage = this.on_message.bind(this);
+      this.ws.onopen = this.on_open.bind(this);
+      this.ws.onclose = this.on_close.bind(this);
       // Our fake backends have "open" methods.  Call them, now that we have
       // set our listeners up.
       if (this.ws.open) {

--- a/jujugui/static/gui/src/app/store/env/base.js
+++ b/jujugui/static/gui/src/app/store/env/base.js
@@ -266,9 +266,13 @@ YUI.add('juju-env-base', function(Y) {
       // Allow an external websocket to be passed in.
       var conn = this.get('conn');
       if (conn) {
+        // This is only used for testing purposes.
         this.ws = conn;
       } else {
-        this.ws = new jujulib.ReconnectingWebSocket(this.get('socket_url'));
+        const url = this.get('socket_url');
+        console.log('connecting to ' + url);
+        this.ws = new jujulib.ReconnectingWebSocket(url);
+        this._txn_callbacks = {};
       }
       this.ws.debug = this.get('debug');
       this.ws.onmessage = Y.bind(this.on_message, this);
@@ -294,30 +298,39 @@ YUI.add('juju-env-base', function(Y) {
       Close the WebSocket connection to the Juju API server.
 
       @method close
-      @param cb Optional callback.
+      @param callback Optional callback called once the connection has been
+        closed and the API cleaned up.
     */
-    close: function(cb) {
-      if (this.ws) {
-        this.beforeClose(this.ws.close.bind(this.ws));
+    close: function(callback) {
+      console.log(`closing the ${this.name} API connection`);
+      if (!callback) {
+        callback = () => {};
       }
-      if (cb) {
-        cb();
+      if (!this.ws) {
+        callback();
+        return;
       }
+      this.cleanup(() => {
+        this.userIsAuthenticated = false;
+        this.setCredentials(null);
+        this.ws.close();
+        callback();
+      });
     },
 
     /**
-      Define optional operations to be performed before closing the WebSocket
-      connection. This method, as defined here, only calls the given callback
-      as it is intended to be overridden by subclasses. Implementations are
-      responsible of calling the given callback that effectively closes the
-      WebSocket connection.
+      Define optional operations to be performed before logging out. This
+      method, as defined here, only calls the given callback as it is intended
+      to be overridden by subclasses. Implementations are responsible of
+      calling the given callback that effectively closes the WebSocket
+      connection. Concrete implementations are assumed to be idempotent.
 
-      @method beforeClose
-      @param {Function} callback A callable that must be called by the
-        function and that actually closes the connection.
+      @method cleanup
+      @param {Function} done A callable that must be called by the function and
+        that actually closes the connection.
     */
-    beforeClose: function(callback) {
-      callback();
+    cleanup: function(done) {
+      done();
     },
 
     /**
@@ -432,21 +445,6 @@ YUI.add('juju-env-base', function(Y) {
         }
       });
       return credentials;
-    },
-
-    /**
-     * Clear login information.
-     *
-     * @method logout
-     * @return {undefined} Nothing.
-     */
-    logout: function() {
-      this.userIsAuthenticated = false;
-      this.setCredentials(null);
-      if (this.ws) {
-        this.ws.close();
-      }
-      this.connect();
     }
 
   });

--- a/jujugui/static/gui/src/app/store/env/controller-api.js
+++ b/jujugui/static/gui/src/app/store/env/controller-api.js
@@ -313,19 +313,31 @@ YUI.add('juju-controller-api', function(Y) {
     },
 
     /**
-      Define optional operations to be performed before closing the WebSocket
-      connection. Operations performed:
+      Define optional operations to be performed before logging out.
+      Operations performed:
         - the pinger interval is stopped;
+        - connection attributes are reset.
 
-      @method beforeClose
-      @param {Function} callback A callable that must be called by the
-        function and that actually closes the connection.
+      Note that this function is intended to be idempotent: clients must be
+      free to call this multiple times even on an already closed connection.
+
+      @method cleanup
+      @param {Function} done A callable that must be called by the function and
+        that actually closes the connection.
     */
-    beforeClose: function(callback) {
+    cleanup: function(done) {
+      console.log('cleaning up the controller API connection');
       if (this._pinger) {
         clearInterval(this._pinger);
         this._pinger = null;
       }
+      // TODO frankban: find a more automated way to clean up attributes.
+      this.setAttrs({
+        controllerAccess: '',
+        facades: [],
+        serverTag: ''
+      });
+      done();
     },
 
     /**

--- a/jujugui/static/gui/src/app/store/env/legacy-api.js
+++ b/jujugui/static/gui/src/app/store/env/legacy-api.js
@@ -390,16 +390,13 @@ YUI.add('juju-env-legacy-api', function(Y) {
       @private
     */
     _stopWatching: function(callback) {
-      var cb = function() {
-        this._allWatcherId = null;
-        callback();
-      }.bind(this);
       this._send_rpc({
         Type: 'AllWatcher',
         Request: 'Stop',
         Id: this._allWatcherId,
         Params: {}
-      }, cb);
+      }, callback);
+      this._allWatcherId = null;
     },
 
     /**
@@ -614,25 +611,47 @@ YUI.add('juju-env-legacy-api', function(Y) {
     },
 
     /**
-      Define optional operations to be performed before closing the WebSocket
-      connection. Operations performed:
+      Define optional operations to be performed before logging out.
+      Operations performed:
         - the pinger interval is stopped;
+        - connection attributes are reset;
         - the mega-watcher is stopped.
       Note that not stopping the mega-watcher before disconnecting causes
       server side disconnection to take a while, therefore preventing new
       connections from being established (for instance when switching between
       models in  controller).
+      Also note that this function is intended to be idempotent: clients must
+      be free to call this multiple times even on an already closed connection.
 
-      @method beforeClose
-      @param {Function} callback A callable that must be called by the
-        function and that actually closes the connection.
+      @method cleanup
+      @param {Function} done A callable that must be called by the function and
+        that actually closes the connection.
     */
-    beforeClose: function(callback) {
+    cleanup: function(done) {
+      console.log('cleaning up the legacy model API connection');
       if (this._pinger) {
         clearInterval(this._pinger);
         this._pinger = null;
       }
-      this._stopWatching(callback);
+      const callback = () => {
+        // TODO frankban: find a more automated way to clean up attributes.
+        this.setAttrs({
+          defaultSeries: '',
+          environmentName: '',
+          facades: [],
+          maasServer: null,
+          providerType: ''
+        });
+        done();
+      };
+      if (!this._allWatcherId) {
+        callback();
+        return;
+      }
+      this._stopWatching(() => {
+        console.log('mega-watcher stopped');
+        callback();
+      });
     },
 
     /**

--- a/jujugui/static/gui/src/test/globalconfig.js
+++ b/jujugui/static/gui/src/test/globalconfig.js
@@ -33,8 +33,12 @@ Mocha.Suite.prototype.beforeEach = function(title, fn) {
 };
 
 Mocha.Suite.prototype.afterEach = function(func) {
-  var newAfterEach = function(done) {
-    func.apply(this, arguments);
+  const newAfterEach = function(done) {
+    let doneCalled = false;
+    const doneWrapper = () => {
+      done();
+      doneCalled = true;
+    };
     if (this._cleanups && this._cleanups.length) {
       while (this._cleanups.length > 0) {
         // Run the clean up method after popping it off the stack.
@@ -42,9 +46,11 @@ Mocha.Suite.prototype.afterEach = function(func) {
       }
       this._cleanups = [];
     }
-    done();
+    func.call(this, doneWrapper);
+    if (!doneCalled) {
+      done();
+    }
   }
-
   origAfterEach.call(this, newAfterEach);
 };
 

--- a/jujugui/static/gui/src/test/test_controller_api.js
+++ b/jujugui/static/gui/src/test/test_controller_api.js
@@ -68,7 +68,6 @@ describe('Controller API', function() {
   };
 
   describe('findFacadeVersion', function() {
-
     beforeEach(function() {
       controllerAPI.set('facades', {'Test': [0, 1]});
     });
@@ -99,7 +98,40 @@ describe('Controller API', function() {
     it('returns null if a facade version is not supported', function() {
       assert.strictEqual(controllerAPI.findFacadeVersion('BadWolf', 42), null);
     });
+  });
 
+  describe('close', () => {
+    it('stops the pinger', function(done) {
+      const originalClearInterval = clearInterval;
+      clearInterval = sinon.stub();
+      this._cleanups.push(() => {
+        clearInterval = originalClearInterval;
+      });
+      controllerAPI._pinger = 'I am the pinger';
+      controllerAPI.close(() => {
+        assert.strictEqual(clearInterval.calledOnce, true);
+        const pinger = clearInterval.getCall(0).args[0];
+        assert.strictEqual(pinger, 'I am the pinger');
+        assert.strictEqual(controllerAPI._pinger, null);
+        done();
+      });
+    });
+
+    it('resets attributes', done => {
+      controllerAPI.set('controllerAccess', 'test');
+      controllerAPI.close(() => {
+        assert.strictEqual(controllerAPI.get('controllerAccess'), '');
+        done();
+      });
+    });
+
+    it('properly disconnects the user', done => {
+      controllerAPI.userIsAuthenticated = true;
+      controllerAPI.close(() => {
+        assert.strictEqual(controllerAPI.userIsAuthenticated, false);
+        done();
+      });
+    });
   });
 
   describe('login', function() {

--- a/jujugui/static/gui/src/test/test_entity_extension.js
+++ b/jujugui/static/gui/src/test/test_entity_extension.js
@@ -19,7 +19,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 'use strict';
 
 describe('Entity Extension', function() {
-  var Y, EntityModel, entityModel, models, utils, config;
+  var Y, EntityModel, entityModel, jujuConfig, models, utils;
 
   before(function(done) {
     Y = YUI(GlobalConfig).use([
@@ -33,8 +33,9 @@ describe('Entity Extension', function() {
   });
 
   beforeEach(function() {
-    EntityModel = Y.Base.create('entity-model', Y.Base,
-                                [models.EntityExtension], {});
+    jujuConfig = window.juju_config;
+    EntityModel = Y.Base.create(
+      'entity-model', Y.Base, [models.EntityExtension], {});
     entityModel = new EntityModel();
     var attrs = {
       id: '~owner/foobar',
@@ -47,13 +48,11 @@ describe('Entity Extension', function() {
       url: 'http://example.com/'
     };
     entityModel.setAttrs(attrs);
-    // Store the juju_config so that it can be reset after the test runs.
-    config = window.juju_config;
   });
 
   afterEach(function() {
     entityModel.destroy();
-    window.juju_config = config;
+    window.juju_config = jujuConfig;
   });
 
   it('parses owner from the ID', function() {

--- a/jujugui/static/gui/src/test/test_utils.js
+++ b/jujugui/static/gui/src/test/test_utils.js
@@ -350,24 +350,22 @@ describe('utilities', function() {
   });
 
   describe('getIconPath', function() {
-    var config, utils;
+    let jujuConfig, utils;
 
     before(function(done) {
-      window.juju_config = {charmstoreURL: 'local/'};
-      YUI(GlobalConfig).use('juju-view-utils',
-          function(Y) {
-            utils = Y.namespace('juju.views.utils');
-            done();
-          });
+      YUI(GlobalConfig).use('juju-view-utils', function(Y) {
+        utils = Y.namespace('juju.views.utils');
+        done();
+      });
     });
 
-    beforeEach(function() {
-      // Store the juju_config so that it can be reset after the test runs.
-      config = window.juju_config;
+    beforeEach(() => {
+      jujuConfig = window.juju_config;
+      window.juju_config = {charmstoreURL: 'http://4.3.2.1/'};
     });
 
-    afterEach(function() {
-      window.juju_config = config;
+    afterEach(() => {
+      window.juju_config = jujuConfig;
     });
 
     it('returns local default bundle icon location for bundles', function() {
@@ -391,11 +389,7 @@ describe('utilities', function() {
       var path = utils.getIconPath('~paulgear/precise/quassel-core-2');
       assert.equal(
           path,
-          'local/v5/~paulgear/precise/quassel-core-2/icon.svg');
-    });
-
-    after(function() {
-      delete window.juju_config;
+          'http://4.3.2.1/v5/~paulgear/precise/quassel-core-2/icon.svg');
     });
   });
 

--- a/jujugui/static/gui/src/test/utils.js
+++ b/jujugui/static/gui/src/test/utils.js
@@ -97,6 +97,46 @@ YUI(GlobalConfig).add('juju-tests-utils', function(Y) {
       return container;
     },
 
+    /**
+      Create and return a container suitable for rendering the whole app.
+
+      Callers are responsible of removing the container from the document when
+      done.
+
+      @method makeAppContainer
+      @param {Object} yui The YUI instance.
+      @return {Object} The container element, already attached to the window
+        document.
+    */
+    makeAppContainer: (yui) => {
+      const elements = [
+        'charmbrowser-container',
+        'deployment-bar-container',
+        'deployment-container',
+        'drag-over-notification-container',
+        'env-size-display-container',
+        'full-screen-mask',
+        'header-breadcrumb',
+        'header-search-container',
+        'import-export-container',
+        'inspector-container',
+        'loading-message',
+        'login-container',
+        'machine-view',
+        'notifications-container',
+        'profile-link-container',
+        'top-page-container'
+      ];
+      const container = yui.Node.create('<div>');
+      container.set('id', 'test-container');
+      container.addClass('container');
+      elements.forEach(function(id) {
+        container.appendChild(yui.Node.create('<div/>')).set('id', id);
+      });
+      container.appendTo(document.body);
+      return container;
+    },
+
     SocketStub: function() {
       // The readyState needs to be defined because we check for its value
       // before sending any requests to avoid errors.


### PR DESCRIPTION
When logging out now WebSocket connections are properly closed, and the API instances (controller and model) are properly cleaned up in order to avoid any information leak from theoretically logged out connections and from the in-memory database.

Included in this work, a bug prevening login/logout/login again has been fixed by correctly handling the existing credentials when logging out and then logging in again. For instance credentials are now explicitly shared when switching to another model.

This branch also includes extensive sanity improvements to our test suite, especially the old app tests. As part of those improvements, a bug causing the app to dispatch after it's destroyed is also fixed, by cancelling the timer for the method called when the database receives changes.

The _cleanups machinery for the testing suite has been fixed so that at least:
- _cleanups registered functions are called before afterEach (and not after);
- afterEach functions can now use done without the usual "done called more than once" issue (one done was called by the wrapped function, and another from the monkey patched newAfterEach).

Finally, attenuate the horror in the app tests.