### PR TITLE
Workaround for allowing committing to newly created models.

### DIFF
--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -1078,7 +1078,9 @@ YUI.add('juju-gui', function(Y) {
       // the controller is connected.
       // XXX frankban: it seems that the profile is rendered even when the
       // profile is not included in the state.
+      const guiState = state.gui || {};
       if (
+        guiState.deploy !== undefined ||
         !state.profile ||
         !this.controllerAPI.get('connected') ||
         !this.controllerAPI.userIsAuthenticated


### PR DESCRIPTION
Starting from anonymous user and logging in as part of the deployment flow.