### PR TITLE
Support for visiting someone else's profile page.

### DIFF
--- a/jujugui/static/gui/src/app/components/header-breadcrumb/header-breadcrumb.js
+++ b/jujugui/static/gui/src/app/components/header-breadcrumb/header-breadcrumb.js
@@ -31,7 +31,7 @@ YUI.add('header-breadcrumb', function() {
       appState: React.PropTypes.object.isRequired,
       authDetails: React.PropTypes.object,
       listModelsWithInfo: React.PropTypes.func,
-      modelName: React.PropTypes.string.isRequired,
+      modelName: React.PropTypes.string,
       modelOwner: React.PropTypes.string,
       showEnvSwitcher: React.PropTypes.bool.isRequired,
       showProfile: React.PropTypes.func.isRequired,
@@ -74,8 +74,6 @@ YUI.add('header-breadcrumb', function() {
         // Nothing to be done: we are already in the profile view.
         return;
       }
-      // TODO frankban: showing a profile different from the current user's one
-      // does not currently work.
       this.props.showProfile(username);
     },
 

--- a/jujugui/static/gui/src/app/components/header-help/header-help.js
+++ b/jujugui/static/gui/src/app/components/header-help/header-help.js
@@ -29,7 +29,7 @@ YUI.add('header-help', function() {
     propTypes: {
       appState: React.PropTypes.object.isRequired,
       gisf: React.PropTypes.bool.isRequired,
-      user: React.PropTypes.object.isRequired
+      user: React.PropTypes.object
     },
 
     getInitialState: function() {

--- a/jujugui/static/gui/src/app/components/user-profile/entity-list/entity-list.js
+++ b/jujugui/static/gui/src/app/components/user-profile/entity-list/entity-list.js
@@ -29,8 +29,7 @@ YUI.add('user-profile-entity-list', function() {
       charmstore: React.PropTypes.object.isRequired,
       getDiagramURL: React.PropTypes.func.isRequired,
       type: React.PropTypes.string.isRequired,
-      user: React.PropTypes.object,
-      users: React.PropTypes.object.isRequired
+      user: React.PropTypes.string,
     },
 
     getInitialState: function() {
@@ -51,8 +50,7 @@ YUI.add('user-profile-entity-list', function() {
     },
 
     componentWillMount: function() {
-      const users = this.props.users;
-      if (users.charmstore && users.charmstore.user) {
+      if (this.props.user) {
         this._fetchEntities(this.props);
       }
     },
@@ -66,9 +64,7 @@ YUI.add('user-profile-entity-list', function() {
     componentWillReceiveProps: function(nextProps) {
       const props = this.props;
       // Compare next and previous charmstore users in a data-safe manner.
-      const prevCSUser = props.users.charmstore || {};
-      const nextCSUser = nextProps.users.charmstore || {};
-      if (nextCSUser.user !== prevCSUser.user) {
+      if (props.user !== nextProps.user) {
         this._fetchEntities(nextProps);
       }
     },
@@ -80,15 +76,14 @@ YUI.add('user-profile-entity-list', function() {
       @param {Object} props the component properties to use.
     */
     _fetchEntities:  function(props) {
-      const callback = this._fetchEntitiesCallback;
       const charmstore = props.charmstore;
-      const username = props.users.charmstore && props.users.charmstore.user;
-      if (charmstore && charmstore.list && username) {
+      if (charmstore && charmstore.list && props.user) {
         this.props.broadcastStatus('starting');
+        const callback = this._fetchEntitiesCallback;
         // Delay the call until after the state change to prevent race
         // conditions.
         this.setState({loadingEntities: true}, () => {
-          const xhr = charmstore.list(username, callback, props.type);
+          const xhr = charmstore.list(props.user, callback, props.type);
           this.xhrs.push(xhr);
         });
       }

--- a/jujugui/static/gui/src/app/components/user-profile/entity-list/test-entity-list.js
+++ b/jujugui/static/gui/src/app/components/user-profile/entity-list/test-entity-list.js
@@ -21,7 +21,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 var juju = {components: {}}; // eslint-disable-line no-unused-vars
 
 describe('UserProfileEntityList', () => {
-  var charmstore, charms, bundles, users;
+  var charmstore, charms, bundles;
 
   beforeAll((done) => {
     // By loading this file it adds the component to the juju components.
@@ -36,18 +36,14 @@ describe('UserProfileEntityList', () => {
     var bundle = jsTestUtils.makeEntity(true).toEntity();
     bundle.series = [bundle.series];
     bundles = [bundle];
-    list.withArgs('test-owner', sinon.match.any, 'charm').callsArgWith(
+    list.withArgs('who', sinon.match.any, 'charm').callsArgWith(
       1, null, charms);
-    list.withArgs('test-owner', sinon.match.any, 'bundle').callsArgWith(
+    list.withArgs('who', sinon.match.any, 'bundle').callsArgWith(
       1, null, bundles);
     charmstore = {
       list: list,
       url: 'example.com/9'
     };
-    users = {charmstore: {
-      user: 'test-owner',
-      usernameDisplay: 'test owner'
-    }};
   });
 
   it('renders the empty state', () => {
@@ -57,8 +53,8 @@ describe('UserProfileEntityList', () => {
         charmstore={{}}
         getDiagramURL={sinon.stub()}
         type='charm'
-        user={users.charmstore}
-        users={users} />, true);
+        user='who'
+      />, true);
     var output = component.getRenderOutput();
     assert.equal(output, null);
   });
@@ -72,8 +68,8 @@ describe('UserProfileEntityList', () => {
         charmstore={charmstore}
         getDiagramURL={sinon.stub()}
         type={type}
-        user={users.charmstore}
-        users={users} />, true);
+        user='who'
+      />, true);
     var output = component.getRenderOutput();
     assert.deepEqual(output, (
       <div className="user-profile__charm-list twelve-col">
@@ -91,8 +87,8 @@ describe('UserProfileEntityList', () => {
         charmstore={charmstore}
         getDiagramURL={sinon.stub()}
         type={type}
-        user={users.charmstore}
-        users={users} />, true);
+        user='who'
+      />, true);
     var output = component.getRenderOutput();
     var expected = (
       <div className="user-profile__charm-list">
@@ -162,8 +158,8 @@ describe('UserProfileEntityList', () => {
         charmstore={charmstore}
         getDiagramURL={getDiagramURL}
         type='bundle'
-        user={users.charmstore}
-        users={users} />, true);
+        user='who'
+      />, true);
     var output = component.getRenderOutput();
     var expected = (
       <div className="user-profile__bundle-list">
@@ -236,12 +232,12 @@ describe('UserProfileEntityList', () => {
         charmstore={charmstore}
         getDiagramURL={sinon.stub()}
         type='charm'
-        user={users.charmstore}
-        users={users} />, true);
+        user='who'
+      />, true);
     var instance = component.getMountedInstance();
     assert.equal(charmstore.list.callCount, 1,
                  'charmstore list not called');
-    assert.equal(charmstore.list.args[0][0], 'test-owner',
+    assert.equal(charmstore.list.args[0][0], 'who',
                  'username not passed to list request');
     assert.deepEqual(instance.state.entityList, charms,
                      'callback does not properly set entity state');
@@ -254,12 +250,12 @@ describe('UserProfileEntityList', () => {
         charmstore={charmstore}
         getDiagramURL={sinon.stub()}
         type='bundle'
-        user={users.charmstore}
-        users={users} />, true);
+        user='who'
+      />, true);
     var instance = component.getMountedInstance();
     assert.equal(charmstore.list.callCount, 1,
                  'charmstore list not called');
-    assert.equal(charmstore.list.args[0][0], 'test-owner',
+    assert.equal(charmstore.list.args[0][0], 'who',
                  'username not passed to list request');
     assert.deepEqual(instance.state.entityList, bundles,
                      'callback does not properly set entity state');
@@ -274,8 +270,8 @@ describe('UserProfileEntityList', () => {
         charmstore={charmstore}
         getDiagramURL={sinon.stub()}
         type='charm'
-        user={users.charmstore}
-        users={users} />, true);
+        user='who'
+      />, true);
     renderer.unmount();
     assert.equal(charmstoreAbort.callCount, 1);
   });
@@ -289,8 +285,7 @@ describe('UserProfileEntityList', () => {
         charmstore={charmstore}
         getDiagramURL={sinon.stub()}
         type='charm'
-        users={{}}
-        user={users.charmstore} />, true);
+        user={null} />, true);
     assert.equal(list.callCount, 0);
     component.render(
       <juju.components.UserProfileEntityList
@@ -298,8 +293,7 @@ describe('UserProfileEntityList', () => {
         charmstore={charmstore}
         getDiagramURL={sinon.stub()}
         type='charm'
-        users={users}
-        user={users.charmstore} />);
+        user='who' />);
     assert.equal(list.callCount, 1);
   });
 
@@ -312,8 +306,7 @@ describe('UserProfileEntityList', () => {
         charmstore={charmstore}
         getDiagramURL={sinon.stub()}
         type='charm'
-        users={users}
-        user={users.charmstore} />);
+        user='who' />);
     assert.equal(broadcastStatus.args[0][0], 'starting');
   });
 
@@ -326,8 +319,7 @@ describe('UserProfileEntityList', () => {
         charmstore={charmstore}
         getDiagramURL={sinon.stub()}
         type='charm'
-        users={users}
-        user={users.charmstore} />);
+        user='who' />);
     assert.equal(broadcastStatus.args[1][0], 'ok');
   });
 
@@ -341,8 +333,7 @@ describe('UserProfileEntityList', () => {
         charmstore={charmstore}
         getDiagramURL={sinon.stub()}
         type='charm'
-        users={users}
-        user={users.charmstore} />);
+        user='who' />);
     assert.equal(broadcastStatus.args[1][0], 'empty');
   });
 
@@ -356,8 +347,7 @@ describe('UserProfileEntityList', () => {
         charmstore={charmstore}
         getDiagramURL={sinon.stub()}
         type='charm'
-        users={users}
-        user={users.charmstore} />);
+        user='who' />);
     assert.equal(broadcastStatus.args[1][0], 'error');
   });
 });

--- a/jujugui/static/gui/src/app/components/user-profile/entity/entity.js
+++ b/jujugui/static/gui/src/app/components/user-profile/entity/entity.js
@@ -54,14 +54,12 @@ YUI.add('user-profile-entity', function() {
       Navigate to the entity details.
 
       @method _viewEntity
-      @param {Object} e The click event.
       @param {String} id The entity id.
+      @param {Object} evt The click event.
     */
-    _viewEntity: function(id, e) {
-      this.props.changeState({
-        profile: null,
-        store: id.replace('cs:', '')
-      });
+    _viewEntity: function(id, evt) {
+      const url = window.jujulib.URL.fromLegacyString(id);
+      this.props.changeState({profile: null, store: url.path()});
     },
 
     /**

--- a/jujugui/static/gui/src/app/components/user-profile/header/header.js
+++ b/jujugui/static/gui/src/app/components/user-profile/header/header.js
@@ -26,8 +26,15 @@ YUI.add('user-profile-header', function() {
       avatar: React.PropTypes.string.isRequired,
       interactiveLogin: React.PropTypes.func,
       links: React.PropTypes.array.isRequired,
-      username: React.PropTypes.string.isRequired,
-      users: React.PropTypes.object.isRequired
+      // userInfo must have the following attributes:
+      // - external: the external user name to use for retrieving data, for
+      //   instance, from the charm store. Might be null if the user is being
+      //   displayed for the current user and they are not authenticated to
+      //   the charm store;
+      // - isCurrent: whether the profile is being displayed for the currently
+      //   authenticated user;
+      // - profile: the user name for whom profile details must be displayed.
+      userInfo: React.PropTypes.object.isRequired
     },
 
     /**
@@ -38,8 +45,7 @@ YUI.add('user-profile-header', function() {
     */
     _generateLogin: function() {
       const props = this.props;
-      const users = props.users;
-      if (users.charmstore && users.charmstore.user) {
+      if (props.userInfo.external) {
         return;
       }
       return (
@@ -64,7 +70,7 @@ YUI.add('user-profile-header', function() {
           </span>);
       }
       return (
-        <img alt={this.props.username}
+        <img alt={this.props.userInfo.profile}
           className={className}
           src={this.props.avatar} />);
     },
@@ -111,14 +117,12 @@ YUI.add('user-profile-header', function() {
     },
 
     render: function () {
-      var props = this.props;
-      var username = props.username;
       return (
         <div className="user-profile-header twelve-col">
           {this._generateLogin()}
           {this._generateAvatar()}
           <h1 className="user-profile-header__username">
-            {username}
+            {this.props.userInfo.profile}
           </h1>
           {this._generateLinks()}
         </div>);

--- a/jujugui/static/gui/src/app/components/user-profile/header/test-header.js
+++ b/jujugui/static/gui/src/app/components/user-profile/header/test-header.js
@@ -29,7 +29,7 @@ describe('UserProfileHeader', () => {
   });
 
   beforeEach(() => {
-    var action = sinon.stub();
+    const action = sinon.stub();
     links = [{
       action: action,
       label: 'a link'
@@ -40,26 +40,26 @@ describe('UserProfileHeader', () => {
   });
 
   it('renders', () => {
-    var interactiveLogin = sinon.stub();
-    var users = {};
-    var output = jsTestUtils.shallowRender(
+    const interactiveLogin = sinon.stub();
+    const userInfo = {profile: 'who'};
+    const output = jsTestUtils.shallowRender(
       <juju.components.UserProfileHeader
-        users={users}
         avatar="avatar.png"
         interactiveLogin={interactiveLogin}
         links={links}
-        username="spinach" />);
-    var expected = (
+        userInfo={userInfo}
+      />);
+    const expected = (
       <div className="user-profile-header twelve-col">
         <juju.components.GenericButton
           title="Log in to the charm store"
           type="inline-neutral"
           action={interactiveLogin} />
-        <img alt="spinach"
+        <img alt="who"
           className="user-profile-header__avatar"
           src="avatar.png" />
         <h1 className="user-profile-header__username">
-          spinach
+          who
         </h1>
         <ul className="user-profile-header__links">
           <li className={
@@ -80,29 +80,29 @@ describe('UserProfileHeader', () => {
     assert.deepEqual(output, expected);
   });
 
-  it('hides the login button when authenticated to charmstore', () => {
-    var users = {charmstore: {user: 'test'}};
-    var output = jsTestUtils.shallowRender(
+  it('hides the login button when authenticated to charm store', () => {
+    const userInfo = {external: 'who-ext', profile: 'who'};
+    const output = jsTestUtils.shallowRender(
       <juju.components.UserProfileHeader
-        users={users}
         avatar="avatar.png"
         interactiveLogin={sinon.stub()}
         links={links}
-        username="spinach" />);
+        userInfo={userInfo}
+      />);
     assert.isUndefined(output.props.children[0]);
   });
 
-  it('shows the login button when no username', () => {
-    var users = {charmstore: {loading: true}};
-    var interactiveLogin = sinon.stub();
-    var output = jsTestUtils.shallowRender(
+  it('shows the login button when no external user', () => {
+    const interactiveLogin = sinon.stub();
+    const userInfo = {profile: 'who'};
+    const output = jsTestUtils.shallowRender(
       <juju.components.UserProfileHeader
-        users={users}
         avatar="avatar.png"
         interactiveLogin={interactiveLogin}
         links={links}
-        username="spinach" />);
-    var expected = (
+        userInfo={userInfo}
+      />);
+    const expected = (
       <juju.components.GenericButton
         title="Log in to the charm store"
         type="inline-neutral"
@@ -112,15 +112,15 @@ describe('UserProfileHeader', () => {
   });
 
   it('can render with a default avatar', () => {
-    var users = {charmstore: {user: 'test'}};
-    var output = jsTestUtils.shallowRender(
+    const userInfo = {external: 'who-ext', profile: 'who'};
+    const output = jsTestUtils.shallowRender(
       <juju.components.UserProfileHeader
-        users={users}
         avatar=""
         interactiveLogin={undefined}
         links={links}
-        username="spinach" />);
-    var expected = (
+        userInfo={userInfo}
+      />);
+    const expected = (
       <span className={
         'user-profile-header__avatar user-profile-header__avatar--default'}>
         <span className="avatar-overlay"></span>

--- a/jujugui/static/gui/src/app/components/user-profile/test-user-profile.js
+++ b/jujugui/static/gui/src/app/components/user-profile/test-user-profile.js
@@ -21,7 +21,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 var juju = {components: {}}; // eslint-disable-line no-unused-vars
 
 describe('UserProfile', () => {
-  let users;
+  let userInfo;
 
   beforeAll((done) => {
     // By loading this file it adds the component to the juju components.
@@ -29,10 +29,7 @@ describe('UserProfile', () => {
   });
 
   beforeEach(() => {
-    users = {charmstore: {
-      user: 'user-dalek',
-      usernameDisplay: 'test owner'
-    }};
+    userInfo = {external: 'who-ext', profile: 'who', isCurrent: true};
   });
 
   afterEach(() => {
@@ -51,14 +48,12 @@ describe('UserProfile', () => {
     const switchModel = sinon.stub();
     const getAgreements = sinon.stub();
     const staticURL = 'test-url';
-    const user = users.charmstore;
     const charmstore = {};
     window.flags = {blues: true};
     const component = jsTestUtils.shallowRender(
       <juju.components.UserProfile
         acl={acl}
         addNotification={addNotification}
-        users={users}
         charmstore={charmstore}
         destroyModels={destroyModels}
         facadesExist={true}
@@ -72,7 +67,8 @@ describe('UserProfile', () => {
         pluralize={sinon.stub()}
         staticURL={staticURL}
         storeUser={sinon.stub()}
-        user={user} />, true);
+        userInfo={userInfo}
+      />, true);
     const instance = component.getMountedInstance();
     const output = component.getRenderOutput();
     const content = output.props.children.props.children;
@@ -94,7 +90,8 @@ describe('UserProfile', () => {
         facadesExist={true}
         listModelsWithInfo={listModelsWithInfo}
         switchModel={switchModel}
-        user={user} />,
+        userInfo={userInfo}
+      />,
       <juju.components.UserProfileEntityList
         ref="bundleList"
         key="bundleList"
@@ -102,8 +99,8 @@ describe('UserProfile', () => {
         charmstore={charmstore}
         getDiagramURL={getDiagramURL}
         type='bundle'
-        user={user}
-        users={users} />,
+        user={userInfo.external}
+      />,
       <juju.components.UserProfileEntityList
         ref="charmList"
         key="charmList"
@@ -111,17 +108,17 @@ describe('UserProfile', () => {
         charmstore={charmstore}
         getDiagramURL={getDiagramURL}
         type='charm'
-        user={user}
-        users={users} />
+        user={userInfo.external}
+       />
     ];
     const expected = (
       <div className="inner-wrapper">
         <juju.components.UserProfileHeader
-          users={users}
           avatar=""
           interactiveLogin={instance._interactiveLogin}
           links={links}
-          username={users.charmstore.usernameDisplay} />
+          userInfo={userInfo}
+        />
         <div>
           <juju.components.SectionLoadWatcher
             EmptyComponent={emptyComponent}
@@ -145,7 +142,6 @@ describe('UserProfile', () => {
     const renderer = jsTestUtils.shallowRender(
       <juju.components.UserProfile
         switchModel={sinon.stub()}
-        users={users}
         listBudgets={sinon.stub()}
         listModelsWithInfo={sinon.stub()}
         changeState={sinon.stub()}
@@ -155,7 +151,8 @@ describe('UserProfile', () => {
         interactiveLogin={true}
         pluralize={sinon.stub()}
         storeUser={storeUser}
-        user={users.charmstore} />, true);
+        userInfo={userInfo}
+      />, true);
     const instance = renderer.getMountedInstance();
     instance._interactiveLogin();
     assert.equal(charmstore.bakery.fetchMacaroonFromStaticPath.callCount, 1);
@@ -170,12 +167,10 @@ describe('UserProfile', () => {
     const listModelsWithInfo = sinon.stub();
     const switchModel = sinon.stub();
     const getAgreements = sinon.stub();
-    const user = users.charmstore;
     window.flags = {blues: false};
     const component = jsTestUtils.shallowRender(
       <juju.components.UserProfile
         addNotification={addNotification}
-        users={users}
         charmstore={{}}
         getAgreements={getAgreements}
         getDiagramURL={getDiagramURL}
@@ -186,7 +181,8 @@ describe('UserProfile', () => {
         changeState={changeState}
         pluralize={sinon.stub()}
         storeUser={sinon.stub()}
-        user={user} />, true);
+        userInfo={userInfo}
+      />, true);
     const instance = component.getMountedInstance();
     assert.isUndefined(instance.refs.budgetList);
   });
@@ -200,7 +196,6 @@ describe('UserProfile', () => {
     const getAgreements = sinon.stub();
     const component = jsTestUtils.shallowRender(
       <juju.components.UserProfile
-        users={{}}
         charmstore={{}}
         getAgreements={getAgreements}
         getDiagramURL={getDiagramURL}
@@ -211,7 +206,8 @@ describe('UserProfile', () => {
         changeState={changeState}
         pluralize={sinon.stub()}
         storeUser={sinon.stub()}
-        user={undefined} />, true);
+        userInfo={userInfo}
+      />, true);
     const instance = component.getMountedInstance();
     assert.isUndefined(instance.refs.bundleList);
     assert.isUndefined(instance.refs.charmList);

--- a/jujugui/static/gui/src/app/store/env/controller-api.js
+++ b/jujugui/static/gui/src/app/store/env/controller-api.js
@@ -161,6 +161,9 @@ YUI.add('juju-controller-api', function(Y) {
             console.log('error retrieving default cloud name', error);
             return;
           }
+          if (name !== 'maas') {
+            return;
+          }
           this.getClouds([name], (error, clouds) => {
             const err = error || clouds[name].err;
             if (err) {


### PR DESCRIPTION
This include groups, and it must work also when the URL is directly referenced.
Also fix navigating to user owned charms/bundles from the profile view.
The profile of other users now include models those users shared with you.
Refreshing on a model page is now more reliable, and less affected by possible races.

Also fix a JS error when logging out and trying to show the Juju logo, and a problem in which the maas server button is always displayed, even when not in a maas cloud.

Fixes https://github.com/juju/juju-gui/issues/2476
