### PR TITLE
Match CLI functionality for creating relations

### DIFF
--- a/jujugui/static/gui/src/app/models/endpoints.js
+++ b/jujugui/static/gui/src/app/models/endpoints.js
@@ -53,34 +53,29 @@ YUI.add('juju-endpoints', function(Y) {
   },
 
   /**
-   * Find available relation targets for a service.
-   *
-   * @method getEndpoints
-   * @param {Object} application A service object.
-   * @param {Object} controller The endpoints controller.
-   *
-   * @return {Object} A mapping with keys of valid relation service targets
-   *   and values consisting of a list of valid endpoints for each.
-   */
+    Find available relation targets for an application.
+    @param {Object} application An application object.
+    @param {Object} controller The endpoints controller.
+    @return {Object} A mapping with keys of valid relation application targets
+      and values consisting of a list of valid endpoints for each.
+  */
   models.getEndpoints = function(application, controller) {
-    const targets = {},
-        requires = [],
-        provides = [],
-        appId = application.get('id'),
-        db = controller.get('db'),
-        endpointsMap = controller.endpointsMap;
+    const targets = {};
+    const appId = application.get('id');
+    const db = controller.get('db');
+    const endpointsMap = controller.endpointsMap;
+    const appEndpoints = endpointsMap[appId];
     const appIsSubordinate = application.get('subordinate');
-    // Bail out if the map doesn't yet exist for this service.  The charm may
+    const appSeries = models._getSeries(db, application);
+    // Bail out if the map doesn't yet exist for this application. The charm may
     // not be loaded yet.
-    if (!endpointsMap[appId]) {
-      return targets;
+    if (!appEndpoints) {
+      return {};
     }
     /**
-     * Convert a service name and its relation endpoint info into a
-     * valid relation target endpoint, ie. including service name.
-     *
-     * @method getEndpoints.convert
-     */
+      Convert an application name and its relation endpoint info into a
+      valid relation target endpoint, ie. including application name.
+    */
     function convert(applicationName, relInfo) {
       return {
         service: applicationName,
@@ -88,78 +83,53 @@ YUI.add('juju-endpoints', function(Y) {
         type: relInfo['interface']
       };
     }
-
     /**
-     * Store endpoints for a relation to target the given service.
-     *
-     * @method getEndpoints.add
-     * @param {Object} targetEndpoint Target endpoint.
-     * @param {Object} originEndpoint Origin endpoint.
-     */
+      Store endpoints for a relation to target the given application.
+      @param {Object} targetEndpoint Target endpoint.
+      @param {Object} originEndpoint Origin endpoint.
+    */
     function add(applicationName, originEndpoint, targetEndpoint) {
       if (!targets.hasOwnProperty(applicationName)) {
         targets[applicationName] = [];
       }
       targets[applicationName].push([originEndpoint, targetEndpoint]);
     }
-
-    // First we process all the endpoints of the origin service.
-    //
-    // For required interfaces, we consider them valid for new relations
-    // only if they are not already satisfied by an existing relation.
-    endpointsMap[appId].requires.forEach(rdata => {
-      const endpoint = convert(appId, rdata);
-      // Subordinate relations are slightly different:
-      // a subordinate typically acts as a client to many services,
-      // against the implicitly provided juju-info interface.
-      if (application.get('subordinate') &&
-        relationUtils.isSubordinateRelation(rdata)) {
-        return requires.push(endpoint);
-      }
-      if (db.relations.has_relation_for_endpoint(endpoint)) {
-        return;
-      }
-      requires.push(endpoint);
-    });
-
-    // Process origin provides endpoints, a bit simpler, as they are
-    // always one to many.
-    endpointsMap[appId].provides.forEach(pdata => {
-      provides.push(convert(appId, pdata));
-    });
-
+    // First we process all the endpoints of the origin application to use a
+    // legacy format because this is what other legacy utils require.
+    const requires = appEndpoints.requires.map(rdata => convert(appId, rdata));
+    const provides = appEndpoints.provides.map(pdata => convert(appId, pdata));
     // Every non subordinate service implicitly provides this.
     if (!appIsSubordinate) {
       provides.push(convert(
           appId, {'interface': 'juju-info', 'name': 'juju-info'}));
     }
-
-    // Now check every other service to see if it can be a valid target.
+    // Now check every other application to see if it can be a valid target.
     db.services.each(target => {
-      const targetId = target.get('id'),
-          targetProvides = endpointsMap[targetId].provides.concat();
+      const targetId = target.get('id');
+      const targetProvides = endpointsMap[targetId].provides.concat();
       const targetIsSubordinate = target.get('subordinate');
-      // Ignore ourselves, peer relations are automatically
-      // established when a service is deployed. The GUI only needs to
-      // concern itself with client/server relations.
-      if (targetId === appId) {
-        return;
-      }
-      // Process each of the service's required endpoints. It is only
-      // considered a valid target if it is not satisfied by an existing
-      // relation.
+      // Ignore ourselves, peer relations are automatically established when an
+      // application is deployed. The GUI only needs to concern itself with
+      // client/server relations.
+      if (targetId === appId) { return; }
+      // Process each of the application's required endpoints.
       endpointsMap[targetId].requires.forEach(rdata => {
         const endpoint = convert(targetId, rdata);
-        // Subordinates are excendpointtions again as they are a client
-        // to many services. We check if a subordinate relation
-        // exists between this subordinate endpoint and the origin
-        // service.
-        if (targetIsSubordinate &&
-          relationUtils.isSubordinateRelation(rdata)) {
-          if (db.relations.has_relation_for_endpoint(endpoint, appId)) {
+        // Subordinate relations are handled differently because they can be
+        // installed on the target machine depending on the defined scope.
+        if (targetIsSubordinate && relationUtils.isSubordinateRelation(rdata)) {
+          // In addition to checking if the relation is of type `subordinate`
+          // The `isSubordinateRelation` function also checks that the
+          // subordinate relation is of scope 'container' which means that
+          // the series must match between the target and source.
+          const targetSeries = models._getSeries(db, target);
+          if (!appSeries.some(series => targetSeries.indexOf(series) > -1)) {
             return;
           }
-        } else if (db.relations.has_relation_for_endpoint(endpoint)) {
+        }
+        // A relation between two applications can only be completed once on
+        // the same interface.
+        if (db.relations.has_relation_for_endpoint(endpoint, appId)) {
           return;
         }
         // If the origin provides it then it is a valid target.

--- a/jujugui/static/gui/src/app/models/endpoints.js
+++ b/jujugui/static/gui/src/app/models/endpoints.js
@@ -70,8 +70,6 @@ YUI.add('juju-endpoints', function(Y) {
         db = controller.get('db'),
         endpointsMap = controller.endpointsMap;
     const appIsSubordinate = application.get('subordinate');
-    const appSeries = models._getSeries(db, application);
-
     // Bail out if the map doesn't yet exist for this service.  The charm may
     // not be loaded yet.
     if (!endpointsMap[appId]) {
@@ -141,23 +139,11 @@ YUI.add('juju-endpoints', function(Y) {
       const targetId = target.get('id'),
           targetProvides = endpointsMap[targetId].provides.concat();
       const targetIsSubordinate = target.get('subordinate');
-      const targetSeries = models._getSeries(db, target);
-
       // Ignore ourselves, peer relations are automatically
-      // established when a service is dendpointloyed. The gui only needs to
+      // established when a service is deployed. The GUI only needs to
       // concern itself with client/server relations.
       if (targetId === appId) {
         return;
-      }
-      // If the provided service is a subordinate it should only match targets
-      // with the same series. Or, if the target is a subordinate it needs to
-      // have a matching series to the provided app.
-      if (targetIsSubordinate || appIsSubordinate) {
-        // If there is no match beween the app and target series then exit out
-        // so this target does not get included in the list.
-        if (!appSeries.some(series => targetSeries.indexOf(series) > -1)) {
-          return;
-        }
       }
       // Process each of the service's required endpoints. It is only
       // considered a valid target if it is not satisfied by an existing

--- a/jujugui/static/gui/src/app/utils/relation-utils.js
+++ b/jujugui/static/gui/src/app/utils/relation-utils.js
@@ -519,9 +519,7 @@ YUI.add('relation-utils', function(Y) {
   };
 
   /**
-    Create a list of relations.
-
-    @method createRelation
+    Create a relation.
     @param {Object} db Reference to the db instance.
     @param {Object} env The current environment.
     @param {Array} endpoints A list of relation endpoints.
@@ -533,45 +531,50 @@ YUI.add('relation-utils', function(Y) {
     const match = RelationUtils.findEndpointMatch(endpointData);
     const relationId = `pending-${endpoints[0][0]}:${endpoints[0][1].name}` +
       `${endpoints[1][0]}:${endpoints[1][1].name}`;
-    const service1 = endpointData[0].service;
-    const service2 = endpointData[1].service;
+    const application1 = endpointData[0].service;
+    const application2 = endpointData[1].service;
     let subordinate;
     let application;
-    // Figure out if one of the services is a subordinate.
-    if (service1.get('subordinate')) {
-      subordinate = service1;
-      application = service2;
-    } else if (service2.get('subordinate')) {
-      subordinate = service2;
-      application = service1;
+    // If either of the applications is a subordinate then assign the
+    // variable appropriately.
+    if (application1.get('subordinate')) {
+      subordinate = application1;
+      application = application2;
+    } else if (application2.get('subordinate')) {
+      subordinate = application2;
+      application = application1;
     }
     if (subordinate) {
       const appSeries = application.get('series');
-      // If there selected subordinate series does not match the application we
-      // are relating it to then it must be a multi-series subordinate and we
-      // need to update the series to match.
+      // If the selected subordinate series does not match the application we
+      // are relating it to and it is on a 'container' scope then it must be
+      // a multi-series subordinate and we need to update the series to match.
       if (subordinate.get('series') !== appSeries) {
-        const existingRelations = RelationUtils.getRelationDataForService(
-          db, subordinate);
-        // If there is an existing relation then we don't want to update the
-        // relation otherwise it will not match the existing application.
-        if (existingRelations.length === 0) {
-          // Update the subordinate series to match the application. We know
-          // that the subordinate is a multi-series charm with a series that
-          // matches the application otherwise we would not have got matching
-          // endpoints.
-          subordinate.set('series', appSeries);
-        } else {
-          // If there is an existing relation then show an error and cancel
-          // adding the relation.
-          db.notifications.add({
-            title: 'Subordinate series does not match',
-            message: 'Subordinates can only be related to applications with ' +
-              'the same series. This subordinate already has a relation to an' +
-              ' application with a different series.',
-            level: 'error'
-          });
-          return;
+        // If the scope isn't container then the series doesn't matter.
+        if (match.scope === 'container') {
+          const existingRelations = RelationUtils.getRelationDataForService(
+            db, subordinate);
+          // If there is an existing relation then we don't want to update the
+          // relation otherwise it will not match the existing application.
+          if (existingRelations.length === 0) {
+            // Update the subordinate series to match the application. We know
+            // that the subordinate is a multi-series charm with a series that
+            // matches the application otherwise we would not have got matching
+            // endpoints.
+            subordinate.set('series', appSeries);
+          } else {
+            // If there is an existing relation then show an error and cancel
+            // adding the relation.
+            db.notifications.add({
+              title: 'Subordinate series does not match',
+              message: 'Subordinates can only have a container scoped ' +
+                'relation between applications with the same series. ' +
+                'This subordinate already has a relation to an application ' +
+                'with a different series.',
+              level: 'error'
+            });
+            return;
+          }
         }
       }
     }

--- a/jujugui/static/gui/src/test/test_endpoints.js
+++ b/jujugui/static/gui/src/test/test_endpoints.js
@@ -208,7 +208,7 @@ describe('Relation endpoints logic', function() {
     var available = models.getEndpoints(service, app.endpointsController);
     var available_svcs = Object.keys(available);
     available_svcs.sort();
-    available_svcs.should.eql(['memcached']);
+    available_svcs.should.eql(['memcached', 'rsyslog-forwarder-ha']);
   });
 
   it('should find valid targets for subordinates', function() {

--- a/jujugui/static/gui/src/test/test_endpoints.js
+++ b/jujugui/static/gui/src/test/test_endpoints.js
@@ -72,7 +72,6 @@ describe('Relation endpoints logic', function() {
       env: env,
       socketTemplate: '/model/$uuid/api',
       controllerSocketTemplate: '/api',
-      consoleEnabled: true,
       jujuCoreVersion: '2.0.0'
     });
     app.navigate = function() { return true; };
@@ -127,37 +126,6 @@ describe('Relation endpoints logic', function() {
         ['mediawiki', 'puppet', 'rsyslog-forwarder-ha', 'wordpress']);
   });
 
-  it('should find subordinates with a matching series', function() {
-    loadDelta(false);
-    app.endpointsController.endpointsMap = sample_endpoints;
-    app.db.services.getById('mediawiki').set('series', 'trusty');
-    app.db.services.getById('puppet').set('series', 'precise');
-    app.db.services.getById('puppet').set('subordinate', true);
-    app.db.services.getById('rsyslog-forwarder-ha').set('series', 'precise');
-    let service = db.services.getById('memcached');
-    service.set('series', 'trusty');
-    const available = models.getEndpoints(service, app.endpointsController);
-    const available_svcs = Object.keys(available);
-    available_svcs.sort();
-    available_svcs.should.eql(
-        ['mediawiki', 'rsyslog-forwarder-ha', 'wordpress']);
-  });
-
-  it('should only match app series if it is a subordinate', function() {
-    loadDelta(false);
-    app.endpointsController.endpointsMap = sample_endpoints;
-    app.db.services.getById('mediawiki').set('series', 'trusty');
-    app.db.services.getById('wordpress').set('series', 'trusty');
-    app.db.services.getById('rsyslog-forwarder-ha').set('series', 'precise');
-    let service = db.services.getById('memcached');
-    service.set('series', 'trusty');
-    service.set('subordinate', true);
-    const available = models.getEndpoints(service, app.endpointsController);
-    const available_svcs = Object.keys(available);
-    available_svcs.sort();
-    available_svcs.should.eql(['mediawiki', 'wordpress']);
-  });
-
   it('should find multi-series subordinates with matching series', function() {
     loadDelta(false);
     app.endpointsController.endpointsMap = sample_endpoints;
@@ -200,50 +168,6 @@ describe('Relation endpoints logic', function() {
     const available_svcs = Object.keys(available);
     available_svcs.sort();
     available_svcs.should.eql(['mediawiki', 'wordpress']);
-  });
-
-  it('should not check multi-series for deployed subordinates', function() {
-    loadDelta(false);
-    app.endpointsController.endpointsMap = sample_endpoints;
-    app.db.services.getById('mediawiki').set('series', 'trusty');
-    const puppet = app.db.services.getById('puppet');
-    puppet.set('series', 'xenial');
-    puppet.set('subordinate', true);
-    puppet.set('pending', false);
-    const charm = app.db.charms.add({
-      id: puppet.get('charm'),
-      is_subordinate: true
-    });
-    charm.set('series', ['xenial', 'trusty']);
-    app.db.services.getById('rsyslog-forwarder-ha').set('series', 'precise');
-    let service = db.services.getById('memcached');
-    service.set('series', 'trusty');
-    const available = models.getEndpoints(service, app.endpointsController);
-    const available_svcs = Object.keys(available);
-    available_svcs.sort();
-    available_svcs.should.eql(
-        ['mediawiki', 'rsyslog-forwarder-ha', 'wordpress']);
-  });
-
-  it('matches app series for a deployed multi-series subordinate', function() {
-    loadDelta(false);
-    app.endpointsController.endpointsMap = sample_endpoints;
-    app.db.services.getById('mediawiki').set('series', 'xenial');
-    app.db.services.getById('wordpress').set('series', 'trusty');
-    app.db.services.getById('rsyslog-forwarder-ha').set('series', 'trusty');
-    let service = db.services.getById('memcached');
-    service.set('series', 'xenial');
-    service.set('subordinate', true);
-    service.set('pending', false);
-    const charm = app.db.charms.add({
-      id: service.get('charm'),
-      is_subordinate: true
-    });
-    charm.set('series', ['xenial', 'trusty']);
-    const available = models.getEndpoints(service, app.endpointsController);
-    const available_svcs = Object.keys(available);
-    available_svcs.sort();
-    available_svcs.should.eql(['mediawiki']);
   });
 
   it('should find ambigious targets', function() {

--- a/jujugui/static/gui/src/test/test_relation_utils.js
+++ b/jujugui/static/gui/src/test/test_relation_utils.js
@@ -849,7 +849,7 @@ describe('RelationUtils', function() {
       charmGet.withArgs('provides').returns({
         db: {
           interface: 'db',
-          scope: 'global'
+          scope: 'container'
         }
       });
       var serviceSet = sinon.stub();
@@ -901,7 +901,7 @@ describe('RelationUtils', function() {
         interface: 'db',
         endpoints: endpoints,
         pending: true,
-        scope: 'global',
+        scope: 'container',
         display_name: 'pending'
       });
       assert.equal(env.add_relation.callCount, 1);
@@ -925,98 +925,6 @@ describe('RelationUtils', function() {
       assert.equal(serviceSet.callCount, 1);
       assert.equal(serviceSet.args[0][0], 'series');
       assert.equal(serviceSet.args[0][1], 'trusty');
-    });
-
-    it('does not relate a multi-series subordinate with relation', function() {
-      var relationId = 'pending-19984570$:db23212464$:db';
-      var charmGet = sinon.stub();
-      charmGet.withArgs('requires').onFirstCall().returns({
-        db: {
-          interface: 'db',
-          scope: 'global'
-        }
-      });
-      charmGet.withArgs('requires').onSecondCall().returns({
-        misc: {
-          interface: 'misc',
-          scope: 'global'
-        }
-      });
-      charmGet.withArgs('provides').returns({
-        db: {
-          interface: 'db',
-          scope: 'global'
-        }
-      });
-      var serviceSet = sinon.stub();
-      var serviceGet = sinon.stub();
-      serviceGet.withArgs('subordinate').onFirstCall().returns(true);
-      serviceGet.withArgs('subordinate').onSecondCall().returns(false);
-      serviceGet.withArgs('series').onFirstCall().returns('trusty');
-      serviceGet.withArgs('series').onSecondCall().returns('xenial');
-      var db = {
-        charms: {
-          getById: sinon.stub().returns({
-            get: charmGet
-          }),
-          size: sinon.stub()
-        },
-        notifications: {
-          add: sinon.stub()
-        },
-        relations: {
-          add: sinon.stub(),
-          remove: sinon.stub(),
-          create: sinon.stub(),
-          getById: sinon.stub().returns(relationId),
-          get_relations_for_service: sinon.stub().returns([{
-            getAttrs: sinon.stub().returns({
-              endpoints: [[{
-                role: 'role',
-                name: 'name'
-              }, {
-                role: 'role',
-                name: 'name'
-              }], [{
-                role: 'role',
-                name: 'name'
-              }, {
-                role: 'role',
-                name: 'name'
-              }]],
-              relation_id: 'relid'
-            })
-          }])
-        },
-        services: {
-          getById: sinon.stub().returns({
-            get: serviceGet,
-            set: serviceSet
-          })
-        }
-      };
-      var env = {
-        add_relation: sinon.stub()
-      };
-      var endpoints = [[
-        '19984570$', {
-          name: 'db',
-          role: 'client'
-        }
-      ], [
-        '23212464$', {
-          name: 'db',
-          role: 'server'
-        }
-      ]];
-      relationUtils.createRelation(
-        db, env, endpoints, sinon.stub());
-      assert.equal(db.relations.add.callCount, 0);
-      assert.equal(env.add_relation.callCount, 0);
-      assert.equal(db.relations.remove.callCount, 0);
-      assert.equal(db.relations.create.callCount, 0);
-      assert.equal(serviceSet.callCount, 0);
-      assert.equal(db.notifications.add.callCount, 1);
     });
   });
 


### PR DESCRIPTION
Match the CLI functionality for creating relations. This fixes the long standing issue of explicitly blocking multiple relations to a `requires` endpoint and properly respecting the subordinate scope when creating relations with multi-series charms.

Fixes #2485 
Fixes #1055 