### PR TITLE
Do not use object destructuring in state because it breaks the minifier.

### DIFF
--- a/jujugui/static/gui/src/app/state/state.js
+++ b/jujugui/static/gui/src/app/state/state.js
@@ -473,7 +473,14 @@ const State = class State {
     }
     // Extract out the user sections.
     if (parts.includes(PATH_DELIMETERS.get('user'))) {
-      ({state, parts, error} = this._parseUser(parts, state));
+      // XXX This return value isn't using object destructuring because babili
+      // minifier incorrectly munges the return values and it breaks. In the
+      // future it can be reverted and tested against a newer version than
+      // 0.0.9
+      let parsed = this._parseUser(parts, state);
+      state = parsed.state;
+      parts = parsed.parts;
+      error = parsed.error;
       if (error !== null) {
         error = `cannot parse the User path: ${error}`;
         return {error, state};

--- a/jujugui/static/gui/src/app/state/state.js
+++ b/jujugui/static/gui/src/app/state/state.js
@@ -463,7 +463,7 @@ const State = class State {
       // minifier incorrectly munges the return values and it breaks. In the
       // future it can be reverted and tested against a newer version than
       // 0.0.9
-      let parsed = this._parseGUI(parts.splice(guiIndex), state);
+      const parsed = this._parseGUI(parts.splice(guiIndex), state);
       error = parsed.error;
       state = parsed.state;
       if (error !== null) {
@@ -477,7 +477,7 @@ const State = class State {
       // minifier incorrectly munges the return values and it breaks. In the
       // future it can be reverted and tested against a newer version than
       // 0.0.9
-      let parsed = this._parseUser(parts, state);
+      const parsed = this._parseUser(parts, state);
       state = parsed.state;
       parts = parsed.parts;
       error = parsed.error;


### PR DESCRIPTION
Fixes #2275 