### PR TITLE
Render the index with a dynamic static URL.

### DIFF
--- a/jujugui/templates/index.html.mako
+++ b/jujugui/templates/index.html.mako
@@ -49,7 +49,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
          below.
     -->
     <script src="${config_url}"></script>
-    <link rel="shortcut icon" href="/static/gui/build/app/favicon.ico">
+    <link rel="shortcut icon" href="${static_url}/static/gui/build/app/favicon.ico">
     <link rel="stylesheet" href="${convoy_url}?app/assets/stylesheets/normalize.css&app/assets/stylesheets/prettify.css&app/assets/stylesheets/cssgrids-responsive-min.css&app/assets/javascripts/yui/app-transitions-css/app-transitions-css-min.css&app/assets/javascripts/yui/panel/assets/panel-core.css&app/assets/javascripts/yui/widget-base/assets/widget-base-core.css&app/assets/javascripts/yui/widget-stack/assets/widget-stack-core.css&app/assets/juju-gui.css">
 
     <!--[if lt IE 9]>

--- a/jujugui/tests/test_views.py
+++ b/jujugui/tests/test_views.py
@@ -42,6 +42,24 @@ class AppTests(ViewTestCase):
             'raw': False,
             'logo_url': '',
             'combine': True,
+            'static_url': '',
+        }
+        context = views.app(self.request)
+        self.assertEqual(expected_context, context)
+
+    def test_static_url(self):
+        self.update_settings({
+            'jujugui.cachebuster': 'foo',
+            'jujugui.static_url': '/new',
+        })
+        jujugui.make_application(self.config)
+        expected_context = {
+            'config_url': '/config.js',
+            'convoy_url': '/foo/combo',
+            'raw': False,
+            'logo_url': '',
+            'combine': True,
+            'static_url': '/new',
         }
         context = views.app(self.request)
         self.assertEqual(expected_context, context)
@@ -55,15 +73,14 @@ class AppTests(ViewTestCase):
             'raw': False,
             'logo_url': '',
             'combine': True,
+            'static_url': '',
         }
         self.request.matchdict['uuid'] = 'env-uuid'
         context = views.app(self.request)
         self.assertEqual(expected_context, context)
 
     def test_sandbox_logo_url(self):
-        self.update_settings({
-            'jujugui.cachebuster': 'foo',
-        })
+        self.update_settings({'jujugui.cachebuster': 'foo'})
         self.request.domain = 'demo.jujucharms.com'
         gui.includeme(self.config)
         expected_context = {
@@ -72,6 +89,7 @@ class AppTests(ViewTestCase):
             'raw': False,
             'logo_url': 'http://jujucharms.com/',
             'combine': True,
+            'static_url': '',
         }
         context = views.app(self.request)
         self.assertEqual(expected_context, context)

--- a/jujugui/views.py
+++ b/jujugui/views.py
@@ -43,6 +43,7 @@ def app(request):
         'combine': settings['jujugui.combine'],
         'logo_url': logo_url,
         'raw': settings['jujugui.raw'],
+        'static_url': settings['jujugui.static_url'],
     }
 
 


### PR DESCRIPTION
This way we have a chance to load the favicon correctly even in places where the gui does not live at /.