### PR TITLE
To avoid unsetting values on empty config save, use configYAML field.

### DIFF
--- a/jujugui/static/gui/src/app/store/env/api.js
+++ b/jujugui/static/gui/src/app/store/env/api.js
@@ -1302,13 +1302,14 @@ YUI.add('juju-env-api', function(Y) {
       const params = {
         application: args.applicationName,
         'charm-url': args.charmURL,
-        // In order to maintain backwards compatibility the Juju API implemented
-        // a new param, configYAML, so that empty configuration values to
-        // not 'unset' keys. This value is parsed by the Go yaml2 package
-        // So as long as we pass a key/value JSON map it will be able to
-        // parse it as YAML.
-        // In the event this needs to be reverted the key can simply be changed
-        // to 'config'.
+        // In order to maintain backwards compatibility, the Juju API
+        // implemented a new param, configYAML, so that an empty configuration
+        // value does not 'unset' keys. This value is parsed by the Go yaml2
+        // package So as long as we pass a key/value JSON map it will be able
+        // to parse it as YAML.
+        // In the event that making this modification causes issues setting
+        // configuration values due to the JSON>YAML conversion and needs to be
+        // reverted the key can simply be changed to 'config'.
         configYAML: stringifyObjectValues(args.config || {}),
         'config-yaml': args.configRaw || '',
         constraints: constraints,

--- a/jujugui/static/gui/src/app/store/env/api.js
+++ b/jujugui/static/gui/src/app/store/env/api.js
@@ -1302,7 +1302,14 @@ YUI.add('juju-env-api', function(Y) {
       const params = {
         application: args.applicationName,
         'charm-url': args.charmURL,
-        config: stringifyObjectValues(args.config || {}),
+        // In order to maintain backwards compatibility the Juju API implemented
+        // a new param, configYAML, so that empty configuration values to
+        // not 'unset' keys. This value is parsed by the Go yaml2 package
+        // So as long as we pass a key/value JSON map it will be able to
+        // parse it as YAML.
+        // In the event this needs to be reverted the key can simply be changed
+        // to 'config'.
+        configYAML: stringifyObjectValues(args.config || {}),
         'config-yaml': args.configRaw || '',
         constraints: constraints,
         'num-units': args.numUnits || 0,

--- a/jujugui/static/gui/src/app/store/env/sandbox.js
+++ b/jujugui/static/gui/src/app/store/env/sandbox.js
@@ -922,7 +922,7 @@ YUI.add('juju-env-sandbox', function(Y) {
       const params = data.params.applications[0];
       state.deploy(params['charm-url'], callback, {
         name: params.application,
-        config: params.config,
+        config: params.configYAML,
         configYAML: params['config-yaml'],
         constraints: params.constraints,
         unitCount: params['num-units']

--- a/jujugui/static/gui/src/test/test_env_api.js
+++ b/jujugui/static/gui/src/test/test_env_api.js
@@ -1614,7 +1614,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
         params: {applications: [{
           application: 'mysql',
           'config-yaml': '',
-          config: {},
+          configYAML: {},
           constraints: {},
           'charm-url': 'precise/mysql',
           'num-units': 1,
@@ -1635,7 +1635,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
         params: {applications: [{
           application: 'wiki',
           // Configuration values are sent as strings.
-          config: {debug: 'true', logo: 'example.com/mylogo.png'},
+          configYAML: {debug: 'true', logo: 'example.com/mylogo.png'},
           'config-yaml': '',
           constraints: {},
           'charm-url': 'precise/mediawiki',
@@ -1661,7 +1661,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
         version: 7,
         params: {applications: [{
           application: 'mysql',
-          config: {},
+          configYAML: {},
           constraints: {},
           'config-yaml': configRaw,
           'charm-url': 'precise/mysql',
@@ -1714,7 +1714,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
         params: {applications: [{
           application: 'wiki',
           // Configuration values are sent as strings.
-          config: {},
+          configYAML: {},
           'config-yaml': '',
           constraints: {},
           'charm-url': 'precise/mediawiki',


### PR DESCRIPTION
Fixes #2325 
