### PR TITLE
When logging out, clean up the state.

### DIFF
--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -2424,9 +2424,6 @@ YUI.add('juju-gui', function(Y) {
       if (controllerAPI) {
         closeController = controllerAPI.close.bind(controllerAPI);
       }
-      this.state.changeState({
-        model: null
-      });
       this.env.close(() => {
         closeController(() => {
           if (controllerAPI) {
@@ -2440,6 +2437,12 @@ YUI.add('juju-gui', function(Y) {
           this.env.get('ecs').clear();
           this.db.reset();
           this.db.fire('update');
+          this.state.changeState({
+            model: null,
+            profile: null,
+            root: null,
+            store: null
+          });
           this._renderLogin(null);
         });
       });

--- a/jujugui/static/gui/src/test/test_app.js
+++ b/jujugui/static/gui/src/test/test_app.js
@@ -1130,7 +1130,10 @@ describe('App', function() {
           assert.strictEqual(app._renderLogin.calledOnce, true, 'login');
           assert.equal(app.state.changeState.callCount, 1);
           assert.deepEqual(app.state.changeState.args[0], [{
-            model: null
+            model: null,
+            profile: null,
+            root: null,
+            store: null
           }]);
           done();
         });
@@ -1178,7 +1181,10 @@ describe('App', function() {
           assert.strictEqual(app._renderLogin.calledOnce, true, 'login');
           assert.equal(app.state.changeState.callCount, 1);
           assert.deepEqual(app.state.changeState.args[0], [{
-            model: null
+            model: null,
+            profile: null,
+            root: null,
+            store: null
           }]);
           done();
         });


### PR DESCRIPTION
So that we don't have dispatched components starting macaroon acquisitions because they don't have a user, and therefore we prevent popups when logging out.
Also, defer the state change to the end of the log out process, to avoid weird connection stages when redispatching.
Fixes https://github.com/juju/juju-gui/issues/2414

Note that, while cleaning up the state is desirable, we'll also need to pay more attention at authentication assumptions in our components, especially before calling out to macaroon protected services.