### PR TITLE
Applications with resources now get deployed with them

### DIFF
--- a/jujugui/static/gui/src/app/components/entity-details/content/resources/resources.js
+++ b/jujugui/static/gui/src/app/components/entity-details/content/resources/resources.js
@@ -34,13 +34,12 @@ YUI.add('entity-resources', function() {
     */
     _generateResources: function() {
       const resources = this.props.resources;
-      if (!resources || Object.keys(resources).length === 0) {
+      if (!resources || resources.length === 0) {
         return;
       }
-      const resourceList = Object.keys(resources).map((key, i) => {
-        const resource = resources[key];
+      const resourceList = resources.map((resource, i) => {
         // Get the file extension.
-        const parts = resource.path.split('.');
+        const parts = resource.Path.split('.');
         let extension = '';
         // If there is a file extension then format it for display.
         if (parts.length > 1) {
@@ -48,8 +47,8 @@ YUI.add('entity-resources', function() {
         }
         return (
           <li className="entity-files__file"
-            key={resource.name + i}>
-            {resource.name} {extension}
+            key={resource.Name + i}>
+            {resource.Name} {extension}
           </li>);
       });
       return (

--- a/jujugui/static/gui/src/app/components/entity-details/content/resources/test-resources.js
+++ b/jujugui/static/gui/src/app/components/entity-details/content/resources/test-resources.js
@@ -33,7 +33,7 @@ describe('EntityResources', function() {
     const renderer = jsTestUtils.shallowRender(
       <juju.components.EntityResources
         pluralize={sinon.stub()}
-        resource={{}} />, true);
+        resource={[]} />, true);
     const output = renderer.getRenderOutput();
     const expected = (
       <div>
@@ -43,20 +43,19 @@ describe('EntityResources', function() {
   });
 
   it('can display a list of resources', function() {
-    const resources = {
-      file1: {
-        description: 'file1 desc',
-        name: 'file1',
-        path: 'file1.zip',
-        revision: 5
-      },
-      file2: {
-        description: 'file2 desc',
-        name: 'file2',
-        path: 'file2',
-        revision: 2
-      }
-    };
+    const resources = [{
+      Description: 'file1 desc',
+      Name: 'file1',
+      Type: 'file',
+      Path: 'file1.zip',
+      Revision: 5
+    }, {
+      Description: 'file2 desc',
+      Name: 'file2',
+      Type: 'file',
+      Path: 'file2',
+      Revision: 2
+    }];
     const renderer = jsTestUtils.shallowRender(
       <juju.components.EntityResources
         pluralize={sinon.stub().returns('resources')}

--- a/jujugui/static/gui/src/app/jujulib/charmstore.js
+++ b/jujugui/static/gui/src/app/jujulib/charmstore.js
@@ -225,6 +225,11 @@ var module = module;
         delete processed.requires;
         processed.is_subordinate = !!metadata.Subordinate;
       }
+      // Use the outer resource data structure as it's the proper format
+      // for the addPendingResources call.
+      if (meta.resources && meta.resources.length) {
+        processed.resources = meta.resources;
+      }
       return processed;
     },
 

--- a/jujugui/static/gui/src/app/store/env/api.js
+++ b/jujugui/static/gui/src/app/store/env/api.js
@@ -1200,14 +1200,25 @@ YUI.add('juju-env-api', function(Y) {
         return;
       }
       const ecs = this.get('ecs');
-      if (args.charmResources) {
+      const resources = args.charmResources;
+      if (resources) {
         // If we have resources then we need to make an addPendingResources
         // call prior to deploying.
         ecs._lazyAddPendingResources([{
           applicationName: args.applicationName,
           charmURL: args.charmURL,
           channel: 'stable',
-          resources: args.charmResources
+          resources: resources
+        }, (error, ids) => {
+          if (error !== null) {
+            callback(error, {});
+            return;
+          }
+          // Store the id map in the application model for use by the ecs
+          // during deploy.
+          const db = this.get('ecs').get('db');
+          const app = db.services.getServiceByName(args.applicationName);
+          app.set('resourceIds', ids);
         }]);
         // The charmResources key is only used to add the charm pending
         // resources so we need to remove it before passing to the deploy

--- a/jujugui/static/gui/src/app/store/env/api.js
+++ b/jujugui/static/gui/src/app/store/env/api.js
@@ -1200,6 +1200,20 @@ YUI.add('juju-env-api', function(Y) {
         return;
       }
       const ecs = this.get('ecs');
+      if (args.charmResources) {
+        // If we have resources then we need to make an addPendingResources
+        // call prior to deploying.
+        ecs._lazyAddPendingResources([{
+          applicationName: args.applicationName,
+          charmURL: args.charmURL,
+          channel: 'stable',
+          resources: args.charmResources
+        }]);
+        // The charmResources key is only used to add the charm pending
+        // resources so we need to remove it before passing to the deploy
+        // method.
+        delete args.charmResources;
+      }
       ecs._lazyDeploy(arguments);
     },
 

--- a/jujugui/static/gui/src/app/utils/bundle-importer.js
+++ b/jujugui/static/gui/src/app/utils/bundle-importer.js
@@ -510,7 +510,8 @@ YUI.add('bundle-importer', function(Y) {
             applicationName: record.args[2],
             series: series,
             config: record.args[3],
-            constraints: constraints
+            constraints: constraints,
+            charmResources: charm.get('resources')
           }, deployCallback, {modelId: ghostService.get('id')});
           this._saveModelToRequires(record.id, ghostService);
           this._collectedServices.push(ghostService);

--- a/jujugui/static/gui/src/app/utils/changes-utils.js
+++ b/jujugui/static/gui/src/app/utils/changes-utils.js
@@ -146,6 +146,12 @@ YUI.add('changes-utils', function(Y) {
             changeItem.icon = services.getById(appId).get('icon');
           }
           break;
+        case 'addPendingResources':
+          const applicationName = change.command.args[0].applicationName;
+          const application = services.getServiceByName(applicationName);
+          changeItem.icon = application.get('icon');
+          changeItem.description = ` ${applicationName} resources added.`;
+          break;
         case '_deploy':
           if (!change.command.options || !change.command.options.modelId) {
             // When using the deploy-target query parameter we want to auto

--- a/jujugui/static/gui/src/app/utils/environment-change-set.js
+++ b/jujugui/static/gui/src/app/utils/environment-change-set.js
@@ -600,7 +600,18 @@ YUI.add('environment-change-set', function(Y) {
         method: 'addPendingResources',
         args: args
       };
-      return this._createNewRecord('addPendingResources', command, []);
+      // Set up the parents of this record.
+      const parents = [];
+      Object.keys(this.changeSet).forEach(key => {
+        const command = this.changeSet[key].command;
+        if (command.method === '_addCharm') {
+          // Get the key to the record which adds the charm for this app.
+          if (command.args[0] === args[0].charmURL) {
+            parents.push(key);
+          }
+        }
+      });
+      return this._createNewRecord('addPendingResources', command, parents);
     },
 
     /**
@@ -650,6 +661,11 @@ YUI.add('environment-change-set', function(Y) {
               delete config[key];
             }
           });
+          // Check if we have any resources, if we do, then add them.
+          const resourceIds = ghostService.get('resourceIds');
+          if (resourceIds) {
+            deployArgs.resources = resourceIds;
+          }
         }
       };
       if (command.args.length !== args.length) {

--- a/jujugui/static/gui/src/app/utils/environment-change-set.js
+++ b/jujugui/static/gui/src/app/utils/environment-change-set.js
@@ -592,6 +592,18 @@ YUI.add('environment-change-set', function(Y) {
     },
 
     /**
+      Creates a new entry in the queue to add the pending resources.
+      @param {Array} The arguments to add the pending resources with.
+    */
+    _lazyAddPendingResources: function(args) {
+      const command = {
+        method: 'addPendingResources',
+        args: args
+      };
+      return this._createNewRecord('addPendingResources', command, []);
+    },
+
+    /**
       Creates a new entry in the queue for creating a new service.
 
       Receives all the parameters received by the environment's "deploy"
@@ -650,6 +662,11 @@ YUI.add('environment-change-set', function(Y) {
         if (record.command.method === '_addCharm') {
           // Get the key to the record which adds the charm for this app.
           if (record.command.args[0] === args[0].charmURL) {
+            parents.push(key);
+          }
+        }
+        if (record.command.method === 'addPendingResources') {
+          if (record.command.args[0] === args[0].applicationName) {
             parents.push(key);
           }
         }

--- a/jujugui/static/gui/src/app/utils/environment-change-set.js
+++ b/jujugui/static/gui/src/app/utils/environment-change-set.js
@@ -658,15 +658,15 @@ YUI.add('environment-change-set', function(Y) {
       // Set up the parents of this record.
       const parents = [];
       Object.keys(this.changeSet).forEach(key => {
-        const record = this.changeSet[key];
-        if (record.command.method === '_addCharm') {
+        const command = this.changeSet[key].command;
+        if (command.method === '_addCharm') {
           // Get the key to the record which adds the charm for this app.
-          if (record.command.args[0] === args[0].charmURL) {
+          if (command.args[0] === args[0].charmURL) {
             parents.push(key);
           }
         }
-        if (record.command.method === 'addPendingResources') {
-          if (record.command.args[0] === args[0].applicationName) {
+        if (command.method === 'addPendingResources') {
+          if (command.args[0].applicationName === args[0].applicationName) {
             parents.push(key);
           }
         }

--- a/jujugui/static/gui/src/app/utils/environment-change-set.js
+++ b/jujugui/static/gui/src/app/utils/environment-change-set.js
@@ -597,7 +597,7 @@ YUI.add('environment-change-set', function(Y) {
     */
     _lazyAddPendingResources: function(args) {
       const command = {
-        method: 'addPendingResources',
+        method: '_addPendingResources',
         args: args
       };
       // Set up the parents of this record.
@@ -681,7 +681,7 @@ YUI.add('environment-change-set', function(Y) {
             parents.push(key);
           }
         }
-        if (command.method === 'addPendingResources') {
+        if (command.method === '_addPendingResources') {
           if (command.args[0].applicationName === args[0].applicationName) {
             parents.push(key);
           }

--- a/jujugui/static/gui/src/app/views/ghost-deployer-extension.js
+++ b/jujugui/static/gui/src/app/views/ghost-deployer-extension.js
@@ -87,6 +87,7 @@ YUI.add('ghost-deployer-extension', function(Y) {
         applicationName: serviceName,
         series: activeSeries,
         config: config,
+        charmResources: charm.get('resources')
       }, this._deployCallbackHandler.bind(this, ghostService), options);
 
       // Add an unplaced unit to this service if it is not a subordinate

--- a/jujugui/static/gui/src/app/views/ghost-deployer-extension.js
+++ b/jujugui/static/gui/src/app/views/ghost-deployer-extension.js
@@ -82,12 +82,35 @@ YUI.add('ghost-deployer-extension', function(Y) {
           {applicationId: ghostServiceId});
       }
       const options = {modelId: ghostServiceId};
+      // Add the resources to the Juju controller if we have any.
+      const charmResources = charm.get('resources');
+      if (charmResources) {
+        this.env.addPendingResources({
+          applicationName: serviceName,
+          charmURL: charmId,
+          channel: 'stable',
+          resources: charmResources
+        }, (error, ids) => {
+          if (error !== null) {
+            db.notifications.add({
+              title: 'Error adding resources',
+              message: `Could not add requested resources for ${charmId}. ` +
+                'Server responded with: ' + error,
+              level: 'error'
+            });
+            return;
+          }
+          // Store the id map in the application model for use by the ecs
+          // during deploy.
+          ghostService.set('resourceIds', ids);
+        });
+      }
+
       this.env.deploy({
         charmURL: charmId,
         applicationName: serviceName,
         series: activeSeries,
-        config: config,
-        charmResources: charm.get('resources')
+        config: config
       }, this._deployCallbackHandler.bind(this, ghostService), options);
 
       // Add an unplaced unit to this service if it is not a subordinate

--- a/jujugui/static/gui/src/test/test_changes_utils.js
+++ b/jujugui/static/gui/src/test/test_changes_utils.js
@@ -109,6 +109,15 @@ describe('ChangesUtils', function() {
       }
     }, {
       icon: 'django.svg',
+      msg: ' django resources added.',
+      change: {
+        command: {
+          method: 'addPendingResources',
+          args: [{applicationName: 'django', charmURL: 'cs:trusty/django-1'}]
+        }
+      }
+    }, {
+      icon: 'django.svg',
       msg: ' django has been added.',
       change: {
         command: {

--- a/jujugui/static/gui/src/test/test_env_api.js
+++ b/jujugui/static/gui/src/test/test_env_api.js
@@ -1300,13 +1300,23 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     });
 
     describe('addPendingResources', function() {
+      it('adds to the ecs on the public method', () => {
+        const stub = sinon.stub(env.get('ecs'), '_lazyAddPendingResources');
+        env.addPendingResources({
+          applicationName: 'wordpress',
+          charmURL: 'wordpress-42',
+          channel: 'stable',
+          resources: []
+        });
+        assert.equal(stub.callCount, 1);
+      });
       it('uploads resources', done => {
         // Perform the request.
         const resources = [
           {Name: 'res1', File: 'res1.tgz'},
           {Name: 'res2', File: 'res2.tgz'}
         ];
-        env.addPendingResources({
+        env._addPendingResources({
           applicationName: 'wordpress',
           charmURL: 'wordpress-42',
           channel: 'stable',
@@ -1343,7 +1353,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
       it('uploads a single resource', done => {
         // Perform the request.
-        env.addPendingResources({
+        env._addPendingResources({
           applicationName: 'hap',
           charmURL: 'cs:xenial/haproxy-47',
           channel: 'beta',
@@ -1378,7 +1388,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
       it('uploads resources with origin', done => {
         // Perform the request.
-        env.addPendingResources({
+        env._addPendingResources({
           applicationName: 'haproxy',
           charmURL: 'xenial/haproxy-47',
           resources: [{Name: 'myres', File: 'myres.tar.bz2', Origin: 'Vulcan'}]
@@ -1417,7 +1427,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
           channel: 'beta',
           resources: [{Name: 'myres', File: 'myres.tar.bz2'}]
         };
-        env.addPendingResources(args, (err, ids) => {
+        env._addPendingResources(args, (err, ids) => {
           assert.equal(err, 'invalid arguments: ' + JSON.stringify(args));
           assert.deepEqual(ids, {});
           done();
@@ -1432,7 +1442,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
           channel: 'candidate',
           resources: [{Name: 'myres', File: 'myres.tar.bz2'}]
         };
-        env.addPendingResources(args, (err, ids) => {
+        env._addPendingResources(args, (err, ids) => {
           assert.equal(err, 'invalid arguments: ' + JSON.stringify(args));
           assert.deepEqual(ids, {});
           done();
@@ -1446,7 +1456,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
           charmURL: 'wordpress-42',
           resources: []
         };
-        env.addPendingResources(args, (err, ids) => {
+        env._addPendingResources(args, (err, ids) => {
           assert.equal(err, 'invalid arguments: ' + JSON.stringify(args));
           assert.deepEqual(ids, {});
           done();
@@ -1455,7 +1465,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
       it('fails when invalid resources are provided', done => {
         // Perform the request.
-        env.addPendingResources({
+        env._addPendingResources({
           applicationName: 'wordpress',
           charmURL: 'wordpress-42',
           resources: [{File: 'bad'}]
@@ -1468,7 +1478,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
       it('handles global failures while adding resources', done => {
         // Perform the request.
-        env.addPendingResources({
+        env._addPendingResources({
           applicationName: 'redis',
           charmURL: 'redis-0',
           resources: [{Name: 'red', File: 'red.tgz'}]
@@ -1483,7 +1493,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
       it('handles local failures while adding resources', done => {
         // Perform the request.
-        env.addPendingResources({
+        env._addPendingResources({
           applicationName: 'redis',
           charmURL: 'redis-0',
           resources: [{Name: 'red', File: 'red.tgz'}]
@@ -1501,7 +1511,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
       it('handles unexpected failures while adding resources', done => {
         // Perform the request.
-        env.addPendingResources({
+        env._addPendingResources({
           applicationName: 'redis',
           charmURL: 'redis-0',
           resources: [{Name: 'red', File: 'red.tgz'}]

--- a/jujugui/static/gui/src/test/test_env_change_set.js
+++ b/jujugui/static/gui/src/test/test_env_change_set.js
@@ -803,7 +803,7 @@ describe('Environment Change Set', function() {
         const key = ecs._lazyAddPendingResources([args]);
         const record = ecs.changeSet[key];
         assert.equal(record.executed, false);
-        assert.equal(record.command.method, 'addPendingResources');
+        assert.equal(record.command.method, '_addPendingResources');
         // Remove the functions, which will not be equal.
         record.command.args.pop();
         assert.deepEqual(record.command.args, [args]);
@@ -1850,35 +1850,6 @@ describe('Environment Change Set', function() {
         assert.equal(lazyDeploy.calledOnce, true);
         // make sure we don't call the env deploy method.
         assert.equal(envObj._deploy.callCount, 0);
-      });
-
-      it('adds an addPendingResources call if charm has resources', function() {
-        const lazyDeploy = testUtils.makeStubMethod(ecs, '_lazyDeploy');
-        const lazyAddResources =
-          testUtils.makeStubMethod(ecs, '_lazyAddPendingResources');
-        this._cleanups.push(lazyDeploy.reset);
-        this._cleanups.push(lazyAddResources.reset);
-
-        envObj.deploy.call(envObj, {
-          applicationName: 'django',
-          charmURL: 'cs:precise/django-42',
-          charmResources: {a: 'resource'}
-        }, function() {});
-
-        assert.equal(lazyAddResources.callCount, 1);
-        assert.deepEqual(lazyAddResources.lastCall.args[0][0], {
-          applicationName: 'django',
-          charmURL: 'cs:precise/django-42',
-          channel: 'stable',
-          resources: {a: 'resource'}
-        }, 'lazyAddResources called with incorrect arguments');
-
-        assert.equal(lazyDeploy.callCount, 1);
-        assert.deepEqual(lazyDeploy.lastCall.args[0][0], {
-          applicationName: 'django',
-          charmURL: 'cs:precise/django-42'
-          // charmResources was supposed to have been removed.
-        }, 'lazyDeploy called with incorrect arguments');
       });
     });
 

--- a/jujugui/static/gui/src/test/test_ghost_deployer_extension.js
+++ b/jujugui/static/gui/src/test/test_ghost_deployer_extension.js
@@ -165,6 +165,7 @@ describe('Ghost Deployer Extension', function() {
 
   it('calls the env deploy method with default charm data', function() {
     const charm = makeCharm();
+    charm.set('resources', {a: 'resource'});
     ghostDeployer.deployService(charm);
     assert.strictEqual(ghostDeployer.env.deploy.calledOnce, true);
     const args = ghostDeployer.env.deploy.lastCall.args[0];
@@ -172,6 +173,7 @@ describe('Ghost Deployer Extension', function() {
     assert.strictEqual(args.applicationName, 'ghost-service-id');
     assert.strictEqual(args.series, 'trusty');
     assert.deepEqual(args.config, {});
+    assert.deepEqual(args.charmResources, {a: 'resource'});
   });
 
   it('properly adds the series to Juju 1 applications', function() {

--- a/jujugui/static/gui/src/test/test_ghost_deployer_extension.js
+++ b/jujugui/static/gui/src/test/test_ghost_deployer_extension.js
@@ -46,7 +46,8 @@ describe('Ghost Deployer Extension', function() {
           env: {
             deploy: sinon.stub(),
             add_unit: sinon.stub(),
-            addCharm: sinon.stub()
+            addCharm: sinon.stub(),
+            addPendingResources: sinon.stub()
           }
         }, {
           ATTRS: {
@@ -163,17 +164,16 @@ describe('Ghost Deployer Extension', function() {
     assert.equal(ghostDeployer.env.deploy.callCount, 1);
   });
 
-  it('calls the env deploy method with default charm data', function() {
+  it('calls the env addPendingResources method with default charm data', () => {
     const charm = makeCharm();
     charm.set('resources', {a: 'resource'});
     ghostDeployer.deployService(charm);
-    assert.strictEqual(ghostDeployer.env.deploy.calledOnce, true);
-    const args = ghostDeployer.env.deploy.lastCall.args[0];
-    assert.strictEqual(args.charmURL, 'cs:trusty/django-42');
-    assert.strictEqual(args.applicationName, 'ghost-service-id');
-    assert.strictEqual(args.series, 'trusty');
-    assert.deepEqual(args.config, {});
-    assert.deepEqual(args.charmResources, {a: 'resource'});
+    assert.strictEqual(ghostDeployer.env.addPendingResources.calledOnce, true);
+    const args = ghostDeployer.env.addPendingResources.lastCall.args;
+    assert.equal(args[0].charmURL, 'cs:trusty/django-42');
+    assert.equal(args[0].applicationName, 'ghost-service-id');
+    assert.deepEqual(args[0].resources, {a: 'resource'});
+    assert.equal(typeof args[1], 'function');
   });
 
   it('properly adds the series to Juju 1 applications', function() {

--- a/jujugui/static/gui/src/test/test_sandbox_go.js
+++ b/jujugui/static/gui/src/test/test_sandbox_go.js
@@ -1410,7 +1410,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
           {Name: 'res2', File: 'res2.tgz'}
         ];
         env.connect();
-        env.addPendingResources({
+        env._addPendingResources({
           applicationName: 'wordpress',
           charmURL: 'wordpress-42',
           channel: 'stable',


### PR DESCRIPTION
When deploying an application that has resources in the charm store we need to call a Juju api method `addPendingResources` prior to deploy to make Juju know about these resources.

Fixes #2166