### PR TITLE
Do not add the same unit id when scaling up without pre-existing units.

### DIFF
--- a/jujugui/static/gui/src/app/views/utils.js
+++ b/jujugui/static/gui/src/app/views/utils.js
@@ -926,11 +926,13 @@ YUI.add('juju-view-utils', function(Y) {
         units = [],
         displayName, ghostUnit, unitId, unitIdCount;
     // u will be a unit OR the previous unit index value.
-    var parseId = u => parseInt((u.id && u.id.split('/')[1]) || u, 10);
-    var serviceUnits = service.get('units').toArray();
-    var highestIndex =
-      serviceUnits.reduce(
+    const parseId = u => parseInt((u.id && u.id.split('/')[1]) || u, 10);
+    const serviceUnits = service.get('units').toArray();
+    let highestIndex = -1;
+    if (serviceUnits.length) {
+      highestIndex = serviceUnits.reduce(
         (prev, curr) => Math.max(parseId(prev), parseId(curr)), 0);
+    }
     // Service names have a $ in them when they are uncommitted. Uncomitted
     // service's display names are also wrapped in parens to display on the
     // canvas.
@@ -940,8 +942,9 @@ YUI.add('juju-view-utils', function(Y) {
     } else {
       displayName = serviceName;
     }
-    for (var i = 1; i <= unitCount; i += 1) {
-      unitIdCount = serviceUnits.length === 0 ? highestIndex : highestIndex + i;
+
+    for (let i = 1; i <= unitCount; i += 1) {
+      unitIdCount = highestIndex + i;
       unitId = serviceName + '/' + unitIdCount;
       ghostUnit = db.addUnits({
         id: unitId,

--- a/jujugui/static/gui/src/test/test_utils.js
+++ b/jujugui/static/gui/src/test/test_utils.js
@@ -422,10 +422,16 @@ describe('utilities', function() {
             case 'units':
               returnVal = {
                 size: function() { return 2; },
-                toArray: function() { return [
-                  {id: applicationName + '/1'},
-                  {id: applicationName + '/2'}
-                ]; }};
+                toArray: function() {
+                  if (applicationName === 'no-units') {
+                    return [];
+                  }
+                  return [
+                    {id: applicationName + '/1'},
+                    {id: applicationName + '/2'}
+                  ];
+                }
+              };
               break;
             case 'displayName':
               if (applicationName.indexOf('$') > 0) {
@@ -462,15 +468,19 @@ describe('utilities', function() {
       // The numbers for the id's are important. The mocks have existing units
       // having indexes of 1 and 2. There was a bug where the next value wasn't
       // being properly computed when there was no 0 unit.
+      let firstIndex = 3;
+      if (applicationName === 'no-units') {
+        firstIndex = 0;
+      }
       assert.deepEqual(addUnitsArgs[0][0], {
-        id: applicationName + '/' + 3,
-        displayName: applicationName + '/' + 3,
+        id: applicationName + '/' + firstIndex,
+        displayName: applicationName + '/' + firstIndex,
         charmUrl: 'I am a charm url',
         subordinate: false
       }, 'addUnits first not called with proper data');
       assert.deepEqual(addUnitsArgs[1][0], {
-        id: applicationName + '/' + 4,
-        displayName: applicationName + '/' + 4,
+        id: applicationName + '/' + (firstIndex+1),
+        displayName: applicationName + '/' + (firstIndex+1),
         charmUrl: 'I am a charm url',
         subordinate: false
       }, 'addUnits second not called with proper data');
@@ -482,14 +492,14 @@ describe('utilities', function() {
       assert.strictEqual(add_unit_args[0][2], null);
       assert.equal(typeof add_unit_args[0][3], 'function');
       assert.deepEqual(add_unit_args[0][4], {
-        modelId: applicationName + '/' + 3
+        modelId: applicationName + '/' + firstIndex
       });
       assert.equal(add_unit_args[1][0], applicationName);
       assert.equal(add_unit_args[1][1], 1);
       assert.strictEqual(add_unit_args[1][2], null);
       assert.equal(typeof add_unit_args[1][3], 'function');
       assert.deepEqual(add_unit_args[1][4], {
-        modelId: applicationName + '/' + 4
+        modelId: applicationName + '/' + (firstIndex+1)
       });
       assert.equal(units.length, 2);
     }
@@ -497,6 +507,12 @@ describe('utilities', function() {
     it('creates machines, units; places units; updates unit lists',
        function() {
          testScaleUp('myService');
+       }
+    );
+
+    it('creates machines, units; places units; updates unit lists (no units)',
+       function() {
+         testScaleUp('no-units');
        }
     );
 


### PR DESCRIPTION
Fixes https://github.com/juju/juju-gui/issues/2425
