### PR TITLE
Improve model sharing: display more information about granted users.

### DIFF
--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -1363,8 +1363,9 @@ YUI.add('juju-gui', function(Y) {
       const db = this.db;
       const utils = views.utils;
       const modelUserInfo = env.modelUserInfo.bind(env);
+      const addNotification = db.notifications.add.bind(db.notifications);
       const sharingVisibility = utils.sharingVisibility.bind(utils, true,
-        modelUserInfo);
+        modelUserInfo, addNotification);
       ReactDOM.render(
         <window.juju.components.ModelActions
           acl={this.acl}

--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -1359,10 +1359,13 @@ YUI.add('juju-gui', function(Y) {
       @method _renderModelActions
     */
     _renderModelActions: function() {
-      const env = this.env;
+      const model = this.env;
+      const modelConnected = () => {
+        return model.get('connected') && this.get('modelUUID');
+      };
       const db = this.db;
       const utils = views.utils;
-      const modelUserInfo = env.modelUserInfo.bind(env);
+      const modelUserInfo = model.modelUserInfo.bind(model);
       const addNotification = db.notifications.add.bind(db.notifications);
       const sharingVisibility = utils.sharingVisibility.bind(utils, true,
         modelUserInfo, addNotification);
@@ -1370,15 +1373,16 @@ YUI.add('juju-gui', function(Y) {
         <window.juju.components.ModelActions
           acl={this.acl}
           changeState={this.state.changeState.bind(this.state)}
-          currentChangeSet={env.get('ecs').getCurrentChangeSet()}
+          currentChangeSet={model.get('ecs').getCurrentChangeSet()}
           exportEnvironmentFile={
             utils.exportEnvironmentFile.bind(utils, db,
-              env.findFacadeVersion('Application') === null)}
+              model.findFacadeVersion('Application') === null)}
           hasEntities={db.services.toArray().length > 0 ||
             db.machines.toArray().length > 0}
           hideDragOverNotification={this._hideDragOverNotification.bind(this)}
           importBundleFile={this.bundleImporter.importBundleFile.bind(
             this.bundleImporter)}
+          modelConnected={modelConnected}
           renderDragOverNotification={
             this._renderDragOverNotification.bind(this)}
           sharingVisibility={sharingVisibility}/>,

--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -1362,6 +1362,9 @@ YUI.add('juju-gui', function(Y) {
       const env = this.env;
       const db = this.db;
       const utils = views.utils;
+      const modelUserInfo = env.modelUserInfo.bind(env);
+      const sharingVisibility = utils.sharingVisibility.bind(utils, true,
+        modelUserInfo);
       ReactDOM.render(
         <window.juju.components.ModelActions
           acl={this.acl}
@@ -1377,7 +1380,7 @@ YUI.add('juju-gui', function(Y) {
             this.bundleImporter)}
           renderDragOverNotification={
             this._renderDragOverNotification.bind(this)}
-          sharingVisibility={utils.sharingVisibility.bind(utils, true)}/>,
+          sharingVisibility={sharingVisibility}/>,
         document.getElementById('model-actions-container'));
     },
 

--- a/jujugui/static/gui/src/app/components/model-actions/model-actions.js
+++ b/jujugui/static/gui/src/app/components/model-actions/model-actions.js
@@ -29,8 +29,9 @@ YUI.add('model-actions', function() {
       hasEntities: React.PropTypes.bool.isRequired,
       hideDragOverNotification: React.PropTypes.func.isRequired,
       importBundleFile: React.PropTypes.func.isRequired,
+      modelConnected: React.PropTypes.func.isRequired,
       renderDragOverNotification: React.PropTypes.func.isRequired,
-      sharingVisibility: React.PropTypes.func
+      sharingVisibility: React.PropTypes.func.isRequired
     },
 
     getDefaultProps: function() {
@@ -94,23 +95,10 @@ YUI.add('model-actions', function() {
     },
 
     render: function() {
+      if (!this.props.modelConnected()) {
+        return null;
+      }
       var isReadOnly = this.props.acl.isReadOnly();
-      const shareFlag = window.juju_config && window.juju_config.shareFlag;
-      const shareIcon = shareFlag ? (
-        <span className="model-actions__share model-actions__button"
-          onClick={this.props.sharingVisibility}
-          role="button"
-          tabIndex="0">
-          <juju.components.SvgIcon name="share_16"
-            className="model-actions__icon"
-            size="16" />
-          <span className="tooltip__tooltip--below">
-            <span className="tooltip__inner tooltip__inner--up">
-              Share
-            </span>
-          </span>
-        </span>
-      ) : undefined;
       return (
         <div className={this._generateClasses()}>
           <div className="model-actions__buttons">
@@ -140,7 +128,19 @@ YUI.add('model-actions', function() {
                 </span>
               </span>
             </span>
-            {shareIcon}
+            <span className="model-actions__share model-actions__button"
+              onClick={this.props.sharingVisibility}
+              role="button"
+              tabIndex="0">
+              <juju.components.SvgIcon name="share_16"
+                className="model-actions__icon"
+                size="16" />
+              <span className="tooltip__tooltip--below">
+                <span className="tooltip__inner tooltip__inner--up">
+                  Share
+                </span>
+              </span>
+            </span>
           </div>
           <input className="model-actions__file"
             type="file"

--- a/jujugui/static/gui/src/app/components/model-actions/model-actions.js
+++ b/jujugui/static/gui/src/app/components/model-actions/model-actions.js
@@ -95,8 +95,23 @@ YUI.add('model-actions', function() {
     },
 
     render: function() {
-      if (!this.props.modelConnected()) {
-        return null;
+      let shareAction;
+      if (this.props.modelConnected()) {
+        shareAction = (
+          <span className="model-actions__share model-actions__button"
+            onClick={this.props.sharingVisibility}
+            role="button"
+            tabIndex="0">
+            <juju.components.SvgIcon name="share_16"
+              className="model-actions__icon"
+              size="16" />
+            <span className="tooltip__tooltip--below">
+              <span className="tooltip__inner tooltip__inner--up">
+                Share
+              </span>
+            </span>
+          </span>
+        );
       }
       var isReadOnly = this.props.acl.isReadOnly();
       return (
@@ -128,19 +143,7 @@ YUI.add('model-actions', function() {
                 </span>
               </span>
             </span>
-            <span className="model-actions__share model-actions__button"
-              onClick={this.props.sharingVisibility}
-              role="button"
-              tabIndex="0">
-              <juju.components.SvgIcon name="share_16"
-                className="model-actions__icon"
-                size="16" />
-              <span className="tooltip__tooltip--below">
-                <span className="tooltip__inner tooltip__inner--up">
-                  Share
-                </span>
-              </span>
-            </span>
+            {shareAction}
           </div>
           <input className="model-actions__file"
             type="file"

--- a/jujugui/static/gui/src/app/components/model-actions/test-model-actions.js
+++ b/jujugui/static/gui/src/app/components/model-actions/test-model-actions.js
@@ -33,13 +33,6 @@ describe('ModelActions', function() {
 
   beforeEach(function() {
     acl = {isReadOnly: sinon.stub().returns(false)};
-    // XXX delete this once the shareFlag is no longer in place.
-    window.juju_config = {shareFlag: false};
-  });
-
-  afterEach(function() {
-    // XXX delete this once the shareFlag is no longer in place.
-    delete window.juju_config;
   });
 
   it('can render and pass the correct props', function() {
@@ -53,7 +46,10 @@ describe('ModelActions', function() {
         hasEntities={true}
         hideDragOverNotification={sinon.stub()}
         importBundleFile={sinon.stub()}
-        renderDragOverNotification={sinon.stub()} />, true);
+        modelConnected={sinon.stub().withArgs().returns(true)}
+        renderDragOverNotification={sinon.stub()}
+        sharingVisibility={sinon.stub()}
+      />, true);
     var instance = renderer.getMountedInstance();
     var output = renderer.getRenderOutput();
     var expected = (
@@ -85,7 +81,19 @@ describe('ModelActions', function() {
               </span>
             </span>
           </span>
-          {undefined}
+          <span className="model-actions__share model-actions__button"
+            onClick={instance.props.sharingVisibility}
+            role="button"
+            tabIndex="0">
+            <juju.components.SvgIcon name="share_16"
+              className="model-actions__icon"
+              size="16" />
+            <span className="tooltip__tooltip--below">
+              <span className="tooltip__inner tooltip__inner--up">
+                Share
+              </span>
+            </span>
+          </span>
         </div>
         <input className="model-actions__file"
           type="file"
@@ -107,7 +115,10 @@ describe('ModelActions', function() {
         hasEntities={false}
         hideDragOverNotification={sinon.stub()}
         importBundleFile={sinon.stub()}
-        renderDragOverNotification={sinon.stub()} />, true);
+        modelConnected={sinon.stub().withArgs().returns(true)}
+        renderDragOverNotification={sinon.stub()}
+        sharingVisibility={sinon.stub()}
+      />, true);
     var output = renderer.getRenderOutput();
     assert.equal(output.props.className,
       'model-actions model-actions--initial');
@@ -124,7 +135,10 @@ describe('ModelActions', function() {
         hasEntities={true}
         hideDragOverNotification={sinon.stub()}
         importBundleFile={sinon.stub()}
-        renderDragOverNotification={sinon.stub()} />, true);
+        modelConnected={sinon.stub().withArgs().returns(true)}
+        renderDragOverNotification={sinon.stub()}
+        sharingVisibility={sinon.stub()}
+      />, true);
     var output = renderer.getRenderOutput();
     assert.equal(output.props.className,
       'model-actions');
@@ -142,7 +156,10 @@ describe('ModelActions', function() {
         hasEntities={false}
         hideDragOverNotification={sinon.stub()}
         importBundleFile={sinon.stub()}
-        renderDragOverNotification={sinon.stub()} />);
+        modelConnected={sinon.stub().withArgs().returns(true)}
+        renderDragOverNotification={sinon.stub()}
+        sharingVisibility={sinon.stub()}
+      />);
     output.props.children[0].props.children[0].props.onClick();
     assert.equal(exportEnvironmentFile.callCount, 1);
   });
@@ -163,7 +180,10 @@ describe('ModelActions', function() {
         hasEntities={false}
         importBundleFile={importBundleFile}
         hideDragOverNotification={hideDragOverNotification}
-        currentChangeSet={currentChangeSet} />, true);
+        modelConnected={sinon.stub().withArgs().returns(true)}
+        currentChangeSet={currentChangeSet}
+        sharingVisibility={sinon.stub()}
+      />, true);
     var instance = shallowRenderer.getMountedInstance();
     instance.refs = {'file-input': {click: fileClick}};
     var output = shallowRenderer.getRenderOutput();
@@ -186,7 +206,10 @@ describe('ModelActions', function() {
         importBundleFile={importBundleFile}
         hasEntities={false}
         hideDragOverNotification={hideDragOverNotification}
-        currentChangeSet={currentChangeSet} />, true);
+        modelConnected={sinon.stub().withArgs().returns(true)}
+        currentChangeSet={currentChangeSet}
+        sharingVisibility={sinon.stub()}
+      />, true);
     var instance = shallowRenderer.getMountedInstance();
     instance.refs = {
       'file-input': {files: ['apache2.yaml']},
@@ -209,7 +232,10 @@ describe('ModelActions', function() {
         hasEntities={true}
         hideDragOverNotification={sinon.stub()}
         importBundleFile={sinon.stub()}
-        renderDragOverNotification={sinon.stub()} />, true);
+        modelConnected={sinon.stub().withArgs().returns(true)}
+        renderDragOverNotification={sinon.stub()}
+        sharingVisibility={sinon.stub()}
+      />, true);
     var instance = renderer.getMountedInstance();
     var output = renderer.getRenderOutput();
     var expected = (
@@ -241,7 +267,19 @@ describe('ModelActions', function() {
               </span>
             </span>
           </span>
-          {undefined}
+          <span className="model-actions__share model-actions__button"
+            onClick={instance.props.sharingVisibility}
+            role="button"
+            tabIndex="0">
+            <juju.components.SvgIcon name="share_16"
+              className="model-actions__icon"
+              size="16" />
+            <span className="tooltip__tooltip--below">
+              <span className="tooltip__inner tooltip__inner--up">
+                Share
+              </span>
+            </span>
+          </span>
         </div>
         <input className="model-actions__file"
           type="file"
@@ -252,9 +290,24 @@ describe('ModelActions', function() {
     assert.deepEqual(output, expected);
   });
 
+  it('disables everything when not connected', function() {
+    const renderer = jsTestUtils.shallowRender(
+      <juju.components.ModelActions
+        acl={sinon.stub()}
+        changeState={sinon.stub()}
+        currentChangeSet={{one: 1, two: 2}}
+        exportEnvironmentFile={sinon.stub()}
+        hasEntities={true}
+        hideDragOverNotification={sinon.stub()}
+        importBundleFile={sinon.stub()}
+        modelConnected={sinon.stub().withArgs().returns(false)}
+        renderDragOverNotification={sinon.stub()}
+        sharingVisibility={sinon.stub()}
+      />, true);
+    assert.deepEqual(renderer.getRenderOutput(), null);
+  });
+
   it('can trigger the sharing UI', function() {
-    // XXX delete this once the shareFlag is no longer in place.
-    window.juju_config['shareFlag'] = true;
     const currentChangeSet = {one: 1, two: 2};
     const sharingVisibility = sinon.stub();
     const renderer = jsTestUtils.shallowRender(
@@ -266,6 +319,7 @@ describe('ModelActions', function() {
         hasEntities={true}
         hideDragOverNotification={sinon.stub()}
         importBundleFile={sinon.stub()}
+        modelConnected={sinon.stub().withArgs().returns(true)}
         renderDragOverNotification={sinon.stub()}
         sharingVisibility={sharingVisibility} />, true);
     const output = renderer.getRenderOutput();

--- a/jujugui/static/gui/src/app/components/model-actions/test-model-actions.js
+++ b/jujugui/static/gui/src/app/components/model-actions/test-model-actions.js
@@ -290,10 +290,10 @@ describe('ModelActions', function() {
     assert.deepEqual(output, expected);
   });
 
-  it('disables everything when not connected', function() {
+  it('disables sharing when not connected', function() {
     const renderer = jsTestUtils.shallowRender(
       <juju.components.ModelActions
-        acl={sinon.stub()}
+        acl={acl}
         changeState={sinon.stub()}
         currentChangeSet={{one: 1, two: 2}}
         exportEnvironmentFile={sinon.stub()}
@@ -304,7 +304,45 @@ describe('ModelActions', function() {
         renderDragOverNotification={sinon.stub()}
         sharingVisibility={sinon.stub()}
       />, true);
-    assert.deepEqual(renderer.getRenderOutput(), null);
+    const instance = renderer.getMountedInstance();
+    const expected = (
+      <div className="model-actions">
+        <div className="model-actions__buttons">
+          <span className="model-actions__export model-actions__button"
+            onClick={instance._handleExport}
+            role="button"
+            tabIndex="0">
+            <juju.components.SvgIcon name="export_16"
+              className="model-actions__icon"
+              size="16" />
+            <span className="tooltip__tooltip--below">
+              <span className="tooltip__inner tooltip__inner--up">
+                Export
+              </span>
+            </span>
+          </span>
+          <span className="model-actions__import model-actions__button"
+            onClick={instance._handleImportClick}
+            role="button"
+            tabIndex="0">
+            <juju.components.SvgIcon name="import_16"
+              className="model-actions__icon"
+              size="16" />
+            <span className="tooltip__tooltip--below">
+              <span className="tooltip__inner tooltip__inner--up">
+                Import
+              </span>
+            </span>
+          </span>
+          {undefined}
+        </div>
+        <input className="model-actions__file"
+          type="file"
+          onChange={instance._handleImportFile}
+          accept=".zip,.yaml,.yml"
+          ref="file-input" />
+      </div>);
+    assert.deepEqual(renderer.getRenderOutput(), expected);
   });
 
   it('can trigger the sharing UI', function() {

--- a/jujugui/static/gui/src/app/components/sharing/_sharing.scss
+++ b/jujugui/static/gui/src/app/components/sharing/_sharing.scss
@@ -13,6 +13,11 @@
     padding: 0 20px 10px 20px;
   }
 
+  &__users {
+    max-height: 300px;
+    overflow-y: scroll;
+  }
+
   &__user {
     margin-bottom: 10px;
     position: relative;
@@ -29,7 +34,7 @@
     &-access {
       @extend .vertical-center;
       position: absolute;
-      right: 0;
+      right: 1px;  // Provide room for scrollbars on longer lists.
     }
 
     &:last-child {

--- a/jujugui/static/gui/src/app/components/sharing/_sharing.scss
+++ b/jujugui/static/gui/src/app/components/sharing/_sharing.scss
@@ -19,7 +19,6 @@
 
     &-name {
       margin-bottom: 3px;
-      text-transform: capitalize;
     }
 
     &-displayname {
@@ -31,7 +30,6 @@
       @extend .vertical-center;
       position: absolute;
       right: 0;
-      text-transform: capitalize;
     }
 
     &:last-child {

--- a/jujugui/static/gui/src/app/components/sharing/_sharing.scss
+++ b/jujugui/static/gui/src/app/components/sharing/_sharing.scss
@@ -37,4 +37,7 @@
     }
   }
 
+  &__loading {
+    text-align: center;
+  }
 }

--- a/jujugui/static/gui/src/app/components/sharing/sharing.js
+++ b/jujugui/static/gui/src/app/components/sharing/sharing.js
@@ -116,20 +116,37 @@ YUI.add('sharing', function() {
         return;
       }
       return users.map((user) => {
-        const accessMarkup = user.access == 'admin' ? (
-          <div className="sharing__user-access">
-            {user.access}
-          </div>
-        ) : undefined;
+        if (user.err) {
+          return (
+            <div key={user.name} className="sharing__user">
+              <div className="sharing__user-name">
+                {user.displayName}
+              </div>
+              <div className="sharing__user-displayname">
+                {user.err}
+              </div>
+            </div>
+          );
+        }
+        let lastConnection = 'never connected';
+        if (user.lastConnection) {
+          const utcDate = user.lastConnection.toUTCString().split(',')[1];
+          lastConnection = `last connection: ${utcDate}`;
+        }
         return (
           <div key={user.name} className="sharing__user">
             <div className="sharing__user-name">
-              {user.name}
-            </div>
-            <div className="sharing__user-displayname">
               {user.displayName}
             </div>
-            {accessMarkup}
+            <div className="sharing__user-displayname">
+              {user.domain} user
+            </div>
+            <div className="sharing__user-displayname">
+              {lastConnection}
+            </div>
+            <div className="sharing__user-access">
+              {user.access}
+            </div>
           </div>
         );
       });
@@ -158,6 +175,7 @@ YUI.add('sharing', function() {
 
 }, '0.1.0', {
   requires: [
+    'loading-spinner',
     'popup'
   ]
 });

--- a/jujugui/static/gui/src/app/components/sharing/sharing.js
+++ b/jujugui/static/gui/src/app/components/sharing/sharing.js
@@ -146,8 +146,8 @@ YUI.add('sharing', function() {
           className="sharing__popup"
           title="Share"
           buttons={buttons}>
+          <h5 className="sharing__users-header">Users with access</h5>
           <div className="sharing__users">
-            <h5 className="sharing__users-header">Users with access</h5>
             {this._generateUsersWithAccess()}
           </div>
         </juju.components.Popup>

--- a/jujugui/static/gui/src/app/components/sharing/sharing.js
+++ b/jujugui/static/gui/src/app/components/sharing/sharing.js
@@ -26,6 +26,7 @@ YUI.add('sharing', function() {
   */
   juju.components.Sharing = React.createClass({
     propTypes: {
+      addNotification: React.PropTypes.func,
       closeHandler: React.PropTypes.func,
       getModelUserInfo: React.PropTypes.func.isRequired
     },
@@ -36,6 +37,17 @@ YUI.add('sharing', function() {
       return {
         loadingUsers: false,
         usersWithAccess: []
+      };
+    },
+
+    getDefaultProps: function() {
+      return {
+        closeHandler: () => {
+          console.log('No closeHandler specified.');
+        },
+        addNotification: () => {
+          console.log('No addNotification specified.');
+        }
       };
     },
 
@@ -71,14 +83,17 @@ YUI.add('sharing', function() {
     _getModelUserInfoCallback: function(error, data) {
       this.setState({loadingUsers: false}, () => {
         if (error) {
-          // TODO kadams54: figure out a better way to handle this.
-          // TODO kadams54: test the error scenario
-          console.error('cannot fetch model user info', error);
+          // Display the error message.
+          this.props.addNotification({
+            title: 'Unable to load users.',
+            message: 'Unable to load user information for this model: ' + error,
+            level: 'error'
+          });
+          // Go ahead and close the popup.
+          this.props.closeHandler();
           return;
         }
-        // TODO kadams54: transform into the expected user objects.
-        const usersWithAccess = data;
-        this.setState({usersWithAccess: usersWithAccess});
+        this.setState({usersWithAccess: data});
       });
     },
 
@@ -89,7 +104,9 @@ YUI.add('sharing', function() {
       @returns {Array} An array of markup objects for each user.
     */
     _generateUsersWithAccess: function() {
-      // TODO kadams54: display a spinner instead when loading data.
+      if (this.state.loadingUsers) {
+        return <juju.components.Spinner />;
+      }
       const users = this.state.usersWithAccess;
       if (!users.length) {
         return;

--- a/jujugui/static/gui/src/app/components/sharing/sharing.js
+++ b/jujugui/static/gui/src/app/components/sharing/sharing.js
@@ -105,7 +105,11 @@ YUI.add('sharing', function() {
     */
     _generateUsersWithAccess: function() {
       if (this.state.loadingUsers) {
-        return <juju.components.Spinner />;
+        return (
+          <div className="sharing__loading">
+            <juju.components.Spinner />
+          </div>
+        );
       }
       const users = this.state.usersWithAccess;
       if (!users.length) {

--- a/jujugui/static/gui/src/app/components/sharing/test-sharing.js
+++ b/jujugui/static/gui/src/app/components/sharing/test-sharing.js
@@ -66,7 +66,11 @@ describe('Sharing', () => {
     instance.setState({loadingUsers: true});
     const output = renderer.getRenderOutput();
     const spinner = output.props.children.props.children[1];
-    const expected = <juju.components.Spinner />;
+    const expected = (
+      <div className="sharing__loading">
+        <juju.components.Spinner />
+      </div>
+    );
     assert.deepEqual(spinner, expected);
   });
 
@@ -122,11 +126,11 @@ describe('Sharing', () => {
     const getModelUserInfo = sinon.stub().callsArgWith(0, 'boom', []);
     const addNotification = sinon.stub();
     const closeHandler = sinon.stub();
-    const renderer = jsTestUtils.shallowRender(
+    jsTestUtils.shallowRender(
       <juju.components.Sharing
         addNotification={addNotification}
         closeHandler={closeHandler}
-        getModelUserInfo={getModelUserInfo} />, true);
+        getModelUserInfo={getModelUserInfo} />);
     assert.equal(addNotification.called, true);
     assert.deepEqual(addNotification.args[0][0], {
       title: 'Unable to load users.',

--- a/jujugui/static/gui/src/app/components/sharing/test-sharing.js
+++ b/jujugui/static/gui/src/app/components/sharing/test-sharing.js
@@ -65,7 +65,7 @@ describe('Sharing', () => {
     const instance = renderer.getMountedInstance();
     instance.setState({loadingUsers: true});
     const output = renderer.getRenderOutput();
-    const spinner = output.props.children.props.children[1];
+    const spinner = output.props.children[1].props.children;
     const expected = (
       <div className="sharing__loading">
         <juju.components.Spinner />
@@ -95,7 +95,7 @@ describe('Sharing', () => {
     const output = renderer.getRenderOutput();
     // Get all the children except the header, which is the first item in the
     // array.
-    const actual = output.props.children.props.children[1];
+    const actual = output.props.children[1].props.children;
     const expected = [(
       <div key="drwho" className="sharing__user">
         <div className="sharing__user-name">

--- a/jujugui/static/gui/src/app/components/sharing/test-sharing.js
+++ b/jujugui/static/gui/src/app/components/sharing/test-sharing.js
@@ -48,8 +48,8 @@ describe('Sharing', () => {
         className="sharing__popup"
         title="Share"
         buttons={expectedButtons}>
+        <h5 className="sharing__users-header">Users with access</h5>
         <div className="sharing__users">
-          <h5 className="sharing__users-header">Users with access</h5>
           {undefined}
         </div>
       </juju.components.Popup>

--- a/jujugui/static/gui/src/app/components/sharing/test-sharing.js
+++ b/jujugui/static/gui/src/app/components/sharing/test-sharing.js
@@ -77,14 +77,24 @@ describe('Sharing', () => {
   it('can render with users', () => {
     const getModelUserInfo = sinon.stub().callsArgWith(0, null, [
       {
-        name: 'drwho',
-        displayName: 'Dr. Who',
-        lastConnection: 'now',
+        name: 'drwho@external',
+        displayName: 'drwho',
+        domain: 'Ubuntu SSO',
+        lastConnection: {
+          toUTCString: sinon.stub().withArgs().returns(
+            'Thu, 09 Feb 2017 09:51:18 GMT')
+        },
         access: 'admin'
+      }, {
+        name: 'rose',
+        displayName: 'Rose',
+        domain: 'local',
+        lastConnection: null,
+        access: 'write',
       }, {
         name: 'dalek',
         displayName: 'Dalek',
-        lastConnection: 'never',
+        lastConnection: null,
         access: 'write',
         err: 'exterminate!'
       }
@@ -95,31 +105,50 @@ describe('Sharing', () => {
     const output = renderer.getRenderOutput();
     // Get all the children except the header, which is the first item in the
     // array.
-    const actual = output.props.children[1].props.children;
+    const obtained = output.props.children[1].props.children;
     const expected = [(
-      <div key="drwho" className="sharing__user">
+      <div key="drwho@external" className="sharing__user">
         <div className="sharing__user-name">
           drwho
         </div>
         <div className="sharing__user-displayname">
-          Dr. Who
+          {'Ubuntu SSO'} user
+        </div>
+        <div className="sharing__user-displayname">
+          last connection:  09 Feb 2017 09:51:18 GMT
         </div>
         <div className="sharing__user-access">
           admin
         </div>
       </div>
     ), (
-      <div key="dalek" className="sharing__user">
+      <div key="rose" className="sharing__user">
         <div className="sharing__user-name">
-          dalek
+          Rose
         </div>
         <div className="sharing__user-displayname">
+          {'local'} user
+        </div>
+        <div className="sharing__user-displayname">
+          never connected
+        </div>
+        <div className="sharing__user-access">
+          write
+        </div>
+      </div>
+    ), (
+      <div key="dalek" className="sharing__user">
+        <div className="sharing__user-name">
           Dalek
         </div>
-        {undefined}
+        <div className="sharing__user-displayname">
+          exterminate!
+        </div>
       </div>
     )];
-    assert.deepEqual(actual, expected);
+    console.log('============ obtained:', JSON.stringify(obtained, null, 2));
+    console.log('\n============ expected:', JSON.stringify(expected, null, 2));
+    assert.deepEqual(obtained, expected);
   });
 
   it('can handle an API call error', () => {

--- a/jujugui/static/gui/src/app/components/sharing/test-sharing.js
+++ b/jujugui/static/gui/src/app/components/sharing/test-sharing.js
@@ -146,8 +146,6 @@ describe('Sharing', () => {
         </div>
       </div>
     )];
-    console.log('============ obtained:', JSON.stringify(obtained, null, 2));
-    console.log('\n============ expected:', JSON.stringify(expected, null, 2));
     assert.deepEqual(obtained, expected);
   });
 

--- a/jujugui/static/gui/src/app/store/env/controller-api.js
+++ b/jujugui/static/gui/src/app/store/env/controller-api.js
@@ -570,7 +570,6 @@ YUI.add('juju-controller-api', function(Y) {
       });
     },
 
-
     /**
       Create a new model within this controller, using the given name, account
       and config.

--- a/jujugui/static/gui/src/app/store/env/controller-api.js
+++ b/jujugui/static/gui/src/app/store/env/controller-api.js
@@ -570,6 +570,7 @@ YUI.add('juju-controller-api', function(Y) {
       });
     },
 
+
     /**
       Create a new model within this controller, using the given name, account
       and config.

--- a/jujugui/static/gui/src/app/store/env/sandbox.js
+++ b/jujugui/static/gui/src/app/store/env/sandbox.js
@@ -337,7 +337,7 @@ YUI.add('juju-env-sandbox', function(Y) {
     },
 
     /**
-    Handle ModelInfo messages.
+    Handle Client.ModelInfo messages.
 
     @method handleClientModelInfo
     @param {Object} data The contents of the API arguments.
@@ -362,7 +362,7 @@ YUI.add('juju-env-sandbox', function(Y) {
     },
 
     /**
-    Handle ModelInfo messages.
+    Handle ModelManager.ModelInfo messages.
 
     @method handleModelManagerModelInfo
     @param {Object} data The contents of the API arguments.
@@ -383,6 +383,36 @@ YUI.add('juju-env-sandbox', function(Y) {
               'controller-uuid': 'controlleruuid1',
               life: 'alive',
               'owner-tag': 'user-admin@local'
+            }
+          }]
+        }
+      });
+    },
+
+    /**
+    Handle Client.ModelUserInfo messages.
+
+    @method handleClientModelUserInfo
+    @param {Object} data The contents of the API arguments.
+    @param {Object} client The active ClientConnection.
+    @param {Object} state An instance of FakeBackend.
+    @return {undefined} Side effects only.
+    */
+    handleClientModelUserInfo: function(data, client, state) {
+      client.receive({
+        'request-id': data['request-id'],
+        response: {
+          results: [{
+            result: {
+              user: 'admin@sandbox',
+              'last-connection': new Date().toString(),
+              access: 'admin'
+            }
+          }, {
+            result: {
+              user: 'dalek@skaro',
+              'last-connection': '',
+              access: 'read'
             }
           }]
         }

--- a/jujugui/static/gui/src/app/views/utils.js
+++ b/jujugui/static/gui/src/app/views/utils.js
@@ -1410,24 +1410,8 @@ YUI.add('juju-view-utils', function(Y) {
     @param {Boolean} visibility Controls whether to show (true) or hide (false);
                      defaults to true.
   */
-  utils.sharingVisibility = function(visibility = true) {
+  utils.sharingVisibility = function(visibility = true, getModelUserInfo) {
     const sharing = document.getElementById('sharing-container');
-    // XXX kadams54: temporary until we wire in the actual modelUserInfo API
-    // call.
-    const getModelUserInfo = function(callback) {
-      callback(null, [{
-        name: 'drwho',
-        displayName: 'Dr. Who',
-        lastConnection: 'now',
-        access: 'admin'
-      }, {
-        name: 'dalek',
-        displayName: 'Dalek',
-        lastConnection: 'never',
-        access: 'write',
-        err: 'exterminate!'
-      }]);
-    };
     if (visibility) {
       ReactDOM.render(
         <window.juju.components.Sharing

--- a/jujugui/static/gui/src/app/views/utils.js
+++ b/jujugui/static/gui/src/app/views/utils.js
@@ -1409,12 +1409,17 @@ YUI.add('juju-view-utils', function(Y) {
     @method sharingVisibility
     @param {Boolean} visibility Controls whether to show (true) or hide (false);
                      defaults to true.
+    @param {Function} getModelUser The API call to list users.
+    @param {Function} addNotification The function to display user
+                      notifications.
   */
-  utils.sharingVisibility = function(visibility = true, getModelUserInfo) {
+  utils.sharingVisibility = function(visibility = true, getModelUserInfo,
+    addNotification) {
     const sharing = document.getElementById('sharing-container');
     if (visibility) {
       ReactDOM.render(
         <window.juju.components.Sharing
+          addNotification={addNotification}
           getModelUserInfo={getModelUserInfo}
           closeHandler={utils.sharingVisibility.bind(utils, false)} />,
       sharing);

--- a/jujugui/static/gui/src/test/test_env_api.js
+++ b/jujugui/static/gui/src/test/test_env_api.js
@@ -3631,6 +3631,78 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       });
     });
 
+    describe('modelUserInfo', function() {
+      it('retrieves model user info', done => {
+        // Perform the request.
+        env.modelUserInfo((err, users) => {
+          assert.strictEqual(err, null);
+          assert.strictEqual(users.length, 1);
+          const actual = users[0];
+          const expected = {
+            name: 'dalek',
+            displayName: 'Dalek',
+            lastConnection: '2000-01-01T00:00:00Z',
+            access: 'owner',
+            err: undefined
+          };
+          assert.deepEqual(actual, expected);
+          assert.equal(conn.messages.length, 1);
+          assert.deepEqual(conn.last_message(), {
+            type: 'Client',
+            version: 1,
+            request: 'ModelUserInfo',
+            params: {},
+            'request-id': 1
+          });
+          done();
+        });
+        // Mimic response.
+        conn.msg({
+          'request-id': 1,
+          response: {
+            results: [{
+              result: {
+                user: 'dalek',
+                'display-name': 'Dalek',
+                'last-connection': '2000-01-01T00:00:00Z',
+                access: 'owner',
+                err: null
+              }
+            }]
+          }
+        });
+      });
+
+      it('handles request failures while fetching model user info', done => {
+        // Perform the request.
+        env.modelUserInfo((err, users) => {
+          assert.strictEqual(err, 'bad wolf');
+          assert.deepEqual(users, []);
+          done();
+        });
+        // Mimic response.
+        conn.msg({'request-id': 1, error: 'bad wolf'});
+      });
+
+      it('handles API failures while retrieving model user info', done => {
+        // Perform the request.
+        env.modelUserInfo((err, users) => {
+          assert.strictEqual(err, null);
+          assert.strictEqual(users.length, 1);
+          assert.strictEqual(users[0].err, 'bad wolf');
+          done();
+        });
+        // Mimic response.
+        conn.msg({
+          'request-id': 1,
+          response: {
+            results: [{
+              error: {message: 'bad wolf'}
+            }]
+          }
+        });
+      });
+    });
   });
 
 })();

--- a/jujugui/static/gui/src/test/test_env_api.js
+++ b/jujugui/static/gui/src/test/test_env_api.js
@@ -3636,16 +3636,23 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
         // Perform the request.
         env.modelUserInfo((err, users) => {
           assert.strictEqual(err, null);
-          assert.strictEqual(users.length, 1);
-          const actual = users[0];
-          const expected = {
+          assert.strictEqual(users.length, 2);
+          assert.deepEqual(users[0], {
             name: 'dalek',
             displayName: 'Dalek',
-            lastConnection: '2000-01-01T00:00:00Z',
-            access: 'owner',
+            domain: 'local',
+            lastConnection: new Date('2000-01-01T00:00:00Z'),
+            access: 'admin',
             err: undefined
-          };
-          assert.deepEqual(actual, expected);
+          });
+          assert.deepEqual(users[1], {
+            name: 'rose@external',
+            displayName: 'rose',
+            domain: 'Ubuntu SSO',
+            lastConnection: null,
+            access: 'write',
+            err: undefined
+          });
           assert.equal(conn.messages.length, 1);
           assert.deepEqual(conn.last_message(), {
             type: 'Client',
@@ -3665,7 +3672,15 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
                 user: 'dalek',
                 'display-name': 'Dalek',
                 'last-connection': '2000-01-01T00:00:00Z',
-                access: 'owner',
+                access: 'admin',
+                err: null
+              }
+            }, {
+              result: {
+                user: 'rose@external',
+                'display-name': '',
+                'last-connection': '',
+                access: 'write',
                 err: null
               }
             }]


### PR DESCRIPTION
This branch includes https://github.com/juju/juju-gui/pull/2406 and it addresses all the comments made there. In the commit I added, I also:
- removed the shareFlag, otherwise there is no reason for trying to include this in 2.3.0;
- changed the model actions so that the share button is only displayed when actually connected to a model;
- added more information in the user share list, contextually hiding `@external`.
Please take a look.