### PR TITLE
Remove defunct add credentials region select

### DIFF
--- a/jujugui/static/gui/src/app/components/deployment-flow/credential/add/add.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/credential/add/add.js
@@ -28,10 +28,7 @@ YUI.add('deployment-credential-add', function() {
       clouds: React.PropTypes.object.isRequired,
       generateCloudCredentialName: React.PropTypes.func.isRequired,
       getCredentials: React.PropTypes.func.isRequired,
-      region: React.PropTypes.string,
-      regions: React.PropTypes.array.isRequired,
       setCredential: React.PropTypes.func.isRequired,
-      setRegion: React.PropTypes.func.isRequired,
       updateCloudCredential: React.PropTypes.func.isRequired,
       user: React.PropTypes.string,
       validateForm: React.PropTypes.func.isRequired
@@ -46,15 +43,6 @@ YUI.add('deployment-credential-add', function() {
       };
     },
 
-    /**
-      Get the region value.
-
-      @method _getRegion
-      @returns {String} The region.
-    */
-    _getRegion: function() {
-      return this.refs.region.getValue();
-    },
 
     /**
       Generate a full credential object in the expected format.
@@ -238,25 +226,6 @@ YUI.add('deployment-credential-add', function() {
         </div>);
     },
 
-    /**
-      Generate the list of region options.
-
-      @method _generateRegions
-      @returns {Array} The list of region options.
-    */
-    _generateRegions: function() {
-      var regions = this.props.regions;
-      if (!regions) {
-        return [];
-      }
-      return regions.map((region) => {
-        return {
-          label: region.name,
-          value: region.name
-        };
-      });
-    },
-
     render: function() {
       var buttons = [{
         action: this.props.close,
@@ -291,7 +260,7 @@ YUI.add('deployment-credential-add', function() {
             </a>
           </div>
           <form className="twelve-col">
-            <div className="six-col">
+            <div className="six-col last-col">
               <juju.components.GenericInput
                 disabled={isReadOnly}
                 label={credentialName}
@@ -307,14 +276,6 @@ YUI.add('deployment-credential-add', function() {
                     'letters, numbers, and hyphens. It must not start or ' +
                     'end with a hyphen.'
                 }]} />
-            </div>
-            <div className="six-col last-col">
-              <juju.components.InsetSelect
-                disabled={isReadOnly}
-                label="Region"
-                options={this._generateRegions()}
-                ref="region"
-                value={this.props.region} />
             </div>
             <h3 className="deployment-panel__section-title twelve-col">
               Enter credentials

--- a/jujugui/static/gui/src/app/components/deployment-flow/credential/add/test-add.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/credential/add/test-add.js
@@ -81,9 +81,7 @@ describe('DeploymentCredentialAdd', function() {
         clouds={clouds}
         generateCloudCredentialName={sinon.stub()}
         getCredentials={sinon.stub()}
-        regions={[{name: 'test-region'}]}
         setCredential={sinon.stub()}
-        setRegion={sinon.stub()}
         user="user-admin"
         validateForm={sinon.stub()} />, true);
     var instance = renderer.getMountedInstance();
@@ -102,7 +100,7 @@ describe('DeploymentCredentialAdd', function() {
           </a>
         </div>
         <form className="twelve-col">
-          <div className="six-col">
+          <div className="six-col last-col">
             <juju.components.GenericInput
               disabled={false}
               label="Project ID (credential name)"
@@ -118,17 +116,6 @@ describe('DeploymentCredentialAdd', function() {
                   'letters, numbers, and hyphens. It must not start or ' +
                   'end with a hyphen.'
               }]} />
-          </div>
-          <div className="six-col last-col">
-            <juju.components.InsetSelect
-              disabled={false}
-              label="Region"
-              options={[{
-                label: 'test-region',
-                value: 'test-region'
-              }]}
-              ref="region"
-              value={undefined} />
           </div>
           <h3 className="deployment-panel__section-title twelve-col">
             Enter credentials
@@ -224,9 +211,7 @@ describe('DeploymentCredentialAdd', function() {
         clouds={clouds}
         generateCloudCredentialName={sinon.stub()}
         getCredentials={sinon.stub()}
-        regions={[{name: 'test-region'}]}
         setCredential={sinon.stub()}
-        setRegion={sinon.stub()}
         user="user-admin"
         validateForm={sinon.stub()} />, true);
     var instance = renderer.getMountedInstance();
@@ -245,7 +230,7 @@ describe('DeploymentCredentialAdd', function() {
           </a>
         </div>
         <form className="twelve-col">
-          <div className="six-col">
+          <div className="six-col last-col">
             <juju.components.GenericInput
               disabled={false}
               label="Project ID (credential name)"
@@ -261,17 +246,6 @@ describe('DeploymentCredentialAdd', function() {
                   'letters, numbers, and hyphens. It must not start or ' +
                   'end with a hyphen.'
               }]} />
-          </div>
-          <div className="six-col last-col">
-            <juju.components.InsetSelect
-              disabled={false}
-              label="Region"
-              options={[{
-                label: 'test-region',
-                value: 'test-region'
-              }]}
-              ref="region"
-              value={undefined} />
           </div>
           <h3 className="deployment-panel__section-title twelve-col">
             Enter credentials
@@ -367,9 +341,7 @@ describe('DeploymentCredentialAdd', function() {
         clouds={clouds}
         generateCloudCredentialName={sinon.stub()}
         getCredentials={sinon.stub()}
-        regions={[{name: 'test-region'}]}
         setCredential={sinon.stub()}
-        setRegion={sinon.stub()}
         user="user-admin"
         validateForm={sinon.stub()} />, true);
     var instance = renderer.getMountedInstance();
@@ -389,7 +361,7 @@ describe('DeploymentCredentialAdd', function() {
           </a>
         </div>
         <form className="twelve-col">
-          <div className="six-col">
+          <div className="six-col last-col">
             <juju.components.GenericInput
               disabled={false}
               label="Project ID (credential name)"
@@ -405,17 +377,6 @@ describe('DeploymentCredentialAdd', function() {
                   'letters, numbers, and hyphens. It must not start or ' +
                   'end with a hyphen.'
               }]} />
-          </div>
-          <div className="six-col last-col">
-            <juju.components.InsetSelect
-              disabled={false}
-              label="Region"
-              options={[{
-                label: 'test-region',
-                value: 'test-region'
-              }]}
-              ref="region"
-              value={undefined} />
           </div>
           <h3 className="deployment-panel__section-title twelve-col">
             Enter credentials
@@ -488,9 +449,7 @@ describe('DeploymentCredentialAdd', function() {
         clouds={clouds}
         generateCloudCredentialName={sinon.stub()}
         getCredentials={sinon.stub()}
-        regions={[{name: 'test-region'}]}
         setCredential={sinon.stub()}
-        setRegion={sinon.stub()}
         user="user-admin"
         validateForm={sinon.stub()} />, true);
     var instance = renderer.getMountedInstance();
@@ -509,7 +468,7 @@ describe('DeploymentCredentialAdd', function() {
           </a>
         </div>
         <form className="twelve-col">
-          <div className="six-col">
+          <div className="six-col last-col">
             <juju.components.GenericInput
               disabled={true}
               label="Project ID (credential name)"
@@ -525,17 +484,6 @@ describe('DeploymentCredentialAdd', function() {
                   'letters, numbers, and hyphens. It must not start or ' +
                   'end with a hyphen.'
               }]} />
-          </div>
-          <div className="six-col last-col">
-            <juju.components.InsetSelect
-              disabled={true}
-              label="Region"
-              options={[{
-                label: 'test-region',
-                value: 'test-region'
-              }]}
-              ref="region"
-              value={undefined} />
           </div>
           <h3 className="deployment-panel__section-title twelve-col">
             Enter credentials
@@ -631,9 +579,7 @@ describe('DeploymentCredentialAdd', function() {
           clouds={clouds}
           generateCloudCredentialName={sinon.stub().returns('new@test')}
           getCredentials={getCredentials}
-          regions={['us-east-1']}
           setCredential={sinon.stub()}
-          setRegion={sinon.stub()}
           user="user-admin"
           validateForm={sinon.stub().returns(true)} />, true);
     var instance = renderer.getMountedInstance();
@@ -684,9 +630,7 @@ describe('DeploymentCredentialAdd', function() {
         clouds={clouds}
         generateCloudCredentialName={sinon.stub()}
         getCredentials={sinon.stub()}
-        regions={[{name: 'test-region'}]}
         setCredential={sinon.stub()}
-        setRegion={sinon.stub()}
         user="user-admin"
         validateForm={sinon.stub().returns(true)} />, true);
     const instance = renderer.getMountedInstance();
@@ -729,9 +673,7 @@ describe('DeploymentCredentialAdd', function() {
           clouds={clouds}
           generateCloudCredentialName={sinon.stub()}
           getCredentials={sinon.stub()}
-          regions={[{name: 'test-regiZon'}]}
           setCredential={sinon.stub()}
-          setRegion={sinon.stub()}
           user="user-admin"
           validateForm={sinon.stub().returns(false)} />, true);
     var instance = renderer.getMountedInstance();

--- a/jujugui/static/gui/src/app/components/deployment-flow/credential/credential.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/credential/credential.js
@@ -249,10 +249,7 @@ YUI.add('deployment-credential', function() {
           clouds={this.props.clouds}
           generateCloudCredentialName={this.props.generateCloudCredentialName}
           getCredentials={this._getCredentials}
-          region={this.props.region}
-          regions={this.props.cloud && this.props.cloud.regions || []}
           setCredential={this.props.setCredential}
-          setRegion={this.props.setRegion}
           updateCloudCredential={this.props.updateCloudCredential}
           user={this.props.user}
           validateForm={this.props.validateForm} />);

--- a/jujugui/static/gui/src/app/components/deployment-flow/credential/test-credential.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/credential/test-credential.js
@@ -107,10 +107,7 @@ describe('DeploymentCredential', function() {
             clouds={clouds}
             generateCloudCredentialName={generateCloudCredentialName}
             getCredentials={instance._getCredentials}
-            region={undefined}
-            regions={regions}
             setCredential={setCredential}
-            setRegion={setRegion}
             user={user}
             validateForm={validateForm}/>
         </juju.components.ExpandingRow>
@@ -220,10 +217,7 @@ describe('DeploymentCredential', function() {
             clouds={clouds}
             generateCloudCredentialName={generateCloudCredentialName}
             getCredentials={instance._getCredentials}
-            region={undefined}
-            regions={[]}
             setCredential={setCredential}
-            setRegion={setRegion}
             user={user}
             validateForm={validateForm} />
         </juju.components.ExpandingRow>
@@ -442,10 +436,7 @@ describe('DeploymentCredential', function() {
             clouds={clouds}
             generateCloudCredentialName={generateCloudCredentialName}
             getCredentials={instance._getCredentials}
-            region={undefined}
-            regions={regions}
             setCredential={setCredential}
-            setRegion={setRegion}
             user={user}
             validateForm={validateForm}/>
         </juju.components.ExpandingRow>


### PR DESCRIPTION
The select was not being used and is not in the latest designs, was left in from a previous version of the deployment flow. Fixes #2064.