### PR TITLE
Fetch and use the canonical entity ID when importing bundles

### DIFF
--- a/jujugui/static/gui/src/app/jujulib/charmstore.js
+++ b/jujugui/static/gui/src/app/jujulib/charmstore.js
@@ -284,7 +284,7 @@ var module = module;
         this._generatePath(entityId.replace('cs:', ''), null, '/meta/id'),
         'GET',
         null,
-        handler.bind(this));
+        handler);
     },
     /**
       Makes a request to the charmstore api for the supplied id. Whether that

--- a/jujugui/static/gui/src/app/jujulib/charmstore.js
+++ b/jujugui/static/gui/src/app/jujulib/charmstore.js
@@ -261,6 +261,32 @@ var module = module;
     },
 
     /**
+      Takes the entity id and returns the canonical id for the entity.
+
+      There are a number of variations on charm and bundle ids which are all
+      associated to a canonical id. Ex) cs:trusty/ghost === cs:ghost.
+
+      @method getCanonicalId
+      @param {String} entityId The id to use to fetch the canonical id of.
+      @param {Function} callback The callback which gets called with an error
+        or the canonical entity id.
+    */
+    getCanonicalId: function(entityId, callback) {
+      const handler = (error, data) => {
+        if (error) {
+          callback(error, null);
+          return;
+        }
+        callback(null, data.Id);
+      };
+      jujulib._makeRequest(
+        this.bakery,
+        this._generatePath(entityId.replace('cs:', ''), null, '/meta/id'),
+        'GET',
+        null,
+        handler.bind(this));
+    },
+    /**
       Makes a request to the charmstore api for the supplied id. Whether that
       be a charm or bundle.
 

--- a/jujugui/static/gui/src/app/jujulib/test-charmstore.js
+++ b/jujugui/static/gui/src/app/jujulib/test-charmstore.js
@@ -498,6 +498,38 @@ describe('jujulib charmstore', function() {
     });
   });
 
+  describe('getCanonicalId', function() {
+    it('makes a request to fetch the canonical id for an entity', function() {
+      const callback = sinon.stub();
+      charmstore.getCanonicalId('cs:xenial/ghost-4', callback);
+      const sendGetRequest = charmstore.bakery.sendGetRequest;
+      assert.equal(sendGetRequest.callCount, 1);
+      assert.equal(
+        sendGetRequest.args[0][0], 'local/v5/xenial/ghost-4/meta/id');
+      // Call the success request callback
+      sendGetRequest.args[0][1]({
+        target: {
+          responseText: '{"Id": "cs:ghost"}'
+        }
+      });
+      assert.equal(callback.callCount, 1);
+      assert.deepEqual(callback.args[0], [null, 'cs:ghost']);
+    });
+
+    it('properly calls the callback when there is an error', function() {
+      const callback = sinon.stub();
+      charmstore.getCanonicalId('cs:xenial/ghost-4', callback);
+      const sendGetRequest = charmstore.bakery.sendGetRequest;
+      assert.equal(sendGetRequest.callCount, 1);
+      assert.equal(
+        sendGetRequest.args[0][0], 'local/v5/xenial/ghost-4/meta/id');
+      // Call the error request callback
+      sendGetRequest.args[0][2]('not found');
+      assert.equal(callback.callCount, 1);
+      assert.deepEqual(callback.args[0], ['not found', null]);
+    });
+  });
+
   describe('getEntity', function() {
     it('strips cs from bundle IDs', function() {
       charmstore.getEntity('cs:foobar', sinon.stub());

--- a/jujugui/static/gui/src/app/jujulib/test-charmstore.js
+++ b/jujugui/static/gui/src/app/jujulib/test-charmstore.js
@@ -504,8 +504,8 @@ describe('jujulib charmstore', function() {
       charmstore.getCanonicalId('cs:xenial/ghost-4', callback);
       const sendGetRequest = charmstore.bakery.sendGetRequest;
       assert.equal(sendGetRequest.callCount, 1);
-      assert.equal(
-        sendGetRequest.args[0][0], 'local/v5/xenial/ghost-4/meta/id');
+      const requestPath = sendGetRequest.args[0][0];
+      assert.equal(requestPath, 'local/v5/xenial/ghost-4/meta/id');
       // Call the success request callback
       sendGetRequest.args[0][1]({
         target: {
@@ -521,9 +521,9 @@ describe('jujulib charmstore', function() {
       charmstore.getCanonicalId('cs:xenial/ghost-4', callback);
       const sendGetRequest = charmstore.bakery.sendGetRequest;
       assert.equal(sendGetRequest.callCount, 1);
-      assert.equal(
-        sendGetRequest.args[0][0], 'local/v5/xenial/ghost-4/meta/id');
-      // Call the error request callback
+      const requestPath = sendGetRequest.args[0][0];
+      assert.equal(requestPath, 'local/v5/xenial/ghost-4/meta/id');
+      // Call the error request callback.
       sendGetRequest.args[0][2]('not found');
       assert.equal(callback.callCount, 1);
       assert.deepEqual(callback.args[0], ['not found', null]);

--- a/jujugui/static/gui/src/test/test_bundle_importer.js
+++ b/jujugui/static/gui/src/test/test_bundle_importer.js
@@ -340,6 +340,11 @@ describe('Bundle Importer', function() {
   describe('Changeset execution', function() {
 
     it('Sets up the correct environment (v5 Integration)', function(done) {
+      let getCanonicalIdCount = 0;
+      fakebackend.get('charmstore').getCanonicalId = (entityId, callback) => {
+        getCanonicalIdCount += 1;
+        callback(null, entityId);
+      };
       var data = utils.loadFixture(
           'data/wordpress-bundle-recordset.json', true);
       bundleImporter.db.after('bundleImportComplete', function() {
@@ -393,6 +398,7 @@ describe('Bundle Importer', function() {
         assert.equal(db.services.item(1).get('exposed'), false);
         assert.equal(db.services.item(2).get('exposed'), true);
         assert.equal(db.services.item(3).get('exposed'), false);
+        assert.equal(getCanonicalIdCount, 3);
         done();
       });
       bundleImporter.importBundleDryRun(data);


### PR DESCRIPTION
It's possible that a user supplied charm ID is not the canonical ID. This would mean an ID mismatch between the charm that was added and then the application that was deployed causing errors on deploy.

Fixes #2021