### PR TITLE
More automated way for resetting connection attribues.

### DIFF
--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -1587,7 +1587,10 @@ YUI.add('juju-gui', function(Y) {
         return null;
       }
       let matching = [];
-      const modelUUID = this.get('modelUUID');
+      // At this point the modelUUID attribute could have been removed by
+      // the logout process, so fall back to the provided configuration.
+      const modelUUID = this.get('modelUUID') ||
+          (window.juju_config && window.juju_config.jujuEnvUUID);
       if (modelUUID) {
         matching = modelList.filter(model => model.uuid === modelUUID);
       }

--- a/jujugui/static/gui/src/app/store/env/api.js
+++ b/jujugui/static/gui/src/app/store/env/api.js
@@ -486,11 +486,12 @@ YUI.add('juju-env-api', function(Y) {
           previous[current.name] = current.versions;
           return previous;
         }, {});
-        this.set('facades', facades);
+        this.setConnectedAttr('facades', facades);
         var userInfo = response['user-info'];
-        this.set('modelAccess', userInfo['model-access']);
-        this.set('controllerAccess', userInfo['controller-access']);
-        this.set('modelTag', response['model-tag']);
+        this.setConnectedAttr('modelAccess', userInfo['model-access']);
+        this.setConnectedAttr(
+          'controllerAccess', userInfo['controller-access']);
+        this.setConnectedAttr('modelTag', response['model-tag']);
         this.currentModelInfo(this._handleCurrentModelInfo.bind(this));
         this._watchAll();
         // Start pinging the server.
@@ -717,21 +718,7 @@ YUI.add('juju-env-api', function(Y) {
         this._pinger = null;
       }
       const callback = () => {
-        // TODO frankban: find a more automated way to clean up attributes.
-        this.setAttrs({
-          controllerAccess: '',
-          credentialTag: '',
-          defaultSeries: '',
-          cloud: '',
-          environmentName: '',
-          facades: [],
-          maasServer: null,
-          modelAccess: '',
-          modelTag: '',
-          modelUUID: '',
-          providerType: '',
-          region: ''
-        });
+        this.resetConnectedAttrs();
         done();
       };
       if (!this._allWatcherId) {
@@ -768,18 +755,18 @@ YUI.add('juju-env-api', function(Y) {
         return;
       }
       // Store default series and provider type in the env.
-      this.set('defaultSeries', data.series);
-      this.set('providerType', data.provider);
-      this.set('environmentName', data.name);
-      this.set('modelUUID', data.uuid);
-      this.set('cloud', data.cloud);
-      this.set('region', data.region);
-      this.set('credentialTag', data.credentialTag);
+      this.setConnectedAttr('defaultSeries', data.series);
+      this.setConnectedAttr('providerType', data.provider);
+      this.setConnectedAttr('environmentName', data.name);
+      this.setConnectedAttr('modelUUID', data.uuid);
+      this.setConnectedAttr('cloud', data.cloud);
+      this.setConnectedAttr('region', data.region);
+      this.setConnectedAttr('credentialTag', data.credentialTag);
       // For now we only need to call modelGet if the provider is MAAS.
       if (data.provider !== 'maas') {
         // Set the MAAS server to null, so that subscribers waiting for this
         // attribute to be set can be released.
-        this.set('maasServer', null);
+        this.setConnectedAttr('maasServer', null);
         return;
       }
       this.modelGet(data => {
@@ -787,7 +774,7 @@ YUI.add('juju-env-api', function(Y) {
           console.warn('error calling ModelGet API: ' + data.err);
           return;
         }
-        this.set('maasServer', data.config['maas-server'].value);
+        this.setConnectedAttr('maasServer', data.config['maas-server'].value);
       });
     },
 

--- a/jujugui/static/gui/src/app/store/env/controller-api.js
+++ b/jujugui/static/gui/src/app/store/env/controller-api.js
@@ -140,10 +140,11 @@ YUI.add('juju-controller-api', function(Y) {
           previous[current.name] = current.versions;
           return previous;
         }, {});
-        this.set('facades', facades);
+        this.setConnectedAttr('facades', facades);
         var userInfo = response['user-info'];
-        this.set('controllerAccess', userInfo['controller-access']);
-        this.set('serverTag', response['server-tag']);
+        this.setConnectedAttr(
+          'controllerAccess', userInfo['controller-access']);
+        this.setConnectedAttr('serverTag', response['server-tag']);
         // Start pinging the server.
         // XXX frankban: this is only required as a temporary workaround to
         // prevent Apache to disconnect the WebSocket in the embedded Juju.
@@ -331,12 +332,7 @@ YUI.add('juju-controller-api', function(Y) {
         clearInterval(this._pinger);
         this._pinger = null;
       }
-      // TODO frankban: find a more automated way to clean up attributes.
-      this.setAttrs({
-        controllerAccess: '',
-        facades: [],
-        serverTag: ''
-      });
+      this.resetConnectedAttrs();
       done();
     },
 

--- a/jujugui/static/gui/src/app/store/env/legacy-api.js
+++ b/jujugui/static/gui/src/app/store/env/legacy-api.js
@@ -482,7 +482,7 @@ YUI.add('juju-env-legacy-api', function(Y) {
           previous[current.Name] = current.Versions;
           return previous;
         }, {});
-        this.set('facades', facades);
+        this.setConnectedAttr('facades', facades);
         this.environmentInfo();
         this._watchAll();
         // Start pinging the server.
@@ -634,14 +634,7 @@ YUI.add('juju-env-legacy-api', function(Y) {
         this._pinger = null;
       }
       const callback = () => {
-        // TODO frankban: find a more automated way to clean up attributes.
-        this.setAttrs({
-          defaultSeries: '',
-          environmentName: '',
-          facades: [],
-          maasServer: null,
-          providerType: ''
-        });
+        this.resetConnectedAttrs();
         done();
       };
       if (!this._allWatcherId) {
@@ -700,14 +693,14 @@ YUI.add('juju-env-legacy-api', function(Y) {
       }
       // Store default series and provider type in the env.
       var response = data.Response;
-      this.set('defaultSeries', response.DefaultSeries);
-      this.set('providerType', response.ProviderType);
-      this.set('environmentName', response.Name);
+      this.setConnectedAttr('defaultSeries', response.DefaultSeries);
+      this.setConnectedAttr('providerType', response.ProviderType);
+      this.setConnectedAttr('environmentName', response.Name);
       // For now we only need to call environmentGet if the provider is MAAS.
       if (response.ProviderType !== 'maas') {
         // Set the MAAS server to null, so that subscribers waiting for this
         // attribute to be set can be released.
-        this.set('maasServer', null);
+        this.setConnectedAttr('maasServer', null);
         return;
       }
       this.environmentGet(data => {
@@ -715,7 +708,7 @@ YUI.add('juju-env-legacy-api', function(Y) {
           console.warn('error calling ModelGet API: ' + data.err);
           return;
         }
-        this.set('maasServer', data.config['maas-server']);
+        this.setConnectedAttr('maasServer', data.config['maas-server']);
       });
     },
 

--- a/jujugui/static/gui/src/test/test_controller_api.js
+++ b/jujugui/static/gui/src/test/test_controller_api.js
@@ -118,7 +118,7 @@ describe('Controller API', function() {
     });
 
     it('resets attributes', done => {
-      controllerAPI.set('controllerAccess', 'test');
+      controllerAPI.setConnectedAttr('controllerAccess', 'test');
       controllerAPI.close(() => {
         assert.strictEqual(controllerAPI.get('controllerAccess'), '');
         done();

--- a/jujugui/static/gui/src/test/test_env.js
+++ b/jujugui/static/gui/src/test/test_env.js
@@ -121,6 +121,61 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       environments.sessionStorage = original;
     });
 
+    describe('attribute resetter', () => {
+      let baseModel;
+
+      beforeEach(() => {
+        const conn = new ClientConnection({
+          juju: {open: function() {}, close: function() {}}
+        });
+        baseModel = new environments.BaseEnvironment({conn: conn});
+      });
+
+      it('sets attributes', () => {
+        baseModel.setConnectedAttr('myattr', 42);
+        assert.strictEqual(baseModel.get('myattr'), 42);
+      });
+
+      it('sets and resets non-existing attributes', () => {
+        baseModel.setConnectedAttr('myattr', 'bannakaffalatta');
+        assert.strictEqual(baseModel.get('myattr'), 'bannakaffalatta');
+        baseModel.resetConnectedAttrs();
+        assert.strictEqual(baseModel.get('myattr'), null);
+      });
+
+      it('sets and resets existing attributes', () => {
+        baseModel.set('existing', 42);
+        baseModel.setConnectedAttr('existing', 47);
+        assert.strictEqual(baseModel.get('existing'), 47);
+        baseModel.resetConnectedAttrs();
+        assert.strictEqual(baseModel.get('existing'), 42);
+      });
+
+      it('sets and resets attributes multiple times', () => {
+        baseModel.set('existing', '');
+        baseModel.setConnectedAttr('existing', 1);
+        baseModel.setConnectedAttr('existing', 2);
+        baseModel.setConnectedAttr('existing', 3);
+        assert.strictEqual(baseModel.get('existing'), 3);
+        baseModel.resetConnectedAttrs();
+        assert.strictEqual(baseModel.get('existing'), '');
+      });
+
+      it('sets and resets multiple attributes', () => {
+        baseModel.set('attr1', 'initial');
+        baseModel.setConnectedAttr('attr1', 'changed');
+        baseModel.setConnectedAttr('attr2', 'non-empty');
+        baseModel.setConnectedAttr('attr3', undefined);
+        assert.strictEqual(baseModel.get('attr1'), 'changed');
+        assert.strictEqual(baseModel.get('attr2'), 'non-empty');
+        assert.strictEqual(baseModel.get('attr3'), undefined);
+        baseModel.resetConnectedAttrs();
+        assert.strictEqual(baseModel.get('attr1'), 'initial');
+        assert.strictEqual(baseModel.get('attr2'), null);
+        assert.strictEqual(baseModel.get('attr3'), null);
+      });
+    });
+
   });
 
   describe('Base Environment module', function() {

--- a/jujugui/static/gui/src/test/test_env_api.js
+++ b/jujugui/static/gui/src/test/test_env_api.js
@@ -181,9 +181,9 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       });
 
       it('resets attributes', done => {
-        env.set('environmentName', 'test');
+        env.setConnectedAttr('environmentName', 'test');
         env.close(() => {
-          assert.strictEqual(env.get('environmentName'), '');
+          assert.strictEqual(env.get('environmentName'), null);
           done();
         });
       });


### PR DESCRIPTION
Also fix a regression introduced by last branch (modelUUID not found when picking the model). 
See QA instructions for how to ensure it now works.