### PR TITLE
Deployment flow: add the ability to specify an AWS VPC.

### DIFF
--- a/jujugui/static/gui/src/app/components/deployment-flow/deployment-flow.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/deployment-flow.js
@@ -222,7 +222,7 @@ YUI.add('deployment-flow', function() {
           cloud.name
         );
       }
-      this.setState({cloud: cloud});
+      this.setState({cloud: cloud, vpcId: INITIAL_VPC_ID});
     },
 
     /**

--- a/jujugui/static/gui/src/app/components/deployment-flow/deployment-flow.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/deployment-flow.js
@@ -20,6 +20,9 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 YUI.add('deployment-flow', function() {
 
+  // Define the VPC ID zero value.
+  const INITIAL_VPC_ID = null;
+
   juju.components.DeploymentFlow = React.createClass({
     propTypes: {
       acl: React.PropTypes.object.isRequired,
@@ -88,7 +91,7 @@ YUI.add('deployment-flow', function() {
         terms: this._getTerms() || [],
         // Whether the user has ticked the checked to agree to terms.
         termsAgreed: false,
-        vpcId: null,
+        vpcId: INITIAL_VPC_ID,
         vpcIdForce: false
       };
     },
@@ -263,7 +266,7 @@ YUI.add('deployment-flow', function() {
     */
     _setVPCId: function(value, force) {
       if (!value) {
-        value = null;
+        value = INITIAL_VPC_ID;
         force = false;
       }
       this.setState({vpcId: value, vpcIdForce: !!force});

--- a/jujugui/static/gui/src/app/components/deployment-flow/deployment-flow.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/deployment-flow.js
@@ -158,6 +158,12 @@ YUI.add('deployment-flow', function() {
           disabled = !hasCloud;
           visible = willCreateModel;
           break;
+        case 'vpc':
+          completed = false;
+          disabled = !hasCloud;
+          visible = (
+            willCreateModel && hasCloud && this.state.cloud.name === 'aws');
+          break;
         case 'machines':
           const addMachines = groupedChanges._addMachines;
           completed = false;
@@ -545,6 +551,27 @@ YUI.add('deployment-flow', function() {
             cloud={cloud}
             setSSHKey={this._setSSHKey}
           />
+        </juju.components.DeploymentSection>);
+    },
+
+    /**
+      Generate the AWS VPC management section.
+
+      @method _generateVPCSection
+      @returns {Object} The react component.
+    */
+    _generateVPCSection: function() {
+      const status = this._getSectionStatus('vpc');
+      if (!status.visible) {
+        return;
+      }
+      return (
+        <juju.components.DeploymentSection
+          completed={status.completed}
+          disabled={status.disabled}
+          instance="deployment-vpc"
+          showCheck={false}>
+          <juju.components.DeploymentVPC setVPCId={this._setVPCId} />
         </juju.components.DeploymentSection>);
     },
 
@@ -984,6 +1011,7 @@ YUI.add('deployment-flow', function() {
             {this._generateCloudSection()}
             {this._generateCredentialSection()}
             {this._generateSSHKeySection()}
+            {this._generateVPCSection()}
             {this._generateMachinesSection()}
             {this._generateServicesSection()}
             {this._generateBudgetSection()}
@@ -1028,6 +1056,7 @@ YUI.add('deployment-flow', function() {
     'deployment-section',
     'deployment-services',
     'deployment-ssh-key',
+    'deployment-vpc',
     'generic-button',
     'generic-input',
     'usso-login-link'

--- a/jujugui/static/gui/src/app/components/deployment-flow/test-deployment-flow.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/test-deployment-flow.js
@@ -634,8 +634,9 @@ describe('DeploymentFlow', function() {
     assert.strictEqual(props.deploy.args[0].length, 4);
     assert.equal(props.deploy.args[0][2], 'Lamington');
     assert.deepEqual(props.deploy.args[0][3], {
-      credential: 'cred',
+      config: {},
       cloud: 'cloud',
+      credential: 'cred',
       region: 'north'
     });
     assert.equal(props.changeState.callCount, 1);
@@ -895,8 +896,9 @@ describe('DeploymentFlow', function() {
     assert.strictEqual(deploy.args[0].length, 4);
     assert.equal(deploy.args[0][2], 'Pavlova');
     assert.deepEqual(deploy.args[0][3], {
-      credential: 'cred',
+      config: {},
       cloud: 'cloud',
+      credential: 'cred',
       region: 'north'
     });
     assert.equal(instance.props.changeState.callCount, 1);
@@ -928,6 +930,66 @@ describe('DeploymentFlow', function() {
       cloud: 'azure',
       region: 'skaro',
       config: {'authorized-keys': 'my SSH key'}
+    });
+    assert.equal(instance.props.changeState.callCount, 1);
+  });
+
+  it('can deploy with a VPC id', function() {
+    const charmsGetById = sinon.stub().withArgs('service1').returns({
+      get: sinon.stub().withArgs('terms').returns([])
+    });
+    const renderer = createDeploymentFlow({
+      charmsGetById: charmsGetById,
+      cloud: {name: 'aws'},
+      credential: 'creds',
+      modelCommitted: true,
+      modelName: 'mymodel',
+      region: 'skaro'
+    });
+    const instance = renderer.getMountedInstance();
+    instance._setVPCId('my VPC id');
+    const output = renderer.getRenderOutput();
+    output.props.children[9].props.children.props.children[1].props.children
+      .props.action();
+    const deploy = instance.props.deploy;
+    assert.equal(deploy.callCount, 1);
+    assert.strictEqual(deploy.args[0].length, 4);
+    assert.equal(deploy.args[0][2], 'mymodel');
+    assert.deepEqual(deploy.args[0][3], {
+      credential: 'creds',
+      cloud: 'aws',
+      region: 'skaro',
+      config: {'vpc-id': 'my VPC id', 'vpc-id-force': false}
+    });
+    assert.equal(instance.props.changeState.callCount, 1);
+  });
+
+  it('can deploy with a forced VPC id', function() {
+    const charmsGetById = sinon.stub().withArgs('service1').returns({
+      get: sinon.stub().withArgs('terms').returns([])
+    });
+    const renderer = createDeploymentFlow({
+      charmsGetById: charmsGetById,
+      cloud: {name: 'aws'},
+      credential: 'creds',
+      modelCommitted: true,
+      modelName: 'mymodel',
+      region: 'skaro'
+    });
+    const instance = renderer.getMountedInstance();
+    instance._setVPCId('my VPC id', true);
+    const output = renderer.getRenderOutput();
+    output.props.children[9].props.children.props.children[1].props.children
+      .props.action();
+    const deploy = instance.props.deploy;
+    assert.equal(deploy.callCount, 1);
+    assert.strictEqual(deploy.args[0].length, 4);
+    assert.equal(deploy.args[0][2], 'mymodel');
+    assert.deepEqual(deploy.args[0][3], {
+      credential: 'creds',
+      cloud: 'aws',
+      region: 'skaro',
+      config: {'vpc-id': 'my VPC id', 'vpc-id-force': true}
     });
     assert.equal(instance.props.changeState.callCount, 1);
   });

--- a/jujugui/static/gui/src/app/components/deployment-flow/test-deployment-flow.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/test-deployment-flow.js
@@ -209,6 +209,7 @@ describe('DeploymentFlow', function() {
             setSSHKey={instance._setSSHKey}
           />
         </juju.components.DeploymentSection>
+        {undefined}
         <juju.components.DeploymentSection
           completed={false}
           disabled={true}
@@ -370,7 +371,7 @@ describe('DeploymentFlow', function() {
       modelCommitted: true
     });
     const output = renderer.getRenderOutput();
-    assert.isFalse(output.props.children[4].props.disabled);
+    assert.strictEqual(output.props.children[5].props.disabled, false);
   });
 
   it('can enable the services section', function() {
@@ -380,7 +381,24 @@ describe('DeploymentFlow', function() {
       modelCommitted: true
     });
     const output = renderer.getRenderOutput();
-    assert.isFalse(output.props.children[5].props.disabled);
+    assert.strictEqual(output.props.children[6].props.disabled, false);
+  });
+
+  it('displays the VPC section in new AWS models', function() {
+    const renderer = createDeploymentFlow({modelCommitted: false});
+    const instance = renderer.getMountedInstance();
+    instance._setCloud({name: 'aws'});
+    const output = renderer.getRenderOutput();
+    const expectedOutput = (
+      <juju.components.DeploymentSection
+        completed={false}
+        disabled={false}
+        instance="deployment-vpc"
+        showCheck={false}>
+        <juju.components.DeploymentVPC setVPCId={instance._setVPCId} />
+      </juju.components.DeploymentSection>
+    );
+    assert.deepEqual(output.props.children[4], expectedOutput);
   });
 
   it('can enable the budget section', function() {
@@ -425,7 +443,7 @@ describe('DeploymentFlow', function() {
           setPaymentUser={instance._setPaymentUser}
           username="spinach" />
       </juju.components.DeploymentSection>);
-    assert.deepEqual(output.props.children[8], expected);
+    assert.deepEqual(output.props.children[9], expected);
   });
 
   it('can hide the agreements section', function() {
@@ -434,7 +452,7 @@ describe('DeploymentFlow', function() {
     });
     const output = renderer.getRenderOutput();
     assert.isUndefined(
-      output.props.children[9].props.children.props.children[0]);
+      output.props.children[10].props.children.props.children[0]);
   });
 
   it('can handle the agreements when there are no added apps', function() {
@@ -446,7 +464,7 @@ describe('DeploymentFlow', function() {
     });
     const output = renderer.getRenderOutput();
     assert.isUndefined(
-      output.props.children[9].props.children.props.children[0]);
+      output.props.children[10].props.children.props.children[0]);
   });
 
   it('can display the agreements section', function() {
@@ -461,7 +479,7 @@ describe('DeploymentFlow', function() {
     });
     const output = renderer.getRenderOutput();
     const instance = renderer.getMountedInstance();
-    const agreements = output.props.children[9].props.children
+    const agreements = output.props.children[10].props.children
       .props.children[0];
     const expected = (
       <div className="deployment-flow__deploy-option">
@@ -483,7 +501,7 @@ describe('DeploymentFlow', function() {
       modelCommitted: false
     });
     const output = renderer.getRenderOutput();
-    const agreements = output.props.children[9].props.children
+    const agreements = output.props.children[10].props.children
       .props.children[0];
     const className = agreements.props.className;
     const expectedClass = 'deployment-flow__deploy-option--disabled';
@@ -628,7 +646,7 @@ describe('DeploymentFlow', function() {
     instance._updateModelName();
     const props = instance.props;
     const output = renderer.getRenderOutput();
-    output.props.children[9].props.children.props.children[1].props.children
+    output.props.children[10].props.children.props.children[1].props.children
       .props.action();
     assert.equal(props.deploy.callCount, 1);
     assert.strictEqual(props.deploy.args[0].length, 4);
@@ -665,7 +683,7 @@ describe('DeploymentFlow', function() {
     instance._handleTermsAgreement({target: {checked: true}});
     const props = instance.props;
     const output = renderer.getRenderOutput();
-    output.props.children[9].props.children.props.children[1].props.children
+    output.props.children[10].props.children.props.children[1].props.children
       .props.action();
     assert.equal(props.deploy.callCount, 0,
       'The deploy function should not be called');
@@ -862,13 +880,13 @@ describe('DeploymentFlow', function() {
       }
     };
     let output = renderer.getRenderOutput();
-    let deployButton = output.props.children[9].props.children.props
+    let deployButton = output.props.children[10].props.children.props
       .children[1].props.children;
     deployButton.props.action();
 
     // .action() rerenders the component so we need to get it again
     output = renderer.getRenderOutput();
-    deployButton = output.props.children[9].props.children.props
+    deployButton = output.props.children[10].props.children.props
       .children[1].props.children;
 
     assert.equal(deployButton.props.disabled, true);
@@ -889,7 +907,7 @@ describe('DeploymentFlow', function() {
     const instance = renderer.getMountedInstance();
     instance.refs = {};
     const output = renderer.getRenderOutput();
-    output.props.children[9].props.children.props.children[1].props.children
+    output.props.children[10].props.children.props.children[1].props.children
       .props.action();
     const deploy = instance.props.deploy;
     assert.equal(deploy.callCount, 1);
@@ -919,7 +937,7 @@ describe('DeploymentFlow', function() {
     const instance = renderer.getMountedInstance();
     instance._setSSHKey('my SSH key');
     const output = renderer.getRenderOutput();
-    output.props.children[9].props.children.props.children[1].props.children
+    output.props.children[10].props.children.props.children[1].props.children
       .props.action();
     const deploy = instance.props.deploy;
     assert.equal(deploy.callCount, 1);
@@ -949,7 +967,7 @@ describe('DeploymentFlow', function() {
     const instance = renderer.getMountedInstance();
     instance._setVPCId('my VPC id');
     const output = renderer.getRenderOutput();
-    output.props.children[9].props.children.props.children[1].props.children
+    output.props.children[10].props.children.props.children[1].props.children
       .props.action();
     const deploy = instance.props.deploy;
     assert.equal(deploy.callCount, 1);
@@ -979,7 +997,7 @@ describe('DeploymentFlow', function() {
     const instance = renderer.getMountedInstance();
     instance._setVPCId('my VPC id', true);
     const output = renderer.getRenderOutput();
-    output.props.children[9].props.children.props.children[1].props.children
+    output.props.children[10].props.children.props.children[1].props.children
       .props.action();
     const deploy = instance.props.deploy;
     assert.equal(deploy.callCount, 1);

--- a/jujugui/static/gui/src/app/components/deployment-flow/vpc/test-vpc.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/vpc/test-vpc.js
@@ -47,6 +47,16 @@ describe('DeploymentVPC', function() {
     };
   };
 
+  // Check that the setVPCId function has been called for the expected number
+  // of times and, the last time, with the expected id value and force flag.
+  const checkSetVPCIdCalled = (expectedTimes, expectedId, expectedForce) => {
+    assert.strictEqual(setVPCId.callCount, expectedTimes, 'call count');
+    const args = setVPCId.args[expectedTimes-1];
+    assert.strictEqual(args.length, 2, 'args');
+    assert.strictEqual(args[0], expectedId, 'id');
+    assert.strictEqual(args[1], expectedForce, 'force');
+  };
+
   it('renders to show the VPC widgets', function() {
     const comp = render('aws');
     const expectedOutput = (
@@ -62,24 +72,66 @@ describe('DeploymentVPC', function() {
           ref="vpcId"
           multiLine={false}
           onBlur={comp.instance._onInputBlur}
+          onKeyUp={comp.instance._onInputKeyUp}
           required={false}
         />
+        <input
+          type="checkbox"
+          id="vpcIdForce"
+          onClick={comp.instance._onCheckboxClick}
+          onChange={comp.instance._onCheckboxChange}
+          checked={false}
+          disabled={true}
+        />
+        &nbsp;
+        Force Juju to use the AWS VPC ID specified above, even when it fails
+        the minimum validation criteria. This is ignored if VPC ID is not
+        set.
       </div>
     );
     assert.deepEqual(comp.output, expectedOutput);
   });
 
-  it('stores the VPC value', function() {
+  it('stores the VPC data', function() {
     const comp = render();
-    const input = comp.output.props.children[1];
-    // Simulate returning a value from a blur event.
-    comp.instance.refs = {vpcId: {getValue: () => 'my VPC id'}};
+    const children = comp.output.props.children;
+    const input = children[1];
+    // Simulate returning a value from the id value field.
+    comp.instance.refs = {vpcId: {getValue: () => 'my-id'}};
     input.props.onBlur();
-    // The VPC id value has been stored.
-    assert.strictEqual(setVPCId.callCount, 1);
-    const args = setVPCId.args[0];
-    assert.strictEqual(args.length, 1);
-    assert.equal(args[0], 'my VPC id');
+    // The VPC data has been stored.
+    checkSetVPCIdCalled(1, 'my-id', false);
   });
 
+  it('forces the VPC data', function() {
+    const comp = render();
+    const children = comp.output.props.children;
+    const input = children[1];
+    const checkbox = children[2];
+    // Simulate forcing a value from the id value field.
+    comp.instance.refs = {vpcId: {getValue: () => 'forced-id'}};
+    checkbox.props.onChange({target: {checked: true}});
+    input.props.onBlur();
+    // The VPC data has been stored.
+    checkSetVPCIdCalled(2, 'forced-id', true);
+  });
+
+  it('enables or disable the force check box', function() {
+    const comp = render();
+    const children = comp.output.props.children;
+    const instance = comp.instance;
+    const input = children[1];
+    // Check that the force check box is initially disabled.
+    assert.strictEqual(instance.state.forceEnabled, false, 'initial');
+    // Simulate returning a value from the id value field.
+    instance.refs = {vpcId: {getValue: () => 'my-id'}};
+    input.props.onKeyUp();
+    // The check box is now enabled.
+    assert.strictEqual(instance.state.forceEnabled, true, 'enabled');
+    // Simulate returning no value from the id value field.
+    instance.refs = {vpcId: {getValue: () => ''}};
+    input.props.onKeyUp();
+    // The check box is now disabled again.
+    assert.strictEqual(instance.state.forceEnabled, false, 'disabled again');
+  });
 });

--- a/jujugui/static/gui/src/app/components/deployment-flow/vpc/test-vpc.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/vpc/test-vpc.js
@@ -1,0 +1,85 @@
+/*
+This file is part of the Juju GUI, which lets users view and manage Juju
+environments within a graphical interface (https://launchpad.net/juju-gui).
+Copyright (C) 2017 Canonical Ltd.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU Affero General Public License version 3, as published by
+the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero
+General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along
+with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+'use strict';
+
+var juju = {components: {}}; // eslint-disable-line no-unused-vars
+
+chai.config.includeStack = true;
+chai.config.truncateThreshold = 0;
+
+describe('DeploymentVPC', function() {
+  let setVPCId;
+
+  beforeAll(function(done) {
+    // By loading this file it adds the component to the juju components.
+    YUI().use('deployment-vpc', function() {
+      done();
+    });
+  });
+
+  beforeEach(() => {
+    setVPCId = sinon.stub();
+  });
+
+  // Render the component and return the instance and the output.
+  const render = () => {
+    const renderer = jsTestUtils.shallowRender(
+      <juju.components.DeploymentVPC setVPCId={setVPCId}/>, true);
+    return {
+      instance: renderer.getMountedInstance(),
+      output: renderer.getRenderOutput()
+    };
+  };
+
+  it('renders to show the VPC widgets', function() {
+    const comp = render('aws');
+    const expectedOutput = (
+      <div>
+        <p>
+          Optionally use a specific AWS VPC ID. When not specified, Juju
+          requires a default VPC or EC2-Classic features to be available for
+          the account/region.
+        </p>
+        <juju.components.GenericInput
+          label="VPC id"
+          key="vpcId"
+          ref="vpcId"
+          multiLine={false}
+          onBlur={comp.instance._onInputBlur}
+          required={false}
+        />
+      </div>
+    );
+    assert.deepEqual(comp.output, expectedOutput);
+  });
+
+  it('stores the VPC value', function() {
+    const comp = render();
+    const input = comp.output.props.children[1];
+    // Simulate returning a value from a blur event.
+    comp.instance.refs = {vpcId: {getValue: () => 'my VPC id'}};
+    input.props.onBlur();
+    // The VPC id value has been stored.
+    assert.strictEqual(setVPCId.callCount, 1);
+    const args = setVPCId.args[0];
+    assert.strictEqual(args.length, 1);
+    assert.equal(args[0], 'my VPC id');
+  });
+
+});

--- a/jujugui/static/gui/src/app/components/deployment-flow/vpc/vpc.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/vpc/vpc.js
@@ -1,0 +1,72 @@
+/*
+This file is part of the Juju GUI, which lets users view and manage Juju
+environments within a graphical interface (https://launchpad.net/juju-gui).
+Copyright (C) 2017 Canonical Ltd.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU Affero General Public License version 3, as published by
+the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero
+General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along
+with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+'use strict';
+
+/**
+  This component allows users to provide their AWS virtual private cloud
+  identifier.
+*/
+YUI.add('deployment-vpc', function() {
+
+  juju.components.DeploymentVPC = React.createClass({
+    propTypes: {
+      setVPCId: React.PropTypes.func.isRequired
+    },
+
+    /**
+      Handle VPC id changes.
+
+      @method _onInputBlur
+      @param {Object} evt The blur event.
+    */
+    _onInputBlur: function(evt) {
+      const value = this.refs.vpcId.getValue();
+      this.props.setVPCId(value);
+    },
+
+    /**
+      Render the component.
+
+      @method render
+    */
+    render: function() {
+      return (
+        <div>
+          <p>
+            Optionally use a specific AWS VPC ID. When not specified, Juju
+            requires a default VPC or EC2-Classic features to be available for
+            the account/region.
+          </p>
+          <juju.components.GenericInput
+            label="VPC id"
+            key="vpcId"
+            ref="vpcId"
+            multiLine={false}
+            onBlur={this._onInputBlur}
+            required={false}
+          />
+        </div>
+      );
+    }
+
+  });
+
+}, '0.1.0', {
+  requires: []
+});

--- a/jujugui/static/gui/src/app/components/deployment-flow/vpc/vpc.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/vpc/vpc.js
@@ -29,21 +29,60 @@ YUI.add('deployment-vpc', function() {
       setVPCId: React.PropTypes.func.isRequired
     },
 
-    /**
-      Handle VPC id changes.
+    getInitialState: function() {
+      return {force: false, forceEnabled: false};
+    },
 
-      @method _onInputBlur
+    /**
+      Handle text input blur changes by setting the VPC data.
+
       @param {Object} evt The blur event.
     */
     _onInputBlur: function(evt) {
-      const value = this.refs.vpcId.getValue();
-      this.props.setVPCId(value);
+      this.setVPC(this.state.force);
+    },
+
+    /**
+      Handle text input key up events by disabling or enabling the VPC force
+      check box based on whether the input is empty.
+
+      @param {Object} evt The key up event.
+    */
+    _onInputKeyUp: function(evt) {
+      this.setState({forceEnabled: !!this.refs.vpcId.getValue()});
+    },
+
+    /**
+      Handle VPC force check box changes by updating the VPC data.
+
+      @param {Object} evt The change event from the check box.
+    */
+    _onCheckboxChange: function(evt) {
+      const force = evt.target.checked;
+      this.setState({force: force});
+      this.setVPC(force);
+    },
+
+    /**
+      Stop the propagation of VPC force check box click events.
+
+      @param {Object} evt The change event from the check box.
+    */
+    _onCheckboxClick: function(evt) {
+      evt.stopPropagation();
+    },
+
+    /**
+      Set VPC id and force values based on the current state of VPC widgets.
+
+      @param {Boolean} force Whether to force the id value, even if not valid.
+    */
+    setVPC: function(force) {
+      this.props.setVPCId(this.refs.vpcId.getValue(), force);
     },
 
     /**
       Render the component.
-
-      @method render
     */
     render: function() {
       return (
@@ -59,8 +98,21 @@ YUI.add('deployment-vpc', function() {
             ref="vpcId"
             multiLine={false}
             onBlur={this._onInputBlur}
+            onKeyUp={this._onInputKeyUp}
             required={false}
           />
+          <input
+            type="checkbox"
+            id="vpcIdForce"
+            onChange={this._onCheckboxChange}
+            onClick={this._onCheckboxClick}
+            checked={this.state.force}
+            disabled={!this.state.forceEnabled}
+          />
+          &nbsp;
+          Force Juju to use the AWS VPC ID specified above, even when it fails
+          the minimum validation criteria. This is ignored if VPC ID is not
+          set.
         </div>
       );
     }


### PR DESCRIPTION
Also include the possibility to force a VPC id despite validation via a check box in the deployment flow.
Fixes https://github.com/juju/juju-gui/issues/2672