### PR TITLE
Allow loading the GUI with store paths

### DIFF
--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -788,16 +788,20 @@ YUI.add('juju-gui', function(Y) {
           this._disambiguateUserState(entityPromise);
         } else {
           // Drop into disconnected mode and show the profile but only if there
-          // is no state defined in root. If there is a state defined in root
-          // then we want to let that dispatcher handle the routing.
+          // is no state defined in root or store. If there is a state defined
+          // either of those then we want to let that dispatcher handle the
+          // routing.
           this.maskVisibility(false);
           const isLogin = current.root === 'login';
           const newState = {
             root: isLogin ? null : current.root,
           };
-          if ((isLogin || !current.root) && this.get('gisf')) {
-            // We only want to redirect the users to the profile page if they
-            // are in gisf(not gijoe) and root state is login.
+          // If the current root is 'login' after logging into the controller,
+          // or there is no root defined and no store defined then we want to
+          // render the users profile.
+          if (!current.store &&
+              (isLogin ||!current.root) &&
+              this.get('gisf')) {
             newState.profile = this._getAuth().rootUserName;
           }
           this.state.changeState(newState);

--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -800,7 +800,7 @@ YUI.add('juju-gui', function(Y) {
           // or there is no root defined and no store defined then we want to
           // render the users profile.
           if (!current.store &&
-              (isLogin ||!current.root) &&
+              (isLogin || !current.root) &&
               this.get('gisf')) {
             newState.profile = this._getAuth().rootUserName;
           }


### PR DESCRIPTION
Loading the GUI with a root path of an entity now shows that entity and loads the model in a disconnected state.