### PR TITLE
Improve controller connection handling.

### DIFF
--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -407,6 +407,9 @@ YUI.add('juju-gui', function(Y) {
       */
       this.userPaths = new Map();
 
+      // Track anonymous mode.
+      this.anonymousMode = false;
+
       this.bakeryFactory = new window.jujulib.bakeryFactory(
         Y.juju.environments.web.Bakery);
 
@@ -777,6 +780,7 @@ YUI.add('juju-gui', function(Y) {
       controllerAPI.setCredentials({ user, password, macaroons, external });
 
       controllerAPI.after('login', evt => {
+        this.anonymousMode = false;
         if (evt.err) {
           this._renderLogin(evt.err);
           return;
@@ -834,8 +838,16 @@ YUI.add('juju-gui', function(Y) {
         const currentState = this.state.current;
         // If an anonymous GISF user lands on the GUI at /new then don't
         // attempt to log into the controller.
-        if (!creds.areAvailable && gisf &&
-            (currentState && currentState.root === 'new')) {
+        if ((
+          !creds.areAvailable &&
+          gisf &&
+          currentState &&
+          currentState.root === 'new'
+        ) || (
+          this.anonymousMode &&
+          currentState.root !== 'login'
+        )) {
+          this.anonymousMode = true;
           console.log('now in anonymous mode');
           this.maskVisibility(false);
           return;

--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -407,7 +407,9 @@ YUI.add('juju-gui', function(Y) {
       */
       this.userPaths = new Map();
 
-      // Track anonymous mode.
+      // Track anonymous mode. This value will be set to true when anonymous
+      // navigation is allowed, in essence when a GISF anonymous user is being
+      // modeling on a new canvas.
       this.anonymousMode = false;
 
       this.bakeryFactory = new window.jujulib.bakeryFactory(

--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -838,16 +838,13 @@ YUI.add('juju-gui', function(Y) {
         const creds = this.controllerAPI.getCredentials();
         const gisf = this.get('gisf');
         const currentState = this.state.current;
+        const rootState = currentState ? currentState.root : null;
         // If an anonymous GISF user lands on the GUI at /new then don't
         // attempt to log into the controller.
         if ((
-          !creds.areAvailable &&
-          gisf &&
-          currentState &&
-          currentState.root === 'new'
+          !creds.areAvailable && gisf && rootState === 'new'
         ) || (
-          this.anonymousMode &&
-          currentState.root !== 'login'
+          this.anonymousMode && rootState !== 'login'
         )) {
           this.anonymousMode = true;
           console.log('now in anonymous mode');

--- a/jujugui/static/gui/src/test/mocha.opts
+++ b/jujugui/static/gui/src/test/mocha.opts
@@ -1,6 +1,6 @@
 --require should
 --reporter dot
 --ui bdd
---ignore-leaks 
+--ignore-leaks
 --debug
 -G

--- a/karma-mocha-old.conf.js.tmpl
+++ b/karma-mocha-old.conf.js.tmpl
@@ -4,6 +4,13 @@
 module.exports = function(config) {
   config.set({
 
+
+    // Mocha timeout configuration.
+    client: {
+      mocha: {timeout : 5000}
+    },
+
+
     // base path that will be used to resolve all patterns (eg. files, exclude)
     basePath: '',
 


### PR DESCRIPTION
Track anonymous mode so that it is not only based on URL state, but potentially kept enabled regardless of user navigation. 
Also start the controller pinger as soon as the controller is connected, without waiting for the user to be logged in. This should prevent disconnections due to timeouts when in anonymous mode (in which the controller is connected but not yet authenticated).

Also increased the mocha "done" timeout from 2 to 5 seconds (while waiting for a new laptop).

Fixes https://github.com/juju/juju-gui/issues/2509
