### PR TITLE
Don't reset the DB when using the blues flag

### DIFF
--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -552,9 +552,10 @@ YUI.add('juju-gui', function(Y) {
           // The model is not connected, do nothing waiting for a reconnection.
           return;
         }
-        // If we're in GISF we do not want to empty the db when we connect
-        // because the user may have made changes to the temporary model.
-        if (!this.get('gisf')) {
+        // If we're in GISF or using the blues flag we do not want to empty the
+        // db when we connect because the user may have made changes to the
+        // temporary model.
+        if (!this.get('gisf') && (!window.flags || !window.flags.blues)) {
           this.db.reset();
         }
         this.env.userIsAuthenticated = false;

--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -552,10 +552,11 @@ YUI.add('juju-gui', function(Y) {
           // The model is not connected, do nothing waiting for a reconnection.
           return;
         }
-        // If we're in GISF or using the blues flag we do not want to empty the
-        // db when we connect because the user may have made changes to the
-        // temporary model.
-        if (!this.get('gisf') && (!window.flags || !window.flags.blues)) {
+        // If we're using the blues flag we do not want to empty the db when we
+        // connect because the user may have made changes to the temporary
+        // model. When flags.blues is removed we can remove the reset as well as
+        // it will never be called.
+        if (!window.flags || !window.flags.blues) {
           this.db.reset();
         }
         this.env.userIsAuthenticated = false;

--- a/jujugui/static/gui/src/app/views/utils.js
+++ b/jujugui/static/gui/src/app/views/utils.js
@@ -1607,22 +1607,9 @@ YUI.add('juju-view-utils', function(Y) {
       app, app.createSocketURL.bind(app, app.get('socketTemplate')),
       app.switchEnv.bind(app), app.env, model.uuid, [model], model.name,
       env => {
-        utils._detachOnLoginHandler();
         env.get('ecs').commit(env);
         callback();
       }, false, false);
-  };
-
-  /**
-    Detach the handler for committing the changeset on login.
-
-    @method _detachOnLoginHandler
-  */
-  utils._detachOnLoginHandler = function() {
-    if (this._onLoginHandler) {
-      this._onLoginHandler.detach();
-      this._onLoginHandler = null;
-    }
   };
 
   /**


### PR DESCRIPTION
Deploying models wouldn't work as the database was being cleared before the changes could be applied.