### PR TITLE
Direct access to /store opens the store in disconnected mode.

### DIFF
--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -781,7 +781,7 @@ YUI.add('juju-gui', function(Y) {
         }
         const modelUUID = this._getModelUUID();
         const current = this.state.current;
-        if (modelUUID && !current.profile) {
+        if (modelUUID && !current.profile && current.root !== 'store') {
           // A model uuid was defined in the config so attempt to connect to it.
           this._listAndSwitchModel(null, modelUUID);
         } else if (entityPromise !== null) {
@@ -815,8 +815,8 @@ YUI.add('juju-gui', function(Y) {
         const creds = this.controllerAPI.getCredentials();
         const gisf = this.get('gisf');
         const currentState = this.state.current;
-        // If an anon user lands on the GUI at /new then don't attempt to log
-        // into the controller.
+        // If an anonymous GISF user lands on the GUI at /new then don't
+        // attempt to log into the controller.
         if (!creds.areAvailable && gisf &&
             (currentState && currentState.root === 'new')) {
           console.log('now in anonymous mode');
@@ -2362,7 +2362,7 @@ YUI.add('juju-gui', function(Y) {
     _displayLogin: function() {
       this.set('loggedIn', false);
       const root = this.state.current.root;
-      if (!root || root !== 'login') {
+      if (root !== 'login') {
         this.state.changeState({
           root: 'login'
         });
@@ -2427,8 +2427,9 @@ YUI.add('juju-gui', function(Y) {
       @param {Function} next The next route handler.
     */
     checkUserCredentials: function(state, next) {
-      // If we're in the /new state then allow the canvas to be shown.
-      if (state && state.root && state.root === 'new') {
+      // If we're in disconnected mode (either "/new" or "/store"), then allow
+      // the canvas to be shown.
+      if (state && (state.root === 'new' || state.root === 'store')) {
         next();
         return;
       }

--- a/jujugui/static/gui/src/test/test_app.js
+++ b/jujugui/static/gui/src/test/test_app.js
@@ -1989,13 +1989,22 @@ describe('App', function() {
       app.destroy();
     });
 
+    // Ensure next is called and the login view is not displayed when
+    // dispatching the given state.
+    const checkNext = state => {
+      const next = sinon.stub().withArgs();
+      const displayLogin = sinon.stub(app, '_displayLogin');
+      app.checkUserCredentials(state, next);
+      assert.equal(next.callCount, 1, 'next not called');
+      assert.equal(displayLogin.callCount, 0, '_displayLogin called');
+    };
+
     it('calls next and returns if root state is new', () => {
-      const next = sinon.stub();
-      const displayStub = sinon.stub(app, '_displayLogin');
-      app.checkUserCredentials({root: 'new'}, next);
-      assert.equal(next.callCount, 1);
-      assert.equal(
-        displayStub.callCount, 0, 'login should not have been displayed');
+      checkNext({root: 'new'});
+    });
+
+    it('calls next and returns if root state is store', () => {
+      checkNext({root: 'store'});
     });
 
     it('displays login if one of the apis is still connecting', () => {


### PR DESCRIPTION
So that an authenticated user directly navigating (or refreshing) the /store is not redirected elsewhere.