### PR TITLE
Use port ranges instead of ports when possible.

### DIFF
--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -1007,8 +1007,10 @@ YUI.add('juju-gui', function(Y) {
           this.controllerAPI, this.bakeryFactory.get('juju'));
       const webhandler = new Y.juju.environments.web.WebHandler();
       const controllerIsConnected = () => {
-        return legacy ? this.env.get('connected') :
-          this.controllerAPI.get('connected');
+        if (legacy) {
+          return this.env && this.env.get('connected');
+        }
+        return this.controllerAPI && this.controllerAPI.get('connected');
       };
       const getDischargeToken = () => {
         return window.localStorage.getItem('discharge-token');

--- a/jujugui/static/gui/src/app/components/inspector/change-version/change-version.js
+++ b/jujugui/static/gui/src/app/components/inspector/change-version/change-version.js
@@ -66,13 +66,11 @@ YUI.add('inspector-change-version', function() {
       The callable to be passed to the version item to view the charm details.
 
       @method _viewCharmDetails
-      @param {String} charmId The charm id.
-      @param {Object} e The click event.
+      @param {Object} url The charm url as a window.jujulib.URL instance.
+      @param {Object} evt The click event.
     */
-    _viewCharmDetails: function(charmId, e) {
-      this.props.changeState({
-        store: charmId.replace('cs:', '')
-      });
+    _viewCharmDetails: function(url, evt) {
+      this.props.changeState({store: url.path()});
     },
 
     /**
@@ -178,19 +176,19 @@ YUI.add('inspector-change-version', function() {
         console.error(error);
         versions = null;
       }
-      var components = [];
+      let components = [];
       if (!versions || versions.length === 1) {
         components = <li className="inspector-change-version__none">
               No other versions found.
             </li>;
       } else {
-        var currentVersion = this._getVersionNumber(this.props.charmId);
+        const url = window.jujulib.URL.fromLegacyString(this.props.charmId);
         versions.forEach(function(version) {
-          var thisVersion = this._getVersionNumber(version);
-          var downgrade = false;
-          if (thisVersion === currentVersion) {
+          const versionURL = window.jujulib.URL.fromLegacyString(version);
+          let downgrade = false;
+          if (versionURL.revision === url.revision) {
             return true;
-          } else if (thisVersion < currentVersion) {
+          } else if (versionURL.revision < url.revision) {
             downgrade = true;
           }
           components.push(
@@ -198,25 +196,14 @@ YUI.add('inspector-change-version', function() {
               acl={this.props.acl}
               key={version}
               downgrade={downgrade}
-              itemAction={this._viewCharmDetails.bind(this, version)}
+              itemAction={this._viewCharmDetails.bind(this, versionURL)}
               buttonAction={this._versionButtonAction.bind(this, version)}
-              id={version} />);
+              url={versionURL}
+            />);
         }, this);
       }
       this.setState({loading: false});
       this.setState({versionsList: components});
-    },
-
-    /**
-      Get the version number from the charm id.
-
-      @method _getVersionNumber
-      @param {String} charmId The charm id.
-      @returns {Integer} The version number.
-    */
-    _getVersionNumber: function(charmId) {
-      var parts = charmId.split('-');
-      return parseInt(parts[parts.length - 1]);
     },
 
     /**
@@ -241,15 +228,15 @@ YUI.add('inspector-change-version', function() {
     },
 
     render: function() {
-      var charmId = this.props.charmId;
+      const url = window.jujulib.URL.fromLegacyString(this.props.charmId);
       return (
         <div className="inspector-change-version">
           <div className="inspector-change-version__current">
             Current version:
             <div className="inspector-change-version__current-version"
               role="button" tabIndex="0"
-              onClick={this._viewCharmDetails.bind(this, charmId)}>
-              {charmId}
+              onClick={this._viewCharmDetails.bind(this, url)}>
+              {url.path()}
             </div>
           </div>
           {this._displayVersionsList(this.state.loading,

--- a/jujugui/static/gui/src/app/components/inspector/change-version/item/item.js
+++ b/jujugui/static/gui/src/app/components/inspector/change-version/item/item.js
@@ -26,8 +26,8 @@ YUI.add('inspector-change-version-item', function() {
       acl: React.PropTypes.object.isRequired,
       buttonAction: React.PropTypes.func.isRequired,
       downgrade: React.PropTypes.bool.isRequired,
-      id: React.PropTypes.string.isRequired,
-      itemAction: React.PropTypes.func.isRequired
+      itemAction: React.PropTypes.func.isRequired,
+      url: React.PropTypes.object.isRequired
     },
 
     /**
@@ -40,39 +40,22 @@ YUI.add('inspector-change-version-item', function() {
       return this.props.downgrade ? 'Downgrade' : 'Upgrade';
     },
 
-    /**
-      Generate the title for the charm.
-
-      @method _generateTitle
-      @returns {String} The charm title.
-    */
-    _generateTitle: function() {
-      var charmId = this.props.id.replace('cs:', '');
-      var title = charmId;
-      var idLength = charmId.length;
-      if (idLength > 13) {
-        var start = charmId.slice(0, 4);
-        var end = charmId.slice(idLength - 9, idLength);
-        title = start + '...' + end;
-      }
-      return title;
-    },
-
     render: function() {
+      const path = this.props.url.path();
+      const props = this.props;
       return (
         <li className="inspector-current-version__item"
           role="button" tabIndex="0"
-          onClick={this.props.itemAction}>
-          <span title={this.props.id}
-           className="inspector-current-version__title">
-            {this._generateTitle()}
+          onClick={props.itemAction}>
+          <span title={path} className="inspector-current-version__title">
+            version {props.url.revision}
           </span>
           <juju.components.GenericButton
-            disabled={this.props.acl.isReadOnly()}
-            key={this.props.id}
+            disabled={props.acl.isReadOnly()}
+            key={path}
             type='inline-neutral'
             title={this._generateButtonLabel()}
-            action={this.props.buttonAction} />
+            action={props.buttonAction} />
         </li>
       );
     }

--- a/jujugui/static/gui/src/app/components/inspector/change-version/item/test-item.js
+++ b/jujugui/static/gui/src/app/components/inspector/change-version/item/test-item.js
@@ -24,7 +24,7 @@ chai.config.includeStack = true;
 chai.config.truncateThreshold = 0;
 
 describe('InspectorChangeVersionItem', function() {
-  var acl;
+  let acl;
 
   beforeAll(function(done) {
     // By loading this file it adds the component to the juju components.
@@ -35,109 +35,88 @@ describe('InspectorChangeVersionItem', function() {
     acl = {isReadOnly: sinon.stub().returns(false)};
   });
 
-  it('can display the version item with a short name', function() {
-    var buttonAction = sinon.stub();
-    var itemAction = sinon.stub();
-    var output = jsTestUtils.shallowRender(
-        <juju.components.InspectorChangeVersionItem
-          acl={acl}
-          key="cs:django-5"
-          downgrade={false}
-          itemAction={itemAction}
-          buttonAction={buttonAction}
-          id="cs:django-5" />);
+  it('can display the version item', function() {
+    const buttonAction = sinon.stub();
+    const itemAction = sinon.stub();
+    const url = window.jujulib.URL.fromString('django/xenial/5');
+    const output = jsTestUtils.shallowRender(
+      <juju.components.InspectorChangeVersionItem
+        acl={acl}
+        key="cs:django-5"
+        downgrade={false}
+        itemAction={itemAction}
+        buttonAction={buttonAction}
+        url={url}
+      />);
     assert.deepEqual(output,
-        <li className="inspector-current-version__item"
-          role="button" tabIndex="0"
-          onClick={itemAction}>
-          <span title="cs:django-5"
-            className="inspector-current-version__title">
-            django-5
-          </span>
-          <juju.components.GenericButton
-            disabled={false}
-            key="cs:django-5"
-            type="inline-neutral"
-            title="Upgrade"
-            action={buttonAction} />
-        </li>);
-  });
-
-  it('can shorten a long name', function() {
-    var buttonAction = sinon.stub();
-    var itemAction = sinon.stub();
-    var output = jsTestUtils.shallowRender(
-        <juju.components.InspectorChangeVersionItem
-          acl={acl}
-          key="cs:django-django-pango-pongo-5"
-          downgrade={false}
-          itemAction={itemAction}
-          buttonAction={buttonAction}
-          id="cs:django-django-pango-pongo-5" />);
-    assert.deepEqual(output,
-        <li className="inspector-current-version__item"
-          role="button" tabIndex="0"
-          onClick={itemAction}>
-          <span title="cs:django-django-pango-pongo-5"
-            className="inspector-current-version__title">
-            djan...o-pongo-5
-          </span>
-          <juju.components.GenericButton
-            disabled={false}
-            key="cs:django-django-pango-pongo-5"
-            type="inline-neutral"
-            title="Upgrade"
-            action={buttonAction} />
-        </li>);
+      <li className="inspector-current-version__item"
+        role="button" tabIndex="0"
+        onClick={itemAction}>
+        <span title="django/xenial/5"
+          className="inspector-current-version__title">
+          version {5}
+        </span>
+        <juju.components.GenericButton
+          disabled={false}
+          key="django/xenial/5"
+          type="inline-neutral"
+          title="Upgrade"
+          action={buttonAction} />
+      </li>);
   });
 
   it('can show a downgrade label', function() {
-    var buttonAction = sinon.stub();
-    var itemAction = sinon.stub();
-    var output = jsTestUtils.shallowRender(
-        <juju.components.InspectorChangeVersionItem
-          acl={acl}
-          key="cs:django-5"
-          downgrade={true}
-          itemAction={itemAction}
-          buttonAction={buttonAction}
-          id="cs:django-5" />);
+    const buttonAction = sinon.stub();
+    const itemAction = sinon.stub();
+    const url = window.jujulib.URL.fromString('django/trusty/42');
+    const output = jsTestUtils.shallowRender(
+      <juju.components.InspectorChangeVersionItem
+        acl={acl}
+        key="django/trusty/42"
+        downgrade={true}
+        itemAction={itemAction}
+        buttonAction={buttonAction}
+        url={url}
+      />);
     assert.deepEqual(output,
-        <li className="inspector-current-version__item"
-          role="button" tabIndex="0"
-          onClick={itemAction}>
-          <span title="cs:django-5"
-            className="inspector-current-version__title">
-            django-5
-          </span>
-          <juju.components.GenericButton
-            disabled={false}
-            key="cs:django-5"
-            type="inline-neutral"
-            title="Downgrade"
-            action={buttonAction} />
-        </li>);
+      <li className="inspector-current-version__item"
+        role="button" tabIndex="0"
+        onClick={itemAction}>
+        <span title="django/trusty/42"
+          className="inspector-current-version__title">
+          version {42}
+        </span>
+        <juju.components.GenericButton
+          disabled={false}
+          key="django/trusty/42"
+          type="inline-neutral"
+          title="Downgrade"
+          action={buttonAction} />
+      </li>);
   });
 
   it('can disable the button when read only', function() {
     acl.isReadOnly = sinon.stub().returns(true);
-    var buttonAction = sinon.stub();
-    var itemAction = sinon.stub();
-    var output = jsTestUtils.shallowRender(
-        <juju.components.InspectorChangeVersionItem
-          acl={acl}
-          key="cs:django-5"
-          downgrade={false}
-          itemAction={itemAction}
-          buttonAction={buttonAction}
-          id="cs:django-5" />);
-    var expected = (
+    const buttonAction = sinon.stub();
+    const itemAction = sinon.stub();
+    const url = window.jujulib.URL.fromString('django/47');
+    const output = jsTestUtils.shallowRender(
+      <juju.components.InspectorChangeVersionItem
+        acl={acl}
+        key="django/47"
+        downgrade={false}
+        itemAction={itemAction}
+        buttonAction={buttonAction}
+        url={url}
+      />);
+    const expected = (
       <juju.components.GenericButton
         disabled={true}
-        key="cs:django-5"
+        key="django/47"
         type="inline-neutral"
         title="Upgrade"
-        action={buttonAction} />);
+        action={buttonAction}
+      />);
     assert.deepEqual(output.props.children[1], expected);
   });
 });

--- a/jujugui/static/gui/src/app/components/inspector/change-version/test-change-version.js
+++ b/jujugui/static/gui/src/app/components/inspector/change-version/test-change-version.js
@@ -62,7 +62,7 @@ describe('InspectorChangeVersion', function() {
           <div className="inspector-change-version__current-version"
             role="button" tabIndex="0"
             onClick={output.props.children[0].props.children[1].props.onClick}>
-            cs:django
+            django
           </div>
         </div>
         <div className="inspector-spinner">
@@ -99,7 +99,7 @@ describe('InspectorChangeVersion', function() {
           <div className="inspector-change-version__current-version"
             role="button" tabIndex="0"
             onClick={output.props.children[0].props.children[1].props.onClick}>
-            cs:django
+            django
           </div>
         </div>
         <ul className="inspector-change-version__versions">
@@ -140,7 +140,7 @@ describe('InspectorChangeVersion', function() {
           <div className="inspector-change-version__current-version"
             role="button" tabIndex="0"
             onClick={output.props.children[0].props.children[1].props.onClick}>
-            cs:django-5
+            django/5
           </div>
         </div>
         <ul className="inspector-change-version__versions">
@@ -150,14 +150,16 @@ describe('InspectorChangeVersion', function() {
             downgrade={true}
             itemAction={list.props.children[0].props.itemAction}
             buttonAction={list.props.children[0].props.buttonAction}
-            id="cs:django-4" />
+            url={window.jujulib.URL.fromString('django/4')}
+          />
           <juju.components.InspectorChangeVersionItem
             acl={acl}
             key="cs:django-6"
             downgrade={false}
             itemAction={list.props.children[1].props.itemAction}
             buttonAction={list.props.children[1].props.buttonAction}
-            id="cs:django-6" />
+            url={window.jujulib.URL.fromString('django/6')}
+          />
         </ul>
       </div>);
   });
@@ -189,7 +191,7 @@ describe('InspectorChangeVersion', function() {
           <div className="inspector-change-version__current-version"
             role="button" tabIndex="0"
             onClick={output.props.children[0].props.children[1].props.onClick}>
-            cs:django
+            django
           </div>
         </div>
         <ul className="inspector-change-version__versions">
@@ -225,7 +227,7 @@ describe('InspectorChangeVersion', function() {
     output.props.children[0].props.children[1].props.onClick();
     assert.equal(changeState.callCount, 1);
     assert.deepEqual(changeState.args[0][0], {
-      store: 'django-5'
+      store: 'django/5'
     });
   });
 
@@ -254,7 +256,7 @@ describe('InspectorChangeVersion', function() {
     output.props.children[1].props.children[0].props.itemAction();
     assert.equal(changeState.callCount, 1);
     assert.deepEqual(changeState.args[0][0], {
-      store: 'django-4'
+      store: 'django/4'
     });
   });
 

--- a/jujugui/static/gui/src/app/components/inspector/expose/unit/test-unit.js
+++ b/jujugui/static/gui/src/app/components/inspector/expose/unit/test-unit.js
@@ -34,7 +34,13 @@ describe('InspectorExposeUnit', function() {
     var unit = {
       id: 'django/1',
       displayName: 'django/1',
-      open_ports: [80, '443/tcp'],
+      portRanges: [{
+        from: 9000, to: 10000, protocol: 'udp', single: false
+      }, {
+        from: 443, to: 443, protocol: 'tcp', single: true
+      }, {
+        from: 8080, to: 8080, protocol: 'tcp', single: true
+      }],
       public_address: '20.20.20.199'
     };
     var action = sinon.stub();
@@ -53,19 +59,23 @@ describe('InspectorExposeUnit', function() {
           </div>
           <ul className="inspector-expose__unit-list">
             <li className="inspector-expose__item"
-              key="http://20.20.20.199:80">
-              <a href="http://20.20.20.199:80"
-                onClick={instance._stopBubble}
-                target="_blank">
-                {"20.20.20.199"}:{"80"}
-              </a>
+              key="20.20.20.199:9000-10000/udp">
+              <span>{"20.20.20.199:9000-10000/udp"}</span>
             </li>
             <li className="inspector-expose__item"
               key="https://20.20.20.199:443">
               <a href="https://20.20.20.199:443"
                 onClick={instance._stopBubble}
                 target="_blank">
-                {"20.20.20.199"}:{"443"}
+                {"20.20.20.199:443"}
+              </a>
+            </li>
+            <li className="inspector-expose__item"
+              key="http://20.20.20.199:8080">
+              <a href="http://20.20.20.199:8080"
+                onClick={instance._stopBubble}
+                target="_blank">
+                {"20.20.20.199:8080"}
               </a>
             </li>
           </ul>

--- a/jujugui/static/gui/src/app/components/inspector/service-overview/service-overview.js
+++ b/jujugui/static/gui/src/app/components/inspector/service-overview/service-overview.js
@@ -224,10 +224,11 @@ YUI.add('service-overview', function() {
       }
       if (!service.get('pending')) {
         const charmId = service.get('charm');
+        const url = window.jujulib.URL.fromLegacyString(charmId);
         actions.push({
           title: 'Change version',
-          linkAction: this._viewCharmDetails.bind(this, charmId),
-          linkTitle: charmId,
+          linkAction: this._viewCharmDetails.bind(this, url),
+          linkTitle: url.path(),
           icon: 'change-version',
           action: this._navigate,
           state: {
@@ -256,13 +257,11 @@ YUI.add('service-overview', function() {
       The callable to view the charm details.
 
       @method _viewCharmDetails
-      @param {String} charmId The charm id.
-      @param {Object} e The click event.
+      @param {Object} url The charm URL as an instance of window.jujulib.URL.
+      @param {Object} evt The click event.
     */
-    _viewCharmDetails: function(charmId, e) {
-      this.props.changeState({
-        store: charmId.replace('cs:', '')
-      });
+    _viewCharmDetails: function(url, e) {
+      this.props.changeState({store: url.path()});
     },
 
     /**

--- a/jujugui/static/gui/src/app/components/inspector/service-overview/test-service-overview.js
+++ b/jujugui/static/gui/src/app/components/inspector/service-overview/test-service-overview.js
@@ -33,6 +33,7 @@ describe('ServiceOverview', function() {
     fakeService = {
       get: sinon.stub()
     };
+    fakeService.get.withArgs('charm').returns('cs:django');
     fakeService.get.withArgs('units').returns({ toArray: () => [] });
     fakeService.get.withArgs('deleted').returns(false);
     fakeService.get.withArgs('pending').returns(false);
@@ -61,6 +62,7 @@ describe('ServiceOverview', function() {
     const getStub = sinon.stub();
     getStub.withArgs('activePlan')
       .throws('it should not fetch this if no metrics');
+    getStub.withArgs('charm').returns('cs:django');
     getStub.withArgs('name').throws('it should not fetch this if no metrics');
     getStub.withArgs('plans').throws('it should not fetch this if no metrics');
     getStub.withArgs('units').returns({
@@ -104,6 +106,7 @@ describe('ServiceOverview', function() {
     const setStub = sinon.stub();
     const getStub = sinon.stub();
     getStub.withArgs('activePlan').returns(undefined);
+    getStub.withArgs('charm').returns('cs:django');
     getStub.withArgs('name').returns('servicename');
     getStub.withArgs('units').returns({
       toArray: sinon.stub().returns([])
@@ -153,6 +156,7 @@ describe('ServiceOverview', function() {
     const planList = [{plan: 'list'}];
     const getStub = sinon.stub();
     getStub.withArgs('activePlan').returns(activePlan);
+    getStub.withArgs('charm').returns('cs:django');
     getStub.withArgs('name').throws('it should not request the service name');
     getStub.withArgs('units').returns({
       toArray: sinon.stub().returns([])
@@ -192,6 +196,7 @@ describe('ServiceOverview', function() {
     const getStub = sinon.stub();
     getStub.withArgs('activePlan')
       .throws('it should not fetch this for Juju 1');
+    getStub.withArgs('charm').returns('cs:django');
     getStub.withArgs('name').throws('it should not fetch this for Juju 1');
     getStub.withArgs('plans').throws('it should not fetch this for Juju 1');
     getStub.withArgs('units').returns({
@@ -476,6 +481,7 @@ describe('ServiceOverview', function() {
 
   it('shows the relations action if there are relations', function() {
     const getStub = sinon.stub();
+    getStub.withArgs('charm').returns('cs:django');
     getStub.withArgs('id').returns('demo');
     getStub.withArgs('units').returns({
       toArray: sinon.stub().returns([])
@@ -622,7 +628,7 @@ describe('ServiceOverview', function() {
     getStub.withArgs('id').returns('demo');
     getStub.withArgs('pending').returns(false);
     getStub.withArgs('exposed').returns(true);
-    getStub.withArgs('charm').returns('cs:demo');
+    getStub.withArgs('charm').returns('cs:xenial/django-42');
     getStub.withArgs('units').returns({
       toArray: sinon.stub().returns([])
     });
@@ -647,7 +653,7 @@ describe('ServiceOverview', function() {
         key="Change version"
         title="Change version"
         linkAction={output.props.children[1].props.children[5].props.linkAction}
-        linkTitle="cs:demo"
+        linkTitle="django/xenial/42"
         icon="change-version"
         action={output.props.children[1].props.children[5].props.action}
         valueType={undefined}
@@ -718,6 +724,7 @@ describe('ServiceOverview', function() {
   it('shows the plans action if there are plans', function() {
     const setAttrs = sinon.stub();
     const getStub = sinon.stub();
+    getStub.withArgs('charm').returns('cs:django');
     getStub.withArgs('id').returns('demo');
     getStub.withArgs('units').returns({
       toArray: sinon.stub().returns([])

--- a/jujugui/static/gui/src/app/components/inspector/unit-details/test-unit-details.js
+++ b/jujugui/static/gui/src/app/components/inspector/unit-details/test-unit-details.js
@@ -48,7 +48,7 @@ describe('UnitDetails', function() {
   });
 
   it('shows the unit properties', function() {
-    var output = jsTestUtils.shallowRender(
+    const output = jsTestUtils.shallowRender(
       <juju.components.UnitDetails
         acl={acl}
         changeState={sinon.stub()}
@@ -56,22 +56,36 @@ describe('UnitDetails', function() {
         service={service}
         previousComponent='units'
         unitStatus='error'
-        unit={fakeUnit} />);
-
-    assert.deepEqual(output.props.children[0],
-        <div className='unit-details__properties'>
-          <p className='unit-details__property'>
-            Status: {fakeUnit.agent_state} {undefined}
-          </p>
-          <p className='unit-details__property'>
-            IP address{''}: {"none"}
-          </p>
-          {undefined}
-          <p className='unit-details__property'>
-            Public address{''}: {"none"}
-          </p>
-          {undefined}
-        </div>);
+        unit={fakeUnit}
+      />);
+    const expectedOutput = (
+      <div className='unit-details__properties'>
+        <p className='unit-details__property'>
+          Status: {fakeUnit.agent_state} {undefined}
+        </p>
+        <p className='unit-details__property'>
+          Public addresses: {null}
+        </p>
+        <ul className="unit-details__list">
+          <li className="unit-details__list-item" key="93.20.93.20">
+            <span>
+              {"93.20.93.20"}
+            </span>
+          </li>
+        </ul>
+        <p className='unit-details__property'>
+          IP addresses: {null}
+        </p>
+        <ul className="unit-details__list">
+          <li className="unit-details__list-item" key="192.168.0.1">
+            <span>
+              {"192.168.0.1"}
+            </span>
+          </li>
+        </ul>
+      </div>
+    );
+    assert.deepEqual(output.props.children[0], expectedOutput);
   });
 
   it('renders workload status when provided', function() {
@@ -91,13 +105,25 @@ describe('UnitDetails', function() {
             Status: {fakeUnit.agent_state} {' - Installing software'}
           </p>
           <p className='unit-details__property'>
-            IP address{''}: {"none"}
+            Public addresses: {null}
           </p>
-          {undefined}
+          <ul className="unit-details__list">
+            <li className="unit-details__list-item" key="93.20.93.20">
+              <span>
+                {"93.20.93.20"}
+              </span>
+            </li>
+          </ul>
           <p className='unit-details__property'>
-            Public address{''}: {"none"}
+            IP addresses: {null}
           </p>
-          {undefined}
+          <ul className="unit-details__list">
+            <li className="unit-details__list-item" key="192.168.0.1">
+              <span>
+                {"192.168.0.1"}
+              </span>
+            </li>
+          </ul>
         </div>);
   });
 
@@ -105,12 +131,17 @@ describe('UnitDetails', function() {
     fakeUnit = {
       private_address: '192.168.0.1',
       public_address: '93.20.93.20',
-      open_ports: ['80/tcp', 443],
+      portRanges: [{
+        from: 9000, to: 10000, protocol: 'udp', single: false
+      }, {
+        from: 443, to: 443, protocol: 'tcp', single: true
+      }, {
+        from: 8080, to: 8080, protocol: 'tcp', single: true
+      }],
       agent_state: 'started',
       id: 'unit1'
     };
-
-    var output = jsTestUtils.shallowRender(
+    const output = jsTestUtils.shallowRender(
       <juju.components.UnitDetails
         acl={acl}
         destroyUnits={sinon.stub()}
@@ -119,40 +150,51 @@ describe('UnitDetails', function() {
         previousComponent='units'
         unitStatus='error'
         unit={fakeUnit} />);
-
-    var expected = (
+    const expected = (
       <div className="unit-details__properties">
         <p className="unit-details__property">
           Status: {fakeUnit.agent_state} {undefined}
         </p>
         <p className="unit-details__property">
-          IP address{'es'}: {null}
+          Public addresses: {null}
         </p>
         <ul className="unit-details__list">
-          <li className="unit-details__list-item" key="http://192.168.0.1:80">
-            <a href="http://192.168.0.1:80" target="_blank">
-              {"192.168.0.1"}:{"80"}
-            </a>
+          <li className="unit-details__list-item"
+            key="93.20.93.20:9000-10000/udp">
+            <span>
+              {"93.20.93.20:9000-10000/udp"}
+            </span>
           </li>
-          <li className="unit-details__list-item" key="https://192.168.0.1:443">
-            <a href="https://192.168.0.1:443" target="_blank">
-              {"192.168.0.1"}:{"443"}
-            </a>
+          <li className="unit-details__list-item" key="93.20.93.20:443">
+            <span>
+              {"93.20.93.20:443"}
+            </span>
+          </li>
+          <li className="unit-details__list-item" key="93.20.93.20:8080">
+            <span>
+              {"93.20.93.20:8080"}
+            </span>
           </li>
         </ul>
         <p className="unit-details__property">
-          Public address{'es'}: {null}
+          IP addresses: {null}
         </p>
         <ul className="unit-details__list">
-          <li className="unit-details__list-item" key="http://93.20.93.20:80">
+          <li className="unit-details__list-item"
+            key="192.168.0.1:9000-10000/udp">
             <span>
-              {"93.20.93.20"}:{"80"}
+              {"192.168.0.1:9000-10000/udp"}
             </span>
           </li>
-          <li className="unit-details__list-item" key="https://93.20.93.20:443">
-            <span>
-              {"93.20.93.20"}:{"443"}
-            </span>
+          <li className="unit-details__list-item" key="192.168.0.1:443">
+            <a href="https://192.168.0.1:443" target="_blank">
+              {"192.168.0.1:443"}
+            </a>
+          </li>
+          <li className="unit-details__list-item" key="192.168.0.1:8080">
+            <a href="http://192.168.0.1:8080" target="_blank">
+              {"192.168.0.1:8080"}
+            </a>
           </li>
         </ul>
       </div>);
@@ -163,7 +205,13 @@ describe('UnitDetails', function() {
     fakeUnit = {
       private_address: '192.168.0.1',
       public_address: '93.20.93.20',
-      open_ports: ['80/tcp', 443],
+      portRanges: [{
+        from: 9000, to: 10000, protocol: 'udp', single: false
+      }, {
+        from: 443, to: 443, protocol: 'tcp', single: true
+      }, {
+        from: 8080, to: 8080, protocol: 'tcp', single: true
+      }],
       agent_state: 'started',
       id: 'unit1'
     };
@@ -176,7 +224,7 @@ describe('UnitDetails', function() {
         }
       }
     };
-    var output = jsTestUtils.shallowRender(
+    const output = jsTestUtils.shallowRender(
       <juju.components.UnitDetails
         acl={acl}
         destroyUnits={sinon.stub()}
@@ -185,39 +233,50 @@ describe('UnitDetails', function() {
         previousComponent='units'
         unitStatus='error'
         unit={fakeUnit} />);
-
-    var expected = (
+    const expected = (
       <div className="unit-details__properties">
         <p className="unit-details__property">
           Status: {fakeUnit.agent_state} {undefined}
         </p>
         <p className="unit-details__property">
-          IP address{'es'}: {null}
+          Public addresses: {null}
         </p>
         <ul className="unit-details__list">
-          <li className="unit-details__list-item" key="http://192.168.0.1:80">
-            <a href="http://192.168.0.1:80" target="_blank">
-              {"192.168.0.1"}:{"80"}
+          <li className="unit-details__list-item"
+            key="93.20.93.20:9000-10000/udp">
+            <span>
+              {"93.20.93.20:9000-10000/udp"}
+            </span>
+          </li>
+          <li className="unit-details__list-item" key="93.20.93.20:443">
+            <a href="https://93.20.93.20:443" target="_blank">
+              {"93.20.93.20:443"}
             </a>
           </li>
-          <li className="unit-details__list-item" key="https://192.168.0.1:443">
-            <a href="https://192.168.0.1:443" target="_blank">
-              {"192.168.0.1"}:{"443"}
+          <li className="unit-details__list-item" key="93.20.93.20:8080">
+            <a href="http://93.20.93.20:8080" target="_blank">
+              {"93.20.93.20:8080"}
             </a>
           </li>
         </ul>
         <p className="unit-details__property">
-          Public address{'es'}: {null}
+          IP addresses: {null}
         </p>
         <ul className="unit-details__list">
-          <li className="unit-details__list-item" key="http://93.20.93.20:80">
-            <a href="http://93.20.93.20:80" target="_blank">
-              {"93.20.93.20"}:{"80"}
+          <li className="unit-details__list-item"
+            key="192.168.0.1:9000-10000/udp">
+            <span>
+              {"192.168.0.1:9000-10000/udp"}
+            </span>
+          </li>
+          <li className="unit-details__list-item" key="192.168.0.1:443">
+            <a href="https://192.168.0.1:443" target="_blank">
+              {"192.168.0.1:443"}
             </a>
           </li>
-          <li className="unit-details__list-item" key="https://93.20.93.20:443">
-            <a href="https://93.20.93.20:443" target="_blank">
-              {"93.20.93.20"}:{"443"}
+          <li className="unit-details__list-item" key="192.168.0.1:8080">
+            <a href="http://192.168.0.1:8080" target="_blank">
+              {"192.168.0.1:8080"}
             </a>
           </li>
         </ul>
@@ -225,15 +284,9 @@ describe('UnitDetails', function() {
     assert.deepEqual(output.props.children[0], expected);
   });
 
-  it('shows no addresses if ports are unavailable', function() {
-    fakeUnit = {
-      private_address: '192.168.0.1',
-      public_address: '93.20.93.20',
-      agent_state: 'started',
-      id: 'unit1'
-    };
-
-    var output = jsTestUtils.shallowRender(
+  it('shows no addresses if no addresses are unavailable', function() {
+    fakeUnit = {agent_state: 'started', id: 'unit1'};
+    const output = jsTestUtils.shallowRender(
       <juju.components.UnitDetails
         acl={acl}
         destroyUnits={sinon.stub()}
@@ -249,11 +302,11 @@ describe('UnitDetails', function() {
           Status: {fakeUnit.agent_state} {undefined}
         </p>
         <p className='unit-details__property'>
-          IP address{''}: {"none"}
+          Public addresses: {"none"}
         </p>
         {undefined}
         <p className='unit-details__property'>
-          Public address{''}: {"none"}
+          IP addresses: {"none"}
         </p>
         {undefined}
       </div>);
@@ -262,12 +315,17 @@ describe('UnitDetails', function() {
   it('shows only public address if available', function() {
     fakeUnit = {
       public_address: '93.20.93.20',
-      open_ports: [80, 443],
+      portRanges: [{
+        from: 9000, to: 10000, protocol: 'udp', single: false
+      }, {
+        from: 443, to: 443, protocol: 'tcp', single: true
+      }, {
+        from: 8080, to: 8080, protocol: 'tcp', single: true
+      }],
       agent_state: 'started',
       id: 'unit1'
     };
-
-    var output = jsTestUtils.shallowRender(
+    const output = jsTestUtils.shallowRender(
       <juju.components.UnitDetails
         acl={acl}
         destroyUnits={sinon.stub()}
@@ -276,44 +334,54 @@ describe('UnitDetails', function() {
         previousComponent='units'
         unitStatus='error'
         unit={fakeUnit} />);
-
-    var expect = (
-      <div className='unit-details__properties'>
-        <p className='unit-details__property'>
+    const expected = (
+      <div className="unit-details__properties">
+        <p className="unit-details__property">
           Status: {fakeUnit.agent_state} {undefined}
         </p>
-        <p className='unit-details__property'>
-          IP address{''}: {"none"}
-        </p>
-        {undefined}
-        <p className='unit-details__property'>
-          Public address{'es'}: {null}
+        <p className="unit-details__property">
+          Public addresses: {null}
         </p>
         <ul className="unit-details__list">
-          <li className="unit-details__list-item" key="http://93.20.93.20:80">
+          <li className="unit-details__list-item"
+            key="93.20.93.20:9000-10000/udp">
             <span>
-              {"93.20.93.20"}:{"80"}
+              {"93.20.93.20:9000-10000/udp"}
             </span>
           </li>
-          <li className="unit-details__list-item" key="https://93.20.93.20:443">
+          <li className="unit-details__list-item" key="93.20.93.20:443">
             <span>
-              {"93.20.93.20"}:{"443"}
+              {"93.20.93.20:443"}
+            </span>
+          </li>
+          <li className="unit-details__list-item" key="93.20.93.20:8080">
+            <span>
+              {"93.20.93.20:8080"}
             </span>
           </li>
         </ul>
+        <p className='unit-details__property'>
+          IP addresses: {"none"}
+        </p>
+        {undefined}
       </div>);
-    assert.deepEqual(output.props.children[0], expect);
+    assert.deepEqual(output.props.children[0], expected);
   });
 
   it('shows only private address if available', function() {
     fakeUnit = {
-      private_address: '93.20.93.20',
-      open_ports: [80, 443],
+      private_address: '192.168.0.1',
+      portRanges: [{
+        from: 9000, to: 10000, protocol: 'udp', single: false
+      }, {
+        from: 443, to: 443, protocol: 'tcp', single: true
+      }, {
+        from: 8080, to: 8080, protocol: 'tcp', single: true
+      }],
       agent_state: 'started',
       id: 'unit1'
     };
-
-    var output = jsTestUtils.shallowRender(
+    const output = jsTestUtils.shallowRender(
       <juju.components.UnitDetails
         acl={acl}
         destroyUnits={sinon.stub()}
@@ -322,31 +390,36 @@ describe('UnitDetails', function() {
         previousComponent='units'
         unitStatus='error'
         unit={fakeUnit} />);
-
-    var expected = (
-      <div className='unit-details__properties'>
-        <p className='unit-details__property'>
+    const expected = (
+      <div className="unit-details__properties">
+        <p className="unit-details__property">
           Status: {fakeUnit.agent_state} {undefined}
         </p>
+        <p className='unit-details__property'>
+          Public addresses: {"none"}
+        </p>
+        {undefined}
         <p className="unit-details__property">
-          IP address{'es'}: {null}
+          IP addresses: {null}
         </p>
         <ul className="unit-details__list">
-          <li className="unit-details__list-item" key="http://93.20.93.20:80">
-            <a href="http://93.20.93.20:80" target="_blank">
-              {"93.20.93.20"}:{"80"}
+          <li className="unit-details__list-item"
+            key="192.168.0.1:9000-10000/udp">
+            <span>
+              {"192.168.0.1:9000-10000/udp"}
+            </span>
+          </li>
+          <li className="unit-details__list-item" key="192.168.0.1:443">
+            <a href="https://192.168.0.1:443" target="_blank">
+              {"192.168.0.1:443"}
             </a>
           </li>
-          <li className="unit-details__list-item" key="https://93.20.93.20:443">
-            <a href="https://93.20.93.20:443" target="_blank">
-              {"93.20.93.20"}:{"443"}
+          <li className="unit-details__list-item" key="192.168.0.1:8080">
+            <a href="http://192.168.0.1:8080" target="_blank">
+              {"192.168.0.1:8080"}
             </a>
           </li>
         </ul>
-        <p className='unit-details__property'>
-          Public address{''}: {"none"}
-        </p>
-        {undefined}
       </div>);
     assert.deepEqual(output.props.children[0], expected);
   });

--- a/jujugui/static/gui/src/app/models/legacy-handlers.js
+++ b/jujugui/static/gui/src/app/models/legacy-handlers.js
@@ -65,24 +65,22 @@ YUI.add('juju-legacy-delta-handlers', function(Y) {
       @return {undefined} Nothing.
      */
     unitLegacyInfo: function(db, action, change) {
-      // Return a list of ports represented as "NUM/PROTOCOL", e.g. "80/tcp".
-      var convertOpenPorts = function(ports) {
-        if (!ports) {
-          return [];
-        }
-        return ports.map(port => {
-          return port.Number + '/' + port.Protocol;
-        });
-      };
-
-      var unitData = {
+      const ports = change.Ports || [];
+      const unitData = {
         id: change.Name,
         charmUrl: change.CharmURL,
         service: change.Application || change.Service,
         machine: change.MachineId,
         public_address: change.PublicAddress,
         private_address: change.PrivateAddress,
-        open_ports: convertOpenPorts(change.Ports),
+        portRanges: ports.map(port => {
+          return {
+            from: port.Number,
+            to: port.Number,
+            protocol: port.Protocol,
+            single: true
+          };
+        }),
         // Since less recent versions of juju-core (<= 1.20.7) do not include
         // the Subordinate field in the mega-watcher for units, the following
         // attribute could be undefined.

--- a/jujugui/static/gui/src/app/models/models.js
+++ b/jujugui/static/gui/src/app/models/models.js
@@ -1006,7 +1006,7 @@ YUI.add('juju-models', function(Y) {
         subordinate: {
           value: false
         },
-        open_ports: {},
+        portRanges: {},
         public_address: {},
         private_address: {}
       }

--- a/jujugui/static/gui/src/app/store/env/controller-api.js
+++ b/jujugui/static/gui/src/app/store/env/controller-api.js
@@ -1308,7 +1308,6 @@ YUI.add('juju-controller-api', function(Y) {
       Modify (grant or revoke) user access to the specified model.
 
       @method _modifyModelAccess
-      @method _modifyModelAccess
       @param {String} modelId The UUID for the model on which the access is
                               being changed.
       @param {Array} users The usernames of the users who need modified access.

--- a/jujugui/static/gui/src/app/store/env/controller-api.js
+++ b/jujugui/static/gui/src/app/store/env/controller-api.js
@@ -1308,6 +1308,7 @@ YUI.add('juju-controller-api', function(Y) {
       Modify (grant or revoke) user access to the specified model.
 
       @method _modifyModelAccess
+      @method _modifyModelAccess
       @param {String} modelId The UUID for the model on which the access is
                               being changed.
       @param {Array} users The usernames of the users who need modified access.

--- a/jujugui/static/gui/src/app/store/env/sandbox.js
+++ b/jujugui/static/gui/src/app/store/env/sandbox.js
@@ -593,7 +593,7 @@ YUI.add('juju-env-sandbox', function(Y) {
         'public-address': 'public_address',
         'private-address': 'private_address',
         'machine-id': 'machine',
-        ports: 'open_ports',
+        'port-ranges': 'portRanges',
         'agent-status': function(attrs) {
           // TODO frankban: handle unit agent status.
           return {

--- a/jujugui/static/gui/src/test/test_model_handlers.js
+++ b/jujugui/static/gui/src/test/test_model_handlers.js
@@ -58,6 +58,11 @@ describe('Juju delta handlers', function() {
           'public-address': 'example.com',
           'private-address': '10.0.0.1',
           subordinate: false,
+          'port-ranges': [{
+            'from-port': 9000, 'to-port': 10000, protocol: 'udp'
+          }, {
+            'from-port': 443, 'to-port': 443, protocol: 'tcp'
+          }],
           ports: [{number: 80, protocol: 'tcp'}, {number: 42, protocol: 'udp'}]
         };
         unitInfo(db, 'add', change);
@@ -71,7 +76,11 @@ describe('Juju delta handlers', function() {
         assert.strictEqual(unit.public_address, 'example.com');
         assert.strictEqual(unit.private_address, '10.0.0.1');
         assert.strictEqual(unit.subordinate, false, 'subordinate');
-        assert.deepEqual(unit.open_ports, ['80/tcp', '42/udp']);
+        assert.deepEqual(unit.portRanges, [{
+          from: 9000, to: 10000, protocol: 'udp', single: false
+        }, {
+          from: 443, to: 443, protocol: 'tcp', single: true
+        }]);
       };
 
       it('creates a unit in the database (global list)', function() {
@@ -1007,29 +1016,6 @@ describe('Juju delta handlers utilities', function() {
       data.forEach(item => {
         assert.equal(item, cleanUpEntityTags(item));
       });
-    });
-
-  });
-
-  describe('Go Juju ports converter', function() {
-    var convertOpenPorts;
-
-    before(function() {
-      convertOpenPorts = utils.convertOpenPorts;
-    });
-
-    it('correctly returns a list of ports', function() {
-      var ports = [
-        {number: 80, protocol: 'tcp'},
-        {number: 42, protocol: 'udp'}
-      ];
-      assert.deepEqual(['80/tcp', '42/udp'], convertOpenPorts(ports));
-    });
-
-    it('returns an empty list if there are no ports', function() {
-      assert.deepEqual([], convertOpenPorts([]));
-      assert.deepEqual([], convertOpenPorts(null));
-      assert.deepEqual([], convertOpenPorts(undefined));
     });
 
   });

--- a/jujugui/static/gui/src/test/test_model_legacy_handlers.js
+++ b/jujugui/static/gui/src/test/test_model_legacy_handlers.js
@@ -67,7 +67,11 @@ describe('Juju legacy delta handlers', function() {
         assert.strictEqual(unit.public_address, 'example.com');
         assert.strictEqual(unit.private_address, '10.0.0.1');
         assert.strictEqual(unit.subordinate, false, 'subordinate');
-        assert.deepEqual(unit.open_ports, ['80/tcp', '42/udp']);
+        assert.deepEqual(unit.portRanges, [{
+          from: 80, to: 80, protocol: 'tcp', single: true
+        }, {
+          from: 42, to: 42, protocol: 'udp', single: true
+        }]);
       };
 
       it('creates a unit in the database (global list)', function() {


### PR DESCRIPTION
Only single ports outside of ranges are turned into links.
Fixes https://github.com/juju/juju-gui/issues/2596

Also reorganize the view so that public ports are on top.
Fixes https://github.com/juju/juju-gui/issues/2598

Avoid showing "none" when no ports are still available but we've got addresses.
Fixes https://github.com/juju/juju-gui/issues/2307

Additionally, fix the inspector behavior when changing charm versions. Now it displays the new-style charm URLs and clicking on those actually works.
Fixes https://github.com/juju/juju-gui/issues/2570

In order to QA port ranges, you can use the eclipse-che charm, which anyway does not work in LXD. Also, since that charm has many ports open, the WebSocket message is too large and cannot be handled by the WebSocket library used by guiproxy (this will change when guiproxy starts using gorilla websockets). So I guess the best way to QA this is with a gijoe connected to a model in a public cloud.