### PR TITLE
Fix ambiguous model loading

### DIFF
--- a/development.ini
+++ b/development.ini
@@ -31,6 +31,10 @@ jujugui.gisf = false
 ;   Setting the sandbox to false will cause the GUI to instantiate a
 ;   WebSocket connection instead of the fakebackend.
 ;jujugui.sandbox = false
+;   Hardcode the uuid to be an empty string to let the URL be the main key
+;   on which model to connect to. Set this to a valid uuid if you'd like to
+;   connect to a specific model by default.
+;jujugui.uuid = ""
 
 # Default to Juju 2 in sandbox mode.
 jujugui.jujuCoreVersion = 2.0.0

--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -514,7 +514,7 @@ YUI.add('juju-gui', function(Y) {
       }
       modelAPI.setCredentials({ user, password, macaroons });
       this.env = modelAPI;
-      // Generate the application state to then see if we have to disambiguate
+      // Generate the application state then see if we have to disambiguate
       // the user portion of the state.
       const pathState = this.state.generateState(window.location.href);
       let entityPromise = null;
@@ -1699,7 +1699,7 @@ YUI.add('juju-gui', function(Y) {
         socketURL = this.createSocketURL(this.get('socketTemplate'), uuid);
       } else {
         this.set('modelUUID', undefined);
-        console.log('no uuid or model name defined: using unconnected mode');
+        console.log('no uuid or model name defined: using disconnected mode');
       }
       this.switchEnv(socketURL);
     },
@@ -1710,8 +1710,8 @@ YUI.add('juju-gui', function(Y) {
       @return {Promise} A promise with the charmstore entity if one exists.
     */
     _fetchEntityFromUserState: function(userState) {
-      const urlParts = window.jujulib.URL.fromString('u/' + userState);
-      const URLlib = new window.jujulib.URL(urlParts);
+      const legacyPath =
+        window.jujulib.URL.fromString('u/' + userState).legacyPath();
       const userPaths = this.userPaths;
       const entityCache = userPaths.get(userState);
       if (entityCache && entityCache.promise) {
@@ -1719,7 +1719,7 @@ YUI.add('juju-gui', function(Y) {
       }
       const entityPromise = new Promise((resolve, reject) => {
         this.get('charmstore').getEntity(
-          URLlib.legacyPath(), (err, entityData) => {
+          legacyPath, (err, entityData) => {
             if (err) {
               console.error(err);
               reject(userState);

--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -1057,9 +1057,7 @@ YUI.add('juju-gui', function(Y) {
           pluralize={utils.pluralize.bind(this)}
           staticURL={window.juju_config.staticURL}
           storeUser={this.storeUser.bind(this)}
-          switchModel={utils.switchModel.bind(this,
-            this.createSocketURL.bind(this, this.get('socketTemplate')),
-            this.switchEnv.bind(this), this.env)}
+          switchModel={utils.switchModel.bind(this, this.env)}
           user={this._getAuth()}
           users={Y.clone(this.get('users'), true)}
           charmstore={this.get('charmstore')} />,

--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -706,7 +706,7 @@ YUI.add('juju-gui', function(Y) {
         this.env.connect();
       }
       this.on('*:autoplaceAndCommitAll', this._autoplaceAndCommitAll, this);
-      this.state.dispatch();
+      this.state.bootstrap();
     },
 
     /**

--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -1678,8 +1678,9 @@ YUI.add('juju-gui', function(Y) {
       @param {Function} next - Run the next route handler, if any.
     */
     _handleModelState: function(state, next) {
+      const env = this.env;
       if (this.get('modelUUID') !== state.model.uuid ||
-          !this.env.get('connected')) {
+          (!env.get('connected') && !env.get('connecting'))) {
         this._switchModelToUUID(state.model.uuid);
       }
       next();

--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -1998,33 +1998,6 @@ YUI.add('juju-gui', function(Y) {
     },
 
     /**
-      Chooses a model to connect to from the model list based on config and/or
-      model availability in this controller.
-
-      @method _pickModel
-      @param {Array} modelList The list of models to pick from.
-      @param {String} modelUUID The uuid of the model to attempt to connect to.
-      @return {Object} The selected model, or null if there are no models
-        accessible by the user.
-     */
-    _pickModel: function(modelList, modelUUID) {
-      if (!modelList.length) {
-        return null;
-      }
-      let matching = [];
-      if (modelUUID) {
-        matching = modelList.filter(model => model.name === modelUUID);
-      }
-      // Connect to the first matching model. Not sure if it's possible to match
-      // more than one UUID.
-      const selectedModel = matching.length ? matching[0] : null;
-      if (selectedModel) {
-        this.set('modelUUID', selectedModel.uuid);
-      }
-      return selectedModel;
-    },
-
-    /**
       Creates a new instance of the new charmstore api and assigns it to the
       charmstore attribute. Idempotent.
 

--- a/jujugui/static/gui/src/app/components/entity-details/entity-details.js
+++ b/jujugui/static/gui/src/app/components/entity-details/entity-details.js
@@ -200,7 +200,7 @@ YUI.add('entity-details', function() {
       // Set the keyboard focus on the component so it can be scrolled with the
       // keyboard. Requires tabIndex to be set on the element.
       this.refs.content.focus();
-      // Be sure to convert the id to the legacy id as the url will be in the
+      // Be sure to convert the id to the legacy id as the URL will be in the
       // new id format.
       const entityId = this.props.id;
       let processedId = entityId;
@@ -208,9 +208,7 @@ YUI.add('entity-details', function() {
       // into the legacy charm format until the charmstore can accept the new
       // format.
       if (entityId.indexOf('/') !== -1 && entityId.indexOf('~') === -1) {
-        const urlParts = window.jujulib.URL.fromString(entityId);
-        const URLlib = new window.jujulib.URL(urlParts);
-        processedId = URLlib.legacyPath();
+        processedId = window.jujulib.URL.fromString(entityId).legacyPath();
       }
       this.detailsXhr = this.props.getEntity(processedId, this.fetchCallback);
     },

--- a/jujugui/static/gui/src/app/components/entity-details/entity-details.js
+++ b/jujugui/static/gui/src/app/components/entity-details/entity-details.js
@@ -200,12 +200,25 @@ YUI.add('entity-details', function() {
       // Set the keyboard focus on the component so it can be scrolled with the
       // keyboard. Requires tabIndex to be set on the element.
       this.refs.content.focus();
-      this.detailsXhr = this.props.getEntity(
-          this.props.id, this.fetchCallback);
+      // Be sure to convert the id to the legacy id as the url will be in the
+      // new id format.
+      const entityId = this.props.id;
+      let processedId = entityId;
+      // If the entityId contains a / and no ~ then it needs to be converted
+      // into the legacy charm format until the charmstore can accept the new
+      // format.
+      if (entityId.indexOf('/') !== -1 && entityId.indexOf('~') === -1) {
+        const urlParts = window.jujulib.URL.fromString(entityId);
+        const URLlib = new window.jujulib.URL(urlParts);
+        processedId = URLlib.legacyPath();
+      }
+      this.detailsXhr = this.props.getEntity(processedId, this.fetchCallback);
     },
 
     componentWillUnmount: function() {
-      this.detailsXhr.abort();
+      if (this.detailsXhr) {
+        this.detailsXhr.abort();
+      }
     },
 
     /**

--- a/jujugui/static/gui/src/app/components/env-switcher/env-switcher.js
+++ b/jujugui/static/gui/src/app/components/env-switcher/env-switcher.js
@@ -115,7 +115,7 @@ YUI.add('env-switcher', function() {
     handleEnvClick: function(model) {
       var props = this.props;
       this.setState({showEnvList: false});
-      props.switchModel(model.id, this.state.envList, model.name);
+      props.switchModel(model.id, model.name);
     },
 
     /**

--- a/jujugui/static/gui/src/app/components/env-switcher/test-env-switcher.js
+++ b/jujugui/static/gui/src/app/components/env-switcher/test-env-switcher.js
@@ -168,7 +168,7 @@ describe('EnvSwitcher', function() {
       showEnvList: false,
       envList: models
     });
-    assert.deepEqual(switchModel.args[0], ['abc123', models, 'abc123']);
+    assert.deepEqual(switchModel.args[0], ['abc123', 'abc123']);
   });
 
   it('can show the profile', function() {

--- a/jujugui/static/gui/src/app/components/user-profile/create-model-button/create-model-button.js
+++ b/jujugui/static/gui/src/app/components/user-profile/create-model-button/create-model-button.js
@@ -22,6 +22,7 @@ YUI.add('create-model-button', function() {
 
   juju.components.CreateModelButton = React.createClass({
     propTypes: {
+      changeState: React.PropTypes.func.isRequired,
       switchModel: React.PropTypes.func.isRequired,
       title: React.PropTypes.string,
       type: React.PropTypes.string,
@@ -34,11 +35,20 @@ YUI.add('create-model-button', function() {
       };
     },
 
+    _createNewModel: function() {
+      // We want to explicitly close the profile when switching to a new
+      // model to resolve a race condition with the new model setup.
+      this.props.changeState({
+        profile: null
+      });
+      this.props.switchModel();
+    },
+
     render: function() {
       return (
         <div className="user-profile__create-new">
           <juju.components.GenericButton
-            action={this.props.switchModel}
+            action={this._createNewModel}
             type={this.props.type}
             title={this.props.title} />
         </div>

--- a/jujugui/static/gui/src/app/components/user-profile/create-model-button/test-create-model-button.js
+++ b/jujugui/static/gui/src/app/components/user-profile/create-model-button/test-create-model-button.js
@@ -28,15 +28,15 @@ describe('CreateModelButton', () => {
   });
 
   it('renders a button with default values', () => {
-    const switchModel = sinon.stub();
     const component = jsTestUtils.shallowRender(
       <juju.components.CreateModelButton
-        switchModel={switchModel} />, true);
+        changeState={sinon.stub()}
+        switchModel={sinon.stub()} />, true);
     const output = component.getRenderOutput();
     const expected = (
       <div className="user-profile__create-new">
         <juju.components.GenericButton
-          action={switchModel}
+          action={output.props.children.props.action}
           type="inline-neutral"
           title="Create new" />
       </div>
@@ -45,21 +45,39 @@ describe('CreateModelButton', () => {
   });
 
   it('renders a button with provided values', () => {
-    const switchModel = sinon.stub();
     const component = jsTestUtils.shallowRender(
       <juju.components.CreateModelButton
         type="positive"
         title="test"
-        switchModel={switchModel} />, true);
+        changeState={sinon.stub()}
+        switchModel={sinon.stub()} />, true);
     const output = component.getRenderOutput();
     const expected = (
       <div className="user-profile__create-new">
         <juju.components.GenericButton
-          action={switchModel}
+          action={output.props.children.props.action}
           type="positive"
           title="test" />
       </div>
     );
     assert.deepEqual(output, expected);
+  });
+
+  it('closes the profile before switching to a new model', () => {
+    const changeState = sinon.stub();
+    const switchModel = sinon.stub();
+    const component = jsTestUtils.shallowRender(
+      <juju.components.CreateModelButton
+        type="positive"
+        title="test"
+        changeState={changeState}
+        switchModel={switchModel} />, true);
+    const output = component.getRenderOutput();
+    // Call the action passed to the GenericButton
+    output.props.children.props.action();
+    assert.equal(changeState.callCount, 1);
+    assert.deepEqual(changeState.args[0], [{profile: null}]);
+    assert.equal(switchModel.callCount, 1);
+    assert.deepEqual(switchModel.args[0], []);
   });
 });

--- a/jujugui/static/gui/src/app/components/user-profile/empty-user-profile.js
+++ b/jujugui/static/gui/src/app/components/user-profile/empty-user-profile.js
@@ -43,12 +43,9 @@ YUI.add('empty-user-profile', function() {
       @method switchModel
       @param {String} uuid The model UUID.
       @param {String} name The model name.
-      @param {Function} callback The function to be called once the model has
-        been switched and logged into. Takes the following parameters:
-        {Object} env The env that has been switched to.
     */
-    switchModel: function(uuid, name, callback) {
-      this.props.switchModel(uuid, [], name, callback);
+    switchModel: function(uuid, name) {
+      this.props.switchModel(uuid, name);
     },
 
 

--- a/jujugui/static/gui/src/app/components/user-profile/empty-user-profile.js
+++ b/jujugui/static/gui/src/app/components/user-profile/empty-user-profile.js
@@ -22,6 +22,7 @@ YUI.add('empty-user-profile', function() {
 
   juju.components.EmptyUserProfile = React.createClass({
     propTypes: {
+      changeState: React.PropTypes.func.isRequired,
       staticURL: React.PropTypes.string,
       switchModel: React.PropTypes.func.isRequired
     },
@@ -68,6 +69,7 @@ YUI.add('empty-user-profile', function() {
             appear here when you create them.
           </p>
           <juju.components.CreateModelButton
+            changeState={props.changeState}
             switchModel={this.switchModel}
             title="Start building"
             type="inline-positive" />

--- a/jujugui/static/gui/src/app/components/user-profile/model-list/model-list.js
+++ b/jujugui/static/gui/src/app/components/user-profile/model-list/model-list.js
@@ -27,6 +27,7 @@ YUI.add('user-profile-model-list', function() {
       acl: React.PropTypes.object,
       addNotification: React.PropTypes.func.isRequired,
       broadcastStatus: React.PropTypes.func,
+      changeState: React.PropTypes.func.isRequired,
       currentModel: React.PropTypes.string,
       destroyModels: React.PropTypes.func.isRequired,
       facadesExist: React.PropTypes.bool.isRequired,
@@ -347,6 +348,7 @@ YUI.add('user-profile-model-list', function() {
       //if (acl && acl.canAddModels()) {
       createNewButton = (
         <juju.components.CreateModelButton
+          changeState={this.props.changeState}
           switchModel={this.switchModel} />
       );
       //}

--- a/jujugui/static/gui/src/app/components/user-profile/model-list/model-list.js
+++ b/jujugui/static/gui/src/app/components/user-profile/model-list/model-list.js
@@ -240,12 +240,9 @@ YUI.add('user-profile-model-list', function() {
       @method switchModel
       @param {String} uuid The model UUID.
       @param {String} name The model name.
-      @param {Function} callback The function to be called once the model has
-        been switched and logged into. Takes the following parameters:
-        {Object} env The env that has been switched to.
     */
-    switchModel: function(uuid, name, callback) {
-      this.props.switchModel(uuid, this.state.modelList, name, callback);
+    switchModel: function(uuid, name) {
+      this.props.switchModel(uuid, name);
     },
 
     /**

--- a/jujugui/static/gui/src/app/components/user-profile/model-list/test-model-list.js
+++ b/jujugui/static/gui/src/app/components/user-profile/model-list/test-model-list.js
@@ -47,10 +47,12 @@ describe('UserProfileModelList', () => {
     const acl = {
       canAddModels: () => true
     };
+    const changeState = sinon.stub();
     const component = jsTestUtils.shallowRender(
       <juju.components.UserProfileModelList
         acl={acl}
         addNotification={sinon.stub()}
+        changeState={changeState}
         currentModel={'model1'}
         listModelsWithInfo={sinon.stub().callsArgWith(0, null, [])}
         switchModel={sinon.stub()}
@@ -65,6 +67,7 @@ describe('UserProfileModelList', () => {
             ({0})
           </span>
           <juju.components.CreateModelButton
+            changeState={changeState}
             switchModel={instance.switchModel} />
         </div>
         {undefined}
@@ -96,10 +99,12 @@ describe('UserProfileModelList', () => {
     const acl = {
       canAddModels: () => true
     };
+    const changeState = sinon.stub();
     const component = jsTestUtils.shallowRender(
       <juju.components.UserProfileModelList
         acl={acl}
         addNotification={sinon.stub()}
+        changeState={changeState}
         currentModel={'model1'}
         destroyModels={sinon.stub()}
         facadesExist={true}
@@ -117,6 +122,7 @@ describe('UserProfileModelList', () => {
             ({1})
           </span>
           <juju.components.CreateModelButton
+            changeState={changeState}
             switchModel={instance.switchModel} />
         </div>
         <ul className="user-profile__list twelve-col">

--- a/jujugui/static/gui/src/app/components/user-profile/model-list/test-model-list.js
+++ b/jujugui/static/gui/src/app/components/user-profile/model-list/test-model-list.js
@@ -219,14 +219,7 @@ describe('UserProfileModelList', () => {
     // We need to call to generate the proper socket URL.
     // Check that switchModel is called with the proper values.
     assert.equal(switchModel.callCount, 1, 'switchModel not called');
-    assert.deepEqual(switchModel.args[0], ['abc123', [{
-      uuid: 'model1',
-      name: 'spinach/sandbox',
-      lastConnection: '2016-09-12T15:42:09Z',
-      ownerTag: 'user-who',
-      owner: 'who',
-      isAlive: true
-    }], 'modelname', undefined]);
+    assert.deepEqual(switchModel.args[0], ['abc123', 'modelname']);
   });
 
   it('can reset the model connection', () => {

--- a/jujugui/static/gui/src/app/components/user-profile/test-empty-user-profile.js
+++ b/jujugui/static/gui/src/app/components/user-profile/test-empty-user-profile.js
@@ -28,8 +28,10 @@ describe('EmptyUserProfile', () => {
 
   it('renders the empty state', () => {
     var staticURL = 'test-url';
+    const changeState = sinon.stub();
     var component = jsTestUtils.shallowRender(
       <juju.components.EmptyUserProfile
+       changeState={changeState}
        switchModel={sinon.stub()}
        staticURL={staticURL} />, true);
     var src = staticURL + '/static/gui/build/app'
@@ -49,6 +51,7 @@ describe('EmptyUserProfile', () => {
           them.
         </p>
         <juju.components.CreateModelButton
+          changeState={changeState}
           switchModel={instance.switchModel}
           title="Start building"
           type="inline-positive" />

--- a/jujugui/static/gui/src/app/components/user-profile/test-user-profile.js
+++ b/jujugui/static/gui/src/app/components/user-profile/test-user-profile.js
@@ -78,6 +78,7 @@ describe('UserProfile', () => {
     const content = output.props.children.props.children;
     const emptyComponent = (
       <juju.components.EmptyUserProfile
+        changeState={changeState}
         staticURL={staticURL}
         switchModel={switchModel} />
     );
@@ -87,6 +88,7 @@ describe('UserProfile', () => {
         addNotification={addNotification}
         ref="modelList"
         key="modelList"
+        changeState={changeState}
         currentModel={undefined}
         destroyModels={destroyModels}
         facadesExist={true}

--- a/jujugui/static/gui/src/app/components/user-profile/user-profile.js
+++ b/jujugui/static/gui/src/app/components/user-profile/user-profile.js
@@ -77,6 +77,7 @@ YUI.add('user-profile', function() {
       const props = this.props;
       const emptyComponent = (
         <juju.components.EmptyUserProfile
+          changeState={props.changeState}
           staticURL={props.staticURL}
           switchModel={props.switchModel} />
       );
@@ -86,6 +87,7 @@ YUI.add('user-profile', function() {
         <juju.components.UserProfileModelList
           acl={props.acl}
           addNotification={props.addNotification}
+          changeState={props.changeState}
           key='modelList'
           ref='modelList'
           currentModel={props.currentModel}

--- a/jujugui/static/gui/src/app/extensions/app-renderer-extension.js
+++ b/jujugui/static/gui/src/app/extensions/app-renderer-extension.js
@@ -76,9 +76,7 @@ YUI.add('app-renderer-extension', function(Y) {
           showProfile={utils.showProfile.bind(
             this, env && env.get('ecs'),
             this.state.changeState.bind(this.state), auth && auth.rootUserName)}
-          switchModel={utils.switchModel.bind(
-            this, this.createSocketURL.bind(this, this.get('socketTemplate')),
-            this.switchEnv.bind(this), env)} />,
+          switchModel={utils.switchModel.bind(this, env)} />,
         document.getElementById('header-breadcrumb'));
     },
 

--- a/jujugui/static/gui/src/app/state/state.js
+++ b/jujugui/static/gui/src/app/state/state.js
@@ -202,6 +202,17 @@ const State = class State {
   }
 
   /**
+    Used to bootstrap the application from state. This calls the dispatch
+    method with the necessary values as we only want to dispatch from the
+    url once on initial application load.
+
+    @return {Object} See dispatch() for return arguments.
+  */
+  bootstrap() {
+    return this.dispatch([], true, false, true);
+  }
+
+  /**
     Checks the current location and parses it, building the state, then
     executing the registered dispatchers.
     @param {Array} nullKeys - A list of keys which we must run the 'cleanup'
@@ -213,13 +224,30 @@ const State = class State {
     @param {Boolean} backDispatch - Whether this dispatch was from the user
       hitting the back button. If it was we have to manually figure out the
       null keys so we know which cleanup dispatchers to run.
+    @param {Boolean} stateFromURL - Whether the dispatch should get its state
+      from the URL or from the latest app state.
+    @return {Object} {error <String|Null>, state <Object>}
+      - error: a string or any errors that may be returned, or null.
+      - state: the application state, or as much state as it was
+               able to generate
   */
-  dispatch(nullKeys = [], updateState = true, backDispatch = false) {
+  dispatch(nullKeys = [], updateState = true,
+    backDispatch = false,  stateFromURL = false) {
     let error, state;
-    ({error, state} = this.generateState(this.location.href));
-    if (error !== null) {
-      error += ` unable to generate state: ${error}`;
-      return {error, state};
+    // We only want to dispatch the state from the URL on application load or
+    // when explicitly requested by the developer.
+    const currentState = this.current;
+    if (!stateFromURL && currentState) {
+      state = currentState;
+    } else {
+      if (!currentState) {
+        console.log('no current state to dispatch, generating state from URL');
+      }
+      ({error, state} = this.generateState(this.location.href));
+      if (error !== null) {
+        error += ` unable to generate state: ${error}`;
+        return {error, state};
+      }
     }
 
     /**
@@ -573,6 +601,10 @@ const State = class State {
     const user = this.current.user || this.current.profile;
     if (user) {
       path = path.concat([PATH_DELIMETERS.get('user'), user]);
+    }
+    const model = this.current.model;
+    if (model) {
+      path = path.concat([PATH_DELIMETERS.get('user'), model.path]);
     }
     const store = this.current.store;
     if (store) {

--- a/jujugui/static/gui/src/app/state/state.js
+++ b/jujugui/static/gui/src/app/state/state.js
@@ -204,7 +204,7 @@ const State = class State {
   /**
     Used to bootstrap the application from state. This calls the dispatch
     method with the necessary values as we only want to dispatch from the
-    url once on initial application load.
+    URL once on initial application load.
 
     @return {Object} See dispatch() for return arguments.
   */
@@ -245,7 +245,7 @@ const State = class State {
       }
       ({error, state} = this.generateState(this.location.href));
       if (error !== null) {
-        error += ` unable to generate state: ${error}`;
+        error = `unable to generate state: ${error}`;
         return {error, state};
       }
     }

--- a/jujugui/static/gui/src/app/store/env/base.js
+++ b/jujugui/static/gui/src/app/store/env/base.js
@@ -222,6 +222,12 @@ YUI.add('juju-env-base', function(Y) {
     */
     'connected': {value: false},
     /**
+      Whether or not we're attempting a connection.
+      @attribute connecting
+      @type {Boolean}
+    */
+    connecting: {value: false},
+    /**
       Whether or not to run in debug mode.
 
       @attribute debug
@@ -357,6 +363,7 @@ YUI.add('juju-env-base', function(Y) {
       } else {
         const url = this.get('socket_url');
         console.log('connecting to ' + url);
+        this.set('connecting', true);
         this.ws = new jujulib.ReconnectingWebSocket(url);
         this._txn_callbacks = {};
       }
@@ -374,10 +381,12 @@ YUI.add('juju-env-base', function(Y) {
 
     on_open: function(data) {
       this.set('connected', true);
+      this.set('connecting', false);
     },
 
     on_close: function(data) {
       this.set('connected', false);
+      this.set('connecting', false);
     },
 
     /**
@@ -390,6 +399,7 @@ YUI.add('juju-env-base', function(Y) {
     close: function(callback) {
       console.log(
         `closing the ${this.name} API connection: ${this.socket_url}`);
+      this.set('connecting', false);
       if (!callback) {
         callback = () => {};
       }

--- a/jujugui/static/gui/src/app/store/env/base.js
+++ b/jujugui/static/gui/src/app/store/env/base.js
@@ -222,7 +222,7 @@ YUI.add('juju-env-base', function(Y) {
     */
     'connected': {value: false},
     /**
-      Whether or not we're attempting a connection.
+      Whether or not a connection is being attempted.
       @attribute connecting
       @type {Boolean}
     */

--- a/jujugui/static/gui/src/app/store/env/base.js
+++ b/jujugui/static/gui/src/app/store/env/base.js
@@ -388,7 +388,8 @@ YUI.add('juju-env-base', function(Y) {
         closed and the API cleaned up.
     */
     close: function(callback) {
-      console.log(`closing the ${this.name} API connection`);
+      console.log(
+        `closing the ${this.name} API connection: ${this.socket_url}`);
       if (!callback) {
         callback = () => {};
       }

--- a/jujugui/static/gui/src/app/views/utils.js
+++ b/jujugui/static/gui/src/app/views/utils.js
@@ -1304,14 +1304,13 @@ YUI.add('juju-view-utils', function(Y) {
     @param {Object} env Reference to the app env.
     @param {String} uuid A model UUID.
     @param {String} name A model name.
-    @param {Function} callback The callback to call after switching models.
     @param {Boolean} confirmUncommitted Whether to show a confirmation if there
       are uncommitted changes.
   */
   utils.switchModel = function(
-    env, uuid, name, callback, confirmUncommitted=true) {
+    env, uuid, name, confirmUncommitted=true) {
     const switchModel =
-      utils._switchModel.bind(this, env, uuid, name, callback);
+      utils._switchModel.bind(this, env, uuid, name);
     const currentChangeSet = env.get('ecs').getCurrentChangeSet();
     // If there are uncommitted changes then show a confirmation popup.
     if (confirmUncommitted && Object.keys(currentChangeSet).length > 0) {
@@ -1368,10 +1367,8 @@ YUI.add('juju-view-utils', function(Y) {
     @param {Object} env Reference to the app env.
     @param {String} uuid A model UUID.
     @param {String} name A model name.
-    @param {Function} callback An optional callback that gets called after
-      switching models.
   */
-  utils._switchModel = function(env, uuid, name, callback) {
+  utils._switchModel = function(env, uuid, name) {
     // Remove the switch model confirmation popup if it has been displayed to
     // the user.
     utils._hidePopup();

--- a/jujugui/static/gui/src/app/views/utils.js
+++ b/jujugui/static/gui/src/app/views/utils.js
@@ -1407,42 +1407,8 @@ YUI.add('juju-view-utils', function(Y) {
       newState.model = null;
     }
     this.state.changeState(newState);
-    // Update the model name. The onEnvironmentNameChange in app.js method will
-    // update the name correctly accross components.
-    // Make sure it is done after the switchEnv.
-    var updateModelName = function(params) {
-      env.set('environmentName', name);
-      if (callback) {
-        callback(params);
-      }
-    };
     env.set('environmentName', name);
     this.set('modelUUID', uuid);
-    var username, password, address, port;
-    if (uuid && modelList) {
-      var found = modelList.some((model) => {
-        if (model.uuid === uuid) {
-          username = model.user;
-          password = model.password;
-          // Note that the hostPorts attribute is only present in models
-          // returned by JEM.
-          if (model.hostPorts && model.hostPorts.length) {
-            var hostport = model.hostPorts[0].split(':');
-            address = hostport[0];
-            port = hostport[1];
-          }
-          return true;
-        }
-      });
-      if (!found) {
-        console.log('No user credentials for model: ', uuid);
-      }
-      var socketUrl = createSocketURL(uuid, address, port);
-      switchEnv(socketUrl, username, password, updateModelName, true, clearDB);
-    } else {
-      // Just reset without reconnecting to an env.
-      switchEnv(null, null, null, callback, false, clearDB);
-    }
   };
 
   /**

--- a/jujugui/static/gui/src/app/views/utils.js
+++ b/jujugui/static/gui/src/app/views/utils.js
@@ -1301,28 +1301,14 @@ YUI.add('juju-view-utils', function(Y) {
     Switch model, displaying a confirmation if there are uncommitted changes.
 
     @method switchModel
-    @param {Function} createSocketURL The function to create a socket URL.
-    @param {Function} switchEnv The function to switch models.
     @param {Object} env Reference to the app env.
     @param {String} uuid A model UUID.
-    @param {Array} modelList A list of models.
     @param {String} name A model name.
-    @param {Function} callback The function to be called once the model has
-      been switched and logged into. Takes the following parameters:
-      {Object} env The env that has been switched to.
-    @param {Boolean} clearDB Whether to clear the database and ecs when
-      switching models.
     @param {Boolean} confirmUncommitted Whether to show a confirmation if there
       are uncommitted changes.
   */
-  utils.switchModel = function(
-    createSocketURL, switchEnv, env, uuid, modelList, name, callback,
-    clearDB, confirmUncommitted=true) {
-
-    const switchModel = utils._switchModel.bind(this,
-      createSocketURL, switchEnv, env, uuid, modelList, name, callback,
-      clearDB);
-
+  utils.switchModel = function(env, uuid, name, confirmUncommitted=true) {
+    const switchModel = utils._switchModel.bind(this, env, uuid, name);
     const currentChangeSet = env.get('ecs').getCurrentChangeSet();
     // If there are uncommitted changes then show a confirmation popup.
     if (confirmUncommitted && Object.keys(currentChangeSet).length > 0) {
@@ -1376,20 +1362,12 @@ YUI.add('juju-view-utils', function(Y) {
     Switch models using the correct username and password.
 
     @method _switchModel
-    @param {Function} createSocketURL The function to create a socket URL.
-    @param {Function} switchEnv The function to switch models.
     @param {Object} env Reference to the app env.
     @param {String} uuid A model UUID.
-    @param {Array} modelList A list of models.
     @param {String} name A model name.
-    @param {Function} callback The function to be called once the model has
-      been switched and logged into. Takes the following parameters:
-      {Object} env The env that has been switched to.
-    @param {Boolean} clearDB Whether to clear the database and ecs when
-      switching models.
+  switching models.
   */
-  utils._switchModel = function(
-    createSocketURL, switchEnv, env, uuid, modelList, name, callback, clearDB) {
+  utils._switchModel = function(env, uuid, name) {
     // Remove the switch model confirmation popup if it has been displayed to
     // the user.
     utils._hidePopup();
@@ -1403,8 +1381,11 @@ YUI.add('juju-view-utils', function(Y) {
       model: {path: `${this._getAuth().rootUserName}/${name}`, uuid}
     };
     if (!uuid || !name) {
-      newState.root = 'new';
       newState.model = null;
+      const current = this.state.current;
+      if (!current || !current.profile) {
+        newState.root = 'new';
+      }
     }
     this.state.changeState(newState);
     env.set('environmentName', name);

--- a/jujugui/static/gui/src/app/views/utils.js
+++ b/jujugui/static/gui/src/app/views/utils.js
@@ -1404,6 +1404,7 @@ YUI.add('juju-view-utils', function(Y) {
     };
     if (!uuid || !name) {
       newState.root = 'new';
+      newState.model = null;
     }
     this.state.changeState(newState);
     // Update the model name. The onEnvironmentNameChange in app.js method will
@@ -1484,7 +1485,8 @@ YUI.add('juju-view-utils', function(Y) {
     }
     changeState({
       profile: username,
-      model: null
+      model: null,
+      root: null
     });
   };
 

--- a/jujugui/static/gui/src/app/views/utils.js
+++ b/jujugui/static/gui/src/app/views/utils.js
@@ -1399,7 +1399,8 @@ YUI.add('juju-view-utils', function(Y) {
     let newState = {
       profile: null,
       gui: null,
-      root: null
+      root: null,
+      model: {path: `${this._getAuth().rootUserName}/${name}`, uuid}
     };
     if (!uuid || !name) {
       newState.root = 'new';
@@ -1482,7 +1483,8 @@ YUI.add('juju-view-utils', function(Y) {
       ecs.clear();
     }
     changeState({
-      profile: username
+      profile: username,
+      model: null
     });
   };
 

--- a/jujugui/static/gui/src/test/test_app.js
+++ b/jujugui/static/gui/src/test/test_app.js
@@ -1107,6 +1107,7 @@ describe('App', function() {
             },
             get: sinon.stub().returns(ecs)
           };
+          app.state.changeState = sinon.stub();
           this._cleanups.push(() => {
             app.controllerAPI = controllerAPI;
             app.env = env;
@@ -1127,6 +1128,10 @@ describe('App', function() {
           assert.strictEqual(ecs.clear.calledOnce, true, 'ecs.clear');
           // The login mask has been displayed.
           assert.strictEqual(app._renderLogin.calledOnce, true, 'login');
+          assert.equal(app.state.changeState.callCount, 1);
+          assert.deepEqual(app.state.changeState.args[0], [{
+            model: null
+          }]);
           done();
         });
       });
@@ -1140,6 +1145,7 @@ describe('App', function() {
         // Create an application instance.
         app = constructAppInstance(true);
         app.after('ready', () => {
+          app.state.changeState = sinon.stub();
           // Mock the API connections for the resulting application.
           app.env = {
             close: (callback) => {
@@ -1170,6 +1176,10 @@ describe('App', function() {
           assert.strictEqual(ecs.clear.calledOnce, true, 'ecs.clear');
           // The login mask has been displayed.
           assert.strictEqual(app._renderLogin.calledOnce, true, 'login');
+          assert.equal(app.state.changeState.callCount, 1);
+          assert.deepEqual(app.state.changeState.args[0], [{
+            model: null
+          }]);
           done();
         });
       });
@@ -1703,85 +1713,6 @@ describe('App', function() {
       Y.getLocation = getLocation;
       container.destroy();
       app.destroy();
-    });
-
-    describe('pickModel', () => {
-      it('can pick the right model from a list based on config', () => {
-        const modelUUID = 'who-uuid';
-        app = new Y.juju.App({
-          apiAddress: 'example.com:17070',
-          baseUrl: 'http://example.com/',
-          conn: {close: function() {}},
-          container: container,
-          jujuCoreVersion: '2.1.1',
-          modelUUID: modelUUID,
-          user: 'rose',
-          socket_protocol: 'ws',
-          socketTemplate: '/juju/api/$server/$port/$uuid',
-          controllerSocketTemplate: '/api',
-          viewContainer: container
-        });
-        const fakeModelList = [{
-          uuid: 'dalek-uuid',
-        }, {
-          uuid: 'who-uuid',
-        }, {
-          uuid: 'rose-uuid'
-        }];
-        const model = app._pickModel(fakeModelList, modelUUID);
-        assert.strictEqual(model.uuid, 'who-uuid');
-        assert.strictEqual(app.get('modelUUID'), 'who-uuid');
-      });
-
-      it('does not pick a model when there is no config', () => {
-        app = new Y.juju.App({
-          apiAddress: 'example.com:17070',
-          baseUrl: 'http://example.com/',
-          conn: {close: function() {}},
-          container: container,
-          jujuCoreVersion: '2.1.1',
-          user: 'rose',
-          socket_protocol: 'ws',
-          socketTemplate: '/juju/api/$server/$port/$uuid',
-          controllerSocketTemplate: '/api',
-          viewContainer: container
-        });
-        const fakeModelList = [{
-          uuid: 'dalek-uuid',
-        }, {
-          uuid: 'who-uuid',
-        }, {
-          uuid: 'rose-uuid'
-        }];
-        const model = app._pickModel(fakeModelList, null);
-        assert.isNull(model);
-      });
-
-      it('handles no model matches', () => {
-        const modelUUID = 'bannakaffalatta-uuid';
-        app = new Y.juju.App({
-          apiAddress: 'example.com:17070',
-          baseUrl: 'http://example.com/',
-          conn: {close: function() {}},
-          container: container,
-          jujuCoreVersion: '2.1.1',
-          modelUUID: modelUUID,
-          user: 'rose',
-          socket_protocol: 'ws',
-          socketTemplate: '/juju/api/$server/$port/$uuid',
-          controllerSocketTemplate: '/api',
-          viewContainer: container
-        });
-        const fakeModelList = [{
-          uuid: 'dalek-uuid',
-        }, {
-          uuid: 'who-uuid',
-        }, {
-          uuid: 'rose-uuid'
-        }];
-        const model = app._pickModel(fakeModelList, modelUUID);
-        assert.isNull(model);
-      });
     });
 
     it('honors socket_protocol and uuid', function() {

--- a/jujugui/static/gui/src/test/test_env.js
+++ b/jujugui/static/gui/src/test/test_env.js
@@ -82,6 +82,15 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       env.destroy();
     });
 
+    it('sets connecting when it is attempting a connection', function() {
+      const env = new environments.BaseEnvironment();
+      env.set('socket_url', 'ws://sandbox');
+      env.connect();
+      assert.equal(env.get('connecting'), true);
+      env.close();
+      env.destroy();
+    });
+
     it('uses the module-defined sessionStorage.', function() {
       var conn = new ClientConnection({juju: {open: function() {}}});
       var env = new environments.BaseEnvironment({conn: conn});

--- a/jujugui/static/gui/src/test/test_utils.js
+++ b/jujugui/static/gui/src/test/test_utils.js
@@ -824,8 +824,7 @@ describe('utilities', function() {
   });
 
   describe('switchModel', function() {
-    var utils, _showUncommittedConfirm, _hidePopup,
-        models;
+    let utils, _showUncommittedConfirm, _hidePopup;
 
     before(function(done) {
       YUI(GlobalConfig).use('juju-view-utils', function(Y) {
@@ -841,13 +840,8 @@ describe('utilities', function() {
       utils._showUncommittedConfirm = sinon.stub();
       utils.state = {changeState: sinon.stub()};
       utils.set = sinon.stub();
+      utils._getAuth = sinon.stub().returns({rootUserName: 'animal'});
       utils.showConnectingMask = sinon.stub();
-      models = [{
-        uuid: 'uuid1',
-        user: 'spinach',
-        password: 'hasselhoff',
-        hostPorts: ['localhost:80', 'localhost:443']
-      }];
     });
 
     afterEach(function() {
@@ -856,97 +850,90 @@ describe('utilities', function() {
     });
 
     it('can switch directly if there are no uncommitted changes', function() {
-      var createSocketURL = sinon.stub().returns('newaddress:80');
-      var switchEnv = sinon.stub();
-      var env = {
+      const env = {
         get: sinon.stub().returns({
           getCurrentChangeSet: sinon.stub().returns({})
         })
       };
-      var callback = sinon.stub();
-      var _switchModel = utils._switchModel;
+      const _switchModel = utils._switchModel;
       utils._switchModel = sinon.stub();
-      utils.switchModel(
-        createSocketURL, switchEnv, env, 'uuid1', models, 'ev', callback);
+      utils.switchModel(env, 'uuid1', 'ev');
       assert.deepEqual(utils._switchModel.callCount, 1);
-      var switchArgs = utils._switchModel.lastCall.args;
-      assert.deepEqual(switchArgs, [
-        createSocketURL, switchEnv, env, 'uuid1', models, 'ev', callback,
-        undefined]);
+      const switchArgs = utils._switchModel.lastCall.args;
+      assert.deepEqual(switchArgs, [env, 'uuid1', 'ev']);
       utils._switchModel = _switchModel;
     });
 
     it('can show a confirmation if there are uncommitted changes', function() {
-      var createSocketURL = sinon.stub().returns('newaddress:80');
-      var switchEnv = sinon.stub();
-      var env = {
+      const env = {
         get: sinon.stub().returns({
           getCurrentChangeSet: sinon.stub().returns({change: 'a change'})
         })
       };
-      var callback = sinon.stub();
-      var _switchModel = utils._switchModel;
+      const _switchModel = utils._switchModel;
       utils._switchModel = sinon.stub();
-      utils.switchModel(
-        createSocketURL, switchEnv, env, 'uuid1', models, 'ev', callback);
+      utils.switchModel(env, 'uuid1', 'ev');
       assert.deepEqual(utils._showUncommittedConfirm.callCount, 1);
       assert.deepEqual(utils._switchModel.callCount, 0);
       utils._switchModel = _switchModel;
     });
 
     it('can switch models', function() {
-      var createSocketURL = sinon.stub().returns('newaddress:80');
-      var switchEnv = sinon.stub();
-      var env = {set: sinon.stub()};
-      var callback = sinon.stub();
-      utils._switchModel(
-        createSocketURL, switchEnv, env, 'uuid1', models, 'ev', callback);
-
-      assert.deepEqual(utils._hidePopup.callCount, 1);
-      assert.deepEqual(createSocketURL.callCount, 1);
-      var socketArgs = createSocketURL.lastCall.args;
-      assert.deepEqual(socketArgs[0], models[0].uuid);
-      assert.deepEqual(socketArgs[1], 'localhost');
-      assert.deepEqual(socketArgs[2], '80');
-
-      assert.deepEqual(switchEnv.callCount, 1);
-      var switchEnvArgs = switchEnv.lastCall.args;
-      assert.deepEqual(switchEnvArgs[0], 'newaddress:80');
-      assert.deepEqual(switchEnvArgs[1], models[0].user);
-      assert.deepEqual(switchEnvArgs[2], models[0].password);
-      //assert.deepEqual(switchEnvArgs[3], callback);
-
-      assert.deepEqual(env.set.callCount, 1);
-      var envSet = env.set.lastCall.args;
-      assert.deepEqual(envSet[0], 'environmentName');
-      assert.deepEqual(envSet[1], 'ev');
-
-      assert.deepEqual(utils.showConnectingMask.callCount, 1);
-      assert.deepEqual(utils.state.changeState.callCount, 1);
+      const env = {set: sinon.stub()};
+      utils._switchModel(env, 'uuid1', 'ev');
+      assert.equal(utils._hidePopup.callCount, 1);
+      assert.equal(utils.showConnectingMask.callCount, 1);
+      assert.equal(utils.state.changeState.callCount, 1);
+      assert.deepEqual(utils.state.changeState.args[0], [{
+        profile: null,
+        gui: null,
+        root: null,
+        model: {
+          path: 'animal/ev',
+          uuid: 'uuid1'
+        }
+      }]);
+      assert.equal(env.set.callCount, 1);
+      assert.deepEqual(env.set.args[0], ['environmentName', 'ev']);
+      assert.equal(utils.set.callCount, 1);
+      assert.deepEqual(utils.set.args[0], ['modelUUID', 'uuid1']);
     });
 
-    it('just disconnects if uuid is missing', function() {
-      var createSocketURL = sinon.stub();
-      var switchEnv = sinon.stub();
-      var env = {set: sinon.stub()};
-      utils._switchModel(createSocketURL, switchEnv, env, undefined, models);
-      assert.deepEqual(createSocketURL.callCount, 0);
-      assert.deepEqual(switchEnv.callCount, 1);
-      assert.deepEqual(
-        switchEnv.lastCall.args,
-        [null, null, null, undefined, false, undefined]);
+    it('changes to disconnected mode if model uuid is missing', function() {
+      const env = {set: sinon.stub()};
+      utils._switchModel(env, undefined, 'foo');
+      assert.deepEqual(utils.state.changeState.args[0], [{
+        profile: null,
+        gui: null,
+        root: 'new',
+        model: null
+      }]);
     });
 
-    it('just disconnects if modelList is missing', function() {
-      var createSocketURL = sinon.stub();
-      var switchEnv = sinon.stub();
-      var env = {set: sinon.stub()};
-      utils._switchModel(createSocketURL, switchEnv, env, 'model1', undefined);
-      assert.deepEqual(createSocketURL.callCount, 0);
-      assert.deepEqual(switchEnv.callCount, 1);
-      assert.deepEqual(
-        switchEnv.lastCall.args,
-        [null, null, null, undefined, false, undefined]);
+    it('changes to disconnected mode if model name is missing', function() {
+      const env = {set: sinon.stub()};
+      utils._switchModel(env, 'foo');
+      assert.deepEqual(utils.state.changeState.args[0], [{
+        profile: null,
+        gui: null,
+        root: 'new',
+        model: null
+      }]);
+    });
+
+    it('does not set root state to new if profile state exists', function() {
+      // when model uuid or name is missing
+      const env = {set: sinon.stub()};
+      utils.state.current = {
+        profile: 'animal'
+      };
+      utils._switchModel(env, 'foo');
+      assert.deepEqual(utils.state.changeState.args[0], [{
+        profile: null,
+        gui: null,
+        root: null,
+        model: null
+      }]);
     });
   });
 
@@ -1001,7 +988,9 @@ describe('utilities', function() {
       utils._showProfile(ecs, changeState, 'spinach', true);
       assert.deepEqual(changeState.callCount, 1);
       assert.deepEqual(changeState.lastCall.args[0], {
-        profile: 'spinach'
+        profile: 'spinach',
+        model: null,
+        root: null
       });
       assert.deepEqual(utils._hidePopup.callCount, 1);
       assert.deepEqual(ecs.clear.callCount, 1);


### PR DESCRIPTION
When loading the GUI with a path like `/u/hatch/foo` we need to determine if `foo` is a model or an entity before being able to dispatch. 

This branch adds this functionality but also adds the ability to state so that it can dispatch the latest state without pulling from the URL. It will still update the URL whenever the state changes.