### PR TITLE
Notify user of error when adding credentials.

### DIFF
--- a/jujugui/static/gui/src/app/components/deployment-flow/credential/add/add.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/credential/add/add.js
@@ -23,6 +23,7 @@ YUI.add('deployment-credential-add', function() {
   juju.components.DeploymentCredentialAdd = React.createClass({
     propTypes: {
       acl: React.PropTypes.object.isRequired,
+      addNotification: React.PropTypes.func.isRequired,
       close: React.PropTypes.func.isRequired,
       cloud: React.PropTypes.object,
       generateCloudCredentialName: React.PropTypes.func.isRequired,
@@ -111,7 +112,11 @@ YUI.add('deployment-credential-add', function() {
     */
     _updateCloudCredentialCallback: function(credential, error) {
       if (error) {
-        console.error('Unable to add credential', error);
+        this.props.addNotification({
+          title: 'Could not add credential',
+          message: `Could not add the credential: ${error}`,
+          level: 'error'
+        });
         return;
       }
       // Load the credentials again so that the list will contain the newly

--- a/jujugui/static/gui/src/app/components/deployment-flow/credential/add/test-add.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/credential/add/test-add.js
@@ -99,6 +99,7 @@ describe('DeploymentCredentialAdd', function() {
     var renderer = jsTestUtils.shallowRender(
       <juju.components.DeploymentCredentialAdd
           acl={acl}
+          addNotification={sinon.stub()}
           updateCloudCredential={sinon.stub()}
           close={sinon.stub()}
           cloud={null}
@@ -242,6 +243,7 @@ describe('DeploymentCredentialAdd', function() {
     const renderer = jsTestUtils.shallowRender(
       <juju.components.DeploymentCredentialAdd
           acl={acl}
+          addNotification={sinon.stub()}
           updateCloudCredential={sinon.stub()}
           close={sinon.stub()}
           cloud={null}
@@ -255,6 +257,7 @@ describe('DeploymentCredentialAdd', function() {
     renderer.render(
       <juju.components.DeploymentCredentialAdd
           acl={acl}
+          addNotification={sinon.stub()}
           updateCloudCredential={sinon.stub()}
           close={close}
           cloud={{name: 'aws', cloudType: 'ec2'}}
@@ -356,6 +359,7 @@ describe('DeploymentCredentialAdd', function() {
     var renderer = jsTestUtils.shallowRender(
     <juju.components.DeploymentCredentialAdd
         acl={acl}
+        addNotification={sinon.stub()}
         updateCloudCredential={sinon.stub()}
         close={sinon.stub()}
         cloud={{name: 'google', cloudType: 'gce'}}
@@ -500,6 +504,7 @@ describe('DeploymentCredentialAdd', function() {
     var renderer = jsTestUtils.shallowRender(
     <juju.components.DeploymentCredentialAdd
         acl={acl}
+        addNotification={sinon.stub()}
         updateCloudCredential={sinon.stub()}
         close={sinon.stub()}
         cloud={{name: 'google', cloudType: 'gce'}}
@@ -598,6 +603,7 @@ describe('DeploymentCredentialAdd', function() {
     var renderer = jsTestUtils.shallowRender(
     <juju.components.DeploymentCredentialAdd
         acl={acl}
+        addNotification={sinon.stub()}
         updateCloudCredential={sinon.stub()}
         close={sinon.stub()}
         cloud={{name: 'google', cloudType: 'gce'}}
@@ -743,6 +749,7 @@ describe('DeploymentCredentialAdd', function() {
     var renderer = jsTestUtils.shallowRender(
       <juju.components.DeploymentCredentialAdd
           acl={acl}
+          addNotification={sinon.stub()}
           updateCloudCredential={updateCloudCredential}
           close={sinon.stub()}
           cloud={{name: 'google', cloudType: 'gce'}}
@@ -798,6 +805,7 @@ describe('DeploymentCredentialAdd', function() {
     const renderer = jsTestUtils.shallowRender(
     <juju.components.DeploymentCredentialAdd
         acl={acl}
+        addNotification={sinon.stub()}
         updateCloudCredential={updateCloudCredential}
         close={sinon.stub()}
         cloud={{name: 'google', cloudType: 'gce'}}
@@ -845,6 +853,7 @@ describe('DeploymentCredentialAdd', function() {
     var renderer = jsTestUtils.shallowRender(
       <juju.components.DeploymentCredentialAdd
           acl={acl}
+          addNotification={sinon.stub()}
           updateCloudCredential={updateCloudCredential}
           close={sinon.stub()}
           cloud={{name: 'google', cloudType: 'gce'}}
@@ -857,5 +866,56 @@ describe('DeploymentCredentialAdd', function() {
     var instance = renderer.getMountedInstance();
     instance._handleAddCredentials();
     assert.equal(updateCloudCredential.callCount, 0);
+  });
+
+  it('displays a notification when updating a credential errors', function() {
+    const error = 'Bad wolf';
+    const updateCloudCredential = sinon.stub().callsArgWith(3, error);
+    const addNotification = sinon.stub();
+    var renderer = jsTestUtils.shallowRender(
+      <juju.components.DeploymentCredentialAdd
+          acl={acl}
+          addNotification={addNotification}
+          updateCloudCredential={updateCloudCredential}
+          close={sinon.stub()}
+          cloud={{name: 'google', cloudType: 'gce'}}
+          getCloudProviderDetails={getCloudProviderDetails}
+          generateCloudCredentialName={sinon.stub().returns('new@test')}
+          getCredentials={sinon.stub()}
+          setCredential={sinon.stub()}
+          user="user-admin"
+          validateForm={sinon.stub().returns(true)} />, true);
+    var instance = renderer.getMountedInstance();
+    instance.refs = {
+      'credentialName': {
+        validate: sinon.stub().returns(true),
+        getValue: sinon.stub().returns('new@test')
+      },
+      'client-id': {
+        validate: sinon.stub().returns(true),
+        getValue: sinon.stub().returns('client id')
+      },
+      'client-email': {
+        validate: sinon.stub().returns(true),
+        getValue: sinon.stub().returns('client email')
+      },
+      'private-key': {
+        validate: sinon.stub().returns(true),
+        getValue: sinon.stub().returns('private key')
+      },
+      'project-id': {
+        getValue: sinon.stub().returns('project id')
+      },
+      'password': {
+        getValue: sinon.stub().returns('password')
+      }
+    };
+    instance._handleAddCredentials();
+    assert.isTrue(addNotification.called, 'addNotification was not called');
+    assert.deepEqual(addNotification.args[0][0], {
+      title: 'Could not add credential',
+      message: `Could not add the credential: ${error}`,
+      level: 'error'
+    }, 'Notification message does not match expected');
   });
 });

--- a/jujugui/static/gui/src/app/components/deployment-flow/credential/credential.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/credential/credential.js
@@ -23,6 +23,7 @@ YUI.add('deployment-credential', function() {
   juju.components.DeploymentCredential = React.createClass({
     propTypes: {
       acl: React.PropTypes.object.isRequired,
+      addNotification: React.PropTypes.func.isRequired,
       cloud: React.PropTypes.object,
       credential: React.PropTypes.string,
       editable: React.PropTypes.bool,
@@ -270,6 +271,7 @@ YUI.add('deployment-credential', function() {
       return (
         <juju.components.DeploymentCredentialAdd
           acl={this.props.acl}
+          addNotification={this.props.addNotification}
           close={this._toggleAdd}
           cloud={this.props.cloud}
           getCloudProviderDetails={this.props.getCloudProviderDetails}

--- a/jujugui/static/gui/src/app/components/deployment-flow/credential/test-credential.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/credential/test-credential.js
@@ -48,6 +48,7 @@ describe('DeploymentCredential', function() {
     var renderer = jsTestUtils.shallowRender(
       <juju.components.DeploymentCredential
         acl={acl}
+        addNotification={sinon.stub()}
         updateCloudCredential={sinon.stub()}
         cloud={cloud}
         editable={true}
@@ -78,6 +79,7 @@ describe('DeploymentCredential', function() {
     var renderer = jsTestUtils.shallowRender(
       <juju.components.DeploymentCredential
         acl={acl}
+        addNotification={sinon.stub()}
         updateCloudCredential={updateCloudCredential}
         cloud={cloud}
         editable={true}
@@ -92,6 +94,7 @@ describe('DeploymentCredential', function() {
         validateForm={validateForm} />, true);
     var instance = renderer.getMountedInstance();
     var output = renderer.getRenderOutput();
+    const props = instance.props;
     var expected = (
       <div>
         <juju.components.ExpandingRow
@@ -101,6 +104,7 @@ describe('DeploymentCredential', function() {
           {undefined}
           <juju.components.DeploymentCredentialAdd
             acl={acl}
+            addNotification={props.addNotification}
             updateCloudCredential={updateCloudCredential}
             close={instance._toggleAdd}
             cloud={cloud}
@@ -123,6 +127,7 @@ describe('DeploymentCredential', function() {
     var renderer = jsTestUtils.shallowRender(
       <juju.components.DeploymentCredential
         acl={acl}
+        addNotification={sinon.stub()}
         updateCloudCredential={updateCloudCredential}
         cloud={cloud}
         credential="lxd_admin@local_default"
@@ -189,6 +194,7 @@ describe('DeploymentCredential', function() {
     var renderer = jsTestUtils.shallowRender(
       <juju.components.DeploymentCredential
         acl={acl}
+        addNotification={sinon.stub()}
         updateCloudCredential={updateCloudCredential}
         cloud={null}
         editable={true}
@@ -203,6 +209,7 @@ describe('DeploymentCredential', function() {
         validateForm={validateForm} />, true);
     var instance = renderer.getMountedInstance();
     var output = renderer.getRenderOutput();
+    const props = instance.props;
     var expected = (
       <div>
         <juju.components.ExpandingRow
@@ -212,6 +219,7 @@ describe('DeploymentCredential', function() {
           {undefined}
           <juju.components.DeploymentCredentialAdd
             acl={acl}
+            addNotification={props.addNotification}
             updateCloudCredential={updateCloudCredential}
             close={instance._toggleAdd}
             cloud={null}
@@ -232,6 +240,7 @@ describe('DeploymentCredential', function() {
     var renderer = jsTestUtils.shallowRender(
       <juju.components.DeploymentCredential
         acl={acl}
+        addNotification={sinon.stub()}
         updateCloudCredential={sinon.stub()}
         cloud={cloud}
         editable={true}
@@ -292,6 +301,7 @@ describe('DeploymentCredential', function() {
     jsTestUtils.shallowRender(
       <juju.components.DeploymentCredential
         acl={acl}
+        addNotification={sinon.stub()}
         updateCloudCredential={sinon.stub()}
         cloud={cloud}
         editable={true}
@@ -317,6 +327,7 @@ describe('DeploymentCredential', function() {
     const renderer = jsTestUtils.shallowRender(
       <juju.components.DeploymentCredential
         acl={acl}
+        addNotification={sinon.stub()}
         updateCloudCredential={sinon.stub()}
         cloud={cloud}
         editable={true}
@@ -345,6 +356,7 @@ describe('DeploymentCredential', function() {
     var renderer = jsTestUtils.shallowRender(
       <juju.components.DeploymentCredential
         acl={acl}
+        addNotification={sinon.stub()}
         updateCloudCredential={sinon.stub()}
         cloud={cloud}
         editable={true}
@@ -405,6 +417,7 @@ describe('DeploymentCredential', function() {
     var renderer = jsTestUtils.shallowRender(
       <juju.components.DeploymentCredential
         acl={acl}
+        addNotification={sinon.stub()}
         updateCloudCredential={sinon.stub()}
         cloud={cloud}
         editable={true}
@@ -442,6 +455,7 @@ describe('DeploymentCredential', function() {
     var renderer = jsTestUtils.shallowRender(
       <juju.components.DeploymentCredential
         acl={acl}
+        addNotification={sinon.stub()}
         updateCloudCredential={updateCloudCredential}
         cloud={cloud}
         editable={true}
@@ -457,6 +471,7 @@ describe('DeploymentCredential', function() {
     var instance = renderer.getMountedInstance();
     instance._handleCredentialChange('add-credential');
     var output = renderer.getRenderOutput();
+    const props = instance.props;
     var expected = (
       <div>
         <juju.components.ExpandingRow
@@ -466,6 +481,7 @@ describe('DeploymentCredential', function() {
           {undefined}
           <juju.components.DeploymentCredentialAdd
             acl={acl}
+            addNotification={props.addNotification}
             updateCloudCredential={updateCloudCredential}
             close={instance._toggleAdd}
             cloud={cloud}
@@ -490,6 +506,7 @@ describe('DeploymentCredential', function() {
     var renderer = jsTestUtils.shallowRender(
       <juju.components.DeploymentCredential
         acl={acl}
+        addNotification={sinon.stub()}
         updateCloudCredential={updateCloudCredential}
         cloud={cloud}
         editable={true}
@@ -514,6 +531,7 @@ describe('DeploymentCredential', function() {
     const renderer = jsTestUtils.shallowRender(
       <juju.components.DeploymentCredential
         acl={acl}
+        addNotification={sinon.stub()}
         updateCloudCredential={sinon.stub()}
         cloud={cloud}
         credential={credential}

--- a/jujugui/static/gui/src/app/components/deployment-flow/deployment-flow.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/deployment-flow.js
@@ -694,6 +694,7 @@ YUI.add('deployment-flow', function() {
           showCheck={false}>
           <juju.components.DeploymentCredential
             acl={this.props.acl}
+            addNotification={this.props.addNotification}
             credential={this.state.credential}
             cloud={cloud}
             getCloudProviderDetails={this.props.getCloudProviderDetails}

--- a/jujugui/static/gui/src/app/components/deployment-flow/test-deployment-flow.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/test-deployment-flow.js
@@ -176,6 +176,7 @@ describe('DeploymentFlow', function() {
           showCheck={false}>
           <juju.components.DeploymentCredential
             acl={props.acl}
+            addNotification={props.addNotification}
             credential={undefined}
             cloud={null}
             getCloudProviderDetails={props.getCloudProviderDetails}


### PR DESCRIPTION
Fixes https://github.com/juju/juju-gui/issues/2594.

It's a partial fix, as the real problem is the underlying Juju bug (see https://bugs.launchpad.net/juju/+bug/1671915) that does not recognize '+' as a legit part of an e-mail address. That said, now the user isn't left wondering why the app did nothing.