### PR TITLE
When removing applications also remove the addCharm call

### DIFF
--- a/jujugui/static/gui/src/app/store/env/api.js
+++ b/jujugui/static/gui/src/app/store/env/api.js
@@ -1985,8 +1985,8 @@ YUI.add('juju-env-api', function(Y) {
       @method destroyApplication
     */
     destroyApplication: function(applicationName, callback, options) {
-      var ecs = this.get('ecs');
-      var args = ecs._getArgs(arguments);
+      const ecs = this.get('ecs');
+      const args = ecs._getArgs(arguments);
       if (options && options.immediate) {
         this._destroyApplication.apply(this, args);
       } else {

--- a/jujugui/static/gui/src/app/utils/environment-change-set.js
+++ b/jujugui/static/gui/src/app/utils/environment-change-set.js
@@ -740,10 +740,20 @@ YUI.add('environment-change-set', function(Y) {
       model.updateSubordinateUnits(db);
       model.destroy();
       this._removeExistingRecord(recordKey);
-      // Remove the record for the addCharm
+      // Check if there are other applications using the same charm. If not
+      // then remove the addCharm call.
       record.parents.some(key => {
         if (key.indexOf('addCharm-') === 0) {
-          this._removeExistingRecord(key);
+          const used = Object.keys(this.changeSet).some(recordKey => {
+            if (recordKey.indexOf('service-') === 0) {
+              return this.changeSet[recordKey].parents.includes(key);
+            }
+          });
+          // If the addCharm call is not used anywhere else then it can be
+          // safely removed.
+          if (!used) {
+            this._removeExistingRecord(key);
+          }
         }
       });
     },

--- a/jujugui/static/gui/src/app/utils/environment-change-set.js
+++ b/jujugui/static/gui/src/app/utils/environment-change-set.js
@@ -576,6 +576,13 @@ YUI.add('environment-change-set', function(Y) {
       @param {Array} args The arguments to add the charm with.
     */
     _lazyAddCharm: function(args) {
+      const existing = Object.keys(this.changeSet).some(key => {
+        return this.changeSet[key].command.args[0] === args[0];
+      });
+      // If there is an existing record for this charm then don't add another.
+      if (existing) {
+        return;
+      }
       var command = {
         method: '_addCharm',
         args: this._getArgs(args),
@@ -640,7 +647,7 @@ YUI.add('environment-change-set', function(Y) {
         const record = this.changeSet[key];
         if (record.command.method === '_addCharm') {
           // Get the key to the record which adds the charm for this app.
-          if (record.command.options.applicationId === args[9].modelId) {
+          if (record.command.args[0] === args[0]) {
             parents.push(key);
           }
         }

--- a/jujugui/static/gui/src/app/utils/environment-change-set.js
+++ b/jujugui/static/gui/src/app/utils/environment-change-set.js
@@ -583,6 +583,7 @@ YUI.add('environment-change-set', function(Y) {
       };
       return this._createNewRecord('addCharm', command, []);
     },
+
     /**
       Creates a new entry in the queue for creating a new service.
 
@@ -636,9 +637,10 @@ YUI.add('environment-change-set', function(Y) {
       // Set up the parents of this record.
       var parents = [];
       Object.keys(this.changeSet).forEach(key => {
-        if (this.changeSet[key].command.method === '_addCharm') {
+        const record = this.changeSet[key];
+        if (record.command.method === '_addCharm') {
           // Get the key to the record which adds the charm for this app.
-          if (this.changeSet[key].command.args[0] === args[0]) {
+          if (record.command.options.applicationId === args[9].modelId) {
             parents.push(key);
           }
         }
@@ -673,17 +675,20 @@ YUI.add('environment-change-set', function(Y) {
       if (command.args.length !== args.length) {
         command.options = args[args.length - 1];
       }
-      var existingService;
+      let existingService;
+      let record;
       // Check if the service is pending in the change set.
-      Object.keys(this.changeSet).forEach(function(key) {
+      Object.keys(this.changeSet).some(key => {
         if (this.changeSet[key].command.method === '_deploy') {
           if (this.changeSet[key].command.options.modelId === args[0]) {
             existingService = key;
+            record = this.changeSet[key];
+            return true;
           }
         }
-      }, this);
+      });
       if (existingService) {
-        this._destroyQueuedService(existingService);
+        this._destroyQueuedService(existingService, record);
       } else {
         var service = this.get('db').services.getById(args[0]);
         // Remove any unplaced units.
@@ -699,21 +704,22 @@ YUI.add('environment-change-set', function(Y) {
 
     /**
       In the event that a service in the change set needs to be destroyed,
-      remove it and all of the entries of which it is a parent.
+      remove it and all of the entries of which it is a parent as well as
+      the addCharm call associated with this application.
 
       @method _destroyQueuedService
-      @param {String} service The key of the service to be destroyed.
+      @param {String} recordKey The key of the service to be destroyed.
     */
-    _destroyQueuedService: function(service) {
+    _destroyQueuedService: function(recordKey, record) {
       // Search for everything that has that service as a parent and remove it.
       Object.keys(this.changeSet).forEach(function(key) {
-        if (this.changeSet[key].parents.indexOf(service) !== -1) {
+        if (this.changeSet[key].parents.indexOf(recordKey) !== -1) {
           this._removeExistingRecord(key);
         }
       }, this);
       // Remove the service itself.
       var db = this.get('db');
-      var modelId = this.changeSet[service].command.options.modelId;
+      var modelId = this.changeSet[recordKey].command.options.modelId;
       var model = db.services.getById(modelId);
       var units = model.get('units');
       var relations = model.get('relations');
@@ -726,7 +732,13 @@ YUI.add('environment-change-set', function(Y) {
       db.services.remove(model);
       model.updateSubordinateUnits(db);
       model.destroy();
-      this._removeExistingRecord(service);
+      this._removeExistingRecord(recordKey);
+      // Remove the record for the addCharm
+      record.parents.some(key => {
+        if (key.indexOf('addCharm-') === 0) {
+          this._removeExistingRecord(key);
+        }
+      });
     },
 
     /**

--- a/jujugui/static/gui/src/app/utils/relation-utils.js
+++ b/jujugui/static/gui/src/app/utils/relation-utils.js
@@ -126,13 +126,18 @@ YUI.add('relation-utils', function(Y) {
         var farService;
         // far will be undefined or the far endpoint service.
         if (far) {
-          var id = far[0];
-          farService = {
-            service: id,
-            serviceName: db.services.getById(id).get('name'),
-            role: far[1].role,
-            name: far[1].name
-          };
+          const id = far[0];
+          const application = db.services.getById(id);
+          // The uncommitted application could been removed so check it is
+          // really there.
+          if (application) {
+            farService = {
+              service: id,
+              serviceName: application.get('name'),
+              role: far[1].role,
+              name: far[1].name
+            };
+          }
         }
         rel.far = farService;
         var relationId = rel.relation_id;


### PR DESCRIPTION
When removing uncommitted applications we also need to remove the addCharm call if there are no other applications using that same addCharm call. This also contains a fix for removing relations when removing uncommitted applications added via a bundle import.

Fixes #2045
Fixes #2088 
