### PR TITLE
Improve deployment flow error handling. Fix the breadcrumb content.

### DIFF
--- a/jujugui/static/gui/src/app/components/deployment-flow/deployment-flow.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/deployment-flow.js
@@ -251,11 +251,15 @@ YUI.add('deployment-flow', function() {
       Handle closing the panel when the close button is clicked.
 
       @method _handleClose
+      @param {String} err An error if deployment failed, null otherwise.
     */
-    _handleClose: function() {
-      this.setState({
-        deploying: false
-      });
+    _handleClose: function(err) {
+      this.setState({deploying: false});
+      if (err) {
+        // Error handling is already done by the original deploy callback.
+        // Here we need to just prevent the deployment flow to close.
+        return;
+      }
       this.props.changeState({
         gui: {
           deploy: null

--- a/jujugui/static/gui/src/app/components/env-switcher/env-switcher.js
+++ b/jujugui/static/gui/src/app/components/env-switcher/env-switcher.js
@@ -22,6 +22,7 @@ YUI.add('env-switcher', function() {
 
   var EnvSwitcher = React.createClass({
     propTypes: {
+      authDetails: React.PropTypes.object,
       environmentName: React.PropTypes.string,
       listModelsWithInfo: React.PropTypes.func,
       showProfile: React.PropTypes.func.isRequired,
@@ -128,10 +129,11 @@ YUI.add('env-switcher', function() {
     environmentList: function() {
       if (this.state.showEnvList) {
         return <juju.components.EnvList
+          authDetails={this.props.authDetails}
           handleEnvClick={this.handleEnvClick}
-          createNewEnv={this.createNewEnv}
+          envs={this.state.envList}
           showProfile={this.props.showProfile}
-          envs={this.state.envList} />;
+        />;
       }
     },
 

--- a/jujugui/static/gui/src/app/components/env-switcher/list/test-list.js
+++ b/jujugui/static/gui/src/app/components/env-switcher/list/test-list.js
@@ -32,61 +32,65 @@ describe('EnvList', function() {
   });
 
   it('renders a list of environments', function() {
-    // JEM and JES use different keys for the name so this checks to make sure
-    // that both are displayed as the name.
-    var envs = [{ uuid: 'abc123', name: 'the name' },
-                { uuid: '123abc', path: 'the path' }];
-    var renderer = jsTestUtils.shallowRender(
+    const models = [
+      {uuid: 'model-uuid-1', name: 'model-name-1', owner: 'who@external'},
+      {uuid: 'model-uuid-2', name: 'model-name-2', owner: 'dalek@external'}
+    ];
+    const renderer = jsTestUtils.shallowRender(
       <juju.components.EnvList
-        envs={envs}
+        authDetails={{user: 'who@external', rootUserName: 'who'}}
+        envs={models}
         handleEnvClick={sinon.stub()}
-        showProfile={sinon.stub()} />, true);
-    var instance = renderer.getMountedInstance();
-    var output = renderer.getRenderOutput();
-    assert.deepEqual(output.props.children[0].props.children,
-      [<li className="env-list__environment"
+        showProfile={sinon.stub()}
+      />, true);
+    const instance = renderer.getMountedInstance();
+    const output = renderer.getRenderOutput();
+    assert.deepEqual(output.props.children[0].props.children, [
+      <li className="env-list__environment"
         role="menuitem"
         tabIndex="0"
-        data-id={envs[0].uuid}
-        data-name={envs[0].name}
+        data-id={models[0].uuid}
+        data-name={models[0].name}
         onClick={instance._handleModelClick}
-        key={envs[0].uuid}>
-        {envs[0].name}
+        key={models[0].uuid}>
+        {models[0].name}
       </li>,
       <li className="env-list__environment"
         role="menuitem"
         tabIndex="0"
-        data-id={envs[1].uuid}
-        data-name={envs[1].path}
+        data-id={models[1].uuid}
+        data-name={models[1].name}
         onClick={instance._handleModelClick}
-        key={envs[1].uuid}>
-        {envs[1].path}
-      </li>]);
+        key={models[1].uuid}>
+        {'dalek/model-name-2'}
+      </li>
+    ]);
   });
 
   it('displays a message if there are no models', function() {
     const output = jsTestUtils.shallowRender(
       <juju.components.EnvList
+        authDetails={{user: 'who@external', rootUserName: 'who'}}
         envs={[]}
         handleEnvClick={sinon.stub()}
         showProfile={sinon.stub()} />);
     assert.deepEqual(output.props.children[0].props.children,
-      <li className="env-list__environment"
-        key="none">
+      <li className="env-list__environment" key="none">
         No models available, click below to view your profile and create a new
         model.
       </li>);
   });
 
   it('clicking an env calls the handleEnvClick prop', function() {
-    var envs = [{ uuid: 'abc123', name: 'the name' }];
-    var handleEnvClick = sinon.stub();
-    var getAttribute = sinon.stub();
+    const models = [{uuid: 'abc123', name: 'the name', owner: 'who@external'}];
+    const handleEnvClick = sinon.stub();
+    const getAttribute = sinon.stub();
     getAttribute.withArgs('data-id').returns('abc123');
     getAttribute.withArgs('data-name').returns('the name');
-    var output = jsTestUtils.shallowRender(
+    const output = jsTestUtils.shallowRender(
       <juju.components.EnvList
-        envs={envs}
+        authDetails={{user: 'who@external', rootUserName: 'who'}}
+        envs={models}
         handleEnvClick={handleEnvClick}
         showProfile={sinon.stub()} />);
     output.props.children[0].props.children[0].props.onClick({
@@ -98,18 +102,17 @@ describe('EnvList', function() {
   });
 
   it('showProfile call is made when clicking on buttonRow button', function() {
-    var showProfile = sinon.stub();
-    var envs = [{ uuid: 'abc123', name: 'the name' }];
-    var component = testUtils.renderIntoDocument(
+    const showProfile = sinon.stub();
+    const models = [{uuid: 'abc123', name: 'the name', owner: 'who@external'}];
+    const component = testUtils.renderIntoDocument(
       <juju.components.EnvList
-        envs={envs}
+        authDetails={{user: 'who@external', rootUserName: 'who'}}
+        envs={models}
         handleEnvClick={sinon.stub()}
         showProfile={showProfile} />);
-
     testUtils.Simulate.click(
         ReactDOM.findDOMNode(component)
                 .querySelector('.button--neutral'));
-
     assert.equal(showProfile.callCount, 1);
   });
 

--- a/jujugui/static/gui/src/app/components/env-switcher/test-env-switcher.js
+++ b/jujugui/static/gui/src/app/components/env-switcher/test-env-switcher.js
@@ -69,14 +69,16 @@ describe('EnvSwitcher', function() {
     assert.deepEqual(output, expected);
   });
 
-  it('open the list on click', function() {
-    var showProfile = sinon.stub();
-    var renderer = jsTestUtils.shallowRender(
+  it('opens the list on click', function() {
+    const showProfile = sinon.stub();
+    const authDetails = {user: 'who@external', rootUserName: 'who'};
+    const renderer = jsTestUtils.shallowRender(
       <juju.components.EnvSwitcher.prototype.wrappedComponent
+        authDetails={authDetails}
         listModelsWithInfo={sinon.stub()}
         showProfile={showProfile}
         switchModel={sinon.stub()} />, true);
-    var output = renderer.getRenderOutput();
+    let output = renderer.getRenderOutput();
     // Click the toggler
     output.props.children[0].props.onClick({
       preventDefault: () => null
@@ -84,19 +86,21 @@ describe('EnvSwitcher', function() {
 
     renderer.render(
       <juju.components.EnvSwitcher.prototype.wrappedComponent
+        authDetails={authDetails}
         listModelsWithInfo={sinon.stub()}
         showProfile={showProfile}
         switchModel={sinon.stub()} />);
 
-    var instance = renderer.getMountedInstance();
+    const instance = renderer.getMountedInstance();
     output = renderer.getRenderOutput();
 
     assert.deepEqual(output.props.children[1],
       <juju.components.EnvList
+        authDetails={authDetails}
+        envs={[]}
         handleEnvClick={instance.handleEnvClick}
-        createNewEnv={instance.createNewEnv}
         showProfile={showProfile}
-        envs={[]} />);
+      />);
   });
 
   it('fetches a list of environments on mount', function() {

--- a/jujugui/static/gui/src/app/components/header-breadcrumb/header-breadcrumb.js
+++ b/jujugui/static/gui/src/app/components/header-breadcrumb/header-breadcrumb.js
@@ -49,11 +49,12 @@ YUI.add('header-breadcrumb', function() {
         return (
           <li className="header-breadcrumb__list-item">
             <window.juju.components.EnvSwitcher
+              authDetails={this.props.authDetails}
               environmentName={this.props.modelName}
               listModelsWithInfo={this.props.listModelsWithInfo}
               showProfile={this.props.showProfile}
               switchModel={this.props.switchModel}
-              authDetails={this.props.authDetails} />
+            />
           </li>);
       }
       return;

--- a/jujugui/static/gui/src/app/components/header-breadcrumb/header-breadcrumb.js
+++ b/jujugui/static/gui/src/app/components/header-breadcrumb/header-breadcrumb.js
@@ -20,17 +20,22 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 YUI.add('header-breadcrumb', function() {
 
+  // Define the name of the uncommitted model.
+  const NO_MODEL = 'untitled-model';
+
+  // This component handles the GUI header, in which the breadcrumb is
+  // displayed, including information about the current model and all other
+  // available models.
   juju.components.HeaderBreadcrumb = React.createClass({
     propTypes: {
       appState: React.PropTypes.object.isRequired,
       authDetails: React.PropTypes.object,
-      envList: React.PropTypes.array,
-      envName: React.PropTypes.string.isRequired,
       listModelsWithInfo: React.PropTypes.func,
+      modelName: React.PropTypes.string.isRequired,
+      modelOwner: React.PropTypes.string,
       showEnvSwitcher: React.PropTypes.bool.isRequired,
       showProfile: React.PropTypes.func.isRequired,
-      switchModel: React.PropTypes.func.isRequired,
-      userName: React.PropTypes.string
+      switchModel: React.PropTypes.func.isRequired
     },
 
     /**
@@ -44,8 +49,7 @@ YUI.add('header-breadcrumb', function() {
         return (
           <li className="header-breadcrumb__list-item">
             <window.juju.components.EnvSwitcher
-              environmentName={this.props.envName}
-              envList={this.props.envList}
+              environmentName={this.props.modelName}
               listModelsWithInfo={this.props.listModelsWithInfo}
               showProfile={this.props.showProfile}
               switchModel={this.props.switchModel}
@@ -58,45 +62,76 @@ YUI.add('header-breadcrumb', function() {
     /**
       Handles clicks on the profile link. Does not navigate to the profile
       if we aren't showing the model switcher.
+
       @method _handleProfileClick
+      @param {String} username The name of the profile.
+      @param {Object} evt The click event.
     */
-    _handleProfileClick: function(e) {
-      e.preventDefault();
+    _handleProfileClick: function(username, evt) {
+      evt.preventDefault();
       if (!this.props.showEnvSwitcher) {
+        // Nothing to be done: we are already in the profile view.
         return;
       }
-      this.props.showProfile();
+      // TODO frankban: showing a profile different from the current user's one
+      // does not currently work.
+      this.props.showProfile(username);
+    },
+
+    /**
+      Generate the model owner link. If there is no model or if the owner is
+      not available yet, fall back to showing the current logged in user.
+
+      TODO frankban: this requires a better UX. We can no longer assume that
+      the second part of the breadcrumb is the logged in user, and so we need a
+      new element showing who currently you are.
+
+      @method _generateOwnerLink
+    */
+    _generateOwnerLink: function() {
+      const modelOwner = this.props.modelOwner;
+      const modelName = this.props.modelName;
+      if (!modelOwner || !modelName || modelName === NO_MODEL) {
+        // There are no models so just render the current user instead.
+        return this._generateUserLink();
+      }
+      return this._buildProfile(modelOwner.split('@')[0]);
     },
 
     /**
       Generate the user link. If we aren't showing the model switcher then the
       link to the profile does not turn the users cursor to a pointer because
       we disable the profile functionality in that case.
+
       @method _generateUserLink
     */
     _generateUserLink: function() {
-      var auth = this.props.authDetails;
+      const auth = this.props.authDetails;
       if (auth && (auth.user || auth.loading)) {
-        var username = auth.loading ? '...' : auth.usernameDisplay;
-        var linkClasses = classNames(
-          'header-breadcrumb--link',
-          {
-            'profile-disabled': !this.props.showEnvSwitcher
-          }
-        );
-        return (
-          <li className="header-breadcrumb__list-item">
-            <a className={linkClasses}
-               onClick={this._handleProfileClick}>
-              {username}
-            </a>
-          </li>);
+        return this._buildProfile(auth.loading ? '...' : auth.rootUserName);
       }
-      return;
+    },
+
+    /**
+      Build a link for the given user name.
+
+      @method _buildProfile
+      @param {String} username The name of the profile.
+    */
+    _buildProfile: function(username) {
+      const linkClasses = classNames('header-breadcrumb--link', {
+        'profile-disabled': !this.props.showEnvSwitcher
+      });
+      const onClick = this._handleProfileClick.bind(this, username);
+      return (
+        <li className="header-breadcrumb__list-item">
+          <a className={linkClasses} onClick={onClick}>{username}</a>
+        </li>
+      );
     },
 
     render: function() {
-      const userItem = this._generateUserLink();
+      const userItem = this._generateOwnerLink();
       const authDetails = this.props.authDetails;
       return (
         <ul className="header-breadcrumb"

--- a/jujugui/static/gui/src/app/extensions/app-renderer-extension.js
+++ b/jujugui/static/gui/src/app/extensions/app-renderer-extension.js
@@ -67,15 +67,15 @@ YUI.add('app-renderer-extension', function(Y) {
       }
       ReactDOM.render(
         <juju.components.HeaderBreadcrumb
-          envName={this.db.environment.get('name')}
-          envList={this.get('environmentList')}
           appState={this.state}
           authDetails={auth}
           listModelsWithInfo={listModelsWithInfo}
+          modelName={this.db.environment.get('name')}
+          modelOwner={env.get('modelOwner')}
           showEnvSwitcher={showEnvSwitcher}
           showProfile={utils.showProfile.bind(
             this, env && env.get('ecs'),
-            this.state.changeState.bind(this.state), auth && auth.rootUserName)}
+            this.state.changeState.bind(this.state))}
           switchModel={utils.switchModel.bind(
             this, this.createSocketURL.bind(this, this.get('socketTemplate')),
             this.switchEnv.bind(this), env)} />,

--- a/jujugui/static/gui/src/app/store/env/api.js
+++ b/jujugui/static/gui/src/app/store/env/api.js
@@ -794,13 +794,14 @@ YUI.add('juju-env-api', function(Y) {
         return;
       }
       // Store received model information on the model.
-      this.setConnectedAttr('defaultSeries', data.series);
-      this.setConnectedAttr('providerType', data.provider);
-      this.setConnectedAttr('environmentName', data.name);
-      this.setConnectedAttr('modelUUID', data.uuid);
       this.setConnectedAttr('cloud', data.cloud);
-      this.setConnectedAttr('region', data.region);
       this.setConnectedAttr('credential', data.credential);
+      this.setConnectedAttr('defaultSeries', data.series);
+      this.setConnectedAttr('environmentName', data.name);
+      this.setConnectedAttr('modelOwner', data.owner);
+      this.setConnectedAttr('modelUUID', data.uuid);
+      this.setConnectedAttr('providerType', data.provider);
+      this.setConnectedAttr('region', data.region);
 
       // For now we only need to call modelGet if the provider is MAAS.
       if (data.provider !== 'maas') {

--- a/jujugui/static/gui/src/app/views/utils.js
+++ b/jujugui/static/gui/src/app/views/utils.js
@@ -1492,7 +1492,8 @@ YUI.add('juju-view-utils', function(Y) {
     @method deploy
     @param {Object} app The app instance itself.
     @param {Function} callback The function to be called once the deploy is
-      complete.
+      complete. It must be passed an error string or null if the operation
+      succeeds.
     @param {Boolean} autoplace Whether the unplace units should be placed.
     @param {String} model The name of the new model.
     @param {Object} args Any other optional argument that can be provided when
@@ -1512,7 +1513,7 @@ YUI.add('juju-view-utils', function(Y) {
     // If we're in a model which exists then just commit the ecs and return.
     if (env.get('connected')) {
       env.get('ecs').commit(env);
-      callback();
+      callback(null);
       return;
     }
     const user = controllerAPI.getCredentials().user;
@@ -1532,11 +1533,9 @@ YUI.add('juju-view-utils', function(Y) {
   */
   utils._newModelCallback = function(app, callback, error, model) {
     if (error) {
-      app.db.notifications.add({
-        title: error,
-        message: error,
-        level: 'error'
-      });
+      const msg = 'cannot create model: ' + error;
+      app.db.notifications.add({title: msg, message: msg, level: 'error'});
+      callback(msg);
       return;
     }
     utils.switchModel.call(
@@ -1544,7 +1543,7 @@ YUI.add('juju-view-utils', function(Y) {
       app.switchEnv.bind(app), app.env, model.uuid, [model], model.name,
       env => {
         env.get('ecs').commit(env);
-        callback();
+        callback(null);
       }, false, false);
   };
 

--- a/jujugui/static/gui/src/test/test_app_renderer_extension.js
+++ b/jujugui/static/gui/src/test/test_app_renderer_extension.js
@@ -102,14 +102,13 @@ describe('App Renderer Extension', function() {
     });
 
     it('renders a normal breadcrumb', function() {
+      renderer.env.set('modelOwner', 'who');
       renderer._renderBreadcrumb();
-      assert.equal(renderStub.callCount, 1,
-                   'React\'s render was not invoked.');
-      var props = createElementStub.lastCall.args[1];
-      assert.equal(props['showEnvSwitcher'], true,
-                   'The showEnvSwitcher prop was not set properly.');
-      assert.equal(props['envName'], 'test-model',
-                   'The envName prop was not set properly.');
+      assert.equal(renderStub.callCount, 1, 'render not invoked');
+      const props = createElementStub.lastCall.args[1];
+      assert.strictEqual(props['showEnvSwitcher'], true, 'showEnvSwitcher');
+      assert.strictEqual(props['modelName'], 'test-model', 'modelName');
+      assert.strictEqual(props['modelOwner'], 'who', 'modelOwner');
     });
 
     it('passes args through to the component', function() {

--- a/jujugui/static/gui/src/test/test_env_api.js
+++ b/jujugui/static/gui/src/test/test_env_api.js
@@ -738,6 +738,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       assert.equal(env.get('defaultSeries'), 'xenial');
       assert.equal(env.get('providerType'), 'aws');
       assert.equal(env.get('environmentName'), 'my-model');
+      assert.equal(env.get('modelOwner'), 'admin@local');
       assert.equal(env.get('modelUUID'), '5bea955d-7a43-47d3-89dd-tag1');
       assert.equal(env.get('cloud'), 'aws');
       assert.equal(env.get('region'), 'us-east-1');

--- a/jujugui/static/gui/src/test/test_utils.js
+++ b/jujugui/static/gui/src/test/test_utils.js
@@ -1112,27 +1112,26 @@ describe('utilities', function() {
     });
 
     it('can commit changes after connecting to a new model', function() {
-      var model = {
-        name: 'koala',
-        uuid: 'uuid123'
-      };
+      const model = {name: 'koala', uuid: 'uuid123'};
       utils._newModelCallback(app, callback, null, model);
       assert.equal(commit.callCount, 1);
       assert.deepEqual(commit.args[0][0], app.env);
       assert.equal(callback.callCount, 1);
+      const args = callback.args[0];
+      assert.strictEqual(args.length, 1);
+      assert.strictEqual(args[0], null);
     });
 
     it('can display an error notification', function() {
-      var model = {
-        name: 'koala',
-        uuid: 'uuid123'
-      };
-      utils._newModelCallback(
-        app, callback, 'Error: no Tasmanian Tigers were found', model);
+      const model = {name: 'koala', uuid: 'uuid123'};
+      utils._newModelCallback(app, callback, 'bad wolf', model);
+      const expectedError = 'cannot create model: bad wolf';
       assert.equal(app.db.notifications.add.callCount, 1);
-      assert.equal(
-        app.db.notifications.add.args[0][0].title,
-        'Error: no Tasmanian Tigers were found');
+      assert.equal(app.db.notifications.add.args[0][0].title, expectedError);
+      assert.equal(callback.callCount, 1);
+      const args = callback.args[0];
+      assert.strictEqual(args.length, 1);
+      assert.strictEqual(args[0], expectedError);
     });
   });
 


### PR DESCRIPTION
Deployment flow: gracefully handle deployment errors by re-enabling the deploy button (fixes #2380)
Breadcrumb component: show model owner instead of user name (fixes #2381).
Model switcher: disambiguate models owned by other users (fixes #2387).