### PR TITLE
Deployment flow and entity detail pages fixes.

### DIFF
--- a/jujugui/static/gui/src/app/components/deployment-flow/machines/machines.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/machines/machines.js
@@ -34,6 +34,7 @@ YUI.add('deployment-machines', function() {
       @returns {Object} The list of machines.
     */
     _generateMachines: function() {
+
       const machines = this.props.machines;
       if (!machines || Object.keys(machines).length === 0) {
         return;
@@ -100,15 +101,15 @@ YUI.add('deployment-machines', function() {
     },
 
     render: function() {
-      var chargeMessage = '';
-      if (this.props.cloud && this.props.cloud.name !== 'local') {
+      let chargeMessage = '';
+      const cloudName = this.props.cloud ? this.props.cloud.name : 'the cloud';
+      if (cloudName !== 'localhost') {
         chargeMessage = 'You will incur a charge from your cloud provider.';
       }
       return (
         <div>
           <p className="deployment-machines__message">
-            These machines will be provisioned on&nbsp;
-            {this.props.cloud && this.props.cloud.name}.
+            These machines will be provisioned on {cloudName}.&nbsp;
             {chargeMessage}
           </p>
           {this._generateMachines()}

--- a/jujugui/static/gui/src/app/components/deployment-flow/machines/test-machines.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/machines/test-machines.js
@@ -101,8 +101,7 @@ describe('DeploymentMachines', function() {
     var expected = (
       <div>
         <p className="deployment-machines__message">
-          These machines will be provisioned on&nbsp;
-          {'My cloud'}.
+          These machines will be provisioned on {'My cloud'}.
           {'You will incur a charge from your cloud provider.'}
         </p>
         <ul className="deployment-machines__list">
@@ -174,14 +173,27 @@ describe('DeploymentMachines', function() {
     var renderer = jsTestUtils.shallowRender(
       <juju.components.DeploymentMachines
         acl={acl}
-        cloud={{name: 'local'}}
+        cloud={{name: 'localhost'}}
         machines={machines} />, true);
     var output = renderer.getRenderOutput();
     var expected = (
       <p className="deployment-machines__message">
-        These machines will be provisioned on&nbsp;
-        {'local'}.
+        These machines will be provisioned on {'localhost'}.
         {''}
+      </p>);
+    assert.deepEqual(output.props.children[0], expected);
+  });
+
+  it('can render with unknown cloud', function() {
+    var renderer = jsTestUtils.shallowRender(
+      <juju.components.DeploymentMachines
+        acl={acl}
+        machines={machines} />, true);
+    var output = renderer.getRenderOutput();
+    var expected = (
+      <p className="deployment-machines__message">
+        These machines will be provisioned on {'the cloud'}.
+        {'You will incur a charge from your cloud provider.'}
       </p>);
     assert.deepEqual(output.props.children[0], expected);
   });

--- a/jujugui/static/gui/src/app/components/deployment-flow/machines/test-machines.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/machines/test-machines.js
@@ -101,7 +101,7 @@ describe('DeploymentMachines', function() {
     var expected = (
       <div>
         <p className="deployment-machines__message">
-          These machines will be provisioned on {'My cloud'}.
+          These machines will be provisioned on {'My cloud'}.&nbsp;
           {'You will incur a charge from your cloud provider.'}
         </p>
         <ul className="deployment-machines__list">
@@ -178,7 +178,7 @@ describe('DeploymentMachines', function() {
     var output = renderer.getRenderOutput();
     var expected = (
       <p className="deployment-machines__message">
-        These machines will be provisioned on {'localhost'}.
+        These machines will be provisioned on {'localhost'}.&nbsp;
         {''}
       </p>);
     assert.deepEqual(output.props.children[0], expected);
@@ -192,7 +192,7 @@ describe('DeploymentMachines', function() {
     var output = renderer.getRenderOutput();
     var expected = (
       <p className="deployment-machines__message">
-        These machines will be provisioned on {'the cloud'}.
+        These machines will be provisioned on {'the cloud'}.&nbsp;
         {'You will incur a charge from your cloud provider.'}
       </p>);
     assert.deepEqual(output.props.children[0], expected);

--- a/jujugui/static/gui/src/app/components/entity-details/content/_content.scss
+++ b/jujugui/static/gui/src/app/components/entity-details/content/_content.scss
@@ -160,8 +160,8 @@
     }
   }
 
-  .revisions {
-    padding-bottom: 20px;
+  .revisions h3 {
+    margin-bottom: 0;
   }
 
   .revisions__list {

--- a/jujugui/static/gui/src/app/components/entity-details/content/content.js
+++ b/jujugui/static/gui/src/app/components/entity-details/content/content.js
@@ -426,7 +426,7 @@ YUI.add('entity-content', function() {
     },
 
     render: function() {
-      var entityModel = this.props.entityModel;
+      const entityModel = this.props.entityModel;
       return (
         <div className="entity-content">
           {this._generateDescription(entityModel)}

--- a/jujugui/static/gui/src/app/components/entity-details/content/files/files.js
+++ b/jujugui/static/gui/src/app/components/entity-details/content/files/files.js
@@ -178,11 +178,10 @@ YUI.add('entity-files', function() {
     },
 
     render: function() {
-      var entityModel = this.props.entityModel;
-      var files = entityModel.get('files');
-      var name = (entityModel.get('entityType') === 'bundle')?
-        entityModel.get('name'):entityModel.get('full_name');
-      var archiveUrl = `${this.props.apiUrl}/${name}/archive`;
+      const entityModel = this.props.entityModel;
+      const files = entityModel.get('files');
+      const url = window.jujulib.URL.fromLegacyString(entityModel.get('id'));
+      const archiveUrl = `${this.props.apiUrl}/${url.legacyPath()}/archive`;
       return (
         <div className="entity-files section" id="files">
           <h3 className="section__title">

--- a/jujugui/static/gui/src/app/components/entity-details/content/files/test-files.js
+++ b/jujugui/static/gui/src/app/components/entity-details/content/files/test-files.js
@@ -49,7 +49,7 @@ describe('EntityFiles', function() {
     , true);
     var output = renderer.getRenderOutput();
     var instance = renderer.getMountedInstance();
-    var archiveUrl = `${apiUrl}/trusty/django/archive`;
+    var archiveUrl = `${apiUrl}/django/archive`;
     var fileItems = [
       <li key="foo.zip" className="entity-files__file">
         <a href={archiveUrl + '/foo.zip'}
@@ -131,34 +131,40 @@ describe('EntityFiles', function() {
     assert.equal(output.refs.codeLink, undefined);
   });
 
-  it('renders file urls correctly for bundle', function() {
-    mockEntity.set('entityType', 'bundle');
-    mockEntity.set('name', 'django');
-    mockEntity.set('full_name', 'wordpress');
-    var apiUrl = 'https://api.jujucharms.com/charmstore/v4';
-    var output = testUtils.renderIntoDocument(
+  // Check that the links for files included in the given entity are rendered
+  // with the given expected path.
+  const checkFileURL = (entityType, entityId, expectedPath) => {
+    mockEntity.set('entityType', entityType);
+    mockEntity.set('id', entityId);
+    const apiUrl = 'https://api.jujucharms.com/charmstore/v5';
+    const expectedURL = apiUrl + expectedPath;
+    const output = testUtils.renderIntoDocument(
       <juju.components.EntityFiles
         apiUrl={apiUrl}
         entityModel={mockEntity}
         pluralize={sinon.spy()} />
     );
-    assert.equal(output.refs.files.children[0].children[0].href,
-      `${apiUrl}/django/archive/foo.zip`);
+    assert.equal(output.refs.files.children[0].children[0].href, expectedURL);
+  };
+
+  it('renders file URLs correctly for promulgated bundles', function() {
+    checkFileURL('bundle', 'cs:django-42', '/django-42/archive/foo.zip');
   });
 
-  it('renders file urls correctly for charm', function() {
-    mockEntity.set('entityType', 'charm');
-    mockEntity.set('name', 'django');
-    mockEntity.set('full_name', 'wordpress');
-    var apiUrl = 'https://api.jujucharms.com/charmstore/v4';
-    var output = testUtils.renderIntoDocument(
-      <juju.components.EntityFiles
-        apiUrl={apiUrl}
-        entityModel={mockEntity}
-        pluralize={sinon.spy()} />
-    );
-    assert.equal(output.refs.files.children[0].children[0].href,
-      `${apiUrl}/wordpress/archive/foo.zip`);
+  it('renders file URLs correctly for promulgated charms', function() {
+    checkFileURL(
+      'charm', 'cs:xenial/wordpress', '/xenial/wordpress/archive/foo.zip');
+  });
+
+  it('renders file URLs correctly for user owned bundles', function() {
+    checkFileURL(
+      'bundle', 'cs:~who/bundle/django-47',
+      '/~who/bundle/django-47/archive/foo.zip');
+  });
+
+  it('renders file URLs correctly for user owned charms', function() {
+    checkFileURL(
+      'charm', 'cs:~dalek/redis-0', '/~dalek/redis-0/archive/foo.zip');
   });
 
   it('properly builds a tree structure from file paths', function() {

--- a/jujugui/static/gui/src/app/components/entity-details/content/revisions/revisions.js
+++ b/jujugui/static/gui/src/app/components/entity-details/content/revisions/revisions.js
@@ -26,96 +26,14 @@ YUI.add('entity-content-revisions', function() {
       revisions: React.PropTypes.array.isRequired
     },
 
-    /**
-      Get the current state of the revisions panel.
-
-      @method getInitialState
-      @returns {String} The current state.
-    */
-    getInitialState: function() {
-      // Setting a default state object.
-      var state = {
-        showMore: false
-      };
-      return state;
-    },
-
-    /**
-      Handle clicks on accordion. Toggles the concealed class on the list node
-      which hides all the list items apart from the first.
-
-      @method _handleAccordionClick
-    */
-    _handleAccordionClick: function(conceal) {
-      this.setState({showMore: conceal});
-    },
-
-    /**
-      Generate the classname to apply based on the state.
-
-      @method _generateRevisions
-      @return {Object} The revisions markup.
-    */
-    _generateClassName: function() {
-      return classNames(
-        'revisions__list',
-        {
-          'list--concealed': !this.state.showMore
-        }
-      );
-    },
-
-    /**
-      Generate the list of revisions.
-
-      @method _generateRevisions
-      @return {Object} The revisions markup.
-    */
-    _generateRevisions: function() {
-      var components = [];
-      var revisions = this.props.revisions;
-      revisions.forEach((revision) => {
-        components.push(
-          <li className="revisions__list-item list-item" key={revision.revno}>
-            <p className="revisions__list-meta smaller">
-              by {revision.authors[0].name}
-              <span className="revisions__list-meta-date">
-                <juju.components.DateDisplay
-                  date={revision.date}
-                  relative={true} />
-              </span>
-            </p>
-            <p className="revisions__list-message">
-              {revision.message}
-            </p>
-          </li>
-        );
-      }, this);
-      return components;
-    },
-
     render: function() {
-      var revisions = this.props.revisions;
-      var revisionsCount = revisions.length;
+      const revisions = this.props.revisions;
       return (
         <div className="revisions section" id="revisions">
-          <h3 className="section__title">{revisionsCount} Revisions</h3>
-          <ol className={this._generateClassName()} ref="list" reversed>
-            {this._generateRevisions()}
-            <li className="list__controls">
-              <a href="" className="btn__see--more"
-                onClick={this._handleAccordionClick.bind(
-                  this, true)}>See more</a>
-              <a href="#revisions" className="btn__see--less"
-                onClick={this._handleAccordionClick.bind(
-                  this, false)}>See less</a>
-            </li>
-          </ol>
+          <h3 className="section__title">{revisions.length} Revisions</h3>
         </div>
       );
     }
   });
 
-}, '0.1.0', {requires: [
-  'date-display'
-]});
+}, '0.1.0', {requires: []});

--- a/jujugui/static/gui/src/app/components/entity-details/content/revisions/test-revisions.js
+++ b/jujugui/static/gui/src/app/components/entity-details/content/revisions/test-revisions.js
@@ -24,7 +24,7 @@ chai.config.includeStack = true;
 chai.config.truncateThreshold = 0;
 
 describe('EntityContentRevisions', function() {
-  var mockEntity;
+  let mockEntity;
 
   beforeAll(function(done) {
     // By loading these files it makes their classes available in the tests.
@@ -39,78 +39,14 @@ describe('EntityContentRevisions', function() {
     mockEntity = undefined;
   });
 
-  it('can render a list of revisions', function() {
-    var output = jsTestUtils.shallowRender(
+  it('can render the number of revisions', function() {
+    const output = jsTestUtils.shallowRender(
       <juju.components.EntityContentRevisions
         revisions={mockEntity.get('revisions')} />);
-    var buttons = output.props.children[1].props.children[1].props.children;
-    var expected = (
+    const expectedOutput = (
       <div className="revisions section" id="revisions">
         <h3 className="section__title">{3} Revisions</h3>
-        <ol className="revisions__list list--concealed" ref="list" reversed>
-          {[
-            <li className="revisions__list-item list-item" key={40}>
-              <p className="revisions__list-meta smaller">
-                by {"Charles Butler"}
-                <span className="revisions__list-meta-date">
-                  <juju.components.DateDisplay
-                    date="2015-06-16T17:09:35Z"
-                    relative={true} />
-                </span>
-              </p>
-              <p className="revisions__list-message">
-                Fix the django 1.8 with postgresql test.
-              </p>
-            </li>,
-            <li className="revisions__list-item list-item" key={39}>
-              <p className="revisions__list-meta smaller">
-                by {"Tim Van Steenburgh"}
-                <span className="revisions__list-meta-date">
-                  <juju.components.DateDisplay
-                    date="2015-06-12T14:02:06Z"
-                    relative={true} />
-                </span>
-              </p>
-              <p className="revisions__list-message">
-                Remove charmhelpers.contrib (not used)
-              </p>
-            </li>,
-            <li className="revisions__list-item list-item" key={38}>
-              <p className="revisions__list-meta smaller">
-                by {"Charles Butler"}
-                <span className="revisions__list-meta-date">
-                  <juju.components.DateDisplay
-                    date="2015-05-22T19:35:18Z"
-                    relative={true} />
-                </span>
-              </p>
-              <p className="revisions__list-message">
-                Run migrate if django is modern enough.
-              </p>
-            </li>
-          ]}
-          <li className="list__controls">
-            <a href="" className="btn__see--more"
-              onClick={buttons[0].props.onClick}>See more</a>
-            <a href="#revisions" className="btn__see--less"
-              onClick={buttons[1].props.onClick}>See less</a>
-          </li>
-        </ol>
       </div>);
-    assert.deepEqual(output, expected);
-  });
-
-  it('can reveal and hide relation list', function() {
-    var changeState = sinon.spy();
-    var output = testUtils.renderIntoDocument(
-      <juju.components.EntityContentRevisions
-        changeState={changeState}
-        revisions={mockEntity.get('revisions')} />);
-    var more = ReactDOM.findDOMNode(output).querySelector('.btn__see--more');
-    var less = ReactDOM.findDOMNode(output).querySelector('.btn__see--less');
-    testUtils.Simulate.click(more);
-    assert.equal(output.state.showMore, true);
-    testUtils.Simulate.click(less);
-    assert.equal(output.state.showMore, false);
+    assert.deepEqual(output, expectedOutput);
   });
 });

--- a/jujugui/static/gui/src/app/components/entity-details/header/header.js
+++ b/jujugui/static/gui/src/app/components/entity-details/header/header.js
@@ -258,38 +258,6 @@ YUI.add('entity-header', function() {
         </li>);
     },
 
-    /**
-     When the latest version link is click, go to that version.
-   */
-    _handleRevisionClick: function(evt) {
-      evt.stopPropagation();
-      this.props.changeState({
-        search: null,
-        store: this.props.entityModel.get('latest_revision').url
-      });
-    },
-
-    /**
-      Generates the list item to link to the latest version
-      or display the latest version
-   */
-    _generateLatestRevision: function() {
-      const entityModel = this.props.entityModel;
-      const latest_revision = entityModel.get('latest_revision');
-      const revision_id = entityModel.get('revision_id');
-
-      if (latest_revision.id !== revision_id) {
-        return (<li>
-          <a className="link" onClick={this._handleRevisionClick}>
-            Latest version (#{latest_revision.id})
-          </a>
-        </li>);
-      } else {
-        return (<li>
-          Latest version (#{latest_revision.id})
-        </li>);
-      }
-    },
 
     /**
       Generates the list of series. Supports bundles, multi-series and
@@ -344,7 +312,6 @@ YUI.add('entity-header', function() {
                     <a href={ownerUrl} className="link"
                       target="_blank">{entity.owner}</a>
                   </li>
-                  {this._generateLatestRevision()}
                   {this._generateSeriesList()}
                   {this._generateCounts()}
                 </ul>

--- a/jujugui/static/gui/src/app/components/entity-details/header/test-header.js
+++ b/jujugui/static/gui/src/app/components/entity-details/header/test-header.js
@@ -82,9 +82,6 @@ describe('EntityHeader', function() {
                     className="link"
                     target="_blank">test-owner</a>
                 </li>
-                <li>
-                  {'Latest version (#'}{123}{')'}
-                </li>
                 {[<li key="trusty" className="entity-header__series">
                   trusty
                 </li>]}
@@ -268,7 +265,7 @@ describe('EntityHeader', function() {
       </li>);
     assert.deepEqual(
       output.props.children.props.children.props.children[0]
-        .props.children[2].props.children[3], expected);
+        .props.children[2].props.children[2], expected);
   });
 
   it('displays an add to model button', function() {

--- a/jujugui/static/gui/src/app/jujulib/charmstore.js
+++ b/jujugui/static/gui/src/app/jujulib/charmstore.js
@@ -147,20 +147,6 @@ var module = module;
     },
 
     /**
-     * Parse a revision string to create an object of info
-     * @param  {String} revision e.g. 'cs:openstack-dashboard-243'
-     * @return {Object}          id: number,
-     */
-    _expandRevision: function(revision_id, charm_name) {
-      const id = parseInt(revision_id.split('-').pop());
-      return {
-        id: id,
-        full_id: revision_id,
-        url: `${charm_name}/${id}`
-      };
-    },
-
-    /**
       The response object returned from the apiv4 search endpoint is a complex
       object with golang style keys. This parses the complex object and
       returns something that we use to instantiate new charm and bundle models.
@@ -175,6 +161,7 @@ var module = module;
           charmMeta = meta['charm-metadata'],
           charmConfig = meta['charm-config'],
           commonInfo = meta['common-info'],
+          revisionInfo = meta['revision-info'] || {},
           bundleMeta = meta['bundle-metadata'],
           owner = meta.owner && meta.owner.User;
 
@@ -186,7 +173,7 @@ var module = module;
         // If the id has a user segment then it has not been promulgated.
         is_approved: data.Id.indexOf('~') > 0 ? false : true,
         owner: owner,
-        revisions: extraInfo['bzr-revisions'] || [],
+        revisions: revisionInfo.Revisions || [],
         code_source: {
           location: extraInfo['bzr-url']
         }
@@ -255,12 +242,6 @@ var module = module;
       // for the addPendingResources call.
       if (meta.resources && meta.resources.length) {
         processed.resources = meta.resources;
-      }
-
-      if (meta['revision-info']) {
-        processed['latest_revision'] =
-          this._expandRevision(meta['revision-info']['Revisions'][0],
-          processed.name);
       }
 
       if (meta['id-revision']) {

--- a/jujugui/static/gui/src/app/jujulib/test-charmstore.js
+++ b/jujugui/static/gui/src/app/jujulib/test-charmstore.js
@@ -133,8 +133,10 @@ describe('jujulib charmstore', function() {
             User: 'hatch'
           },
           'extra-info': {
-            'bzr-revisions': 5,
             'bzr-url': 'cs:precise/mongodb'
+          },
+          'revision-info': {
+            Revisions: ['rev1', 'rev2', 'rev4']
           },
           'charm-config': {
             Options: {
@@ -177,7 +179,7 @@ describe('jujulib charmstore', function() {
           metric: 'metric'
         },
         owner: 'hatch',
-        revisions: 5,
+        revisions: ['rev1', 'rev2', 'rev4'],
         code_source: {
           location: 'cs:precise/mongodb'
         },
@@ -244,8 +246,10 @@ describe('jujulib charmstore', function() {
             User: 'hatch'
           },
           'extra-info': {
-            'bzr-revisions': 5,
             'bzr-url': 'lp:~charmers/charms/bundles/mongodb-cluster/bundle'
+          },
+          'revision-info': {
+            Revisions: ['rev1', 'rev2']
           },
           stats: {
             ArchiveDownloadCount: 10
@@ -265,7 +269,7 @@ describe('jujulib charmstore', function() {
         is_approved: false,
         name: 'mongodb-cluster',
         owner: 'hatch',
-        revisions: 5,
+        revisions: ['rev1', 'rev2'],
         services: '',
         unitCount: 7
       });

--- a/jujugui/static/gui/src/app/models/charm.js
+++ b/jujugui/static/gui/src/app/models/charm.js
@@ -592,7 +592,6 @@ YUI.add('juju-charm-models', function(Y) {
       },
       is_approved: {},
       is_subordinate: {},
-      latest_revision: {},
       maintainer: {},
       /*
         API related metadata information for this charm object.

--- a/jujugui/static/gui/src/app/models/entity-extension.js
+++ b/jujugui/static/gui/src/app/models/entity-extension.js
@@ -61,7 +61,6 @@ YUI.add('entity-extension', function(Y) {
         displayName: attrs.name.replace('-', ' '),
         downloads: attrs.downloads,
         id: attrs.id,
-        latest_revision: attrs.latest_revision,
         storeId: attrs.storeId,
         name: attrs.name,
         owner: attrs.owner || this.ownerFromId(),

--- a/jujugui/static/gui/src/app/utils/component-test-utils.js
+++ b/jujugui/static/gui/src/app/utils/component-test-utils.js
@@ -189,11 +189,6 @@ var jsTestUtils = {
         promulgated: true,
         id: 'django-cluster',
         revision_id: 123,
-        latest_revision: {
-          id: 123,
-          url: 'django-cluster/123',
-          full_id: 'cs:django-cluster-123'
-        },
         type: 'bundle',
         entityType: 'bundle',
         iconPath: 'data:image/gif;base64,',
@@ -235,11 +230,6 @@ var jsTestUtils = {
         promulgated: true,
         id: 'cs:django',
         revision_id: 123,
-        latest_revision: {
-          id: 123,
-          url: 'django/123',
-          full_id: 'cs:django-123'
-        },
         type: 'charm',
         entityType: 'charm',
         iconPath: 'data:image/gif;base64,',

--- a/jujugui/static/gui/src/app/views/utils.js
+++ b/jujugui/static/gui/src/app/views/utils.js
@@ -1662,14 +1662,13 @@ YUI.add('juju-view-utils', function(Y) {
         },
         message: (
           <p>
-            You can obtain your AWS credentials at:<br />
+            You can obtain your AWS credentials at&nbsp;
             <a className="deployment-panel__link"
               href={'https://console.aws.amazon.com/iam/home?region=' +
                 'eu-west-1#security_credential'}
               target="_blank">
-              https://console.aws.amazon.com/iam/home?region=eu-west-1#
-              security_credential
-            </a>
+              the AWS panel
+            </a>.
           </p>)
       },
       'openstack': {

--- a/jujugui/static/gui/src/test/test_entity_extension.js
+++ b/jujugui/static/gui/src/test/test_entity_extension.js
@@ -43,11 +43,6 @@ describe('Entity Extension', function() {
       name: 'foo-bar',
       description: 'A test description.',
       revision_id: 132,
-      latest_revision: {
-        id: 132,
-        url: '/foobar-132',
-        full_id: 'foobar-123'
-      },
       downloads: '0',
       is_approved: false,
       revisions: [],
@@ -88,11 +83,6 @@ describe('Entity Extension', function() {
       downloads: '0',
       id: '~owner/foobar',
       revision_id: 132,
-      latest_revision: {
-        id: 132,
-        url: '/foobar-132',
-        full_id: 'foobar-123'
-      },
       storeId: 'cs:~owner/foobar-132',
       name: 'foo-bar',
       owner: 'owner',
@@ -117,11 +107,6 @@ describe('Entity Extension', function() {
       owner: 'foobar-charmers',
       entityType: 'bundle',
       revision_id: '132',
-      latest_revision: {
-        id: 132,
-        url: '/foobar-132',
-        full_id: 'foobar-123'
-      },
       applications: [],
       machineCount: 2,
       serviceCount: 3,
@@ -135,11 +120,6 @@ describe('Entity Extension', function() {
       downloads: '0',
       id: 'foobar',
       revision_id: '132',
-      latest_revision: {
-        id: 132,
-        url: '/foobar-132',
-        full_id: 'foobar-123'
-      },
       storeId: 'cs:~owner/foobar-132',
       machineCount: 2,
       name: 'foo-bar',

--- a/jujugui/static/gui/src/test/test_model_bundle.js
+++ b/jujugui/static/gui/src/test/test_model_bundle.js
@@ -169,36 +169,6 @@ describe('The bundle model', function() {
     assert.equal(instance.constructor.entityType, 'bundle');
   });
 
-  it('parses author name correctly', function() {
-    instance = new models.Bundle(data);
-    var revisions = instance.get('revisions');
-    assert.equal('Jorge O. Castro', revisions[1].authors[0].name);
-    assert.equal('jorge@ubuntu.com', revisions[1].authors[0].email);
-  });
-
-  it('has the revnos in reverse order', function() {
-    instance = new models.Bundle(data);
-    var commits = instance.get('revisions');
-    assert.equal(4, commits[0].revno);
-    assert.equal(3, commits[1].revno);
-    assert.equal(2, commits[2].revno);
-  });
-
-  it('has the correct date in GMT', function() {
-    instance = new models.Bundle(data);
-    // IE doesn't format 03 but as just 3. They also end in UTC vs GMT. So we
-    // regex the match to say this is close enough to work in each browser.
-    var expected = 'Thu 2014-03-06 11:39:13 -0500';
-    var commits = instance.get('revisions');
-    assert.equal(commits[0].date, expected);
-  });
-
-  it('has the commit message', function() {
-    instance = new models.Bundle(data);
-    var commits = instance.get('revisions');
-    assert.equal(commits[0].message, '  Bump charm revision.\n');
-  });
-
   it('parses full name-email string', function() {
     instance = new models.Bundle();
     var parts = instance.parseNameEmail(


### PR DESCRIPTION
Changes include:
- improving the machines message on the deployment flow (fixes https://github.com/juju/juju-gui/issues/2510);
- making the link in the AWS credentials notes in the deployment flow a proper link vs full URL (fixes https://github.com/juju/juju-gui/issues/2591);
- fixing the links to files and zip archive in user owned charms and bundles (fixes https://github.com/juju/juju-gui/issues/2494);
- correctly displaying the number of revisions in charm/bundle detail pages (fixes https://github.com/juju/juju-gui/issues/2495).

QA:
- go to the deployment flow on your local lxd model and on a cloud model, and check that the machines message makes sense (and has the correct punctuation, space after the end of the sentence, etc.);
- in the deployment flow, select AWS, click to add credentials and check that the link points to the AWS credentials page correctly, and it is a link, not a full URL;
- go to the detail page of a promulgated charm, a promulgated bundle, a user owned charm and a user owned bundle: in all pages, the links to download the zip and to the included files should work;
- go to charm/bundle detail pages and check that the number of revisions is visible at the bottom right and it's not 0. Note that we can argue on the helpfulness of this information, but at least now it works, and in the future it might contain actual info, like charm push commits.
