### PR TITLE
Prepare for creating models with SSH keys.

### DIFF
--- a/jujugui/static/gui/src/app/components/deployment-flow/deployment-flow.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/deployment-flow.js
@@ -59,9 +59,10 @@ YUI.add('deployment-flow', function() {
       return {
         cloud: modelCommitted ? this.props.cloud : null,
         credential: this.props.credential,
+        loggedIn: !!this.props.getAuth(),
         region: this.props.region,
         showChangelogs: false,
-        loggedIn: !!this.props.getAuth(),
+        sshKey: null
       };
     },
 
@@ -177,6 +178,16 @@ YUI.add('deployment-flow', function() {
     },
 
     /**
+      Store the provided SSH key in state.
+
+      @method _setSSHKey
+      @param {String} key The SSH key.
+    */
+    _setSSHKey: function(key) {
+      this.setState({sshKey: key});
+    },
+
+    /**
       Store the selected budget in state.
 
       @method _setBudget
@@ -250,15 +261,19 @@ YUI.add('deployment-flow', function() {
       @method _handleDeploy
     */
     _handleDeploy: function() {
-      const credential = this.state.credential;
-      const cloud = this.state.cloud && this.state.cloud.name || null;
-      const region = this.state.region;
       let modelName = '';
       if (this.refs.modelName) {
         modelName = this.refs.modelName.getValue();
       }
-      this.props.deploy(
-        this._handleClose, true, modelName, credential, cloud, region);
+      const args = {
+        credential: this.state.credential,
+        cloud: this.state.cloud && this.state.cloud.name || undefined,
+        region: this.state.region
+      };
+      if (this.state.sshKey) {
+        args.config = {'authorized-keys': this.state.sshKey};
+      }
+      this.props.deploy(this._handleClose, true, modelName, args);
     },
 
     /**

--- a/jujugui/static/gui/src/app/components/deployment-flow/test-deployment-flow.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/test-deployment-flow.js
@@ -775,10 +775,13 @@ describe('DeploymentFlow', function() {
     output.props.children[8].props.children.props.children[1].props.children
       .props.action();
     assert.equal(deploy.callCount, 1);
+    assert.strictEqual(deploy.args[0].length, 4);
     assert.equal(deploy.args[0][2], 'Lamington');
-    assert.equal(deploy.args[0][3], 'cred');
-    assert.equal(deploy.args[0][4], 'cloud');
-    assert.equal(deploy.args[0][5], 'north');
+    assert.deepEqual(deploy.args[0][3], {
+      credential: 'cred',
+      cloud: 'cloud',
+      region: 'north'
+    });
     assert.equal(changeState.callCount, 1);
   });
 
@@ -818,12 +821,68 @@ describe('DeploymentFlow', function() {
     output.props.children[8].props.children.props.children[1].props.children
       .props.action();
     assert.equal(deploy.callCount, 1);
+    assert.strictEqual(deploy.args[0].length, 4);
     assert.equal(deploy.args[0][2], '');
-    assert.equal(deploy.args[0][3], 'cred');
-    assert.equal(deploy.args[0][4], 'cloud');
-    assert.equal(deploy.args[0][5], 'north');
+    assert.deepEqual(deploy.args[0][3], {
+      credential: 'cred',
+      cloud: 'cloud',
+      region: 'north'
+    });
     assert.equal(changeState.callCount, 1);
   });
+
+  it('can deploy with SSH keys', function() {
+    var deploy = sinon.stub().callsArg(0);
+    var changeState = sinon.stub();
+    var renderer = jsTestUtils.shallowRender(
+      <juju.components.DeploymentFlow
+        acl={acl}
+        changes={{}}
+        changesFilterByParent={sinon.stub()}
+        changeState={changeState}
+        deploy={deploy}
+        generateAllChangeDescriptions={sinon.stub()}
+        generateCloudCredentialName={sinon.stub()}
+        getAuth={sinon.stub().returns(true)}
+        getCloudCredentials={sinon.stub()}
+        getCloudCredentialNames={sinon.stub()}
+        getCloudProviderDetails={sinon.stub()}
+        getUserName={sinon.stub()}
+        groupedChanges={groupedChanges}
+        listBudgets={sinon.stub()}
+        listClouds={sinon.stub()}
+        listPlansForCharm={sinon.stub()}
+        modelCommitted={true}
+        modelName="Pavlova"
+        servicesGetById={sinon.stub()}
+        updateCloudCredential={sinon.stub()}>
+        <span>content</span>
+      </juju.components.DeploymentFlow>, true);
+    var instance = renderer.getMountedInstance();
+    instance.refs = {
+      modelName: {
+        getValue: sinon.stub().returns('mymodel')
+      }
+    };
+    instance._setCloud({name: 'azure'});
+    instance._setCredential('creds');
+    instance._setRegion('skaro');
+    instance._setSSHKey('my SSH key');
+    var output = renderer.getRenderOutput();
+    output.props.children[8].props.children.props.children[1].props.children
+      .props.action();
+    assert.equal(deploy.callCount, 1);
+    assert.strictEqual(deploy.args[0].length, 4);
+    assert.equal(deploy.args[0][2], 'mymodel');
+    assert.deepEqual(deploy.args[0][3], {
+      credential: 'creds',
+      cloud: 'azure',
+      region: 'skaro',
+      config: {'authorized-keys': 'my SSH key'}
+    });
+    assert.equal(changeState.callCount, 1);
+  });
+
 
   it('can deploy with Juju 1', function() {
     var deploy = sinon.stub().callsArg(0);
@@ -859,10 +918,13 @@ describe('DeploymentFlow', function() {
     output.props.children[8].props.children.props.children[1].props.children
       .props.action();
     assert.equal(deploy.callCount, 1);
+    assert.strictEqual(deploy.args[0].length, 4);
     assert.equal(deploy.args[0][2], '');
-    assert.equal(deploy.args[0][3], null);
-    assert.equal(deploy.args[0][4], null);
-    assert.equal(deploy.args[0][5], null);
+    assert.deepEqual(deploy.args[0][3], {
+      credential: undefined,
+      cloud: undefined,
+      region: undefined
+    });
     assert.equal(changeState.callCount, 1);
   });
 

--- a/jujugui/static/gui/src/app/views/utils.js
+++ b/jujugui/static/gui/src/app/views/utils.js
@@ -1492,12 +1492,15 @@ YUI.add('juju-view-utils', function(Y) {
       complete.
     @param {Boolean} autoplace Whether the unplace units should be placed.
     @param {String} model The name of the new model.
-    @param {String} credential The credentials to be used with the new model.
-    @param {String} cloud The cloud to deploy to.
-    @param {String} region The cloud region to deploy to.
+    @param {Object} args Any other optional argument that can be provided when
+      creating a new model. This includes the following fields:
+      - config: the optional model config;
+      - cloud: the name of the cloud to create the model in;
+      - region: the name of the cloud region to create the model in;
+      - credential: the name of the cloud credential to use for managing the
+        model's resources.
   */
-  utils.deploy = function(
-    app, callback, autoplace=true, model, credential, cloud, region) {
+  utils.deploy = function(app, callback, autoplace=true, model, args) {
     const env = app.env;
     const controllerAPI = app.controllerAPI;
     if (autoplace) {
@@ -1509,13 +1512,9 @@ YUI.add('juju-view-utils', function(Y) {
       callback();
       return;
     }
-    controllerAPI.createModel(
-      model,
-      controllerAPI.getCredentials().user, {
-        credential: credential,
-        cloud: cloud,
-        region: region
-      }, utils._newModelCallback.bind(this, app, callback));
+    const user = controllerAPI.getCredentials().user;
+    const cb = utils._newModelCallback.bind(this, app, callback);
+    controllerAPI.createModel(model, user, args, cb);
   };
 
   /**

--- a/jujugui/static/gui/src/test/test_utils.js
+++ b/jujugui/static/gui/src/test/test_utils.js
@@ -1074,15 +1074,17 @@ describe('utilities', function() {
 
     it('can create a new model', function() {
       envGet.withArgs('connected').returns(false);
-      utils.deploy(
-        app, callback, true, 'new-model', 'the-credential',
-        'azure', 'north');
+      utils.deploy(app, callback, true, 'new-model', {
+        credential: 'the-credential',
+        cloud: 'azure',
+        region: 'north'
+      });
       assert.equal(commit.callCount, 0);
       assert.equal(callback.callCount, 0);
       assert.equal(app.controllerAPI.createModel.callCount, 1);
-      var args = app.controllerAPI.createModel.args[0];
-      assert.equal(args[0], 'new-model');
-      assert.equal(args[1], 'user-spinach');
+      const args = app.controllerAPI.createModel.args[0];
+      assert.strictEqual(args[0], 'new-model');
+      assert.strictEqual(args[1], 'user-spinach');
       assert.deepEqual(args[2], {
         credential: 'the-credential',
         cloud: 'azure',


### PR DESCRIPTION
The deployment flow component now has the ability to store an SSH key in its state, and to use that when deploying the workload and creating a new model.