### PR TITLE
Use the new state system when adding local charms to the canvas.

### DIFF
--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -1470,7 +1470,7 @@ YUI.add('juju-gui', function(Y) {
             linkify={utils.linkify}
             appState={this.state} />
         );
-      } else if (localType && inspectorState.file) {
+      } else if (localType && window.localCharmFile) {
         // When dragging a local charm zip over the canvas it animates the
         // drag over notification which needs to be closed when the inspector
         // is opened.
@@ -1479,7 +1479,7 @@ YUI.add('juju-gui', function(Y) {
         inspector = (
           <window.juju.components.LocalInspector
             acl={this.acl}
-            file={inspectorState.file}
+            file={window.localCharmFile}
             localType={localType}
             services={this.db.services}
             series={utils.getSeriesList()}

--- a/jujugui/static/gui/src/app/store/env/fakebackend.js
+++ b/jujugui/static/gui/src/app/store/env/fakebackend.js
@@ -1869,7 +1869,7 @@ YUI.add('juju-env-fakebackend', function(Y) {
       @return {String} The full URL to the charm file.
     */
     getLocalCharmFileUrl: function(charmUrl, filename) {
-      if (filename === 'icon.svg') {
+      if (!filename || filename === 'icon.svg') {
         // This is a request for a local charm icon URL. Just return the
         // fallback icon.
         return '/static/gui/build/app/assets/images/non-sprites/charm_160.svg';

--- a/jujugui/static/gui/src/app/views/topology/service.js
+++ b/jujugui/static/gui/src/app/views/topology/service.js
@@ -883,15 +883,14 @@ YUI.add('juju-topology-service', function(Y) {
      * @return {undefined} Nothing.
      */
     _deployLocalCharm: function(file, env, db) {
-      var topo = this.get('component');
-      topo.get('state').changeState({
+      // Store the local file in the global store.
+      window.localCharmFile = file;
+      this.get('component').get('state').changeState({
         gui: {
           inspector: {
             id: null,
             localType: 'new',
-            flash: {
-              file: file
-            }}}
+          }}
       });
     },
 
@@ -973,11 +972,10 @@ YUI.add('juju-topology-service', function(Y) {
         keys: "config", "revision" and "readme".
     */
     _checkForExistingServices: function(file, topo, env, db, contents) {
-      var charmName = jsyaml.safeLoad(contents.metadata).name;
-      var services = db.services.getServicesFromCharmName(charmName);
-
+      const charmName = jsyaml.safeLoad(contents.metadata).name;
+      const services = db.services.getServicesFromCharmName(charmName);
       if (services.length > 0) {
-        this._showUpgradeOrNewInspector(services, file, env, db);
+        this._showUpgradeOrNewInspector(file, env, db);
       } else {
         this._deployLocalCharm(file, env, db);
       }
@@ -1005,30 +1003,19 @@ YUI.add('juju-topology-service', function(Y) {
       Shows an inspector allowing the user to decide if they want to upgrade
       an existing service with a local charm or deploy a new service. Or calls
       _deployLocalCharm if there are no existing services.
-
-      @method _showUpgradeOrNewInspector
-      @param {Array} services An array of services which use a charm with the
-        same name.
       @param {Object} file The file that was dropped on the canvas.
       @param {Object} env A reference to the app env.
       @param {Object} db A reference to the apps db.
     */
-    _showUpgradeOrNewInspector: function(services, file, env, db) {
-      services.forEach(function(service, index, source) {
-        // `source` param is the services array.
-        source[index] = service.getAttrs();
-      });
-
-      var topo = this.get('component');
-      topo.get('state').changeState({
+    _showUpgradeOrNewInspector: function(file, env, db) {
+      // Store the local file in the global store.
+      window.localCharmFile = file;
+      this.get('component').get('state').changeState({
         gui: {
           inspector: {
             id: null,
-            localType: 'update',
-            flash: {
-              file: file,
-              services: services
-            }}}
+            localType: 'update'
+          }}
       });
     },
 
@@ -1850,19 +1837,9 @@ YUI.add('juju-topology-service', function(Y) {
       @param {Object} topo The reference to the topology object.
     */
     showServiceDetails: function(box, topo) {
-      // We set the hideHelp flag when the user clicks on an existing service in
-      // the canvas; in otherwords, we're not in the "create a service"
-      // workflow, which is the only one where we want to display the help
-      // notification. Right now there are multiple entrances to the "create a
-      // service" workflow, but only one to "show details for existing service",
-      // so it was easier to hide the help on that one entrance and then show it
-      // by default for all the rest.
       topo.get('state').changeState({
         gui: {
-          inspector: {
-            id: box.id,
-            flash: { hideHelp: true }
-          }
+          inspector: {id: box.id}
         }});
     },
 

--- a/jujugui/static/gui/src/test/test_service_module.js
+++ b/jujugui/static/gui/src/test/test_service_module.js
@@ -235,17 +235,6 @@ describe.skip('service module events', function() {
     serviceModule.update();
   });
 
-  it('hides onboarding for existing services', function(done) {
-    topo.on('changeState', function(e) {
-      var state = e.details[0];
-      assert.equal(true, state.gui.inspector.flash.hideHelp);
-      done();
-    });
-    var menuStub = sinon.stub(serviceModule, 'showServiceMenu');
-    this._cleanups.push(menuStub.restore);
-    serviceModule.showServiceDetails({id: 'test'}, topo);
-  });
-
   it('must not process service clicks after a dragend', function() {
     // Test the work-around that prevents serviceClick from doing its work if
     // called after dragend.  Behaviour-driven testing via a tool such as


### PR DESCRIPTION
The new state system can no longer pass arbitrary data so local charms needed some modifications to deploy correctly.