### PR TITLE
In Firefox, text box for entering SSH key is misaligned

### DIFF
--- a/jujugui/static/gui/src/app/components/generic-input/_generic-input.scss
+++ b/jujugui/static/gui/src/app/components/generic-input/_generic-input.scss
@@ -27,6 +27,8 @@
     margin-bottom: 20px;
     padding-top: 25px;
     padding-bottom: 7px;
+    box-sizing: content-box;
+    min-height: 18px;
 
     &[aria-invalid='true'] {
       border-color: $error;


### PR DESCRIPTION
Fixes https://github.com/juju/juju-gui/issues/2443