### PR TITLE
Juju logo should link to appropriate place

### DIFF
--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -1202,9 +1202,13 @@ YUI.add('juju-gui', function(Y) {
     },
 
     _renderHeaderLogo: function() {
+      const userName = this.user.controller.user.split('@')[0];
+      const gisf = this.get('gisf');
+      const homePath = gisf ? '/' :
+        this.state.generatePath({profile: userName});
       const showProfile = () =>
         this.state.changeState({
-          profile: this.user.controller.user.split('@')[0],
+          profile: userName,
           model: null,
           store: null,
           root: null,
@@ -1214,8 +1218,10 @@ YUI.add('juju-gui', function(Y) {
         });
       ReactDOM.render(
         <window.juju.components.HeaderLogo
+          gisf={gisf}
+          homePath={homePath}
           showProfile={showProfile}
-          gisf={this.get('gisf')} />,
+           />,
         document.getElementById('header-logo'));
     },
 

--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -1202,9 +1202,20 @@ YUI.add('juju-gui', function(Y) {
     },
 
     _renderHeaderLogo: function() {
+      const showProfile = () =>
+        this.state.changeState({
+          profile: this.user.controller.user.split('@')[0],
+          model: null,
+          store: null,
+          root: null,
+          search: null,
+          account: null,
+          user: null
+        });
       ReactDOM.render(
         <window.juju.components.HeaderLogo
-          resetState={this.state.reset.bind(this.state)}/>,
+          showProfile={showProfile}
+          gisf={this.get('gisf')} />,
         document.getElementById('header-logo'));
     },
 

--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -1203,7 +1203,8 @@ YUI.add('juju-gui', function(Y) {
 
     _renderHeaderLogo: function() {
       ReactDOM.render(
-        <window.juju.components.HeaderLogo />,
+        <window.juju.components.HeaderLogo
+          resetState={this.state.reset.bind(this.state)}/>,
         document.getElementById('header-logo'));
     },
 

--- a/jujugui/static/gui/src/app/components/header-logo/header-logo.js
+++ b/jujugui/static/gui/src/app/components/header-logo/header-logo.js
@@ -27,12 +27,19 @@ YUI.add('header-logo', function() {
   juju.components.HeaderLogo = React.createClass({
 
     propTypes: {
+      resetState: React.PropTypes.func.isRequired
+    },
+
+    _navigateToRoot: function(e) {
+      e.preventDefault();
+      this.props.resetState();
     },
 
     render: function() {
       return (
-        <a href="/"
-          role="button" title="Go to user profile">
+        <a onClick={this._navigateToRoot}
+           role="button"
+           title="Home">
           <juju.components.SvgIcon name="juju-logo"
             className="svg-icon"
             width="90" height="35" />

--- a/jujugui/static/gui/src/app/components/header-logo/header-logo.js
+++ b/jujugui/static/gui/src/app/components/header-logo/header-logo.js
@@ -28,6 +28,7 @@ YUI.add('header-logo', function() {
 
     propTypes: {
       gisf: React.PropTypes.bool.isRequired,
+      homePath: React.PropTypes.string,
       showProfile: React.PropTypes.func
     },
 
@@ -36,6 +37,11 @@ YUI.add('header-logo', function() {
       @param {Object} e The click event.
     */
     _showProfile: function(e) {
+      if (this.props.gisf) {
+        // If we're in gisf then we want to allow the href to
+        // continue as normal
+        return;
+      }
       e.preventDefault();
       this.props.showProfile();
     },
@@ -51,16 +57,9 @@ YUI.add('header-logo', function() {
     },
 
     render: function() {
-      if (this.props.gisf) {
-        return (
-          <a href="/"
-             role="button"
-             title="Home">
-            {this._svg()}
-          </a>);
-      }
       return (
-        <a onClick={this._showProfile}
+        <a href={this.props.homePath}
+           onClick={this._showProfile}
            role="button"
            title="Home">
           {this._svg()}

--- a/jujugui/static/gui/src/app/components/header-logo/header-logo.js
+++ b/jujugui/static/gui/src/app/components/header-logo/header-logo.js
@@ -27,22 +27,43 @@ YUI.add('header-logo', function() {
   juju.components.HeaderLogo = React.createClass({
 
     propTypes: {
-      resetState: React.PropTypes.func.isRequired
+      gisf: React.PropTypes.bool.isRequired,
+      showProfile: React.PropTypes.func
     },
 
-    _navigateToRoot: function(e) {
+    /**
+      Calls the showProfile prop
+      @param {Object} e The click event.
+    */
+    _showProfile: function(e) {
       e.preventDefault();
-      this.props.resetState();
+      this.props.showProfile();
+    },
+
+    /**
+      Returns the Juju logo SvgIcon component.
+      @return {Object} The SvgIcon component of the Juju logo.
+    */
+    _svg: function() {
+      return (<juju.components.SvgIcon name="juju-logo"
+        className="svg-icon"
+        width="90" height="35" />);
     },
 
     render: function() {
+      if (this.props.gisf) {
+        return (
+          <a href="/"
+             role="button"
+             title="Home">
+            {this._svg()}
+          </a>);
+      }
       return (
-        <a onClick={this._navigateToRoot}
+        <a onClick={this._showProfile}
            role="button"
            title="Home">
-          <juju.components.SvgIcon name="juju-logo"
-            className="svg-icon"
-            width="90" height="35" />
+          {this._svg()}
         </a>);
     }
   });

--- a/jujugui/static/gui/src/app/components/header-logo/test-header-logo.js
+++ b/jujugui/static/gui/src/app/components/header-logo/test-header-logo.js
@@ -30,31 +30,46 @@ describe('HeaderLogo', function() {
     YUI().use('header-logo', function() { done(); });
   });
 
-  it('renders', () => {
+  it('renders for gisf', () => {
     const renderer = jsTestUtils.shallowRender(
       <juju.components.HeaderLogo
-        resetState={sinon.stub()}/>, true);
+        gisf={true} />, true);
     const output = renderer.getRenderOutput();
     const expected = (
-      <a onClick={output.props.onClick}
-        role="button" title="Home">
-      <juju.components.SvgIcon name="juju-logo"
-        className="svg-icon"
-        width="90" height="35" />
-    </a>);
+      <a href="/" role="button" title="Home">
+        <juju.components.SvgIcon name="juju-logo"
+          className="svg-icon"
+          width="90" height="35" />
+      </a>);
     expect(output).toEqualJSX(expected);
   });
 
-  it('calls resetState on click', () => {
-    const resetState = sinon.stub();
+  it('renders for gijoe', () => {
+    const showProfile = sinon.stub();
+    const renderer = jsTestUtils.shallowRender(
+      <juju.components.HeaderLogo
+        gisf={false}
+        showProfile={showProfile} />, true);
+    const output = renderer.getRenderOutput();
+    const expected = (
+      <a onClick={showProfile} role="button" title="Home">
+        <juju.components.SvgIcon name="juju-logo"
+          className="svg-icon"
+          width="90" height="35" />
+      </a>);
+    expect(output).toEqualJSX(expected);
+  });
+
+  it('calls showProfil on click in gisf', () => {
+    const showProfile = sinon.stub();
     const preventDefault = sinon.stub();
     const renderer = jsTestUtils.shallowRender(
       <juju.components.HeaderLogo
-        resetState={resetState}/>, true);
+        showProfile={showProfile}/>, true);
     const output = renderer.getRenderOutput();
     // Call the click handler
     output.props.onClick({preventDefault});
     assert.equal(preventDefault.callCount, 1);
-    assert.equal(resetState.callCount, 1);
+    assert.equal(showProfile.callCount, 1);
   });
 });

--- a/jujugui/static/gui/src/app/components/header-logo/test-header-logo.js
+++ b/jujugui/static/gui/src/app/components/header-logo/test-header-logo.js
@@ -31,12 +31,15 @@ describe('HeaderLogo', function() {
   });
 
   it('renders for gisf', () => {
+    const showProfile = sinon.stub();
     const renderer = jsTestUtils.shallowRender(
       <juju.components.HeaderLogo
-        gisf={true} />, true);
+        gisf={true}
+        homePath="/"
+        showProfile={showProfile}/>, true);
     const output = renderer.getRenderOutput();
     const expected = (
-      <a href="/" role="button" title="Home">
+      <a href="/" onClick={showProfile} role="button" title="Home">
         <juju.components.SvgIcon name="juju-logo"
           className="svg-icon"
           width="90" height="35" />
@@ -49,10 +52,11 @@ describe('HeaderLogo', function() {
     const renderer = jsTestUtils.shallowRender(
       <juju.components.HeaderLogo
         gisf={false}
+        homePath="/u/hatch"
         showProfile={showProfile} />, true);
     const output = renderer.getRenderOutput();
     const expected = (
-      <a onClick={showProfile} role="button" title="Home">
+      <a href="/u/hatch" onClick={showProfile} role="button" title="Home">
         <juju.components.SvgIcon name="juju-logo"
           className="svg-icon"
           width="90" height="35" />
@@ -60,16 +64,33 @@ describe('HeaderLogo', function() {
     expect(output).toEqualJSX(expected);
   });
 
-  it('calls showProfil on click in gisf', () => {
+  it('calls showProfile on click in gijoe', () => {
     const showProfile = sinon.stub();
     const preventDefault = sinon.stub();
     const renderer = jsTestUtils.shallowRender(
       <juju.components.HeaderLogo
+        gisf={false}
+        homePath="/u/hatch"
         showProfile={showProfile}/>, true);
     const output = renderer.getRenderOutput();
     // Call the click handler
     output.props.onClick({preventDefault});
     assert.equal(preventDefault.callCount, 1);
     assert.equal(showProfile.callCount, 1);
+  });
+
+  it('does not call showProfile on click in gisf', () => {
+    const showProfile = sinon.stub();
+    const preventDefault = sinon.stub();
+    const renderer = jsTestUtils.shallowRender(
+      <juju.components.HeaderLogo
+        gisf={true}
+        homePath="/u/hatch"
+        showProfile={showProfile}/>, true);
+    const output = renderer.getRenderOutput();
+    // Call the click handler
+    output.props.onClick({preventDefault});
+    assert.equal(preventDefault.callCount, 0);
+    assert.equal(showProfile.callCount, 0);
   });
 });

--- a/jujugui/static/gui/src/app/components/header-logo/test-header-logo.js
+++ b/jujugui/static/gui/src/app/components/header-logo/test-header-logo.js
@@ -30,17 +30,31 @@ describe('HeaderLogo', function() {
     YUI().use('header-logo', function() { done(); });
   });
 
-  it('renders', function() {
+  it('renders', () => {
     const renderer = jsTestUtils.shallowRender(
-      <juju.components.HeaderLogo />, true);
+      <juju.components.HeaderLogo
+        resetState={sinon.stub()}/>, true);
     const output = renderer.getRenderOutput();
-
-    const expected = (<a href="/"
-      role="button" title="Go to user profile">
+    const expected = (
+      <a onClick={output.props.onClick}
+        role="button" title="Home">
       <juju.components.SvgIcon name="juju-logo"
         className="svg-icon"
         width="90" height="35" />
     </a>);
-    assert.deepEqual(output, expected);
+    expect(output).toEqualJSX(expected);
+  });
+
+  it('calls resetState on click', () => {
+    const resetState = sinon.stub();
+    const preventDefault = sinon.stub();
+    const renderer = jsTestUtils.shallowRender(
+      <juju.components.HeaderLogo
+        resetState={resetState}/>, true);
+    const output = renderer.getRenderOutput();
+    // Call the click handler
+    output.props.onClick({preventDefault});
+    assert.equal(preventDefault.callCount, 1);
+    assert.equal(resetState.callCount, 1);
   });
 });

--- a/jujugui/static/gui/src/app/state/state.js
+++ b/jujugui/static/gui/src/app/state/state.js
@@ -573,15 +573,18 @@ const State = class State {
 
   /**
     Takes the existing app state and generates the path.
+    @param {Object} stateObj An optional argument to generate a path from using
+      the same logic as the normal state path generation. If not provided,
+      defaults to `this.current`.
     @return {String} The path representing the current application state.
   */
-  generatePath() {
+  generatePath(stateObj = this.current) {
     let path = [];
-    const root = this.current.root;
+    const root = stateObj.root;
     if (root) {
       path.push(root);
     }
-    const search = this.current.search;
+    const search = stateObj.search;
     if (search) {
       path.push(PATH_DELIMETERS.get('search'));
       // Append the text if it is truthy, i.e. not a blank string etc.
@@ -605,19 +608,19 @@ const State = class State {
         }
       }
     }
-    const user = this.current.user || this.current.profile;
+    const user = stateObj.user || stateObj.profile;
     if (user) {
       path = path.concat([PATH_DELIMETERS.get('user'), user]);
     }
-    const model = this.current.model;
+    const model = stateObj.model;
     if (model) {
       path = path.concat([PATH_DELIMETERS.get('user'), model.path]);
     }
-    const store = this.current.store;
+    const store = stateObj.store;
     if (store) {
       path.push(store);
     }
-    const gui = this.current.gui;
+    const gui = stateObj.gui;
     if (gui) {
       path.push(PATH_DELIMETERS.get('gui'));
       Object.keys(gui).forEach(key => {

--- a/jujugui/static/gui/src/app/state/state.js
+++ b/jujugui/static/gui/src/app/state/state.js
@@ -652,6 +652,17 @@ const State = class State {
   }
 
   /**
+    Sets every top level key in state to null to reset the UI back to its
+    root state.
+  */
+  reset() {
+    // Generate a new null changeState
+    const newState = {};
+    Object.keys(this.current).map(key => newState[key] = null);
+    this.changeState(newState);
+  }
+
+  /**
     Inspects the query path to see if there are parts in the special section.
     @param {Object} query - The query path split into parts.
     @param {Object} state - The application state object as being parsed

--- a/jujugui/static/gui/src/app/state/test-state.js
+++ b/jujugui/static/gui/src/app/state/test-state.js
@@ -1285,7 +1285,30 @@ describe('State', () => {
       assert.deepEqual(historyStub.pushState.args[0], [
         {}, 'Juju GUI', 'http://abc.com:123/u/hatch/staging']);
     });
+  });
 
+  describe('State.reset()', () => {
+    it('generates a new null state and calls changeState', () => {
+      const state = new window.jujugui.State({
+        baseURL: 'http://abc.com:123',
+        seriesList:  ['precise', 'trusty', 'xenial'],
+        location: {href: '/u/hatch/staging'}
+      });
+      const changeState = sinon.stub(state, 'changeState');
+      // Fake a current state.
+      state._appStateHistory = [{
+        root: 'foo',
+        special: {
+          next: 'bar'
+        }
+      }];
+      state.reset();
+      assert.equal(changeState.callCount, 1);
+      assert.deepEqual(changeState.args[0], [{
+        root: null,
+        special: null
+      }]);
+    });
   });
 
   describe('State.generatePath()', () => {

--- a/jujugui/static/gui/src/app/state/test-state.js
+++ b/jujugui/static/gui/src/app/state/test-state.js
@@ -1353,6 +1353,17 @@ describe('State', () => {
         });
       });
     });
+
+    it('can be passed a custom state object', () => {
+      const state = new window.jujugui.State({
+        baseURL: 'http://abc.com:123',
+        seriesList:  ['precise', 'trusty', 'xenial']
+      });
+      // Because this uses the same logic as above, we're only checking
+      // that it actually accepts the argument.
+      assert.equal(
+        state.generatePath({profile: 'hatch'}), 'http://abc.com:123/u/hatch');
+    });
   });
 
 });


### PR DESCRIPTION
This branch updates the header logo so that it links to the appropriate place depending on its environment. In GISF we want the Juju logo to navigate to / and in GIJOE we want it to navigate to /u/{username}.

As a driveby two updates were made to the state system.
- A `reset` method was added which sets every active state object to null
- `generatePath` method now takes an arbitrary state object.

Fixes #2729