### PR TITLE
Add dispatcher registration and null states

### DIFF
--- a/jujugui/static/gui/src/app/state/state.js
+++ b/jujugui/static/gui/src/app/state/state.js
@@ -185,9 +185,37 @@ const State = class State {
   /**
     Changes the internal state of the app, updating the location and
     dispatching the app.
-    @param {Object} state - The new state delta to apply to the existing state.
+    @param {Object} stateSegment - The new state delta to apply to the
+      existing state.
   */
-  changeState(state) {}
+  changeState(stateSegment) {
+    /**
+      Merge two objects together or clone one. Only works with simple values.
+      @param {Object} target - The root object.
+      @param {Object} source - The object to clone or merge into the target.
+      @return {Object} The merged or cloned object.
+    */
+    function merge(target, source) {
+      if (typeof source === 'object') {
+        Object.keys(source).forEach(key => {
+          const value = source[key];
+          if (typeof value === 'object') {
+            target[key] = merge(target[key] || {}, value);
+          } else {
+            target[key] = value;
+          }
+        });
+      } else {
+        target = source;
+      }
+      return target;
+    }
+
+    this._appStateHistory.push(
+      merge(
+        // Clone the appState so we don't end up clobbering old states.
+        merge({}, this.appState), stateSegment));
+  }
 
   /**
     Splits the URL up and generates a state object.

--- a/jujugui/static/gui/src/app/state/state.js
+++ b/jujugui/static/gui/src/app/state/state.js
@@ -156,10 +156,32 @@ const State = class State {
     this._appStateHistory.push(state);
     // First execute the 'all' dispatchers.
     this._dispatch(state, '*');
-    // Loop through the state keys to execute their dispatchers.
-    Object.keys(state).forEach(key => {
+
+    /**
+      Extract out the state path for the dispatcher key.
+      @param {Object} state - The app state.
+    */
+    function extract(state) {
+      let allKeys = [];
+      function concat(state, keys = []) {
+        Object.keys(state).forEach(key => {
+          keys.push(key);
+          if (typeof state[key] === 'object' && state[key] !== null) {
+            concat(state[key], keys);
+          } else {
+            allKeys.push(keys.join('.'));
+          }
+          keys = [];
+        });
+      }
+      concat(state);
+      return allKeys;
+    }
+    // Extract and loop through the state keys to execute their dispatchers.
+    extract(state).forEach(key => {
       this._dispatch(state, key);
     });
+
     return {error: null, state};
   }
 

--- a/jujugui/static/gui/src/app/state/state.js
+++ b/jujugui/static/gui/src/app/state/state.js
@@ -77,6 +77,13 @@ const State = class State {
     */
     this._location = cfg.location || null;
     /**
+      Internal storage value for the history object to use. Only used when
+      history is set externally.
+      @private
+      @type {Object}
+    */
+    this._history = cfg.history || null;
+    /**
       Internal storage for the app state history.
       @private
       @type {Array}
@@ -88,6 +95,8 @@ const State = class State {
       @type {Array}
     */
     this._dispatchers = {};
+
+    window.onpopstate = this.dispatch;
   }
 
   /**
@@ -115,6 +124,20 @@ const State = class State {
 
   set location(location) {
     this._location = location;
+  }
+
+  /**
+    The browser history object to use. If set has been called on this property
+    then it will return the externally set option. Typically this option will
+    be used for testing.
+    @type {Object}
+  */
+  get history() {
+    return this._history || window.history;
+  }
+
+  set history(history) {
+    this._history = history;
   }
 
   /**
@@ -297,6 +320,13 @@ const State = class State {
     this._appStateHistory.push(purgedState);
     this._pushState();
     this.dispatch(nullKeys, false);
+  }
+
+  /**
+    Pushes the current state to the browser history using pushState.
+  */
+  _pushState() {
+    this.history.pushState({}, 'Juju GUI', this.generatePath());
   }
 
   /**

--- a/jujugui/static/gui/src/app/state/state.js
+++ b/jujugui/static/gui/src/app/state/state.js
@@ -79,6 +79,12 @@ const State = class State {
       @type {Array}
     */
     this._appStateHistory = [];
+    /**
+      Internal storage for the dispatchers.
+      @private
+      @type {Array}
+    */
+    this._dispatchers = {};
   }
 
   /**
@@ -114,6 +120,23 @@ const State = class State {
   */
   get appState() {
     return this._appStateHistory[this._appStateHistory.length-1];
+  }
+
+  /**
+    Stores the dispatchers that are to be called when the appropriate state
+    changes in the application.
+    @param {Array} dispatchers - An array of dispatchers in the format:
+      [['section', callback], ...]
+  */
+  register(dispatchers) {
+    const stored = this._dispatchers;
+    dispatchers.forEach(dispatcher => {
+      if (!stored[dispatcher[0]]) {
+        stored[dispatcher[0]] = [dispatcher[1]];
+        return;
+      }
+      stored[dispatcher[0]].push(dispatcher[1]);
+    });
   }
 
   /**

--- a/jujugui/static/gui/src/app/state/state.js
+++ b/jujugui/static/gui/src/app/state/state.js
@@ -157,11 +157,12 @@ const State = class State {
   register(dispatchers) {
     const stored = this._dispatchers;
     dispatchers.forEach(dispatcher => {
+      const record = [dispatcher[1], dispatcher[2]];
       if (!stored[dispatcher[0]]) {
-        stored[dispatcher[0]] = [dispatcher[1]];
+        stored[dispatcher[0]] = [record];
         return;
       }
-      stored[dispatcher[0]].push(dispatcher[1]);
+      stored[dispatcher[0]].push(record);
     });
   }
 
@@ -208,7 +209,7 @@ const State = class State {
     }
     // First run all of the 'null state' dispatchers to clear out the old
     // state representations.
-    nullKeys.forEach(key => this.dispatch(state, key, true));
+    nullKeys.forEach(key => this._dispatch(state, key, true));
     // Then execute the 'all' dispatchers.
     this._dispatch(state, '*');
     // Extract and loop through the state keys to execute their dispatchers.
@@ -235,7 +236,13 @@ const State = class State {
     function next() {
       const data = iterator.next();
       if (!data.done) {
-        data.value(state, next);
+        const index = cleanup ? 1 : 0;
+        // The 0 index is the 'create' dispatcher, the 1 index is the
+        // 'cleanup' dispatcher.
+        const dispatcher = data.value[index];
+        if (typeof dispatcher === 'function') {
+          dispatcher(state, next);
+        }
       }
     }
     next();

--- a/jujugui/static/gui/src/app/state/test-state.js
+++ b/jujugui/static/gui/src/app/state/test-state.js
@@ -780,6 +780,30 @@ describe('State', () => {
     });
   });
 
+  describe('State.changeState()', () => {
+    it('can update state', () => {
+      const state = new window.jujugui.State({
+        baseURL: 'http://abc.com:123',
+        seriesList:  ['precise', 'trusty', 'xenial'],
+        location: {href: '/u/hatch/staging/i/applications/inspector/ghost'}
+      });
+      state.dispatch();
+      assert.deepEqual(
+        state.appState,
+        {user: 'hatch/staging', gui: {applications: '', inspector: 'ghost' }},
+        'generateState() did not parse location properly');
+      state.changeState({
+        gui: {
+          applications: 'foo'
+        }
+      });
+      assert.deepEqual(state._appStateHistory, [
+        {user: 'hatch/staging', gui: {applications: '', inspector: 'ghost' }},
+        {user: 'hatch/staging', gui: {applications: 'foo', inspector: 'ghost' }}
+      ]);
+    });
+  });
+
   describe('State.generatePath()', () => {
     // Generate all of the test cases for the various states.
     [{

--- a/jujugui/static/gui/src/app/state/test-state.js
+++ b/jujugui/static/gui/src/app/state/test-state.js
@@ -711,7 +711,22 @@ describe('State', () => {
     });
   });
 
-  describe('State.dispatch()', () => {
+  describe('State.register()', () => {
+    it('stores the supplied dispatchers', () => {
+      const state = new window.jujugui.State({
+        baseURL: 'http://abc.com:123',
+        seriesList:  ['precise', 'trusty', 'xenial']
+      });
+      const stub1 = sinon.stub();
+      const stub2 = sinon.stub();
+      state.register([['*', stub1], ['store', stub2]]);
+      assert.deepEqual(state._dispatchers, {
+        '*': [stub1],
+        store: [stub2]
+      });
+    });
+  });
+
     it('passes the current location to generateState', () => {
       const state = new window.jujugui.State({
         baseURL: 'http://abc.com:123',

--- a/jujugui/static/gui/src/app/state/test-state.js
+++ b/jujugui/static/gui/src/app/state/test-state.js
@@ -757,7 +757,7 @@ describe('State', () => {
       const state = new window.jujugui.State({
         baseURL: 'http://abc.com:123',
         seriesList:  ['precise', 'trusty', 'xenial'],
-        location: {href: 'ghost/trusty'}
+        location: {href: 'ghost/trusty/i/machines'}
       });
       let counter = 0;
       let increment = () => counter += 1;
@@ -774,9 +774,15 @@ describe('State', () => {
         execution.stub3 = increment();
         next();
       };
-      state.register([['*', stub], ['store', stub2],['*', stub3]]);
+      const stub4 = function(state, next) {
+        execution.stub4 = increment();
+        next();
+      };
+      state.register([
+        ['*', stub], ['store', stub2], ['*', stub3], ['gui.machines', stub4]
+      ]);
       state.dispatch();
-      assert.deepEqual(execution, { stub: 1, stub2: 3, stub3: 2 });
+      assert.deepEqual(execution, {stub: 1, stub2: 4, stub3: 2, stub4: 3});
     });
   });
 

--- a/jujugui/static/gui/src/app/state/test-state.js
+++ b/jujugui/static/gui/src/app/state/test-state.js
@@ -859,6 +859,23 @@ describe('State', () => {
     });
   });
 
+  describe('State.pushState()', () => {
+    it('pushes state to history', () => {
+      const historyStub = {
+        pushState: sinon.stub()
+      };
+      const state = new window.jujugui.State({
+        baseURL: 'http://abc.com:123',
+        seriesList:  ['precise', 'trusty', 'xenial'],
+        location: {href: '/u/hatch/staging'},
+        history: historyStub
+      });
+      state.dispatch();
+      state._pushState();
+      assert.deepEqual(historyStub.pushState.args[0], [
+        {}, 'Juju GUI', '/u/hatch/staging']);
+    });
+
   });
 
   describe('State.generatePath()', () => {


### PR DESCRIPTION
With an instance of State you can now register dispatchers which will be called when a state matches the supplied paths. If that value is then nulled out then the cleanup dispatcher will be called.