### PR TITLE
Use new Juju 2 endpoint for getting the local charm icon.

### DIFF
--- a/jujugui/static/gui/src/app/store/env/api.js
+++ b/jujugui/static/gui/src/app/store/env/api.js
@@ -911,18 +911,38 @@ YUI.add('juju-env-api', function(Y) {
       Return the full URL to the Juju HTTPS API serving a local charm file.
 
       @method getLocalCharmFileUrl
-      @param {String} charmUrl The local charm URL,
-        e.g. "local:strusty/django-42".
-      @param {String} filename The file name/path.
-        e.g. "icon.svg" or "hooks/install".
+      @param {String} charmUrl The local charm URL, for instance
+        local:trusty/django-42".
+      @param {String} filename The file name/path, for instance "icon.svg" or
+        "hooks/install".
       @return {String} The full URL to the file contents, including auth
         credentials.
     */
     getLocalCharmFileUrl: function(charmUrl, filename) {
-      var credentials = this.getCredentials();
-      var path = _getCharmAPIPath(
+      const credentials = this.getCredentials();
+      const path = _getCharmAPIPath(
           this.get('modelUUID'), 'url=' + charmUrl + '&file=' + filename);
-      var webHandler = this.get('webHandler');
+      const webHandler = this.get('webHandler');
+      // TODO frankban: allow macaroons based auth here.
+      return webHandler.getUrl(
+        path, tags.build(tags.USER, credentials.user), credentials.password);
+    },
+
+    /**
+      Return the full URL to a local charm icon.
+
+      If the local charm has no icon, a default icon is served.
+
+      @method getLocalCharmIcon
+      @param {String} charmUrl The local charm URL, for instance
+        "local:trusty/django-42".
+      @return {String} The full URL to the icon, including auth credentials.
+    */
+    getLocalCharmIcon: function(charmUrl) {
+      const credentials = this.getCredentials();
+      const uuid = this.get('modelUUID');
+      const path = _getCharmAPIPath(uuid, 'url=' + charmUrl + '&icon=1');
+      const webHandler = this.get('webHandler');
       // TODO frankban: allow macaroons based auth here.
       return webHandler.getUrl(
         path, tags.build(tags.USER, credentials.user), credentials.password);

--- a/jujugui/static/gui/src/app/store/env/fakebackend.js
+++ b/jujugui/static/gui/src/app/store/env/fakebackend.js
@@ -1862,6 +1862,10 @@ YUI.add('juju-env-fakebackend', function(Y) {
       Return the URL to a local charm file.
 
       @method getLocalCharmFileUrl
+      @param {String} charmUrl The local charm URL, for instance
+        local:trusty/django-42".
+      @param {String} filename The file name/path, for instance "icon.svg" or
+        "hooks/install".
       @return {String} The full URL to the charm file.
     */
     getLocalCharmFileUrl: function(charmUrl, filename) {
@@ -1873,6 +1877,18 @@ YUI.add('juju-env-fakebackend', function(Y) {
       // This is in theory unreachable: with the exception of the icon, other
       // file URLs are not currently requested.
       console.error('unexpected getLocalCharmFileUrl request for ' + filename);
+    },
+
+    /**
+      Return the full URL to a local charm icon.
+
+      @method getLocalCharmIcon
+      @param {String} charmUrl The local charm URL, for instance
+        "local:trusty/django-42".
+      @return {String} The full URL to the icon, including auth credentials.
+    */
+    getLocalCharmIcon: function(charmUrl) {
+      return this.getLocalCharmFileUrl(charmUrl, 'icon.svg');
     }
 
   });

--- a/jujugui/static/gui/src/app/store/env/legacy-api.js
+++ b/jujugui/static/gui/src/app/store/env/legacy-api.js
@@ -809,10 +809,10 @@ YUI.add('juju-env-legacy-api', function(Y) {
       Return the full URL to the Juju HTTPS API serving a local charm file.
 
       @method getLocalCharmFileUrl
-      @param {String} charmUrl The local charm URL,
-        e.g. "local:strusty/django-42".
-      @param {String} filename The file name/path.
-        e.g. "icon.svg" or "hooks/install".
+      @param {String} charmUrl The local charm URL, for instance
+        local:trusty/django-42".
+      @param {String} filename The file name/path, for instance "icon.svg" or
+        "hooks/install".
       @return {String} The full URL to the file contents, including auth
         credentials.
     */
@@ -823,6 +823,18 @@ YUI.add('juju-env-legacy-api', function(Y) {
       // TODO frankban: allow macaroons based auth here.
       return webHandler.getUrl(
         path, tags.build(tags.USER, credentials.user), credentials.password);
+    },
+
+    /**
+      Return the full URL to a local charm icon.
+
+      @method getLocalCharmIcon
+      @param {String} charmUrl The local charm URL, for instance
+        "local:trusty/django-42".
+      @return {String} The full URL to the icon, including auth credentials.
+    */
+    getLocalCharmIcon: function(charmUrl) {
+      return this.getLocalCharmFileUrl(charmUrl, 'icon.svg');
     },
 
     /**

--- a/jujugui/static/gui/src/app/views/utils.js
+++ b/jujugui/static/gui/src/app/views/utils.js
@@ -1190,7 +1190,7 @@ YUI.add('juju-view-utils', function(Y) {
         localIndex = charmId.indexOf('local:'),
         path;
     if (localIndex > -1 && env) {
-      path = env.getLocalCharmFileUrl(charmId, 'icon.svg');
+      path = env.getLocalCharmIcon(charmId);
     } else if (localIndex === -1) {
       if (typeof isBundle === 'boolean' && isBundle) {
         var staticURL = '';

--- a/jujugui/static/gui/src/test/test_env_api.js
+++ b/jujugui/static/gui/src/test/test_env_api.js
@@ -1065,7 +1065,6 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     });
 
     describe('getLocalCharmFileUrl', function() {
-
       it('uses the stored webHandler to retrieve the file URL', function() {
         const mockWebHandler = {getUrl: sinon.stub().returns('myurl')};
         env.set('webHandler', mockWebHandler);
@@ -1083,7 +1082,25 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
         assert.strictEqual(lastArguments[1], 'user-user@local'); // User name.
         assert.strictEqual(lastArguments[2], 'password'); // Password.
       });
+    });
 
+    describe('getLocalCharmIcon', function() {
+      it('uses the stored webHandler to retrieve the icon URL', function() {
+        const mockWebHandler = {getUrl: sinon.stub().returns('myurl')};
+        env.set('webHandler', mockWebHandler);
+        const url = env.getLocalCharmIcon('local:trusty/django-2', 'icon.svg');
+        assert.strictEqual(url, 'myurl');
+        // Ensure the web handler's getUrl method has been called with the
+        // expected arguments.
+        assert.strictEqual(mockWebHandler.getUrl.callCount, 1);
+        const lastArguments = mockWebHandler.getUrl.lastCall.args;
+        assert.strictEqual(lastArguments.length, 3);
+        const expected = '/juju-core/model/this-is-a-uuid/charms?' +
+            'url=local:trusty/django-2&icon=1';
+        assert.strictEqual(lastArguments[0], expected);
+        assert.strictEqual(lastArguments[1], 'user-user@local'); // User name.
+        assert.strictEqual(lastArguments[2], 'password'); // Password.
+      });
     });
 
     describe('listLocalCharmFiles', function() {

--- a/jujugui/static/gui/src/test/test_env_legacy_api.js
+++ b/jujugui/static/gui/src/test/test_env_legacy_api.js
@@ -707,7 +707,6 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     });
 
     describe('getLocalCharmFileUrl', function() {
-
       it('uses the stored webHandler to retrieve the file URL', function() {
         const mockWebHandler = {getUrl: sinon.stub().returns('myurl')};
         env.set('webHandler', mockWebHandler);
@@ -725,7 +724,25 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
         assert.strictEqual(lastArguments[1], 'user-user@local'); // User name.
         assert.strictEqual(lastArguments[2], 'password'); // Password.
       });
+    });
 
+    describe('getLocalCharmIcon', function() {
+      it('uses the stored webHandler to retrieve the icon URL', function() {
+        const mockWebHandler = {getUrl: sinon.stub().returns('myurl')};
+        env.set('webHandler', mockWebHandler);
+        const url = env.getLocalCharmIcon('local:trusty/django-2', 'icon.svg');
+        assert.strictEqual(url, 'myurl');
+        // Ensure the web handler's getUrl method has been called with the
+        // expected arguments.
+        assert.strictEqual(mockWebHandler.getUrl.callCount, 1);
+        const lastArguments = mockWebHandler.getUrl.lastCall.args;
+        assert.strictEqual(lastArguments.length, 3);
+        assert.strictEqual(
+            lastArguments[0],
+            '/juju-core/charms?url=local:trusty/django-2&file=icon.svg');
+        assert.strictEqual(lastArguments[1], 'user-user@local'); // User name.
+        assert.strictEqual(lastArguments[2], 'password'); // Password.
+      });
     });
 
     describe('listLocalCharmFiles', function() {

--- a/jujugui/static/gui/src/test/test_environment_view.js
+++ b/jujugui/static/gui/src/test/test_environment_view.js
@@ -1642,7 +1642,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
     it('retrieves local charms icons from the Juju env', function() {
       var fakeEnv = {
-        getLocalCharmFileUrl: sinon.stub().returns('local charm icon')
+        getLocalCharmIcon: sinon.stub().returns('local charm icon')
       };
       var services = new models.ServiceList();
       services.add([


### PR DESCRIPTION
This way, if the local charm has no icon, a default one is still displayed.

Fixes #1649