### PR TITLE
Implicitly assume @external domain for jaas users.

### DIFF
--- a/jujugui/static/gui/src/app/components/sharing/sharing.js
+++ b/jujugui/static/gui/src/app/components/sharing/sharing.js
@@ -140,7 +140,7 @@ YUI.add('sharing', function() {
       }
       const username = this.refs.username.getValue();
       const access = this.refs.access.getValue();
-      this.props.grantModelAccess([username], access,
+      this.props.grantModelAccess(username, access,
         this._modifyModelAccessCallback);
     },
 
@@ -155,7 +155,7 @@ YUI.add('sharing', function() {
       // downgrades it to the next level at the moment (as of 2.0). So if you
       // want a user to have no access, you have to specify 'read'. Because:
       // admin -> write -> read -> no access.
-      this.props.revokeModelAccess([user.name], 'read',
+      this.props.revokeModelAccess(user.name, 'read',
         this._modifyModelAccessCallback);
     },
 

--- a/jujugui/static/gui/src/app/components/sharing/test-sharing.js
+++ b/jujugui/static/gui/src/app/components/sharing/test-sharing.js
@@ -274,7 +274,7 @@ describe('Sharing', () => {
     assert.equal(grantModelAccess.called, true,
       'grantModelAccess was not called');
     assert.deepEqual(grantModelAccess.args[0], [
-      ['chekov'],
+      'chekov',
       'read',
       instance._modifyModelAccessCallback
     ], 'grantModelAccess not called with the correct data');
@@ -313,7 +313,7 @@ describe('Sharing', () => {
     assert.equal(revokeModelAccess.called, true,
       'revokeModelAccess was not called');
     assert.deepEqual(revokeModelAccess.args[0], [
-      ['drwho@external'],
+      'drwho@external',
       'read',
       instance._modifyModelAccessCallback
     ], 'revokeModelAccess not called with the correct data');


### PR DESCRIPTION
This way, when in Jujucharms.com, model access can be granted/revoked to users without specifying the domain. If you instead explicitly specify a domain, the value is left untouched.