### PR TITLE
Simplify ECS code, and fix pending expose callbacks.

### DIFF
--- a/jujugui/static/gui/src/app/store/env/api.js
+++ b/jujugui/static/gui/src/app/store/env/api.js
@@ -1044,14 +1044,11 @@ YUI.add('juju-env-api', function(Y) {
       @method addCharm
     */
     addCharm: function(url, macaroon, callback, options) {
-      var ecs = this.get('ecs');
-      var args = ecs._getArgs(arguments);
       if (options && options.immediate) {
-        // Call the _addCharm method right away bypassing the queue.
-        this._addCharm.apply(this, args);
-      } else {
-        ecs._lazyAddCharm(arguments);
+        this._addCharm(url, macaroon, callback);
+        return;
       }
+      this.get('ecs').lazyAddCharm([url, macaroon, callback], options);
     },
 
     /**
@@ -1103,11 +1100,10 @@ YUI.add('juju-env-api', function(Y) {
     */
     addPendingResources: function(args, callback, options) {
       if (options && options.immediate) {
-        // Call the deploy method right away bypassing the queue.
         this._addPendingResources(args, callback);
         return;
       }
-      this.get('ecs')._lazyAddPendingResources(arguments);
+      this.get('ecs').lazyAddPendingResources([args, callback], options);
     },
 
     /**
@@ -1229,11 +1225,10 @@ YUI.add('juju-env-api', function(Y) {
     */
     deploy: function(args, callback, options) {
       if (options && options.immediate) {
-        // Call the deploy method right away bypassing the queue.
         this._deploy(args, callback);
         return;
       }
-      this.get('ecs')._lazyDeploy(arguments);
+      this.get('ecs').lazyDeploy([args, callback], options);
     },
 
     /**
@@ -1379,13 +1374,11 @@ YUI.add('juju-env-api', function(Y) {
       @method addMachines
     */
     addMachines: function(params, callback, options) {
-      var ecs = this.get('ecs');
-      var args = ecs._getArgs(arguments);
       if (options && options.immediate) {
-        return this._addMachines.apply(this, args);
-      } else {
-        return ecs.lazyAddMachines(args, options);
+        this._addMachines(params, callback);
+        return;
       }
+      this.get('ecs').lazyAddMachines([params, callback], options);
     },
 
     /**
@@ -1518,13 +1511,11 @@ YUI.add('juju-env-api', function(Y) {
       @method destroyMachines
     */
     destroyMachines: function(names, force, callback, options) {
-      var ecs = this.get('ecs');
-      var args = ecs._getArgs(arguments);
       if (options && options.immediate) {
-        return this._destroyMachines.apply(this, args);
-      } else {
-        return ecs._lazyDestroyMachines(args, options);
+        this._destroyMachines(names, force, callback);
+        return;
       }
+      this.get('ecs').lazyDestroyMachines([names, force, callback], options);
     },
 
     /**
@@ -1689,15 +1680,14 @@ YUI.add('juju-env-api', function(Y) {
 
       @method add_unit
     */
-    add_unit: function(applicationName, numUnits, toMachine,
-                       callback, options) {
-      var ecs = this.get('ecs');
-      var args = ecs._getArgs(arguments);
+    add_unit: function(
+        applicationName, numUnits, toMachine, callback, options) {
       if (options && options.immediate) {
-        this._add_unit.apply(this, args);
-      } else {
-        ecs.lazyAddUnits(args, options);
+        this._add_unit(applicationName, numUnits, toMachine, callback);
+        return;
       }
+      this.get('ecs').lazyAddUnits(
+        [applicationName, numUnits, toMachine, callback], options);
     },
 
     /**
@@ -1783,13 +1773,11 @@ YUI.add('juju-env-api', function(Y) {
       @method remove_units
     */
     remove_units: function(unitNames, callback, options) {
-      var ecs = this.get('ecs'),
-          args = ecs._getArgs(arguments);
       if (options && options.immediate) {
-        this._remove_units.apply(this, args);
-      } else {
-        ecs._lazyRemoveUnit(args);
+        this._remove_units(unitNames, callback);
+        return;
       }
+      this.get('ecs').lazyRemoveUnit([unitNames, callback], options);
     },
 
     /**
@@ -1829,13 +1817,11 @@ YUI.add('juju-env-api', function(Y) {
       @method expose
     */
     expose: function(applicationName, callback, options) {
-      var ecs = this.get('ecs'),
-          args = ecs._getArgs(arguments);
-      if (options.immediate) {
-        this._expose.apply(this, args);
-      } else {
-        ecs.lazyExpose(args);
+      if (options && options.immediate) {
+        this._expose(applicationName, callback);
+        return;
       }
+      this.get('ecs').lazyExpose([applicationName, callback], options);
     },
 
     /**
@@ -1874,13 +1860,11 @@ YUI.add('juju-env-api', function(Y) {
       @method unexpose
     */
     unexpose: function(applicationName, callback, options) {
-      var ecs = this.get('ecs'),
-          args = ecs._getArgs(arguments);
-      if (options.immediate) {
-        this._unexpose.apply(this, args);
-      } else {
-        ecs.lazyUnexpose(args);
+      if (options && options.immediate) {
+        this._unexpose(applicationName, callback);
+        return;
       }
+      this.get('ecs').lazyUnexpose([applicationName, callback], options);
     },
 
     /**
@@ -2091,19 +2075,18 @@ YUI.add('juju-env-api', function(Y) {
       @method set_config
     */
     set_config: function(applicationName, config, callback, options) {
-      var ecs = this.get('ecs');
-      var args = ecs._getArgs(arguments);
+      const ecs = this.get('ecs');
       if (options && options.immediate) {
-        // Need to check that the applicationName is a real application name
+        // We need to check that the applicationName is a real application name
         // and not a queued application id before allowing immediate or not.
         if (ecs.changeSet[applicationName]) {
-          throw 'You cannot immediately set config on a queued application';
-        } else {
-          this._set_config.apply(this, args);
+          throw new Error(
+            'You cannot immediately set config on a queued application');
         }
-      } else {
-        ecs._lazySetConfig(args);
+        this._set_config(applicationName, config, callback);
+        return;
       }
+      ecs.lazySetConfig([applicationName, config, callback], options);
     },
 
     /**
@@ -2142,13 +2125,12 @@ YUI.add('juju-env-api', function(Y) {
       @method destroyApplication
     */
     destroyApplication: function(applicationName, callback, options) {
-      const ecs = this.get('ecs');
-      const args = ecs._getArgs(arguments);
       if (options && options.immediate) {
-        this._destroyApplication.apply(this, args);
-      } else {
-        ecs.lazyDestroyApplication(args);
+        this._destroyApplication(applicationName, callback);
+        return;
       }
+      this.get('ecs').lazyDestroyApplication(
+        [applicationName, callback], options);
     },
 
     /**
@@ -2239,13 +2221,12 @@ YUI.add('juju-env-api', function(Y) {
       @method add_relation
     */
     add_relation: function(endpointA, endpointB, callback, options) {
-      var ecs = this.get('ecs'),
-          args = ecs._getArgs(arguments);
       if (options && options.immediate) {
-        this._add_relation.apply(this, args);
-      } else {
-        ecs._lazyAddRelation(args, options);
+        this._add_relation(endpointA, endpointB, callback);
+        return;
       }
+      this.get('ecs').lazyAddRelation(
+        [endpointA, endpointB, callback], options);
     },
 
     /**
@@ -2319,13 +2300,12 @@ YUI.add('juju-env-api', function(Y) {
       @method remove_relation
     */
     remove_relation: function(endpointA, endpointB, callback, options) {
-      var ecs = this.get('ecs'),
-          args = ecs._getArgs(arguments);
       if (options && options.immediate) {
-        this._remove_relation.apply(this, args);
-      } else {
-        ecs._lazyRemoveRelation(args);
+        this._remove_relation(endpointA, endpointB, callback);
+        return;
       }
+      this.get('ecs').lazyRemoveRelation(
+        [endpointA, endpointB, callback], options);
     },
 
     /**

--- a/jujugui/static/gui/src/app/store/env/legacy-api.js
+++ b/jujugui/static/gui/src/app/store/env/legacy-api.js
@@ -1048,14 +1048,11 @@ YUI.add('juju-env-legacy-api', function(Y) {
       @method addCharm
     */
     addCharm: function(url, macaroon, callback, options) {
-      var ecs = this.get('ecs');
-      var args = ecs._getArgs(arguments);
       if (options && options.immediate) {
-        // Call the _addCharm method right away bypassing the queue.
-        this._addCharm.apply(this, args);
-      } else {
-        ecs._lazyAddCharm(arguments);
+        this._addCharm(url, macaroon, callback);
+        return;
       }
+      this.get('ecs').lazyAddCharm([url, macaroon, callback], options);
     },
 
     /**
@@ -1109,12 +1106,10 @@ YUI.add('juju-env-legacy-api', function(Y) {
     */
     deploy: function(args, callback, options) {
       if (options && options.immediate) {
-        // Call the deploy method right away bypassing the queue.
         this._deploy(args, callback);
         return;
       }
-      const ecs = this.get('ecs');
-      ecs._lazyDeploy(arguments);
+      this.get('ecs').lazyDeploy([args, callback], options);
     },
 
     /**
@@ -1204,13 +1199,11 @@ YUI.add('juju-env-legacy-api', function(Y) {
       @method addMachines
     */
     addMachines: function(params, callback, options) {
-      var ecs = this.get('ecs');
-      var args = ecs._getArgs(arguments);
       if (options && options.immediate) {
-        return this._addMachines.apply(this, args);
-      } else {
-        return ecs.lazyAddMachines(args, options);
+        this._addMachines(params, callback);
+        return;
       }
+      this.get('ecs').lazyAddMachines([params, callback], options);
     },
 
     /**
@@ -1342,13 +1335,11 @@ YUI.add('juju-env-legacy-api', function(Y) {
       @method destroyMachines
     */
     destroyMachines: function(names, force, callback, options) {
-      var ecs = this.get('ecs');
-      var args = ecs._getArgs(arguments);
       if (options && options.immediate) {
-        return this._destroyMachines.apply(this, args);
-      } else {
-        return ecs._lazyDestroyMachines(args, options);
+        this._destroyMachines(names, force, callback);
+        return;
       }
+      this.get('ecs').lazyDestroyMachines([names, force, callback], options);
     },
 
     /**
@@ -1516,15 +1507,14 @@ YUI.add('juju-env-legacy-api', function(Y) {
 
       @method add_unit
     */
-    add_unit: function(applicationName, numUnits, toMachine,
-                       callback, options) {
-      var ecs = this.get('ecs');
-      var args = ecs._getArgs(arguments);
+    add_unit: function(
+        applicationName, numUnits, toMachine, callback, options) {
       if (options && options.immediate) {
-        this._add_unit.apply(this, args);
-      } else {
-        ecs.lazyAddUnits(args, options);
+        this._add_unit(applicationName, numUnits, toMachine, callback);
+        return;
       }
+      this.get('ecs').lazyAddUnits(
+        [applicationName, numUnits, toMachine, callback], options);
     },
 
     /**
@@ -1610,13 +1600,11 @@ YUI.add('juju-env-legacy-api', function(Y) {
       @method remove_units
     */
     remove_units: function(unitNames, callback, options) {
-      var ecs = this.get('ecs'),
-          args = ecs._getArgs(arguments);
       if (options && options.immediate) {
-        this._remove_units.apply(this, args);
-      } else {
-        ecs._lazyRemoveUnit(args);
+        this._remove_units(unitNames, callback);
+        return;
       }
+      this.get('ecs').lazyRemoveUnit([unitNames, callback], options);
     },
 
     /**
@@ -1656,13 +1644,11 @@ YUI.add('juju-env-legacy-api', function(Y) {
       @method expose
     */
     expose: function(applicationName, callback, options) {
-      var ecs = this.get('ecs'),
-          args = ecs._getArgs(arguments);
-      if (options.immediate) {
-        this._expose.apply(this, args);
-      } else {
-        ecs.lazyExpose(args);
+      if (options && options.immediate) {
+        this._expose(applicationName, callback);
+        return;
       }
+      this.get('ecs').lazyExpose([applicationName, callback], options);
     },
 
     /**
@@ -1701,13 +1687,11 @@ YUI.add('juju-env-legacy-api', function(Y) {
       @method unexpose
     */
     unexpose: function(applicationName, callback, options) {
-      var ecs = this.get('ecs'),
-          args = ecs._getArgs(arguments);
-      if (options.immediate) {
-        this._unexpose.apply(this, args);
-      } else {
-        ecs.lazyUnexpose(args);
+      if (options && options.immediate) {
+        this._unexpose(applicationName, callback);
+        return;
       }
+      this.get('ecs').lazyUnexpose([applicationName, callback], options);
     },
 
     /**
@@ -1925,19 +1909,18 @@ YUI.add('juju-env-legacy-api', function(Y) {
       @method set_config
     */
     set_config: function(applicationName, config, callback, options) {
-      var ecs = this.get('ecs');
-      var args = ecs._getArgs(arguments);
+      const ecs = this.get('ecs');
       if (options && options.immediate) {
         // Need to check that the applicationName is a real application name
         // and not a queued application id before allowing immediate or not.
         if (ecs.changeSet[applicationName]) {
-          throw 'You cannot immediately set config on a queued application';
-        } else {
-          this._set_config.apply(this, args);
+          throw new Error(
+            'You cannot immediately set config on a queued application');
         }
-      } else {
-        ecs._lazySetConfig(args);
+        this._set_config(applicationName, config, callback);
+        return;
       }
+      ecs.lazySetConfig([applicationName, config, callback], options);
     },
 
     /**
@@ -1976,13 +1959,12 @@ YUI.add('juju-env-legacy-api', function(Y) {
       @method destroyApplication
     */
     destroyApplication: function(applicationName, callback, options) {
-      var ecs = this.get('ecs');
-      var args = ecs._getArgs(arguments);
       if (options && options.immediate) {
-        this._destroyApplication.apply(this, args);
-      } else {
-        ecs.lazyDestroyApplication(args);
+        this._destroyApplication(applicationName, callback);
+        return;
       }
+      this.get('ecs').lazyDestroyApplication(
+        [applicationName, callback], options);
     },
 
     /**
@@ -2077,13 +2059,12 @@ YUI.add('juju-env-legacy-api', function(Y) {
       @method add_relation
     */
     add_relation: function(endpointA, endpointB, callback, options) {
-      var ecs = this.get('ecs'),
-          args = ecs._getArgs(arguments);
       if (options && options.immediate) {
-        this._add_relation.apply(this, args);
-      } else {
-        ecs._lazyAddRelation(args, options);
+        this._add_relation(endpointA, endpointB, callback);
+        return;
       }
+      this.get('ecs').lazyAddRelation(
+        [endpointA, endpointB, callback], options);
     },
 
     /**
@@ -2159,13 +2140,12 @@ YUI.add('juju-env-legacy-api', function(Y) {
       @method remove_relation
     */
     remove_relation: function(endpointA, endpointB, callback, options) {
-      var ecs = this.get('ecs'),
-          args = ecs._getArgs(arguments);
       if (options && options.immediate) {
-        this._remove_relation.apply(this, args);
-      } else {
-        ecs._lazyRemoveRelation(args);
+        this._remove_relation(endpointA, endpointB, callback);
+        return;
       }
+      this.get('ecs').lazyRemoveRelation(
+        [endpointA, endpointB, callback], options);
     },
 
     /**

--- a/jujugui/static/gui/src/app/utils/bundle-importer.js
+++ b/jujugui/static/gui/src/app/utils/bundle-importer.js
@@ -695,9 +695,9 @@ YUI.add('bundle-importer', function(Y) {
         move on to the next record.
     */
     _execute_addRelation: function(record, next) {
-      var ep1 = record.args[0].split(':');
-      var ep2 = record.args[1].split(':');
-      var endpoints = [
+      const ep1 = record.args[0].split(':');
+      const ep2 = record.args[1].split(':');
+      const endpoints = [
         [ep1[0], { name: ep1[1] }],
         [ep2[0], { name: ep2[1] }]
       ];
@@ -706,8 +706,8 @@ YUI.add('bundle-importer', function(Y) {
         endpoints[index][0] = record[ep[0].replace(/^\$/, '')].get('id');
       }, this);
 
-      var relationId = 'pending-' + record.args[0] + record.args[1];
-      var relation = this.db.relations.add({
+      const relationId = 'pending-' + record.args[0] + record.args[1];
+      const pendingRelation = this.db.relations.add({
         relation_id: relationId,
         'interface': endpoints[0][1].name,
         endpoints: endpoints,
@@ -717,16 +717,17 @@ YUI.add('bundle-importer', function(Y) {
       });
       this.modelAPI.add_relation(
           endpoints[0], endpoints[1],
-          function(e) {
+          function(evt) {
             this.db.relations.create({
-              relation_id: e.result.id,
-              type: e.result['interface'],
+              relation_id: evt.result.id,
+              type: evt.result['interface'],
               endpoints: endpoints,
               pending: false,
-              scope: e.result.scope
+              scope: evt.result.scope
             });
+            this.db.relations.remove(pendingRelation);
           }.bind(this),
-          {modelId: relation.get('id')});
+          {modelId: pendingRelation.get('id')});
       next();
     },
 

--- a/jujugui/static/gui/src/test/test_env_api.js
+++ b/jujugui/static/gui/src/test/test_env_api.js
@@ -1316,7 +1316,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
     describe('addPendingResources', function() {
       it('adds to the ecs on the public method', () => {
-        const stub = sinon.stub(env.get('ecs'), '_lazyAddPendingResources');
+        const stub = sinon.stub(env.get('ecs'), 'lazyAddPendingResources');
         env.addPendingResources({
           applicationName: 'wordpress',
           charmURL: 'wordpress-42',
@@ -2446,8 +2446,8 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     });
 
     it('calls the ecs remove relation', function() {
-      var lazy = utils.makeStubMethod(env.get('ecs'), '_lazyRemoveRelation');
-      this._cleanups.push(lazy.reset);
+      var lazy = sinon.stub(env.get('ecs'), 'lazyRemoveRelation');
+      this._cleanups.push(lazy.restore);
       env.remove_relation([], [], function() {});
       assert.equal(lazy.calledOnce, true);
     });
@@ -2489,8 +2489,8 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     });
 
     it('calls the ecs remove unit', function() {
-      var lazy = utils.makeStubMethod(env.get('ecs'), '_lazyRemoveUnit');
-      this._cleanups.push(lazy.reset);
+      var lazy = sinon.stub(env.get('ecs'), 'lazyRemoveUnit');
+      this._cleanups.push(lazy.restore);
       env.remove_units([], function() {});
       assert.equal(lazy.calledOnce, true);
     });

--- a/jujugui/static/gui/src/test/test_env_legacy_api.js
+++ b/jujugui/static/gui/src/test/test_env_legacy_api.js
@@ -1657,8 +1657,8 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     });
 
     it('calls the ecs remove relation', function() {
-      var lazy = utils.makeStubMethod(env.get('ecs'), '_lazyRemoveRelation');
-      this._cleanups.push(lazy.reset);
+      var lazy = sinon.stub(env.get('ecs'), 'lazyRemoveRelation');
+      this._cleanups.push(lazy.restore);
       env.remove_relation([], [], function() {});
       assert.equal(lazy.calledOnce, true);
     });
@@ -1700,8 +1700,8 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     });
 
     it('calls the ecs remove unit', function() {
-      var lazy = utils.makeStubMethod(env.get('ecs'), '_lazyRemoveUnit');
-      this._cleanups.push(lazy.reset);
+      var lazy = sinon.stub(env.get('ecs'), 'lazyRemoveUnit');
+      this._cleanups.push(lazy.restore);
       env.remove_units([], function() {});
       assert.equal(lazy.calledOnce, true);
     });


### PR DESCRIPTION
This fixes https://github.com/juju/juju-gui/issues/2297 by addressing the underlaying issue: not providing callbacks to some API calls causes the ECS to not being able to complete.
In that scenario, for instance, expose callbacks are never called because the existing code failed to identify the missing argument and react accordingly.
This branch makes calling the ECS lazy methods explicit, so that we are more in control of what arguments are passed. As a consequence, some magic is also removed, which is always good.

To QA this, deploy the canonical k8s in sandbox mode and on real models. Also please exercise all the API calls and ECS interactons, as this branch introduces major changes in the logic there.

Conflicts:
	jujugui/static/gui/src/test/test_env_api.js
	jujugui/static/gui/src/test/test_env_change_set.js
	jujugui/static/gui/src/test/test_env_legacy_api.js