### PR TITLE
When removing applications also remove the addCharm call

### DIFF
--- a/jujugui/static/gui/src/app/store/env/api.js
+++ b/jujugui/static/gui/src/app/store/env/api.js
@@ -1990,11 +1990,7 @@ YUI.add('juju-env-api', function(Y) {
       if (options && options.immediate) {
         this._destroyApplication.apply(this, args);
       } else {
-        const charmId = ecs.get('db').services.getById(args[0]).get('charm');
         ecs.lazyDestroyApplication(args);
-        // When destroying an application we also need to remove the added
-        // charm from the ecs if it exists.
-        ecs.lazyRemoveCharm(charmId);
       }
     },
 

--- a/jujugui/static/gui/src/app/store/env/api.js
+++ b/jujugui/static/gui/src/app/store/env/api.js
@@ -1985,12 +1985,16 @@ YUI.add('juju-env-api', function(Y) {
       @method destroyApplication
     */
     destroyApplication: function(applicationName, callback, options) {
-      var ecs = this.get('ecs');
-      var args = ecs._getArgs(arguments);
+      const ecs = this.get('ecs');
+      const args = ecs._getArgs(arguments);
       if (options && options.immediate) {
         this._destroyApplication.apply(this, args);
       } else {
+        const charmId = ecs.get('db').services.getById(args[0]).get('charm');
         ecs.lazyDestroyApplication(args);
+        // When destroying an application we also need to remove the added
+        // charm from the ecs if it exists.
+        ecs.lazyRemoveCharm(charmId);
       }
     },
 

--- a/jujugui/static/gui/src/app/utils/environment-change-set.js
+++ b/jujugui/static/gui/src/app/utils/environment-change-set.js
@@ -637,9 +637,10 @@ YUI.add('environment-change-set', function(Y) {
       // Set up the parents of this record.
       var parents = [];
       Object.keys(this.changeSet).forEach(key => {
-        if (this.changeSet[key].command.method === '_addCharm') {
+        const record = this.changeSet[key];
+        if (record.command.method === '_addCharm') {
           // Get the key to the record which adds the charm for this app.
-          if (this.changeSet[key].command.args[0] === args[0]) {
+          if (record.command.options.applicationId === args[9].modelId) {
             parents.push(key);
           }
         }

--- a/jujugui/static/gui/src/app/utils/environment-change-set.js
+++ b/jujugui/static/gui/src/app/utils/environment-change-set.js
@@ -715,7 +715,8 @@ YUI.add('environment-change-set', function(Y) {
       the addCharm call associated with this application.
 
       @method _destroyQueuedService
-      @param {String} recordKey The key of the service to be destroyed.
+      @param {String} recordKey The key of the application to be destroyed.
+      @param {String} record The changeSet record for the application.
     */
     _destroyQueuedService: function(recordKey, record) {
       // Search for everything that has that service as a parent and remove it.

--- a/jujugui/static/gui/src/app/utils/environment-change-set.js
+++ b/jujugui/static/gui/src/app/utils/environment-change-set.js
@@ -740,10 +740,20 @@ YUI.add('environment-change-set', function(Y) {
       model.updateSubordinateUnits(db);
       model.destroy();
       this._removeExistingRecord(recordKey);
-      // Remove the record for the addCharm
+      // Check if there are other applications using the same charm. If not
+      // then remove the addCharm call.
       record.parents.some(key => {
         if (key.indexOf('addCharm-') === 0) {
-          this._removeExistingRecord(key);
+          const used = Object.keys(this.changeSet).some(recordKey => {
+            if (recordKey.indexOf('service-') === 0) {
+              return this.changeSet[recordKey].parents.includes(key);
+            }
+          });
+          // If the addCharm call is not used anywhere else then it can be
+          // safely removed.
+          if (!used) {
+            this._removeExistingRecord(key);
+          }
         }
       });
     },

--- a/jujugui/static/gui/src/app/utils/environment-change-set.js
+++ b/jujugui/static/gui/src/app/utils/environment-change-set.js
@@ -583,6 +583,29 @@ YUI.add('environment-change-set', function(Y) {
       };
       return this._createNewRecord('addCharm', command, []);
     },
+
+    /**
+      Removes the addCharm entry from the ecs for the supplied charm. This
+      is typically required when an application has yet to be deployed
+      and is then destroyed. At this point we no longer want to add the charm
+      to the model.
+
+      @method lazyRemoveCharm
+      @param {String} charmId The charm id to remove from the changeset.
+    */
+    lazyRemoveCharm: function(charmId) {
+      // Loop through the changeSet looking for addCharm commands and check
+      // if the added charm matches the supplied charm.
+      Object.keys(this.changeSet).some(key => {
+        if (key.indexOf('addCharm-') === 0) {
+          if (this.changeSet[key].command.args[0] === charmId) {
+            delete this.changeSet[key];
+            this.fire('changeSetModified');
+            return true;
+          }
+        }
+      });
+    },
     /**
       Creates a new entry in the queue for creating a new service.
 

--- a/jujugui/static/gui/src/app/utils/environment-change-set.js
+++ b/jujugui/static/gui/src/app/utils/environment-change-set.js
@@ -576,6 +576,13 @@ YUI.add('environment-change-set', function(Y) {
       @param {Array} args The arguments to add the charm with.
     */
     _lazyAddCharm: function(args) {
+      const existing = Object.keys(this.changeSet).some(key => {
+        return this.changeSet[key].command.args[0] === args[0];
+      });
+      // If there is an existing record for this charm then don't add another.
+      if (existing) {
+        return;
+      }
       var command = {
         method: '_addCharm',
         args: this._getArgs(args),
@@ -640,7 +647,7 @@ YUI.add('environment-change-set', function(Y) {
         const record = this.changeSet[key];
         if (record.command.method === '_addCharm') {
           // Get the key to the record which adds the charm for this app.
-          if (record.command.options.applicationId === args[9].modelId) {
+          if (record.command.args[0] === args[0]) {
             parents.push(key);
           }
         }

--- a/jujugui/static/gui/src/app/utils/relation-utils.js
+++ b/jujugui/static/gui/src/app/utils/relation-utils.js
@@ -126,13 +126,18 @@ YUI.add('relation-utils', function(Y) {
         var farService;
         // far will be undefined or the far endpoint service.
         if (far) {
-          var id = far[0];
-          farService = {
-            service: id,
-            serviceName: db.services.getById(id).get('name'),
-            role: far[1].role,
-            name: far[1].name
-          };
+          const id = far[0];
+          const application = db.services.getById(id);
+          // The uncommitted application could been removed so check it is
+          // really there.
+          if (application) {
+            farService = {
+              service: id,
+              serviceName: application.get('name'),
+              role: far[1].role,
+              name: far[1].name
+            };
+          }
         }
         rel.far = farService;
         var relationId = rel.relation_id;

--- a/jujugui/static/gui/src/test/test_env_change_set.js
+++ b/jujugui/static/gui/src/test/test_env_change_set.js
@@ -778,6 +778,18 @@ describe('Environment Change Set', function() {
         assert.deepEqual(record.command.options, {applicationId: 'foo'});
         cb(); // Will call done().
       });
+
+      it('only adds one `add Charm` record for duplicates', function() {
+        ecs._lazyAddCharm(
+          ['cs:wordpress', 'cookies', null, {applicationId: 'foo'}]);
+        assert.equal(Object.keys(ecs.changeSet).length, 1);
+        ecs._lazyAddCharm(
+          ['cs:wordpress', 'cookies', null, {applicationId: 'foo'}]);
+        assert.equal(Object.keys(ecs.changeSet).length, 1);
+        ecs._lazyAddCharm(
+          ['cs:mysql', 'cookies', null, {applicationId: 'foo'}]);
+        assert.equal(Object.keys(ecs.changeSet).length, 2);
+      });
     });
 
     describe('_lazyDeploy', function() {

--- a/jujugui/static/gui/src/test/test_env_change_set.js
+++ b/jujugui/static/gui/src/test/test_env_change_set.js
@@ -947,6 +947,37 @@ describe('Environment Change Set', function() {
         assert.deepEqual(ecs.changeSet, {});
       });
 
+      it('only destroys the last charm', function() {
+        const db = ecs.get('db');
+        db.services = {
+          remove: sinon.stub(),
+          getById: function() {
+            return {
+              destroy: sinon.stub(),
+              get: function(key) {
+                if (key === 'units') { return {each: sinon.stub()}; }
+              },
+              set: sinon.stub(),
+              updateSubordinateUnits: sinon.stub()
+            };
+          },
+        };
+        db.relations = {
+          remove: sinon.stub()
+        };
+        ecs._lazyAddCharm(
+          ['cs:wordpress', 'cookies', null, {applicationId: 'foo'}]);
+        ecs._lazyDeploy(
+          ['cs:wordpress', 2, 'foo', 'bar', function() {}, {modelId: 'baz'}]);
+        ecs._lazyDeploy(
+          ['cs:wordpress', 2, 'foo', 'bar', function() {}, {modelId: 'baz2'}]);
+        assert.equal(Object.keys(ecs.changeSet).length, 3);
+        ecs.lazyDestroyApplication(['baz']);
+        assert.equal(Object.keys(ecs.changeSet).length, 2);
+        ecs.lazyDestroyApplication(['baz2']);
+        assert.equal(Object.keys(ecs.changeSet).length, 0);
+      });
+
       it('destroys unplaced units when the service is removed', function(done) {
         var args = ['foo', done, {modelId: 'baz'}];
         var units = new Y.juju.models.ServiceUnitList();

--- a/jujugui/static/gui/src/test/test_relation_utils.js
+++ b/jujugui/static/gui/src/test/test_relation_utils.js
@@ -427,6 +427,23 @@ describe('RelationUtils', function() {
       assert.strictEqual(result.near.serviceName, 'cs:mysql');
       assert.strictEqual(result.far.serviceName, 'mediawiki');
     });
+
+    it('does not fail if the far application has been removed', function() {
+      db.relations.add({
+        'interface': 'mysql',
+        scope: 'global',
+        endpoints: [
+          ['mysql', {role: 'provider', name: 'mydb'}],
+          ['mediawiki', {role: 'requirer', name: 'db'}]
+        ],
+        'id': 'mediawiki:db mysql:mydb'
+      });
+      db.services.getById = sinon.stub().returns(null);
+      const results = relationUtils.getRelationDataForService(db, service);
+      const result = results[0];
+      assert.strictEqual(result.near.serviceName, 'cs:mysql');
+      assert.isUndefined(result.far);
+    });
   });
 
   describe('DecoratedRelation and RelationCollection', function() {

--- a/jujugui/static/gui/src/test/test_relation_utils.js
+++ b/jujugui/static/gui/src/test/test_relation_utils.js
@@ -438,6 +438,8 @@ describe('RelationUtils', function() {
         ],
         'id': 'mediawiki:db mysql:mydb'
       });
+      // By not returning an application we're simulating that the service no
+      // longer exists, i.e. has been destroyed.
       db.services.getById = sinon.stub().returns(null);
       const results = relationUtils.getRelationDataForService(db, service);
       const result = results[0];


### PR DESCRIPTION
When removing uncommitted applications we also need to remove the addCharm call if there are no other applications using that same addCharm call. This also contains a fix for removing relations when removing uncommitted applications added via a bundle import.

Fixes #2045
Fixes #2088 
