### PR TITLE
[#2306] Request actual machine count from API.

### DIFF
--- a/jujugui/static/gui/src/app/jujulib/charmstore.js
+++ b/jujugui/static/gui/src/app/jujulib/charmstore.js
@@ -211,6 +211,9 @@ var module = module;
         if (meta['bundle-unit-count']) {
           processed.unitCount = meta['bundle-unit-count']['Count'];
         }
+        if (meta['bundle-machine-count']) {
+          processed.machineCount = meta['bundle-machine-count']['Count'];
+        }
         processed.deployerFileUrl =
             this.url +
             '/' +
@@ -306,6 +309,7 @@ var module = module;
       entityId = entityId.replace('cs:', '');
       var endpoints = 'include=' + [
         'bundle-metadata',
+        'bundle-machine-count',
         'charm-metadata',
         'charm-config',
         'manifest',

--- a/jujugui/static/gui/src/app/jujulib/test-charmstore.js
+++ b/jujugui/static/gui/src/app/jujulib/test-charmstore.js
@@ -543,6 +543,7 @@ describe('jujulib charmstore', function() {
       var path = charmstore.bakery.sendGetRequest.lastCall.args[0];
       assert.equal(
         path, 'local/v5/foobar/meta/any?include=bundle-metadata' +
+        '&include=bundle-machine-count' +
         '&include=charm-metadata&include=charm-config&include=manifest' +
         '&include=stats&include=extra-info&include=tags&include=charm-metrics' +
         '&include=owner&include=resources&include=supported-series');

--- a/jujugui/static/gui/src/app/models/bundle.js
+++ b/jujugui/static/gui/src/app/models/bundle.js
@@ -329,6 +329,18 @@ YUI.add('juju-bundle-models', function(Y) {
           });
           return count;
         }
+      },
+
+      /**
+       * Determine the number of machines the bundle will use.
+       *
+       * @attribute machineCount
+       * @default 0
+       * @type {Number}
+       *
+       */
+      machineCount: {
+        value: 0
       }
     }
   });

--- a/jujugui/static/gui/src/app/models/entity-extension.js
+++ b/jujugui/static/gui/src/app/models/entity-extension.js
@@ -75,8 +75,7 @@ YUI.add('entity-extension', function(Y) {
         entity.applications = this.parseBundleServices(
           this.get('applications'));
         entity.serviceCount = attrs.serviceCount;
-        entity.machineCount = attrs.machines ?
-          Object.keys(attrs.machines).length : attrs.serviceCount;
+        entity.machineCount = attrs.machineCount;
         entity.unitCount = attrs.unitCount;
       } else {
         entity.iconPath = utils.getIconPath(entity.id, false);

--- a/jujugui/static/gui/src/test/test_entity_extension.js
+++ b/jujugui/static/gui/src/test/test_entity_extension.js
@@ -101,11 +101,11 @@ describe('Entity Extension', function() {
     entityModel.parseBundleServices = sinon.stub().returns([]);
     var attrs = {
       id: 'foobar',
-      machines: {machine1: 1, machine2: 2},
       owner: 'foobar-charmers',
       entityType: 'bundle',
-      serviceCount: 3,
       applications: [],
+      machineCount: 2,
+      serviceCount: 3,
       unitCount: 5
     };
     entityModel.setAttrs(attrs);


### PR DESCRIPTION
Fixes #2306.

Machine counts were previously based on derived information. The charmstore API can now provide direct machine counts, so we can just query that data directly.