### PR TITLE
Show subordinate units in subordinate inspector

### DIFF
--- a/jujugui/static/gui/src/app/utils/environment-change-set.js
+++ b/jujugui/static/gui/src/app/utils/environment-change-set.js
@@ -1001,9 +1001,6 @@ YUI.add('environment-change-set', function(Y) {
             // Remove the relation from the relations db. Even the ghost
             // relations are stored in the db.
             relations.remove(relations.getRelationFromEndpoints(argsEndpoints));
-            argsEndpoints.forEach(endpoint => {
-              const service = db.services.getServiceByName(endpoint[0]);
-            });
           }
         }
       }, this);

--- a/jujugui/static/gui/src/app/utils/environment-change-set.js
+++ b/jujugui/static/gui/src/app/utils/environment-change-set.js
@@ -735,7 +735,6 @@ YUI.add('environment-change-set', function(Y) {
       // Remove the associated relations
       db.relations.remove(relations);
       db.services.remove(model);
-      model.updateSubordinateUnits(db);
       model.destroy();
       this._removeExistingRecord(recordKey);
       // Check if there are other applications using the same charm. If not
@@ -941,11 +940,6 @@ YUI.add('environment-change-set', function(Y) {
           }
         }
       });
-      var db = this.get('db');
-      // Reduce duplicated effort by only updating one service; if the other is
-      // subordinate, this method will catch that.
-      var service = db.services.getServiceByName(args[0][0]);
-      service.updateSubordinateUnits(db);
       var parent = [serviceA, serviceB];
       var command = {
         method: '_add_relation',
@@ -1009,9 +1003,6 @@ YUI.add('environment-change-set', function(Y) {
             relations.remove(relations.getRelationFromEndpoints(argsEndpoints));
             argsEndpoints.forEach(endpoint => {
               const service = db.services.getServiceByName(endpoint[0]);
-              if (service.get('subordinate')) {
-                service.updateSubordinateUnits(db);
-              }
             });
           }
         }
@@ -1064,8 +1055,6 @@ YUI.add('environment-change-set', function(Y) {
             // stored in the DB.
             var unit = units.getById(unitName);
             db.removeUnits(unit);
-            db.services.getServiceByName(unit.service)
-              .updateSubordinateUnits(db);
           }
         }
       }, this);
@@ -1333,8 +1322,6 @@ YUI.add('environment-change-set', function(Y) {
           }
         }
       };
-      var service = db.services.getServiceByName(args[0]);
-      service.updateSubordinateUnits(db);
       return this._createNewRecord('addUnits', command, parent);
     },
 

--- a/jujugui/static/gui/src/test/test_env_change_set.js
+++ b/jujugui/static/gui/src/test/test_env_change_set.js
@@ -924,7 +924,6 @@ describe('Environment Change Set', function() {
       it('destroys create records for undeployed services', function() {
         var stubRemove = sinon.stub();
         var stubDestroy = sinon.stub();
-        var stubUpdateSubordinates = sinon.stub();
         var db = ecs.get('db');
         var fakeUnits = new Y.LazyModelList();
         fakeUnits.add({});
@@ -935,8 +934,7 @@ describe('Environment Change Set', function() {
               destroy: stubDestroy,
               get: function(key) {
                 if (key === 'units') { return fakeUnits; }
-              },
-              updateSubordinateUnits: stubUpdateSubordinates
+              }
             };
           }
         };
@@ -954,8 +952,6 @@ describe('Environment Change Set', function() {
             stubRemoveUnits.calledOnce, true, 'remove units not called');
         assert.equal(db.relations.remove.calledOnce, true,
             'remove relations not called');
-        assert.equal(stubUpdateSubordinates.calledOnce, true,
-            'subordinate units not updated');
         assert.deepEqual(ecs.changeSet, {});
       });
 
@@ -969,8 +965,7 @@ describe('Environment Change Set', function() {
               get: function(key) {
                 if (key === 'units') { return {each: sinon.stub()}; }
               },
-              set: sinon.stub(),
-              updateSubordinateUnits: sinon.stub()
+              set: sinon.stub()
             };
           },
         };
@@ -1305,14 +1300,10 @@ describe('Environment Change Set', function() {
     });
 
     describe('lazyAddUnits', function() {
-      var stubUpdateSubordinates;
 
       beforeEach(function() {
-        stubUpdateSubordinates = sinon.stub();
         ecs.get('db').services.getServiceByName = function() {
-          return {
-            updateSubordinateUnits: stubUpdateSubordinates
-          };
+          return {};
         };
       });
 
@@ -1327,7 +1318,6 @@ describe('Environment Change Set', function() {
         var cb = record.command.args.pop();
         args.pop();
         assert.deepEqual(record.command.args, args);
-        assert.equal(stubUpdateSubordinates.calledOnce, true);
         cb();
       });
 
@@ -1345,7 +1335,6 @@ describe('Environment Change Set', function() {
         var key = ecs.lazyAddUnits(args);
         var record = ecs.changeSet[key];
         assert.equal(record.parents[0], 'service-1');
-        assert.equal(stubUpdateSubordinates.calledOnce, true);
       });
 
       it('creates a record with a queued machine', function() {
@@ -1361,7 +1350,6 @@ describe('Environment Change Set', function() {
         var key = ecs.lazyAddUnits(args);
         var record = ecs.changeSet[key];
         assert.equal(record.parents[0], 'addMachines-1');
-        assert.equal(stubUpdateSubordinates.calledOnce, true);
       });
 
       it('updates the machine where to deploy on parent results', function() {
@@ -1373,7 +1361,6 @@ describe('Environment Change Set', function() {
         command.onParentResults(parentRecord, parentResults);
         // The unit will be added to the real machine.
         assert.strictEqual(command.args[2], '42');
-        assert.equal(stubUpdateSubordinates.calledOnce, true);
       });
 
       it('updates the service and unit on parent results', function() {
@@ -1413,7 +1400,6 @@ describe('Environment Change Set', function() {
                            'service name not set properly');
         assert.equal(command.options.modelId, 'my-service/3',
                      'options model id not updated');
-        assert.equal(stubUpdateSubordinates.calledOnce, true);
       });
 
     });
@@ -1521,11 +1507,8 @@ describe('Environment Change Set', function() {
             }
           }
         };
-        const stubUpdateSubordinates = sinon.stub();
         ecs.get('db').services.getServiceByName = function() {
-          return {
-            updateSubordinateUnits: stubUpdateSubordinates
-          };
+          return {};
         };
         const args = [
           ['serviceId1$', ['db', 'client']],
@@ -1550,7 +1533,6 @@ describe('Environment Change Set', function() {
         assert.equal(Object.keys(ecs.changeSet).length, 3);
         // Perform this last, as it will mutate ecs.changeSet.
         assert.equal(ecs._buildHierarchy(ecs.changeSet).length, 2);
-        assert.equal(stubUpdateSubordinates.calledOnce, true);
       });
     });
 
@@ -1568,15 +1550,11 @@ describe('Environment Change Set', function() {
         });
         const arg1 = ['svc1', 'endpoints1'];
         const arg2 = ['svc2', 'endpoints2'];
-        const updateSubordinateUnits = sinon.stub();
         db.services.getServiceByName = name => {
           const subordinate = name === 'svc2';
           const service = {
             get: sinon.stub().withArgs('subordinate').returns(subordinate)
           };
-          if (subordinate) {
-            service.updateSubordinateUnits = updateSubordinateUnits;
-          }
           return service;
         };
         ecs.changeSet['addRelation-982'] = {
@@ -1594,7 +1572,6 @@ describe('Environment Change Set', function() {
         assert.strictEqual(ecs.changeSet['addRelation-982'], undefined);
         assert.deepEqual(getRelation.lastCall.args[0], [arg1, arg2]);
         assert.strictEqual(remove.calledOnce, true);
-        assert.strictEqual(updateSubordinateUnits.calledOnce, true);
       });
 
       it('can add a remove relation record into the changeset', function() {
@@ -1636,11 +1613,8 @@ describe('Environment Change Set', function() {
             };
           }
         };
-        var stubUpdateSubordinates = sinon.stub();
         ecs.get('db').services.getServiceByName = function() {
-          return {
-            updateSubordinateUnits: stubUpdateSubordinates
-          };
+          return {};
         };
         ecs.changeSet['addUnit-982'] = {
           command: {
@@ -1652,7 +1626,6 @@ describe('Environment Change Set', function() {
         assert.strictEqual(record, undefined);
         assert.strictEqual(ecs.changeSet['addUnit-982'], undefined);
         assert.equal(remove.calledOnce, true);
-        assert.equal(stubUpdateSubordinates.calledOnce, true);
       });
 
       it('can add a remove unit record into the changeset', function() {

--- a/jujugui/static/gui/src/test/test_model.js
+++ b/jujugui/static/gui/src/test/test_model.js
@@ -2550,62 +2550,6 @@ describe('test_model.js', function() {
       });
     });
 
-    describe('updateSubordinateUnits', function() {
-      var db;
-      beforeEach(function() {
-        db = new models.Database();
-        db.services = list;
-        rails.set('subordinate', true);
-        db.addUnits({
-          id: 'mysql/0'
-        });
-        db.addUnits({
-          id: 'django/0'
-        });
-
-        db.relations.add([
-          {
-            id: 'rails:db mysql:db',
-            endpoints: [
-              ['mysql', {name: 'db', role: 'provider'}],
-              ['rails', {name: 'db', role: 'requirer'}]
-            ],
-            interface: 'mysql',
-            scope: 'container'
-          },
-          {
-            id: 'rails:sub django:sub',
-            endpoints: [
-              ['django', {name: 'sub', role: 'provider'}],
-              ['rails', {name: 'sub', role: 'requirer'}]
-            ],
-            interface: 'django',
-            scope: 'container'
-          },
-          {
-            id: 'rails:nonsub django:nonsub',
-            endpoints: [
-              ['django', {name: 'nonsub', role: 'provider'}],
-              ['rails', {name: 'nonsub', role: 'requirer'}]
-            ],
-            interface: 'django',
-            scope: 'global'
-          }
-        ]);
-      });
-
-      it('updates subordinate unit lists', function() {
-        assert.equal(rails.get('units').size(), 0);
-        rails.updateSubordinateUnits(db);
-        assert.equal(rails.get('units').size(), 2);
-      });
-
-      it('attempts to update opposite units if not subordinate', function() {
-        assert.equal(rails.get('units').size(), 0);
-        mysql.updateSubordinateUnits(db);
-        assert.equal(rails.get('units').size(), 2);
-      });
-    });
   });
 
   describe('db.charms.addFromCharmData', function() {


### PR DESCRIPTION
Fixes #2309 
Fixes #2329 

The subordinate inspector used to show only the principal units in the unit list. It now shows only the subordinate units.