### PR TITLE
Leave owner off non-model profile lists.

### DIFF
--- a/jujugui/static/gui/src/app/components/user-profile/entity-list/entity-list.js
+++ b/jujugui/static/gui/src/app/components/user-profile/entity-list/entity-list.js
@@ -220,11 +220,9 @@ YUI.add('user-profile-entity-list', function() {
             'user-profile__list-icons'}>
             {services}
           </span>
-          <span className="user-profile__list-col one-col prepend-one">
+          <span className={'user-profile__list-col three-col prepend-one ' +
+            'last-col'}>
             {unitCount}
-          </span>
-          <span className="user-profile__list-col two-col last-col">
-            {bundle.owner}
           </span>
         </juju.components.UserProfileEntity>);
     },
@@ -245,12 +243,9 @@ YUI.add('user-profile-entity-list', function() {
             'user-profile__list-icons'}>
             Charms
           </span>
-          <span className="user-profile__list-col one-col prepend-one">
+          <span className={'user-profile__list-col three-col prepend-one ' +
+            'last-col'}>
             Units
-          </span>
-          <span className={
-            'user-profile__list-col two-col last-col'}>
-            Owner
           </span>
         </li>);
     },
@@ -272,23 +267,20 @@ YUI.add('user-profile-entity-list', function() {
           entity={charm}
           key={id}
           type="charm">
-          <span className={'user-profile__list-col three-col ' +
+          <span className={'user-profile__list-col five-col ' +
             'user-profile__list-name'}>
             {charm.name}
             {this._generateTags(charm.tags, id)}
           </span>
-          <span className="user-profile__list-col four-col">
-            {this._generateSeries(charm.series, id)}
-          </span>
-          <span className={'user-profile__list-col one-col ' +
+          <span className={'user-profile__list-col three-col ' +
             'user-profile__list-icons'}>
             <img className="user-profile__list-icon"
               src={charm.icon}
               title={charm.name} />
           </span>
-          <span className={'user-profile__list-col two-col ' +
-            'prepend-two last-col'}>
-            {charm.owner}
+          <span className={'user-profile__list-col prepend-one three-col ' +
+            'last-col'}>
+            {this._generateSeries(charm.series, id)}
           </span>
         </juju.components.UserProfileEntity>);
     },
@@ -302,14 +294,12 @@ YUI.add('user-profile-entity-list', function() {
     _generateCharmHeader: function() {
       return (
         <li className="user-profile__list-header twelve-col">
-          <span className="user-profile__list-col three-col">
+          <span className="user-profile__list-col eight-col">
             Name
           </span>
-          <span className="user-profile__list-col seven-col">
+          <span className={'user-profile__list-col prepend-one three-col ' +
+            'last-col'}>
             Series
-          </span>
-          <span className="user-profile__list-col two-col last-col">
-            Owner
           </span>
         </li>);
     },

--- a/jujugui/static/gui/src/app/components/user-profile/entity-list/test-entity-list.js
+++ b/jujugui/static/gui/src/app/components/user-profile/entity-list/test-entity-list.js
@@ -100,14 +100,12 @@ describe('UserProfileEntityList', () => {
         </div>
         <ul className="user-profile__list twelve-col">
           <li className="user-profile__list-header twelve-col">
-            <span className="user-profile__list-col three-col">
+            <span className="user-profile__list-col eight-col">
               Name
             </span>
-            <span className="user-profile__list-col seven-col">
+            <span className={'user-profile__list-col prepend-one three-col ' +
+              'last-col'}>
               Series
-            </span>
-            <span className="user-profile__list-col two-col last-col">
-              Owner
             </span>
           </li>
           {[<juju.components.UserProfileEntity
@@ -115,7 +113,7 @@ describe('UserProfileEntityList', () => {
             entity={charms[0]}
             key="cs:django"
             type="charm">
-            <span className={'user-profile__list-col three-col ' +
+            <span className={'user-profile__list-col five-col ' +
               'user-profile__list-name'}>
               django
               <ul className="user-profile__list-tags">
@@ -125,23 +123,20 @@ describe('UserProfileEntityList', () => {
                 </li>]}
               </ul>
             </span>
-            <span className="user-profile__list-col four-col">
+            <span className={'user-profile__list-col three-col ' +
+              'user-profile__list-icons'}>
+              <img className="user-profile__list-icon"
+                src="example.com/9/django/icon.svg"
+                title="django" />
+            </span>
+            <span className={'user-profile__list-col prepend-one three-col ' +
+              'last-col'}>
               <ul className="user-profile__list-series">
                 {[<li className="user-profile__comma-item"
                   key="cs:django-trusty">
                   trusty
                 </li>]}
               </ul>
-            </span>
-            <span className={'user-profile__list-col one-col ' +
-              'user-profile__list-icons'}>
-              <img className="user-profile__list-icon"
-                src="example.com/9/django/icon.svg"
-                title="django" />
-            </span>
-            <span className={'user-profile__list-col two-col ' +
-              'prepend-two last-col'}>
-              test-owner
             </span>
           </juju.components.UserProfileEntity>]}
         </ul>
@@ -178,12 +173,9 @@ describe('UserProfileEntityList', () => {
               'user-profile__list-col three-col user-profile__list-icons'}>
               Charms
             </span>
-            <span className="user-profile__list-col one-col prepend-one">
-              Units
-            </span>
             <span className={
-              'user-profile__list-col two-col last-col'}>
-              Owner
+              'user-profile__list-col three-col prepend-one last-col'}>
+              Units
             </span>
           </li>
           {[<juju.components.UserProfileEntity
@@ -213,11 +205,9 @@ describe('UserProfileEntityList', () => {
                 src="example.com/9/django/icon.svg"
                 title="django" />
             </span>
-            <span className="user-profile__list-col one-col prepend-one">
+            <span className={
+              'user-profile__list-col three-col prepend-one last-col'}>
               {5}
-            </span>
-            <span className="user-profile__list-col two-col last-col">
-              test-owner
             </span>
           </juju.components.UserProfileEntity>]}
         </ul>

--- a/jujugui/static/gui/src/app/components/user-profile/entity/entity.js
+++ b/jujugui/static/gui/src/app/components/user-profile/entity/entity.js
@@ -206,7 +206,7 @@ YUI.add('user-profile-entity', function() {
         return;
       }
       return (
-        <div className="nine-col">
+        <div className="twelve-col last-col">
           Series: {this.props.entity.series}
         </div>);
     },
@@ -232,12 +232,30 @@ YUI.add('user-profile-entity', function() {
           </li>);
       });
       return (
-        <div className="nine-col">
+        <div className="twelve-col last-col">
           Composed of:
           <ul className="user-profile__entity-service-list">
             {services}
           </ul>
         </div>);
+    },
+
+    /**
+      Generate the owner for a model.
+
+      @method _generateOwner
+      @return {Object} The owner markup.
+    */
+    _generateOwner: function() {
+      const entity = this.props.entity;
+      if (this.props.type !== 'model' || !entity.owner) {
+        return;
+      }
+      return (
+        <div className="three-col last-col">
+          Owner: {entity.owner}
+        </div>
+      );
     },
 
     render: function() {
@@ -297,9 +315,7 @@ YUI.add('user-profile-entity', function() {
               'no-margin-bottom'}>
               {this._generateSeries()}
               {this._generateServices()}
-              <div className="three-col last-col">
-                Owner: {entity.owner}
-              </div>
+              {this._generateOwner()}
               {this._generateDiagram()}
               {this._generateDescription()}
               {this._generateTags()}

--- a/jujugui/static/gui/src/app/components/user-profile/entity/test-entity.js
+++ b/jujugui/static/gui/src/app/components/user-profile/entity/test-entity.js
@@ -141,7 +141,7 @@ describe('UserProfileEntity', () => {
           <div className={'expanding-row__expanded-content twelve-col ' +
             'no-margin-bottom'}>
             {undefined}
-            <div className="nine-col">
+            <div className="twelve-col last-col">
               Composed of:
               <ul className="user-profile__entity-service-list">
                 <li className="user-profile__comma-item"
@@ -154,9 +154,7 @@ describe('UserProfileEntity', () => {
                 </li>
               </ul>
             </div>
-            <div className="three-col last-col">
-              Owner: {"test-owner"}
-            </div>
+            {undefined}
             <div className="user-profile__entity-diagram twelve-col">
               <object type="image/svg+xml" data="bundle.svg"
                 className="entity-content__diagram-image" />
@@ -234,7 +232,7 @@ describe('UserProfileEntity', () => {
           <div className={'expanding-row__expanded-content twelve-col ' +
             'no-margin-bottom'}>
             {undefined}
-            <div className="nine-col">
+            <div className="twelve-col last-col">
               Composed of:
               <ul className="user-profile__entity-service-list">
                 <li className="user-profile__comma-item"
@@ -247,9 +245,7 @@ describe('UserProfileEntity', () => {
                 </li>
               </ul>
             </div>
-            <div className="three-col last-col">
-              Owner: {"test-owner"}
-            </div>
+            {undefined}
             <div className="user-profile__entity-diagram twelve-col">
               <object type="image/svg+xml" data="bundle.svg"
                 className="entity-content__diagram-image" />
@@ -322,13 +318,11 @@ describe('UserProfileEntity', () => {
           </div>
           <div className={'expanding-row__expanded-content twelve-col ' +
             'no-margin-bottom'}>
-            <div className="nine-col">
+            <div className="twelve-col last-col">
               Series: {"trusty"}
             </div>
             {undefined}
-            <div className="three-col last-col">
-              Owner: {"test-owner"}
-            </div>
+            {undefined}
             {undefined}
             <div className="twelve-col no-margin-bottom">
               <div className="two-col">


### PR DESCRIPTION
Fixes #2504. The owner for charms and bundles is always going to be the same user as the current profile. Consequently there's no point in displaying that column for charms and bundles.