### PR TITLE
YUI node handling replacement

### DIFF
--- a/jujugui/static/gui/src/app/d3-components/d3-components.js
+++ b/jujugui/static/gui/src/app/d3-components/d3-components.js
@@ -265,7 +265,7 @@ YUI.add('d3-components', function(Y) {
               // For this reason, it is not possible here to just pass the
               // context as third argument.
               var target = self,
-                  callback = Y.bind(handler.callback, handler.context);
+                  callback = handler.callback.bind(handler.context);
               if (['windowresize'].indexOf(name) !== -1) {
                 target = Y;
                 handler.context = null;

--- a/jujugui/static/gui/src/app/d3-components/d3-components.js
+++ b/jujugui/static/gui/src/app/d3-components/d3-components.js
@@ -486,7 +486,7 @@ YUI.add('d3-components', function(Y) {
     attachContainer: function() {
       var container = this.get('container');
       if (container && !container.inDoc()) {
-        Y.one('body').append(container);
+        document.body.appendChild(container);
       }
       return this;
     },

--- a/jujugui/static/gui/src/app/d3-components/d3-components.js
+++ b/jujugui/static/gui/src/app/d3-components/d3-components.js
@@ -485,7 +485,7 @@ YUI.add('d3-components', function(Y) {
      **/
     attachContainer: function() {
       var container = this.get('container');
-      if (container && !container.inDoc()) {
+      if (container && !document.body.contains(container)) {
         document.body.appendChild(container);
       }
       return this;
@@ -499,7 +499,7 @@ YUI.add('d3-components', function(Y) {
      **/
     detachContainer: function() {
       var container = this.get('container');
-      if (container.inDoc()) {
+      if (document.body.contains(container)) {
         container.remove();
       }
       return container;

--- a/jujugui/static/gui/src/app/extensions/app-cookies-extension.js
+++ b/jujugui/static/gui/src/app/extensions/app-cookies-extension.js
@@ -28,7 +28,7 @@ YUI.add('app-cookies-extension', function(Y) {
      @param {Object} test_node DOM node only passed in in tests.
    */
   function Cookies(test_node) {
-    this.node = test_node || Y.one('body');
+    this.node = test_node || document.body;
   }
 
   Cookies.prototype = {
@@ -41,16 +41,16 @@ YUI.add('app-cookies-extension', function(Y) {
       @return {undefined} Side-effects only.
     */
     check: function() {
-      var self = this;
       if (Y.Cookie.get('_cookies_accepted') !== 'true' &&
           !localStorage.getItem('disable-cookie')) {
-        this.node.addClass('display-cookie-notice');
-        Y.one('.link-cta').once('click', function(evt) {
-          evt.preventDefault();
-          self.close();
-        });
+        this.node.classList.add('display-cookie-notice');
+        document.querySelector('.link-cta').addEventListener('click',
+          evt => {
+            evt.preventDefault();
+            this.close();
+          });
       } else {
-        this.node.removeClass('display-cookie-notice');
+        this.node.classList.remove('display-cookie-notice');
       }
     },
 
@@ -61,7 +61,7 @@ YUI.add('app-cookies-extension', function(Y) {
       @return {undefined} Side-effects only.
     */
     close: function() {
-      this.node.removeClass('display-cookie-notice');
+      this.node.classList.remove('display-cookie-notice');
       Y.Cookie.set('_cookies_accepted', 'true',
           {expires: new Date('January 12, 2025')});
     }

--- a/jujugui/static/gui/src/app/extensions/autodeploy-extension.js
+++ b/jujugui/static/gui/src/app/extensions/autodeploy-extension.js
@@ -73,7 +73,7 @@ YUI.add('autodeploy-extension', function(Y) {
       // empty function, the ECS relies on wrapping this function so if
       // it's null it'll just stop executing. This should probably be
       // handled properly on the ECS side. Jeff May 12 2014
-      var callback = Y.bind(this._onMachineCreated, this, machine);
+      var callback = this._onMachineCreated.bind(this, machine);
       env.addMachines([{
         series: series,
         containerType: containerType,

--- a/jujugui/static/gui/src/app/utils/environment-change-set.js
+++ b/jujugui/static/gui/src/app/utils/environment-change-set.js
@@ -263,7 +263,7 @@ YUI.add('environment-change-set', function(Y) {
       }
 
       // Take care of top-level objects quickly.
-      keys.forEach(Y.bind(function(key) {
+      keys.forEach(key => {
         command = this.changeSet[key];
         command.key = key;
         if (!command.parents || command.parents.length === 0) {
@@ -275,7 +275,7 @@ YUI.add('environment-change-set', function(Y) {
           // Default everything else to the first level.
           keyToLevelMap[key] = 1;
         }
-      }, this));
+      });
 
       // Now build the other levels of the hierarchy as long as there are still
       // commands in the change set. Functions defined outside of loop for
@@ -364,7 +364,7 @@ YUI.add('environment-change-set', function(Y) {
         this.levelTimer.cancel();
         if (this.currentLevel < this.currentCommit.length - 1) {
           // Defer execution to prevent stack overflow.
-          Y.soon(Y.bind(this._commitNext, this, env, currentIndex));
+          Y.soon(this._commitNext.bind(this, env, currentIndex));
         } else {
           this.currentLevel = -1;
           delete this.currentCommit;

--- a/jujugui/static/gui/src/app/views/environment.js
+++ b/jujugui/static/gui/src/app/views/environment.js
@@ -90,14 +90,14 @@ YUI.add('juju-view-environment', function(Y) {
       topo.recordSubscription(
           'ServiceModule',
           db.services.after('remove',
-                            Y.bind(this.updateHelpIndicator, this)));
+                            this.updateHelpIndicator.bind(this)));
 
       topo.recordSubscription(
           'ServiceModule',
-          db.services.after('add', Y.bind(this.updateHelpIndicator, this)));
+          db.services.after('add', this.updateHelpIndicator.bind(this)));
 
       topo.render();
-      topo.once('rendered', Y.bind(this.updateHelpIndicator, this));
+      topo.once('rendered', this.updateHelpIndicator.bind(this));
       return this;
     },
 

--- a/jujugui/static/gui/src/app/views/environment.js
+++ b/jujugui/static/gui/src/app/views/environment.js
@@ -82,7 +82,7 @@ YUI.add('juju-view-environment', function(Y) {
         EnvironmentView.superclass.render.apply(this, arguments);
         ReactDOM.render(
           <juju.components.Environment />,
-          container.getDOMNode());
+            container.getDOMNode());
         this._rendered = true;
       }
 

--- a/jujugui/static/gui/src/app/views/environment.js
+++ b/jujugui/static/gui/src/app/views/environment.js
@@ -201,8 +201,8 @@ YUI.add('juju-view-environment', function(Y) {
         } else {
           dropMessage.classList.remove(helpActiveClass);
         }
-        tooltip.setStyle('opacity', showOnboarding && !fade ? 1 : 0);
-        helpImg.setStyle('opacity', showOnboarding ? 1 : 0);
+        tooltip.style.opacity = showOnboarding && !fade ? 1 : 0;
+        helpImg.style.opacity = showOnboarding ? 1 : 0;
       }
     },
     /**

--- a/jujugui/static/gui/src/app/views/environment.js
+++ b/jujugui/static/gui/src/app/views/environment.js
@@ -73,16 +73,16 @@ YUI.add('juju-view-environment', function(Y) {
      * @chainable
      */
     render: function() {
-      var container = this.get('container'),
-          topo = this.topo,
-          db = this.get('db');
+      const container = this.getContainer();
+      let topo = this.topo;
+      const db = this.get('db');
 
       // If we need the initial HTML template, take care of that.
       if (!this._rendered) {
         EnvironmentView.superclass.render.apply(this, arguments);
         ReactDOM.render(
           <juju.components.Environment />,
-            container.getDOMNode());
+            container);
         this._rendered = true;
       }
 
@@ -102,13 +102,25 @@ YUI.add('juju-view-environment', function(Y) {
     },
 
     /**
+      Get the DOM node if the container has been provided by YUI, otherwise the
+      container will be the DOM node already.
+
+      @method getContainer
+      @return {Object} A DOM node.
+    */
+    getContainer: function() {
+      const container = this.get('container');
+      return container.getDOMNode && container.getDOMNode() || container;
+    },
+
+    /**
       createTopology, called automatically.
 
       @method createTopology
      */
     createTopology: function() {
-      var container = this.get('container'),
-          topo = this.topo;
+      const container = this.getContainer();
+      let topo = this.topo;
       if (!topo) {
         topo = new views.Topology({includePlus: true});
         topo.setAttrs({
@@ -141,17 +153,18 @@ YUI.add('juju-view-environment', function(Y) {
      * @method updateHelpIndicator
      */
     updateHelpIndicator: function(evt) {
-      var helpText = this.get('container').one('.environment-help'),
+      const container = this.getContainer();
+      var helpText = container.querySelector('.environment-help'),
           includedPlus = this.topo.vis.select('.included-plus'),
           db = this.get('db'),
           services = db.services;
       if (helpText) {
         if (services.size() === 0) {
-          helpText.show();
-          helpText.removeClass('shrink');
+          helpText.style.display = 'block';
+          helpText.classList.remove('shrink');
           includedPlus.classed('show', false);
         } else {
-          helpText.addClass('shrink');
+          helpText.classList.add('shrink');
           includedPlus.classed('show', true);
         }
       }
@@ -164,10 +177,11 @@ YUI.add('juju-view-environment', function(Y) {
       @param {Boolean} fade Whether it should fade it in or out.
     */
     fadeHelpIndicator: function(fade) {
-      const container = this.get('container');
-      const helpImg = container.one('.environment-help__image');
-      const tooltip = container.one('.environment-help__tooltip');
-      const dropMessage = container.one('.environment-help__drop-message');
+      const container = this.getContainer();
+      const helpImg = container.querySelector('.environment-help__image');
+      const tooltip = container.querySelector('.environment-help__tooltip');
+      const dropMessage = container.querySelector(
+        '.environment-help__drop-message');
       const existingApps = this.get('db').services.size() > 0;
       // If there are existing apps then the onboarding should not be
       // displayed behind the drop notification.
@@ -180,11 +194,12 @@ YUI.add('juju-view-environment', function(Y) {
             // need to display it again temporarily to display the drop
             // notification. This class will be re-added when the drop finishes
             // and updateHelpIndicator is called above.
-            container.one('.environment-help').removeClass('shrink');
+            container.querySelector('.environment-help').classList.remove(
+              'shrink');
           }
-          dropMessage.addClass(helpActiveClass);
+          dropMessage.classList.add(helpActiveClass);
         } else {
-          dropMessage.removeClass(helpActiveClass);
+          dropMessage.classList.remove(helpActiveClass);
         }
         tooltip.setStyle('opacity', showOnboarding && !fade ? 1 : 0);
         helpImg.setStyle('opacity', showOnboarding ? 1 : 0);

--- a/jujugui/static/gui/src/app/views/environment.js
+++ b/jujugui/static/gui/src/app/views/environment.js
@@ -160,7 +160,7 @@ YUI.add('juju-view-environment', function(Y) {
           services = db.services;
       if (helpText) {
         if (services.size() === 0) {
-          helpText.style.display = 'block';
+          helpText.removeAttribute('style');
           helpText.classList.remove('shrink');
           includedPlus.classed('show', false);
         } else {

--- a/jujugui/static/gui/src/app/views/ghost-deployer-extension.js
+++ b/jujugui/static/gui/src/app/views/ghost-deployer-extension.js
@@ -136,7 +136,7 @@ YUI.add('ghost-deployer-extension', function(Y) {
             ghostServiceId, // The service to which the unit is added.
             1, // Add a single unit.
             null, // For now the unit is unplaced.
-            Y.bind(this._addUnitCallback, this, ghostUnit), // The callback.
+            this._addUnitCallback.bind(this, ghostUnit), // The callback.
             // Options used by ECS, ignored by environment.
             {modelId: unitId}
         );

--- a/jujugui/static/gui/src/app/views/topology/relation.js
+++ b/jujugui/static/gui/src/app/views/topology/relation.js
@@ -996,23 +996,21 @@ YUI.add('juju-topology-relation', function(Y) {
       @param {Object} context The target rectangle.
     */
     _attachAmbiguousReleationSelect: function(menu, view, context) {
-      // For each endpoint choice, delegate a click event to add the specified
-      // relation. Use event delegation in order to avoid weird behaviors
-      // encountered when using "on" on a YUI NodeList: in some situations,
-      // e.g. our production server, NodeList.on does not work.
-      menu.querySelector('.menu').addEventListener('click', function(evt) {
-        var el = evt.currentTarget;
-        var endpoints_item = [
-          [el.getAttribute('data-startservice'), {
-            name: el.getAttribute('data-startname'),
-            role: 'server' }],
-          [el.getAttribute('data-endservice'), {
-            name: el.getAttribute('data-endname'),
-            role: 'client' }]
-        ];
-        menu.classList.remove('active');
-        view.addRelationEnd(endpoints_item, view, context);
-      }, 'li');
+      menu.querySelectorAll('.menu li').forEach(node => {
+        node.addEventListener('click', function(evt) {
+          var el = evt.currentTarget;
+          var endpoints_item = [
+            [el.getAttribute('data-startservice'), {
+              name: el.getAttribute('data-startname'),
+              role: 'server' }],
+            [el.getAttribute('data-endservice'), {
+              name: el.getAttribute('data-endname'),
+              role: 'client' }]
+          ];
+          menu.classList.remove('active');
+          view.addRelationEnd(endpoints_item, view, context);
+        });
+      });
       // Add a cancel item.
       menu.querySelector('.cancel').addEventListener('click', function(evt) {
         menu.classList.remove('active');

--- a/jujugui/static/gui/src/app/views/topology/relation.js
+++ b/jujugui/static/gui/src/app/views/topology/relation.js
@@ -965,11 +965,15 @@ YUI.add('juju-topology-relation', function(Y) {
         DOM.
     */
     _renderAmbiguousRelationMenu: function(endpoints) {
-      var menu = this.get('container').one('#ambiguous-relation-menu');
+      // Get the DOM node if the container has been provided by YUI,
+      // otherwise the container will be the DOM node already.
+      const container = this.get('container').getDOMNode &&
+        this.get('container').getDOMNode() || this.get('container');
+      var menu = container.querySelector('#ambiguous-relation-menu');
       ReactDOM.render(
         <juju.components.AmbiguousRelationMenu
           endpoints={endpoints} />,
-        menu.one('#ambiguous-relation-menu-content').getDOMNode());
+        menu.querySelector('#ambiguous-relation-menu-content'));
       return menu;
     },
 
@@ -987,7 +991,7 @@ YUI.add('juju-topology-relation', function(Y) {
       // relation. Use event delegation in order to avoid weird behaviors
       // encountered when using "on" on a YUI NodeList: in some situations,
       // e.g. our production server, NodeList.on does not work.
-      menu.one('.menu').delegate('click', function(evt) {
+      menu.querySelector('.menu').addEventListener('click', function(evt) {
         var el = evt.currentTarget;
         var endpoints_item = [
           [el.getData('startservice'), {
@@ -997,12 +1001,12 @@ YUI.add('juju-topology-relation', function(Y) {
             name: el.getData('endname'),
             role: 'client' }]
         ];
-        menu.removeClass('active');
+        menu.classList.remove('active');
         view.addRelationEnd(endpoints_item, view, context);
       }, 'li');
       // Add a cancel item.
-      menu.one('.cancel').on('click', function(evt) {
-        menu.removeClass('active');
+      menu.querySelector('.cancel').addEventListener('click', function(evt) {
+        menu.classList.remove('active');
         view.cancelRelationBuild();
       });
     },
@@ -1021,9 +1025,9 @@ YUI.add('juju-topology-relation', function(Y) {
       var tr = topo.zoom.translate();
       var z = topo.zoom.scale();
       var locateAt = topoUtils.locateRelativePointOnCanvas(m, tr, z);
-      menu.setStyle('left', locateAt[0]);
-      menu.setStyle('top', locateAt[1]);
-      menu.addClass('active');
+      menu.style.left = locateAt[0];
+      menu.style.top = locateAt[1];
+      menu.classList.add('active');
       topo.set('active_service', m);
       topo.set('active_context', context);
       // Firing resized will ensure the menu's positioned properly.

--- a/jujugui/static/gui/src/app/views/topology/relation.js
+++ b/jujugui/static/gui/src/app/views/topology/relation.js
@@ -1142,8 +1142,7 @@ YUI.add('juju-topology-relation', function(Y) {
     relationRemoveClick: function(_, self) {
       var topo = self.get('component');
       var db = topo.get('db');
-      const relationId = document.querySelector(this).get(
-        'parentNode').getAttribute('data-relationid');
+      const relationId = this.parentNode.getAttribute('data-relationid');
       var relation = db.relations.getById(relationId);
       relation = self.decorateRelations([relation])[0];
       topo.fire('clearState');

--- a/jujugui/static/gui/src/app/views/topology/relation.js
+++ b/jujugui/static/gui/src/app/views/topology/relation.js
@@ -211,6 +211,18 @@ YUI.add('juju-topology-relation', function(Y) {
       this.update();
     },
 
+    /**
+      Get the DOM node if the container has been provided by YUI, otherwise the
+      container will be the DOM node already.
+
+      @method getContainer
+      @return {Object} A DOM node.
+    */
+    getContainer: function() {
+      const container = this.get('container');
+      return container.getDOMNode && container.getDOMNode() || container;
+    },
+
     renderedHandler: function() {
       this.update();
     },
@@ -494,9 +506,9 @@ YUI.add('juju-topology-relation', function(Y) {
      * @return {undefined} Side effects only.
      */
     mouseMoveHandler: function(evt) {
-      var container = this.get('container');
+      const container = this.getContainer();
       this.mousemove.call(
-          container.one('.zoom-plane').getDOMNode(),
+          container.querySelector('.zoom-plane'),
           null, this);
     },
 
@@ -577,7 +589,7 @@ YUI.add('juju-topology-relation', function(Y) {
 
         // Start the line between the cursor and the nearest connector
         // point on the service.
-        this.set('dragplane', Y.one('.the-canvas g').getDOMNode());
+        this.set('dragplane', document.querySelector('.the-canvas g'));
         var mouse = d3.mouse(this.get('dragplane'));
         self.cursorBox = new views.BoundingBox();
         self.cursorBox.pos = {x: mouse[0], y: mouse[1], w: 0, h: 0};
@@ -961,14 +973,11 @@ YUI.add('juju-topology-relation', function(Y) {
 
       @method _renderAmbiguousRelationMenu
       @param {Array} endpoints The possible endpoints for the relation.
-      @return {Object} A Y.Node instance from the menu which was added to the
+      @return {Object} A node instance from the menu which was added to the
         DOM.
     */
     _renderAmbiguousRelationMenu: function(endpoints) {
-      // Get the DOM node if the container has been provided by YUI,
-      // otherwise the container will be the DOM node already.
-      const container = this.get('container').getDOMNode &&
-        this.get('container').getDOMNode() || this.get('container');
+      const container = this.getContainer();
       var menu = container.querySelector('#ambiguous-relation-menu');
       ReactDOM.render(
         <juju.components.AmbiguousRelationMenu
@@ -994,11 +1003,11 @@ YUI.add('juju-topology-relation', function(Y) {
       menu.querySelector('.menu').addEventListener('click', function(evt) {
         var el = evt.currentTarget;
         var endpoints_item = [
-          [el.getData('startservice'), {
-            name: el.getData('startname'),
+          [el.getAttribute('data-startservice'), {
+            name: el.getAttribute('data-startname'),
             role: 'server' }],
-          [el.getData('endservice'), {
-            name: el.getData('endname'),
+          [el.getAttribute('data-endservice'), {
+            name: el.getAttribute('data-endname'),
             role: 'client' }]
         ];
         menu.classList.remove('active');
@@ -1025,8 +1034,8 @@ YUI.add('juju-topology-relation', function(Y) {
       var tr = topo.zoom.translate();
       var z = topo.zoom.scale();
       var locateAt = topoUtils.locateRelativePointOnCanvas(m, tr, z);
-      menu.style.left = locateAt[0];
-      menu.style.top = locateAt[1];
+      menu.style.left = `${locateAt[0]}px`;
+      menu.style.top = `${locateAt[1]}px`;
       menu.classList.add('active');
       topo.set('active_service', m);
       topo.set('active_context', context);
@@ -1094,12 +1103,12 @@ YUI.add('juju-topology-relation', function(Y) {
      *   relation line.
      */
     showRelationMenu: function(relation) {
-      var menu = Y.one('#relation-menu');
+      const menu = document.querySelector('#relation-menu');
       ReactDOM.render(
         <juju.components.RelationMenu
           relations={relation.relations} />,
-        menu.getDOMNode());
-      menu.addClass('active');
+        menu);
+      menu.classList.add('active');
       this.set('relationMenuActive', true);
       this.set('relationMenuRelation', relation);
       var topo = this.get('component');
@@ -1111,13 +1120,13 @@ YUI.add('juju-topology-relation', function(Y) {
       var locateAt = topoUtils.locateRelativePointOnCanvas(point, tr, z);
       // Shift the menu to the left by half its width, and up by its height
       // plus the height of the arrow (16px).
-      locateAt[0] -= menu.get('clientWidth') / 2;
-      locateAt[1] -= menu.get('clientHeight') + 16;
-      menu.setStyle('left', locateAt[0]);
-      menu.setStyle('top', locateAt[1]);
+      locateAt[0] -= menu.clientWidth / 2;
+      locateAt[1] -= menu.clientHeight + 16;
+      menu.style.left = `${locateAt[0]}px`;
+      menu.style.top = `${locateAt[1]}px`;
       // Shift the arrow to the left by half the menu's width minus half the
       // width of the arrow itself (10px).
-      menu.one('.triangle').setStyle('left', menu.get('clientWidth') / 2 - 5);
+      menu.querySelector('.triangle').style.left = menu.clientWidth / 2 - 5;
 
       // Firing resized will ensure the menu's positioned properly.
       topo.fire('resized');
@@ -1133,7 +1142,8 @@ YUI.add('juju-topology-relation', function(Y) {
     relationRemoveClick: function(_, self) {
       var topo = self.get('component');
       var db = topo.get('db');
-      var relationId = Y.one(this).get('parentNode').getData('relationid');
+      const relationId = document.querySelector(this).get(
+        'parentNode').getAttribute('data-relationid');
       var relation = db.relations.getById(relationId);
       relation = self.decorateRelations([relation])[0];
       topo.fire('clearState');
@@ -1161,7 +1171,7 @@ YUI.add('juju-topology-relation', function(Y) {
      */
     inspectRelationClick: function(_, self) {
       var topo = self.get('component');
-      var endpoint = Y.one(this).getAttribute('data-endpoint');
+      var endpoint = this.getAttribute('data-endpoint');
       var serviceId = endpoint.split(':')[0].trim();
       topo.get('state').changeState({
         gui: {

--- a/jujugui/static/gui/src/app/views/topology/service.js
+++ b/jujugui/static/gui/src/app/views/topology/service.js
@@ -519,7 +519,7 @@ YUI.add('juju-topology-service', function(Y) {
       @method _attachDragEvents
     */
     _attachDragEvents: function() {
-      var container = Y.one(this.get('container')),
+      var container = Y.Node(this.get('container')),
           ZP = '.zoom-plane',
           EC = '.environment-help';
 

--- a/jujugui/static/gui/src/app/views/topology/service.js
+++ b/jujugui/static/gui/src/app/views/topology/service.js
@@ -498,6 +498,20 @@ YUI.add('juju-topology-service', function(Y) {
     },
 
     /**
+      Get the DOM node if the container has been provided by YUI, otherwise the
+      container will be the DOM node already.
+
+      @method getContainer
+      @param {Object} context The context to get the container for.
+      @return {Object} A DOM node.
+    */
+    getContainer: function(context) {
+      context = context ? context : this;
+      const container = context.get('container');
+      return container.getDOMNode && container.getDOMNode() || container;
+    },
+
+    /**
       Attaches the drag and drop events for this view. These events need to be
       here because attaching them in the events object causes drag and drop
       events to stop bubbling at odd places cross browser.
@@ -505,7 +519,7 @@ YUI.add('juju-topology-service', function(Y) {
       @method _attachDragEvents
     */
     _attachDragEvents: function() {
-      var container = this.get('container'),
+      var container = Y.one(this.get('container')),
           ZP = '.zoom-plane',
           EC = '.environment-help';
 
@@ -574,12 +588,12 @@ YUI.add('juju-topology-service', function(Y) {
       @param {DOM Element} node SVG DOM element.
     */
     attachTouchstartEvents: function(data, node) {
-      var topo = this.get('component'),
-          yuiNode = Y.Node(node);
+      const topo = this.get('component');
 
       // Do not attach the event to the ghost nodes
       if (!d3.select(node).classed('pending')) {
-        yuiNode.on('touchstart', this._touchstartServiceTap, this, topo);
+        node.addEventListener(
+          'touchstart', this._touchstartServiceTap, this, topo);
       }
     },
 
@@ -593,7 +607,7 @@ YUI.add('juju-topology-service', function(Y) {
     _touchstartServiceTap: function(e, topo) {
       // To execute the serviceClick method under the same context as
       // click we call it under the touch target context
-      var node = e.currentTarget.getDOMNode(),
+      var node = e.currentTarget,
           box = d3.select(node).datum();
       // If we're dragging with two fingers, ignore this as a tap and let
       // drag take over.
@@ -717,12 +731,12 @@ YUI.add('juju-topology-service', function(Y) {
     serviceClick: function(box, self, eType) {
       // Ignore if we clicked outside the actual service node.
       var topo = self.get('component');
-      var container = self.get('container');
+      const container = self.getContainer(self);
 
       // This check is required because d3.mouse() throws an internal error
       // on touch events
       if (eType !== 'touch') {
-        var mouse_coords = d3.mouse(container.one('.the-canvas').getDOMNode());
+        var mouse_coords = d3.mouse(container.querySelector('.the-canvas'));
         if (!box.containsPoint(mouse_coords, topo.zoom)) {
           return;
         }
@@ -764,7 +778,7 @@ YUI.add('juju-topology-service', function(Y) {
     serviceMouseEnter: function(box, context) {
       var topo = context.get('component');
       topo.fire('hoverService', {id: box.id});
-      var rect = Y.one(this);
+      var rect = this;
       if (!utils.hasSVGClass(rect, 'selectable-service')) {
         return;
       }
@@ -775,9 +789,10 @@ YUI.add('juju-topology-service', function(Y) {
       var topo = context.get('component');
       topo.fire('hoverService', {id: null});
       context.unhoverServices();
+
+      const container = context.getContainer(context);
       // Do not fire if we're within the service box.
-      var container = context.get('container');
-      var mouse_coords = d3.mouse(container.one('.the-canvas').getDOMNode());
+      var mouse_coords = d3.mouse(container.querySelector('.the-canvas'));
       if (box.containsPoint(mouse_coords, topo.zoom)) {
         return;
       }
@@ -1084,9 +1099,11 @@ YUI.add('juju-topology-service', function(Y) {
      * @return {undefined} Side effects only.
      */
     clearStateHandler: function() {
-      var container = this.get('container'),
-          topo = this.get('component');
-      container.all('.environment-menu.active').removeClass('active');
+      var topo = this.get('component');
+      const container = this.getContainer();
+      container.querySelectorAll('.environment-menu.active').forEach(node => {
+        node.classList.remove('active');
+      });
       this.deselectNodes();
       this.unhoverServices();
       topo.get('state').changeState({
@@ -1270,9 +1287,10 @@ YUI.add('juju-topology-service', function(Y) {
         return d.translateStr;
       });
 
+      const container = this.getContainer();
       // Remove any active menus.
-      self.get('container').all('.environment-menu.active')
-      .removeClass('active');
+      container.querySelectorAll('.environment-menu.active')
+        .classList.remove('active');
       if (box.inDrag === views.DRAG_START) {
         box.inDrag = views.DRAG_ACTIVE;
       }

--- a/jujugui/static/gui/src/app/views/topology/service.js
+++ b/jujugui/static/gui/src/app/views/topology/service.js
@@ -1287,10 +1287,11 @@ YUI.add('juju-topology-service', function(Y) {
         return d.translateStr;
       });
 
-      const container = this.getContainer();
+      const container = self.getContainer();
       // Remove any active menus.
-      container.querySelectorAll('.environment-menu.active')
-        .classList.remove('active');
+      container.querySelectorAll('.environment-menu.active').forEach(node => {
+        node.classList.remove('active');
+      });
       if (box.inDrag === views.DRAG_START) {
         box.inDrag = views.DRAG_ACTIVE;
       }

--- a/jujugui/static/gui/src/app/views/topology/topology.js
+++ b/jujugui/static/gui/src/app/views/topology/topology.js
@@ -100,7 +100,10 @@ YUI.add('juju-topology', function(Y) {
           vis,
           width = this.get('width'),
           height = this.get('height'),
-          container = this.get('container');
+          // Get the DOM node if the container has been provided by YUI,
+          // otherwise the container will be the DOM node already.
+          container = this.get('container').getDOMNode &&
+            this.get('container').getDOMNode() || this.get('container');
 
       if (this._templateRendered) {
         return;
@@ -113,7 +116,7 @@ YUI.add('juju-topology', function(Y) {
       this.computeScales();
 
       // Set up the visualization with a pack layout.
-      var canvas = d3.select(container.getDOMNode());
+      var canvas = d3.select(container);
       var base = canvas.select('.topology-canvas');
       if (base.empty()) {
         base = canvas.append('div')
@@ -121,7 +124,7 @@ YUI.add('juju-topology', function(Y) {
       }
 
       // Cache the canvas element for style modifications.
-      this.set('canvas', container.one('.topology-canvas'));
+      this.set('canvas', container.querySelector('.topology-canvas'));
 
       svg = base.append('svg:svg')
                 .attr('width', width)

--- a/jujugui/static/gui/src/app/views/topology/topology.js
+++ b/jujugui/static/gui/src/app/views/topology/topology.js
@@ -60,6 +60,18 @@ YUI.add('juju-topology', function(Y) {
     },
 
     /**
+      Get the DOM node if the container has been provided by YUI, otherwise the
+      container will be the DOM node already.
+
+      @method getContainer
+      @return {Object} A DOM node.
+    */
+    getContainer: function() {
+      const container = this.get('container');
+      return container.getDOMNode && container.getDOMNode() || container;
+    },
+
+    /**
      * Called by render, conditionally attach container to the DOM if
      * it isn't already. The framework calls this before module
      * rendering so that d3 Events will have attached DOM elements. If
@@ -100,10 +112,7 @@ YUI.add('juju-topology', function(Y) {
           vis,
           width = this.get('width'),
           height = this.get('height'),
-          // Get the DOM node if the container has been provided by YUI,
-          // otherwise the container will be the DOM node already.
-          container = this.get('container').getDOMNode &&
-            this.get('container').getDOMNode() || this.get('container');
+          container = this.getContainer();
 
       if (this._templateRendered) {
         return;

--- a/jujugui/static/gui/src/app/views/topology/viewport.js
+++ b/jujugui/static/gui/src/app/views/topology/viewport.js
@@ -59,7 +59,10 @@ YUI.add('juju-topology-viewport', function(Y) {
      * @method getContainer
      */
     getContainer: function() {
-      return this.get('container');
+      // Get the DOM node if the container has been provided by YUI,
+      // otherwise the container will be the DOM node already.
+      const container = this.get('container');
+      return container.getDOMNode && container.getDOMNode() || container;
     },
 
     /**
@@ -86,9 +89,8 @@ YUI.add('juju-topology-viewport', function(Y) {
       topo.vis.attr('height', dimensions.height);
       zoomPlane.setAttribute('width', dimensions.width);
       zoomPlane.setAttribute('height', dimensions.height);
-      canvas.setStyles({
-        width: dimensions.width + 'px',
-        height: dimensions.height + 'px'});
+      canvas.style.width = dimensions.width + 'px';
+      canvas.style.height = dimensions.height + 'px';
       // Reset the scale parameters
       var oldSize = topo.get('size');
       topo.set('size', [dimensions.width, dimensions.height]);
@@ -114,14 +116,14 @@ YUI.add('juju-topology-viewport', function(Y) {
      */
     resized: function() {
       var container = this.getContainer();
-      var svg = container.one('.the-canvas');
-      var canvas = container.one('.topology-canvas');
+      var svg = container.querySelector('.the-canvas');
+      var canvas = container.querySelector('.topology-canvas');
       // Early out for tests that do not provide a full rendering environment.
       if (!utils.isValue(canvas) || !utils.isValue(svg)) {
         return;
       }
       var topo = this.get('component');
-      var zoomPlane = container.one('.zoom-plane');
+      var zoomPlane = container.querySelector('.zoom-plane');
       Y.fire('beforePageSizeRecalculation');
       // This sets the minimum viewport size - y was reduced to 200 to render
       // properly on 7" tablets in horizontal view.

--- a/jujugui/static/gui/src/app/views/utils.js
+++ b/jujugui/static/gui/src/app/views/utils.js
@@ -102,7 +102,7 @@ YUI.add('juju-view-utils', function(Y) {
 
     @method addSVGClass
     @param {Object} selector A YUI-wrapped SVG node or a selector string used
-      with Y.all that must return only SVG nodes.
+      with querySelectorAll that must return only SVG nodes.
     @param {String} class_name The class name to add.
     @return {Undefined} Mutates only.
   */
@@ -113,7 +113,7 @@ YUI.add('juju-view-utils', function(Y) {
     }
 
     if (typeof(selector) === 'string') {
-      Y.all(selector).each(function(n) {
+      document.querySelectorAll(selector).forEach(function(n) {
         var classes = this.getAttribute('class');
         if (!self.hasSVGClass(this, class_name)) {
           this.setAttribute('class', classes + ' ' + class_name);
@@ -134,7 +134,7 @@ YUI.add('juju-view-utils', function(Y) {
 
     @method removeSVGClass
     @param {Object} selector A YUI-wrapped SVG node or a selector string used
-      with Y.all that must return only SVG nodes.
+      with querySelectorAll that must return only SVG nodes.
     @param {String} class_name The class name to remove.
     @return {Undefined} Mutates only.
   */
@@ -144,7 +144,7 @@ YUI.add('juju-view-utils', function(Y) {
     }
 
     if (typeof(selector) === 'string') {
-      Y.all(selector).each(function() {
+      document.querySelectorAll(selector).each(function() {
         var classes = this.getAttribute('class');
         this.setAttribute('class', classes.replace(class_name, ''));
       });

--- a/jujugui/static/gui/src/app/views/utils.js
+++ b/jujugui/static/gui/src/app/views/utils.js
@@ -774,20 +774,27 @@ YUI.add('juju-view-utils', function(Y) {
   utils.getEffectiveViewportSize = function(primary, minwidth, minheight) {
     // Attempt to get the viewport height minus the navbar at top and
     // control bar at the bottom.
-    var containerHeight = Y.one('body').get(
-        primary ? 'winHeight' : 'docHeight'),
-        bottomNavbar = Y.one('.bottom-navbar'),
-        navbar = Y.one('.header-banner'),
-        viewport = Y.one('#viewport'),
+    var containerHeight,
+        bottomNavbar = document.querySelector('.bottom-navbar'),
+        navbar = document.querySelector('.header-banner'),
+        viewport = document.querySelector('#viewport'),
         result = {height: minheight || 0, width: minwidth || 0};
+    if (primary) {
+      containerHeight = document.documentElement.clientHeight;
+    } else {
+      const body = document.body;
+      const html = document.documentElement;
+      containerHeight = Math.max(body.scrollHeight, body.offsetHeight,
+        html.clientHeight, html.scrollHeight, html.offsetHeight);
+    }
     // If all elements are present and the viewport is not set to display none
-    if (containerHeight && navbar && viewport &&
-      viewport.getComputedStyle('width') !== 'auto') {
+    const viewportHeight = viewport && window.getComputedStyle(
+      viewport).getPropertyValue('width');
+    if (containerHeight && navbar && viewport && viewportHeight !== 'auto') {
       result.height = containerHeight -
           (bottomNavbar ? bottomNavbar.get('offsetHeight') : 0);
 
-      result.width = Math.floor(parseFloat(
-          viewport.getComputedStyle('width')));
+      result.width = Math.floor(parseFloat(viewportHeight));
 
       // Make sure we don't get sized any smaller than the minimum.
       result.height = Math.max(result.height, minheight || 0);

--- a/jujugui/static/gui/src/test/test_app.js
+++ b/jujugui/static/gui/src/test/test_app.js
@@ -68,7 +68,7 @@ describe('App', function() {
       plansURL: 'http://plans.example.com/',
       termsURL: 'http://terms.example.com/'
     };
-    container = testUtils.makeAppContainer(yui);
+    container = testUtils.makeAppContainer();
     getMockStorage = function() {
       return new function() {
         return {
@@ -289,7 +289,7 @@ describe('App', function() {
     before(function(done) {
       // Need to define the container before the juju-gui module is loaded so
       // that the DOM exists when it initializes.
-      container = testUtils.makeAppContainer(yui);
+      container = testUtils.makeAppContainer();
       Y = YUI(GlobalConfig).use(
           ['juju-gui', 'juju-tests-utils', 'juju-view-utils', 'juju-views'],
           function(Y) {

--- a/jujugui/static/gui/src/test/test_app.js
+++ b/jujugui/static/gui/src/test/test_app.js
@@ -51,11 +51,10 @@ function injectData(app, data) {
 }
 
 describe('App', function() {
-  let container, getMockStorage, jujuConfig, testUtils, yui;
+  let container, getMockStorage, jujuConfig, testUtils;
 
   before(done => {
     YUI(GlobalConfig).use(['juju-tests-utils'], function(Y) {
-      yui = Y;
       testUtils = Y.namespace('juju-tests.utils');
       done();
     });
@@ -1076,10 +1075,10 @@ describe('App', function() {
   });
 
   describe('getUser', function() {
-    var app, juju, Y;
+    var app, juju;
 
     before(function(done) {
-      Y = YUI(GlobalConfig).use([
+      YUI(GlobalConfig).use([
         'juju-gui',
         'juju-tests-utils',
         'juju-view-utils',
@@ -1135,10 +1134,10 @@ describe('App', function() {
   });
 
   describe('clearUser', function() {
-    var app, juju, Y;
+    var app, juju;
 
     before(function(done) {
-      Y = YUI(GlobalConfig).use([
+      YUI(GlobalConfig).use([
         'juju-gui',
         'juju-tests-utils',
         'juju-view-utils',

--- a/jujugui/static/gui/src/test/test_app.js
+++ b/jujugui/static/gui/src/test/test_app.js
@@ -788,13 +788,12 @@ describe('App', function() {
       Y = YUI(GlobalConfig).use(['juju-gui', 'juju-tests-utils'],
           function(Y) {
             juju = Y.namespace('juju');
-            container = Y.Node.create(
-                '<div id="test" class="container"></div>');
             done();
           });
     });
 
     beforeEach(function() {
+      container = testUtils.makeContainer(this);
       conn = new testUtils.SocketStub();
       userClass = new window.jujugui.User({sessionStorage: getMockStorage()});
       userClass.controller = {user: 'user', password: 'password'};
@@ -1022,7 +1021,7 @@ describe('App', function() {
     });
 
     beforeEach(function() {
-      container = Y.Node.create('<div id="test" class="container"></div>');
+      container = testUtils.makeContainer(this);
     });
 
     afterEach(function() {
@@ -1124,7 +1123,7 @@ describe('App', function() {
     });
 
     it('gets the set user for the supplied service', function() {
-      container = Y.Node.create('<div id="test" class="container"></div>');
+      container = testUtils.makeContainer(this);
       var charmstoreUser = {
         name: 'foo'
       };
@@ -1183,7 +1182,7 @@ describe('App', function() {
     });
 
     it('clears the set user for the supplied service', function() {
-      container = Y.Node.create('<div id="test" class="container"></div>');
+      container = testUtils.makeContainer(this);
       var charmstoreUser = {
         name: 'foo'
       };
@@ -1206,7 +1205,7 @@ describe('App', function() {
     });
 
     beforeEach(function() {
-      container = Y.Node.create('<div id="test" class="container"></div>');
+      container = testUtils.makeContainer(this);
       const userClass = new window.jujugui.User(
         {sessionStorage: getMockStorage()});
       userClass.controller = {user: 'user', password: 'password'};
@@ -1275,7 +1274,7 @@ describe('App', function() {
     });
 
     beforeEach(function() {
-      container = Y.Node.create('<div id="test" class="container"></div>');
+      container = testUtils.makeContainer(this);
       const userClass = new window.jujugui.User(
         {sessionStorage: getMockStorage()});
       userClass.controller = {user: 'user', password: 'password'};
@@ -1428,7 +1427,7 @@ describe('App', function() {
     });
 
     beforeEach(function() {
-      container = Y.Node.create('<div id="test" class="container"></div>');
+      container = testUtils.makeContainer(this);
       // Monkey patch.
       getLocation = Y.getLocation;
       Y.getLocation = function() {
@@ -1438,7 +1437,7 @@ describe('App', function() {
 
     afterEach(function() {
       Y.getLocation = getLocation;
-      container.destroy();
+      container.remove();
       app.destroy();
     });
 

--- a/jujugui/static/gui/src/test/test_app_hotkeys.js
+++ b/jujugui/static/gui/src/test/test_app_hotkeys.js
@@ -20,7 +20,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 describe('application hotkeys', function() {
   let app, container, env, juju, jujuConfig, keyboard, utils, Y;
-  const requirements = ['juju-gui', 'juju-tests-utils', 'node-event-simulate'];
+  const requirements = ['juju-gui', 'juju-tests-utils'];
 
   before(function(done) {
     Y = YUI(GlobalConfig).use(requirements, function(Y) {

--- a/jujugui/static/gui/src/test/test_changes_utils.js
+++ b/jujugui/static/gui/src/test/test_changes_utils.js
@@ -26,10 +26,8 @@ describe('ChangesUtils', function() {
     var requirements = [
       'changes-utils',
       'environment-change-set',
-      'event-simulate',
       'juju-models',
-      'node',
-      'node-event-simulate'
+      'node'
     ];
     Y = YUI(GlobalConfig).use(requirements, function(Y) {
       models = Y.namespace('juju.models');

--- a/jujugui/static/gui/src/test/test_cookies_app_extension.js
+++ b/jujugui/static/gui/src/test/test_cookies_app_extension.js
@@ -25,8 +25,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
     before(function(done) {
       Y = YUI(GlobalConfig).use([
-        'app-cookies-extension', 'cookie', 'juju-tests-utils',
-        'node-event-simulate'
+        'app-cookies-extension', 'cookie', 'juju-tests-utils'
       ], function(Y) {
         utils = Y.namespace('juju-tests.utils');
         done();

--- a/jujugui/static/gui/src/test/test_cookies_app_extension.js
+++ b/jujugui/static/gui/src/test/test_cookies_app_extension.js
@@ -35,9 +35,9 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
     beforeEach(function() {
       container = utils.makeContainer(this, 'container');
-      container.setHTML('<div class="cookie-policy">' +
-          '<a class="link-cta"></a></div>');
-      node = container.one('.cookie-policy');
+      container.innerHTML = '<div class="cookie-policy">' +
+          '<a class="link-cta"></a></div>';
+      node = container.querySelector('.cookie-policy');
       cookieHandler = new Y.juju.Cookies(node);
     });
 
@@ -47,28 +47,28 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     });
 
     it('calling check makes the node visible', function() {
-      assert.isFalse(node.hasClass('display-cookie-notice'));
+      assert.isFalse(node.classList.contains('display-cookie-notice'));
       cookieHandler.check();
-      assert.isTrue(node.hasClass('display-cookie-notice'));
+      assert.isTrue(node.classList.contains('display-cookie-notice'));
     });
 
     it('closing the banner sets the cookie', function() {
       assert.isNull(Y.Cookie.get('_cookies_accepted'));
       cookieHandler.check();
-      node.one('.link-cta').simulate('click');
+      node.querySelector('.link-cta').click();
       assert.equal(Y.Cookie.get('_cookies_accepted'), 'true');
     });
 
     it('the cookie prevents the node from getting visible', function() {
       Y.Cookie.set('_cookies_accepted', 'true');
       cookieHandler.check();
-      assert.isFalse(node.hasClass('display-cookie-notice'));
+      assert.isFalse(node.classList.contains('display-cookie-notice'));
     });
 
     it('the custom setting also does', function() {
       localStorage.setItem('disable-cookie', 'true');
       cookieHandler.check();
-      assert.isFalse(node.hasClass('display-cookie-notice'));
+      assert.isFalse(node.classList.contains('display-cookie-notice'));
     });
 
   });

--- a/jujugui/static/gui/src/test/test_d3_components.js
+++ b/jujugui/static/gui/src/test/test_d3_components.js
@@ -115,7 +115,7 @@ describe('d3-components', function() {
     // Simulated events on DOM handlers better work.
     // These require a bound DOM element however
     comp.render();
-    Y.one('.thing').simulate('click');
+    document.querySelector('.thing').click();
     state.thing.should.equal('decorated');
   });
 
@@ -141,10 +141,15 @@ describe('d3-components', function() {
        comp.addModule(modA);
        comp.render();
 
-       Y.one('.thing').simulate('click');
+       document.querySelector('.thing').click();
        state.clicked.should.equal(true);
 
-       Y.one('.thing').simulate('dblclick');
+       const event = new MouseEvent('dblclick', {
+         'view': window,
+         'bubbles': true,
+         'cancelable': true
+       });
+       document.querySelector('.thing').dispatchEvent(event);
        state.dbldbl.should.equal(true);
 
      });
@@ -167,6 +172,7 @@ describe('d3-components', function() {
       done();
     });
     Y.one('window').simulate('resize');
+    window.dispatchEvent(new Event('resize'));
   });
 
   it('deep clones event objects to avoid shared bindings', function() {
@@ -209,8 +215,8 @@ describe('d3-components', function() {
         .addModule(modB);
 
        comp.render();
-       viewUtils.isValue(Y.one('#fromA')).should.equal(true);
-       viewUtils.isValue(Y.one('#fromB')).should.equal(true);
+       viewUtils.isValue(document.querySelector('#fromA')).should.equal(true);
+       viewUtils.isValue(document.querySelector('#fromB')).should.equal(true);
      });
 
   it('should support d3 event bindings post render', function() {
@@ -222,7 +228,7 @@ describe('d3-components', function() {
     comp.render();
 
     // This is a d3 bound handler that occurs only after render.
-    container.one('.target').simulate('click');
+    document.querySelector('.target').click();
     state.targeted.should.equal(true);
   });
 

--- a/jujugui/static/gui/src/test/test_d3_components.js
+++ b/jujugui/static/gui/src/test/test_d3_components.js
@@ -26,8 +26,7 @@ describe('d3-components', function() {
     Y = YUI(GlobalConfig).use(['d3-components',
       'juju-tests-utils',
       'juju-view-utils',
-      'node',
-      'node-event-simulate'],
+      'node'],
     function(Y) {
       NS = Y.namespace('d3-components');
 

--- a/jujugui/static/gui/src/test/test_d3_components.js
+++ b/jujugui/static/gui/src/test/test_d3_components.js
@@ -171,7 +171,6 @@ describe('d3-components', function() {
       assert.isTrue(resized);
       done();
     });
-    Y.one('window').simulate('resize');
     window.dispatchEvent(new Event('resize'));
   });
 

--- a/jujugui/static/gui/src/test/test_d3_components.js
+++ b/jujugui/static/gui/src/test/test_d3_components.js
@@ -60,10 +60,12 @@ describe('d3-components', function() {
 
   beforeEach(function() {
     container = utils.makeContainer(this, 'container');
-    container.append(Y.Node.create('<button/>')
-             .addClass('thing'))
-             .append(Y.Node.create('<button/>')
-             .addClass('target'));
+    const button1 = document.createElement('button');
+    button1.classList.add('thing');
+    container.appendChild(button1);
+    const button2 = document.createElement('button');
+    button2.classList.add('target');
+    container.appendChild(button2);
     state = {};
   });
 
@@ -201,12 +203,16 @@ describe('d3-components', function() {
        // Give each of these a render method that adds to container
        modA.name = 'moda';
        modA.render = function() {
-         this.get('container').append(Y.Node.create('<div id="fromA"></div>'));
+         const node = document.createElement('div');
+         node.setAttribute('id', 'fromA');
+         this.get('container').appendChild(node);
        };
 
        modB.name = 'modb';
        modB.render = function() {
-         this.get('container').append(Y.Node.create('<div id="fromB"></div>'));
+         const node = document.createElement('div');
+         node.setAttribute('id', 'fromB');
+         this.get('container').appendChild(node);
        };
 
        comp.setAttrs({container: container});

--- a/jujugui/static/gui/src/test/test_endpoints.js
+++ b/jujugui/static/gui/src/test/test_endpoints.js
@@ -59,7 +59,7 @@ describe('Relation endpoints logic', function() {
       plansURL: 'http://plans.example.com/',
       termsURL: 'http://terms.example.com/'
     };
-    container = utils.makeAppContainer(Y);
+    container = utils.makeAppContainer();
     var conn = new utils.SocketStub();
     ecs = new juju.EnvironmentChangeSet();
     env = new juju.environments.GoEnvironment({
@@ -432,7 +432,7 @@ describe('Endpoints map handlers', function() {
       termsURL: 'http://terms.example.com/'
     };
     destroyMe = [];
-    container = utils.makeAppContainer(Y);
+    container = utils.makeAppContainer();
     conn = new utils.SocketStub();
     ecs = new juju.EnvironmentChangeSet();
     env = new juju.environments.GoEnvironment({
@@ -662,7 +662,7 @@ describe('Application config handlers', function() {
       termsURL: 'http://terms.example.com/'
     };
     destroyMe = [];
-    container = utils.makeAppContainer(Y);
+    container = utils.makeAppContainer();
     conn = new utils.SocketStub();
     var ecs = new juju.EnvironmentChangeSet();
     env = new juju.environments.GoEnvironment({

--- a/jujugui/static/gui/src/test/test_environment_view.js
+++ b/jujugui/static/gui/src/test/test_environment_view.js
@@ -22,7 +22,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
   describe('juju environment view', function() {
     var view, views, models, Y, container, d3, db, conn, juju, jujuConfig,
-        charm, ecs, env, relationUtils, testUtils, fakeStore;
+        charm, click, ecs, env, relationUtils, testUtils, fakeStore;
 
     var environment_delta = {
       'result': [
@@ -277,6 +277,11 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
         state: {changeState: sinon.stub()},
         sendAnalytics: sinon.stub()
       });
+      click = new MouseEvent('click', {
+        view: window,
+        bubbles: true,
+        cancelable: true,
+      });
     });
 
     afterEach(function() {
@@ -302,16 +307,16 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       view.render().rendered();
 
       // Verify we have help text.
-      var help = Y.one('.environment-help');
-      assert.isFalse(help.hasClass('shrink'));
+      var help = document.querySelector('.environment-help');
+      assert.isFalse(help.classList.contains('shrink'));
     });
 
     it('should not display help text when canvas is populated', function() {
       view.render().rendered();
 
       // Verify we do not have help text.
-      var help = Y.one('.environment-help');
-      assert.strictEqual(help.getStyle('display'), 'none');
+      var help = document.querySelector('.environment-help');
+      assert.strictEqual(help.style.display, 'none');
     });
 
     it('should handle clicking the plus', function() {
@@ -324,8 +329,8 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       view.set('state', state);
       view.render().rendered();
 
-      var plus = Y.one('.environment-help .plus-service');
-      plus.simulate('click');
+      var plus = document.querySelector('.environment-help .plus-service');
+      plus.dispatchEvent(click);
       assert.equal(state.changeState.callCount, 1);
       assert.deepEqual(state.changeState.args[0][0], {
         root: 'store'
@@ -345,7 +350,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
         assert.isTrue(beforeResizeEventFired);
         done();
       });
-      Y.one('window').simulate('resize');
+      window.dispatchEvent(new Event('resize'));
     });
 
     it('must render services blocks correctly',
@@ -359,7 +364,8 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
             state: {changeState: sinon.stub()}
           });
           view.render();
-          var serviceBlock = container.one('.service').one('.service-block');
+          const serviceBlock = container.querySelector(
+            '.service').querySelector('.service-block');
           serviceBlock.getAttribute('r').should.equal('90');
           serviceBlock.getAttribute('cy').should.equal('95');
           serviceBlock.getAttribute('cx').should.equal('95');
@@ -375,12 +381,12 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
         state: {changeState: sinon.stub()}
       });
       view.render();
-      var relationIcon = container.one('.service').one('.relation-button');
-      var line = relationIcon.one('line');
-      var circles = relationIcon.all('circle');
-      var img = relationIcon.one('image');
+      var relationIcon = container.querySelector('.service .relation-button');
+      var line = relationIcon.querySelector('line');
+      var circles = relationIcon.querySelectorAll('circle');
+      var img = relationIcon.querySelector('image');
 
-      assert.equal(relationIcon._node.classList[0], 'relation-button');
+      assert.equal(relationIcon.classList.contains('relation-button'), true);
       assert.equal(relationIcon.getAttribute('transform'), 'translate(95,30)');
 
       assert.equal(line.getAttribute('x1'), '0');
@@ -395,7 +401,8 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       assert.equal(circles.item(0).getAttribute('r'), '4');
       assert.equal(circles.item(0).getAttribute('fill'), '#888888');
 
-      assert.equal(circles.item(1)._node.classList[0], 'relation-button__link');
+      assert.equal(
+        circles.item(1).classList.contains('relation-button__link'), true);
       assert.equal(circles.item(1).getAttribute('cx'), '0');
       assert.equal(circles.item(1).getAttribute('cy'), '0');
       assert.equal(circles.item(1).getAttribute('r'), '15');
@@ -403,7 +410,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       assert.equal(circles.item(1).getAttribute('stroke'), '#888888');
       assert.equal(circles.item(1).getAttribute('stroke-width'), '1.1');
 
-      assert.equal(img._node.classList[0], 'relation-button__image');
+      assert.equal(img.classList.contains('relation-button__image'), true);
       assert.equal(
         img.getAttribute('href'),
         'static/gui/build/app/assets/svgs/build-relation_16.svg');
@@ -423,8 +430,9 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
         staticURL: 'staticpath'
       });
       view.render();
-      var relationIcon = container.one('.service').one('.relation-button');
-      var img = relationIcon.one('image');
+      const relationIcon = container.querySelector('.service').querySelector(
+        '.relation-button');
+      const img = relationIcon.querySelector('image');
       assert.equal(
         img.getAttribute('href'),
         'staticpath/static/gui/build/app/assets/svgs/build-relation_16.svg');
@@ -442,27 +450,27 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
             state: {changeState: sinon.stub()}
           });
           view.render();
-          container.all('.service').size().should.equal(4);
+          container.querySelectorAll('.service').length.should.equal(4);
 
           // Count all the real relations.
-          (container.all('.relation').size() -
-           container.all('.pending-relation').size())
+          (container.querySelectorAll('.relation').length -
+           container.querySelectorAll('.pending-relation').length)
               .should.equal(2);
 
           // Count all the subordinate relations.
-          container.all('.rel-group .relation.subordinate').size()
+          container.querySelectorAll('.rel-group .relation.subordinate').length
               .should.equal(1);
 
           // Verify that the paths render 'properly' where this
           // means no NaN in the paths
-          var line = container.one('.relation');
+          var line = container.querySelector('.relation');
           ['x1', 'y1', 'x2', 'y2'].forEach(e => {
             isNaN(parseInt(line.getAttribute(e), 10)).should.equal(false);
           });
 
           // Verify that the node id has been munged as expected from the
           // relation id. This is particularly important for Juju Core.
-          var node = container.one(
+          var node = container.querySelector(
               '#' + relationUtils.generateSafeDOMId(
                   'puppet:juju-info wordpress:juju-info', getParentId(view)));
           assert.isNotNull(node);
@@ -480,8 +488,9 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
             state: {changeState: sinon.stub()}
           });
           view.render();
-          container.all('.service').size().should.equal(4);
-          container.all('.subordinate.service').size().should.equal(1);
+          container.querySelectorAll('.service').length.should.equal(4);
+          container.querySelectorAll(
+            '.subordinate.service').length.should.equal(1);
 
           done();
         }
@@ -497,9 +506,9 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
         state: {changeState: sinon.stub()}
       });
       view.render();
-      var service = container.one('.service');
+      var service = container.querySelector('.service');
       assert.equal(
-        service.one('.service-icon').getAttribute('href'),
+        service.querySelector('.service-icon').getAttribute('href'),
         'http://1.2.3.4/v5/precise/wordpress-6/icon.svg');
       done();
     });
@@ -515,7 +524,8 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
         state: {changeState: sinon.stub()}
       });
       view.render();
-      assert.equal(container.one('.service .service-block').getAttribute(
+      assert.equal(
+        container.querySelector('.service .service-block').getAttribute(
           'stroke'), '#19b6ee');
     });
 
@@ -589,26 +599,26 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       var relationModule = view.topo.modules.RelationModule;
 
       function validateRelationCount(serviceNode, module, count) {
-        var service = d3.select(serviceNode.getDOMNode()).datum();
+        var service = d3.select(serviceNode).datum();
         return module.subordinateRelationsForService(service)
           .length === count;
       }
 
-      container.all('.subordinate.service').each(function(service) {
+      container.querySelectorAll('.subordinate.service').forEach(service => {
         validateRelationCount(service, relationModule, 1).should.equal(true);
       });
 
       db.onDelta({ data: addSubordinate });
       view.update();
 
-      container.all('.subordinate.service').each(function(service) {
+      container.querySelectorAll('.subordinate.service').forEach(service => {
         validateRelationCount(service, relationModule, 1).should.equal(true);
       });
 
       db.onDelta({ data: addRelation });
       view.update();
 
-      validateRelationCount(container.one('.subordinate.service'),
+      validateRelationCount(container.querySelector('.subordinate.service'),
           relationModule, 2).should.equal(true);
     });
 
@@ -645,10 +655,10 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       db.onDelta({ data: tmp_data });
       view.render();
 
-      container.all('.service').each(function(serviceNode) {
+      container.querySelectorAll('.service').forEach(serviceNode => {
         // There should not be any duplicate nodes within the service.
-        serviceNode.all('.service-icon').size().should.equal(1);
-        serviceNode.all('.service-block').size().should.equal(1);
+        serviceNode.querySelectorAll('.service-icon').length.should.equal(1);
+        serviceNode.querySelectorAll('.service-block').length.should.equal(1);
       });
     });
 
@@ -688,14 +698,14 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
             return parseFloat(outerRadius) === parseFloat(maskWidth) / 2.05;
           }
 
-          container.all('.service').each(function(service) {
-            chartSizedProperly(service.getDOMNode()).should.equal(true);
+          container.querySelectorAll('.service').forEach(service => {
+            chartSizedProperly(service).should.equal(true);
           });
 
           db.onDelta({ data: tmp_data });
 
-          container.all('.service').each(function(service) {
-            chartSizedProperly(service.getDOMNode()).should.equal(true);
+          container.querySelectorAll('.service').forEach(service => {
+            chartSizedProperly(service).should.equal(true);
           });
         }
     );
@@ -763,8 +773,8 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
           // Ensure that endpoints match for all services before any
           // service is resized.
-          container.all('.rel-group').each(function(relationGroup) {
-            endpointsCalculatedProperly(relationGroup.getDOMNode())
+          container.querySelectorAll('.rel-group').forEach(relationGroup => {
+            endpointsCalculatedProperly(relationGroup)
               .should.equal(true);
           });
 
@@ -773,8 +783,8 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
           // Ensure that endpoints still match for all services, now that
           // one service has been resized.  This is the real test here.
-          container.all('.rel-group').each(function(relationGroup) {
-            endpointsCalculatedProperly(relationGroup.getDOMNode())
+          container.querySelectorAll('.rel-group').forEach(relationGroup => {
+            endpointsCalculatedProperly(relationGroup)
               .should.equal(true);
           });
         }
@@ -818,7 +828,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
           properTransform = /translate\(\d+\.?\d*[, ]\d+\.?\d*\)/;
       view.render();
 
-      container.all('.service').each(function(serviceNode) {
+      container.querySelectorAll('.service').forEach(serviceNode => {
         // Ensure that all initial service nodes' transform attributes are
         // properly formated (i.e.: no NaN values).
         properTransform.test(serviceNode.getAttribute('transform'))
@@ -828,15 +838,15 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       db.onDelta({ data: tmp_data });
       view.render();
 
-      container.all('.service').each(function(serviceNode) {
+      container.querySelectorAll('.service').forEach(serviceNode => {
         // Ensure that all new service nodes' transform attributes are properly
         // formatted as well (i.e.: no NaN values).
         properTransform.test(serviceNode.getAttribute('transform'))
           .should.equal(true);
 
         // There should not be any duplicate nodes within the service.
-        serviceNode.all('.service-block').size().should.equal(1);
-        serviceNode.all('.service-icon').size().should.equal(1);
+        serviceNode.querySelectorAll('.service-block').length.should.equal(1);
+        serviceNode.querySelectorAll('.service-icon').length.should.equal(1);
       });
     });
 
@@ -938,7 +948,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
            charmstore: fakeStore,
            state: {changeState: sinon.stub()}
          }).render();
-         var rel_block = container.one('.sub-rel-count').getDOMNode();
+         var rel_block = container.querySelector('.sub-rel-count');
 
          // Get the contents of the subordinate relation count; YUI cannot
          // get this directly as the node is not an HTMLElement, so use
@@ -962,14 +972,14 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
          // from the viewport (only available from DOM).
          view.rendered();
 
-         var svg = Y.one('.the-canvas');
+         var svg = document.querySelector('.the-canvas');
 
-         parseInt(svg.one('g').getAttribute('height'), 10)
+         parseInt(svg.querySelector('g').getAttribute('height'), 10)
           .should.equal(
-         parseInt(svg.getComputedStyle('height'), 10));
-         parseInt(svg.one('g').getAttribute('width'), 10)
+         parseInt(window.getComputedStyle(svg).getPropertyValue('height'), 10));
+         parseInt(svg.querySelector('g').getAttribute('width'), 10)
           .should.equal(
-         parseInt(svg.getComputedStyle('width'), 10));
+         parseInt(window.getComputedStyle(svg).getPropertyValue('width'), 10));
        }
     );
 
@@ -978,12 +988,14 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
        function() {
          // The height of a navbar is used in calculating the viewport size,
          // so add a temporary one to the DOM
-         var navbar = Y.Node.create('<div class="header-banner" ' +
-             'style="height:70px;">Navbar</div>');
-         Y.one('body').append(navbar);
-         var viewport = Y.Node.create('<div id="viewport" ' +
-             'style="width:800px;">viewport</div>');
-         Y.one('body').append(viewport);
+         const navbar = document.createElement('div');
+         navbar.classList.add('header-banner');
+         navbar.style.height = '70px';
+         document.body.appendChild(navbar);
+         const viewport = document.createElement('div');
+         viewport.setAttribute('id', 'viewport');
+         viewport.style.width = '800px';
+         document.body.appendChild(viewport);
          var view = new views.environment({
            container: container,
            db: db,
@@ -994,10 +1006,10 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
          // Attach the view to the DOM so that sizes get set properly
          // from the viewport (only available from DOM).
          view.rendered();
-         var svg = container.one('.the-canvas'),
-             canvas = container.one('.topology');
+         var svg = container.querySelector('.the-canvas'),
+             canvas = container.querySelector('.topology');
          // We have to hide the canvas so it does not affect our calculations.
-         canvas.setStyle('display', 'none');
+         canvas.style.display = 'none';
          parseInt(svg.getAttribute('height'), 10)
           .should.be.above(199);
          // Destroy the navbar
@@ -1040,12 +1052,12 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
         charmstore: fakeStore,
         state: {changeState: sinon.stub()}
       }).render();
-      container.all('.service').each(function(node, i) {
+      container.querySelectorAll('.service').forEach((node, i) => {
         node.after('click', function() {
           view.hasSVGClass(
-              node.one('.service-control-panel'),
+              node.querySelector('.service-control-panel'),
               'active').should.equal(true);
-          container.all('.service-control-panel.active').size()
+          container.querySelectorAll('.service-control-panel.active').length
               .should.equal(1);
         });
       });
@@ -1064,12 +1076,13 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
            charmstore: fakeStore,
            state: {changeState: sinon.stub()}
          }).render();
-         var serviceNode = container.one('.service'),
-             add_rel = container.one('.relation-button__link');
-         var service = d3.select(serviceNode.getDOMNode()).datum();
+         var serviceNode = container.querySelector('.service'),
+             add_rel = container.querySelector('.relation-button__link');
+         var service = d3.select(serviceNode).datum();
          var endpoints = {},
              serviceName = serviceNode.getAttribute('data-name'),
-             nextServiceName = serviceNode.next().getAttribute('data-name');
+             nextServiceName = serviceNode.nextSibling.getAttribute(
+               'data-name');
          endpoints[nextServiceName] = [
            [{
              service: serviceName,
@@ -1104,20 +1117,20 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
          });
          // Mock an event object so that d3.mouse does not throw a NPE.
          d3.event = {};
-         add_rel.simulate('click');
-         container.all('.selectable-service')
-               .size()
+         add_rel.dispatchEvent(click);
+         container.querySelectorAll('.selectable-service')
+               .length
                .should.equal(2);
-         container.all('.dragline')
-               .size()
+         container.querySelectorAll('.dragline')
+               .length
                .should.equal(1);
 
          // Start the process of adding a relation.
          module.ambiguousAddRelationCheck(
-             d3.select(serviceNode.next().getDOMNode()).datum(),
+             d3.select(serviceNode.nextSibling).datum(),
              module,
-             serviceNode.next());
-         container.all('.selectable-service').size()
+             serviceNode.nextSibling);
+         container.querySelectorAll('.selectable-service').length
             .should.equal(0);
          // The database is initialized with three relations in beforeEach.
          assert.equal(4, db.relations.size());
@@ -1143,15 +1156,14 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
            state: {changeState: sinon.stub()}
          }).render();
 
-         var relation = container.one(
-              '#' + relationUtils.generateSafeDOMId('mysql:db wordpress:db',
-         getParentId(view)) +
-              ' .rel-indicator'),
-             menu;
-
-         relation.simulate('click');
-         menu = container.one('#relation-menu');
-         menu.one('.relation-remove').simulate('click');
+         var relation = container.querySelector(
+           '#' +
+           relationUtils.generateSafeDOMId(
+             'mysql:db wordpress:db', getParentId(view)) +
+           ' .rel-indicator');
+         relation.dispatchEvent(click);
+         const menu = container.querySelector('#relation-menu');
+         menu.querySelector('.relation-remove').dispatchEvent(click);
          assert.isTrue(remove_called);
        });
 
@@ -1167,17 +1179,19 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       var module = view.topo.modules.RelationModule;
 
       // Single relation
-      var relation = container.one(
+      var relation = container.querySelector(
           '#' + relationUtils.generateSafeDOMId('mysql:db wordpress:db',
           getParentId(view)) +
           ' .rel-indicator'),
           menu;
-      relation.simulate('click');
-      menu = container.one('#relation-menu');
+      relation.dispatchEvent(click);
+      menu = container.querySelector('#relation-menu');
 
-      assert.equal(menu.all('.relation-container').size(), 1);
-      assert.equal(menu.one('.relation-container').getData('relationid'),
-          'mysql:db wordpress:db');
+      assert.equal(menu.querySelectorAll('.relation-container').length, 1);
+      assert.equal(
+        menu.querySelector('.relation-container').getAttribute(
+          'data-relationid'),
+        'mysql:db wordpress:db');
 
       // Assert that relation module is storing the menu state for rerendering.
       assert.equal(module.get('relationMenuActive'), true);
@@ -1185,20 +1199,22 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
           'mysql:db wordpress:db');
 
       // Multiple relations
-      relation = container.one(
+      relation = container.querySelector(
           '#' +
           relationUtils.generateSafeDOMId('mysql:db mediawiki:db',
           getParentId(view)) +
           ' .rel-indicator');
-      relation.simulate('click');
-      menu = container.one('#relation-menu');
+      relation.dispatchEvent(click);
+      menu = container.querySelector('#relation-menu');
 
-      var relContainers = menu.all('.relation-container');
-      assert.equal(relContainers.size(), 2);
-      assert.equal(relContainers.item(0).getData('relationid'),
-          'mysql:db mediawiki:db');
-      assert.equal(relContainers.item(1).getData('relationid'),
-          'mysql:db-slave mediawiki:db-slave');
+      var relContainers = menu.querySelectorAll('.relation-container');
+      assert.equal(relContainers.length, 2);
+      assert.equal(
+        relContainers.item(0).getAttribute('data-relationid'),
+        'mysql:db mediawiki:db');
+      assert.equal(
+        relContainers.item(1).getAttribute('data-relationid'),
+        'mysql:db-slave mediawiki:db-slave');
 
       // Errors are shown.
       var unit = db.services.getById('mysql').get('units').item(0);
@@ -1206,11 +1222,13 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       unit.agent_state_data = {
         hook: 'db-relation'
       };
-      relation.simulate('click');
-      menu = container.one('#relation-menu');
-      assert.equal(menu.all('.endpoint.error').size(), 1);
-      assert.equal(menu.all('.relation-container.error').size(), 1);
-      assert.equal(menu.all('.relation-container.running').size(), 1);
+      relation.dispatchEvent(click);
+      menu = container.querySelector('#relation-menu');
+      assert.equal(menu.querySelectorAll('.endpoint.error').length, 1);
+      assert.equal(menu.querySelectorAll(
+        '.relation-container.error').length, 1);
+      assert.equal(menu.querySelectorAll(
+        '.relation-container.running').length, 1);
     });
 
     it('shows relation status with an indicator', function() {
@@ -1288,20 +1306,20 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       container.append(
           '<div id="bws-sidebar"><div class="bws-content"></div></div>');
       // Single relation.
-      var relation = container.one(
+      var relation = container.querySelector(
           '#' + relationUtils.generateSafeDOMId('mysql:db wordpress:db',
           getParentId(view)) +
           ' .rel-indicator'),
           menu;
 
-      relation.simulate('click');
-      menu = Y.one('#relation-menu .menu');
+      relation.dispatchEvent(click);
+      menu = document.querySelector('#relation-menu .menu');
 
       // Click the first endpoint.
-      var endpoints = menu.all('.inspect-relation'),
+      var endpoints = menu.querySelectorAll('.inspect-relation'),
           endpoint = endpoints.item(0),
-          endpointName = endpoint.get('text').split(':')[0].trim();
-      endpoint.simulate('click');
+          endpointName = endpoint.innerText.split(':')[0].trim();
+      endpoint.dispatchEvent(click);
       assert.equal(state.changeState.callCount, 1);
       assert.deepEqual(state.changeState.args[0][0], {
         gui: {
@@ -1322,16 +1340,16 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
           assert.equal(db.notifications.size(), 0);
 
          // Get a subordinate relation.
-          var relation = container.one(
+          var relation = container.querySelector(
               '#' + relationUtils.generateSafeDOMId(
                   'puppet:juju-info wordpress:juju-info',
          getParentId(view)) +
               ' .rel-indicator'),
               menu;
 
-          relation.simulate('click');
-          menu = container.one('#relation-menu');
-          menu.one('.relation-remove').simulate('click');
+          relation.dispatchEvent(click);
+          menu = container.querySelector('#relation-menu');
+          menu.querySelector('.relation-remove').click();
           assert.equal(db.notifications.size(), 1);
         });
 
@@ -1347,16 +1365,14 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
           db.relations.item(1).set('pending', true);
 
          // Get a subordinate relation.
-          var relation = container.one(
+          const relation = container.querySelector(
               '#' + relationUtils.generateSafeDOMId(
                   'puppet:juju-info wordpress:juju-info',
          getParentId(view)) +
-              ' .rel-indicator'),
-              menu;
-
-          relation.simulate('click');
-          menu = container.one('#relation-menu');
-          menu.one('.relation-remove').simulate('click');
+              ' .rel-indicator');
+          relation.dispatchEvent(click);
+          const menu = container.querySelector('#relation-menu');
+          menu.querySelector('.relation-remove').dispatchEvent(click);
           assert.equal(db.notifications.size(), 0);
         });
 
@@ -1436,21 +1452,15 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     });
 
     describe('onboarding integration with the environment', function() {
-      // XXX This test does not run in Phantom, but passes in the browser.
-      // See https://github.com/ariya/phantomjs/issues/12782 for details.
-      // Makyo - 2015-09-21
       it('shows/hides the integrated button when a service is added',
           function() {
-            if (Y.UA.phantomjs) {
-              return;
-            }
             db = new models.Database();
             view.set('db', db);
             view.render().rendered();
             var includedPlus = view.topo.vis.select('.included-plus');
-            var helpText = container.one('.environment-help');
+            var helpText = container.querySelector('.environment-help');
             assert.equal(false, includedPlus.classed('show'));
-            assert.equal(false, helpText.hasClass('shrink'));
+            assert.equal(false, helpText.classList.contains('shrink'));
 
             var service = new models.Service({
               id: 'service-1',
@@ -1459,7 +1469,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
             db.services.add([service]);
 
             assert.equal(true, includedPlus.classed('show'));
-            assert.equal(true, helpText.hasClass('shrink'));
+            assert.equal(true, helpText.classList.contains('shrink'));
             view.destroy();
           }
         );

--- a/jujugui/static/gui/src/test/test_environment_view.js
+++ b/jujugui/static/gui/src/test/test_environment_view.js
@@ -1311,7 +1311,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
         state: state
       }).render();
       // This stops the simulate() call later on from causing a 'script error'
-      container.append(
+      container.insertAdjacentHTML('beforeend',
           '<div id="bws-sidebar"><div class="bws-content"></div></div>');
       // Single relation.
       var relation = container.querySelector(

--- a/jujugui/static/gui/src/test/test_environment_view.js
+++ b/jujugui/static/gui/src/test/test_environment_view.js
@@ -1051,27 +1051,6 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       view.topo.fire('show', {serviceNames: ['mysql']});
     });
 
-    // Tests for the service menu.
-    it('must be able to toggle the service menu', function(done) {
-      var view = new views.environment({
-        container: container,
-        db: db,
-        env: env,
-        charmstore: fakeStore,
-        state: {changeState: sinon.stub()}
-      }).render();
-      container.querySelectorAll('.service').forEach((node, i) => {
-        node.after('click', function() {
-          view.hasSVGClass(
-              node.querySelector('.service-control-panel'),
-              'active').should.equal(true);
-          container.querySelectorAll('.service-control-panel.active').length
-              .should.equal(1);
-        });
-      });
-      done();
-    });
-
     it('must be able to add a relation from the service menu',
        function() {
          if (Y.UA.phantomjs) {

--- a/jujugui/static/gui/src/test/test_environment_view.js
+++ b/jujugui/static/gui/src/test/test_environment_view.js
@@ -213,7 +213,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     before(function(done) {
       Y = YUI(GlobalConfig).use([
         'juju-views', 'juju-tests-utils', 'charmstore-api',
-        'd3', 'node-event-simulate', 'juju-gui',
+        'd3', 'juju-gui',
         'landscape', 'dump', 'juju-view-utils',
         'juju-charm-models', 'environment-change-set', 'relation-utils'
       ], function(Y) {

--- a/jujugui/static/gui/src/test/test_model.js
+++ b/jujugui/static/gui/src/test/test_model.js
@@ -1545,13 +1545,14 @@ describe('test_model.js', function() {
   });
 
   describe('Charm load', function() {
-    var Y, models, conn, env, container, juju;
+    var Y, models, conn, env, container, juju, testUtils;
 
     before(function(done) {
       Y = YUI(GlobalConfig).use(['juju-models', 'juju-gui', 'datasource-local',
         'juju-tests-utils', 'json-stringify'], function(Y) {
         models = Y.namespace('juju.models');
         juju = Y.namespace('juju');
+        testUtils = Y.namespace('juju-tests.utils');
         done();
       });
     });
@@ -1575,13 +1576,13 @@ describe('test_model.js', function() {
       env.connect();
       env.set('facades', {Client: [0], Charms: [1]});
       conn.open();
-      container = Y.Node.create('<div id="test" class="container"></div>');
+      container = testUtils.makeContainer(this);
     });
 
     afterEach(function() {
       env.close();
       env.destroy();
-      container.destroy();
+      container.remove();
     });
 
     it('will throw an exception with non-read sync', function() {

--- a/jujugui/static/gui/src/test/test_panzoom.js
+++ b/jujugui/static/gui/src/test/test_panzoom.js
@@ -26,8 +26,7 @@ describe('pan zoom module', function() {
       'juju-models',
       'juju-views',
       'juju-gui',
-      'juju-tests-utils',
-      'node-event-simulate'],
+      'juju-tests-utils'],
     function(Y) {
       models = Y.namespace('juju.models');
       views = Y.namespace('juju.views');

--- a/jujugui/static/gui/src/test/test_panzoom.js
+++ b/jujugui/static/gui/src/test/test_panzoom.js
@@ -50,7 +50,7 @@ describe('pan zoom module', function() {
   afterEach(function() {
     db.destroy();
     view.destroy();
-    viewContainer.destroy();
+    viewContainer.remove();
   });
 
   function fixTranslate(translate) {

--- a/jujugui/static/gui/src/test/test_service_module.js
+++ b/jujugui/static/gui/src/test/test_service_module.js
@@ -856,12 +856,12 @@ describe('canvasDropHandler', function() {
 });
 
 describe('_canvasDropHandler', function() {
-  var Y, views, utils, models, serviceModule;
+  var views, utils, models, serviceModule;
 
   // Requiring this much setup (before() and beforeEach() to call a single
   // method on a single object is obscene.
   before(function(done) {
-    Y = YUI(GlobalConfig).use([
+    YUI(GlobalConfig).use([
       'juju-models',
       'juju-tests-utils',
       'juju-view-environment'],

--- a/jujugui/static/gui/src/test/test_service_module.js
+++ b/jujugui/static/gui/src/test/test_service_module.js
@@ -29,8 +29,7 @@ describe('service module annotations', function() {
       'juju-tests-utils',
       'juju-views',
       'juju-view-environment',
-      'node',
-      'node-event-simulate'],
+      'node'],
     function(Y) {
       models = Y.namespace('juju.models');
       utils = Y.namespace('juju-tests.utils');
@@ -124,8 +123,7 @@ describe('service updates', function() {
       'juju-tests-utils',
       'juju-views',
       'juju-view-environment',
-      'node',
-      'node-event-simulate'],
+      'node'],
     function(Y) {
       models = Y.namespace('juju.models');
       utils = Y.namespace('juju-tests.utils');
@@ -198,8 +196,7 @@ describe.skip('service module events', function() {
       'juju-views',
       'juju-gui',
       'juju-view-environment',
-      'juju-topology-service',
-      'node-event-simulate'],
+      'juju-topology-service'],
     function(Y) {
       models = Y.namespace('juju.models');
       views = Y.namespace('juju.views');

--- a/jujugui/static/gui/src/test/test_service_module.js
+++ b/jujugui/static/gui/src/test/test_service_module.js
@@ -900,7 +900,7 @@ describe('_canvasDropHandler', function() {
     var self = {
       _deployFromCharmbrowser: function() {done();}
     };
-    Y.bind(serviceModule._canvasDropHandler, self)(files);
+    serviceModule._canvasDropHandler.call(self, files);
   });
 
   it('extracts a zipped charm directory when dropped', function(done) {
@@ -908,7 +908,7 @@ describe('_canvasDropHandler', function() {
     var self = {
       _extractCharmMetadata: function() {done();}
     };
-    Y.bind(serviceModule._canvasDropHandler, self)([file]);
+    serviceModule._canvasDropHandler.call(self, [file]);
   });
 
   it('recognizes zip files of type x-zip-compressed', function(done) {
@@ -917,7 +917,7 @@ describe('_canvasDropHandler', function() {
     var self = {
       _extractCharmMetadata: function() {done();}
     };
-    Y.bind(serviceModule._canvasDropHandler, self)(files);
+    serviceModule._canvasDropHandler.call(self, files);
   });
 
 });

--- a/jujugui/static/gui/src/test/test_topology.js
+++ b/jujugui/static/gui/src/test/test_topology.js
@@ -24,7 +24,7 @@ describe('topology', function() {
 
   before(function(done) {
     YUI(GlobalConfig).use(['juju-topology', 'd3-components',
-      'juju-tests-utils', 'juju-view-utils', 'node', 'node-event-simulate'],
+      'juju-tests-utils', 'juju-view-utils', 'node'],
     function(Y) {
       NS = Y.namespace('d3-components');
       views = Y.namespace('juju.views');

--- a/jujugui/static/gui/src/test/test_topology.js
+++ b/jujugui/static/gui/src/test/test_topology.js
@@ -20,10 +20,10 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 describe('topology', function() {
   var NS, TestModule, container, db, models, state, topo,
-      utils, views, viewUtils, Y;
+      utils, views, viewUtils;
 
   before(function(done) {
-    Y = YUI(GlobalConfig).use(['juju-topology', 'd3-components',
+    YUI(GlobalConfig).use(['juju-topology', 'd3-components',
       'juju-tests-utils', 'juju-view-utils', 'node', 'node-event-simulate'],
     function(Y) {
       NS = Y.namespace('d3-components');
@@ -60,10 +60,12 @@ describe('topology', function() {
 
   beforeEach(function() {
     container = utils.makeContainer(this);
-    container.append(Y.Node.create('<button/>')
-             .addClass('thing'))
-             .append(Y.Node.create('<button/>')
-             .addClass('target'));
+    const button1 = document.createElement('button');
+    button1.classList.add('thing');
+    container.appendChild(button1);
+    const button2 = document.createElement('button');
+    button2.classList.add('target');
+    container.appendChild(button2);
     state = {};
   });
 

--- a/jujugui/static/gui/src/test/test_topology_relation.js
+++ b/jujugui/static/gui/src/test/test_topology_relation.js
@@ -339,9 +339,7 @@ describe('topology relation module', function() {
       menuNode.appendChild(menuContent);
       container.appendChild(menuNode);
       var menu = view._renderAmbiguousRelationMenu.call({
-        get: function() {
-          return container;
-        }
+        getContainer: sinon.stub().returns(container)
       }, endpoints);
       assert.isNotNull(menu.querySelector('.menu'));
       assert.equal(menu.querySelectorAll('li').length, 2);
@@ -385,8 +383,8 @@ describe('topology relation module', function() {
       assert.equal(locate.callCount, 1, 'locateRelativePointOnCanvas');
       assert.deepEqual(locate.lastCall.args, ['m', 'translate', 'scale']);
       assert.deepEqual(menu.style, {
-        left: 'locate1',
-        top: 'locate2'
+        left: 'locate1px',
+        top: 'locate2px'
       });
       assert.equal(addClass.callCount, 1, 'addClass');
       assert.equal(addClass.lastCall.args[0], 'active');

--- a/jujugui/static/gui/src/test/test_topology_relation.js
+++ b/jujugui/static/gui/src/test/test_topology_relation.js
@@ -350,7 +350,10 @@ describe('topology relation module', function() {
       const menu = {
         querySelector: sinon.stub().returns({
           addEventListener: addEventListener,
-        })
+        }),
+        querySelectorAll: sinon.stub().returns([{
+          addEventListener: addEventListener,
+        }])
       };
       view._attachAmbiguousReleationSelect(menu);
       assert.equal(addEventListener.callCount, 2);

--- a/jujugui/static/gui/src/test/test_topology_relation.js
+++ b/jujugui/static/gui/src/test/test_topology_relation.js
@@ -138,7 +138,7 @@ describe('topology relation module', function() {
         assert.equal(state.changeState.callCount, 1);
         assert.deepEqual(state.changeState.args[0][0], {
           gui: {
-            inspector: { id: container.get('text').split(':')[0].trim() }
+            inspector: { id: container.innerText.split(':')[0].trim() }
           }});
       });
 
@@ -330,17 +330,19 @@ describe('topology relation module', function() {
       }, {
         name: 'db', service: 'mysql', type: 'mysql', displayName: 'mysql'
       }]];
-      container.append(
-        '<div id="ambiguous-relation-menu">' +
-          '<div id="ambiguous-relation-menu-content"></div>' +
-        '</div>');
+      const menuNode = document.createElement('div');
+      menuNode.setAttribute('id', 'ambiguous-relation-menu');
+      const menuContent = document.createElement('div');
+      menuContent.setAttribute('id', 'ambiguous-relation-menu-content');
+      menuNode.appendChild(menuContent);
+      container.appendChild(menuNode);
       var menu = view._renderAmbiguousRelationMenu.call({
         get: function() {
           return container;
         }
       }, endpoints);
-      assert.isNotNull(menu.one('.menu'));
-      assert.equal(menu.all('li').size(), 2);
+      assert.isNotNull(menu.querySelector('.menu'));
+      assert.equal(menu.querySelectorAll('li').length, 2);
     });
 
     it('attaches the click events for the menu', function() {

--- a/jujugui/static/gui/src/test/test_topology_relation.js
+++ b/jujugui/static/gui/src/test/test_topology_relation.js
@@ -24,7 +24,7 @@ describe('topology relation module', function() {
   before(function(done) {
     Y = YUI(GlobalConfig).use(
       ['juju-tests-utils', 'juju-topology', 'node', 'relation-utils',
-        'node-event-simulate', 'juju-models'],
+        'juju-models'],
         function(Y) {
           views = Y.namespace('juju.views');
           utils = Y.namespace('juju-tests.utils');

--- a/jujugui/static/gui/src/test/test_topology_relation.js
+++ b/jujugui/static/gui/src/test/test_topology_relation.js
@@ -134,11 +134,13 @@ describe('topology relation module', function() {
           get: sinon.stub().withArgs('state').returns(state)
         };
         view.set('component', topo);
-        view.inspectRelationClick.call(container, undefined, view);
+        const relation = document.createElement('div');
+        relation.setAttribute('data-endpoint', 'one:two');
+        view.inspectRelationClick.call(relation, undefined, view);
         assert.equal(state.changeState.callCount, 1);
         assert.deepEqual(state.changeState.args[0][0], {
           gui: {
-            inspector: { id: container.innerText.split(':')[0].trim() }
+            inspector: { id: 'one' }
           }});
       });
 
@@ -346,28 +348,24 @@ describe('topology relation module', function() {
     });
 
     it('attaches the click events for the menu', function() {
-      var delegate = sinon.stub();
-      var on = sinon.stub();
-      var menu = {
-        one: function() {
-          return {
-            delegate: delegate,
-            on: on
-          };
-        }
+      const addEventListener = sinon.stub();
+      const menu = {
+        querySelector: sinon.stub().returns({
+          addEventListener: addEventListener,
+        })
       };
       view._attachAmbiguousReleationSelect(menu);
-      assert.equal(delegate.callCount, 1);
-      assert.equal(on.callCount, 1);
+      assert.equal(addEventListener.callCount, 2);
     });
 
     it('calls to position the menu to the terminating endpoint', function() {
-      var setStyle = sinon.stub();
       var addClass = sinon.stub();
       var set = sinon.stub();
       var menu = {
-        setStyle: setStyle,
-        addClass: addClass
+        style: {},
+        classList: {
+          add: addClass
+        }
       };
       var topo = {
         zoom: {
@@ -386,11 +384,10 @@ describe('topology relation module', function() {
 
       assert.equal(locate.callCount, 1, 'locateRelativePointOnCanvas');
       assert.deepEqual(locate.lastCall.args, ['m', 'translate', 'scale']);
-      assert.equal(setStyle.callCount, 2);
-      assert.deepEqual(setStyle.args, [
-        ['left', 'locate1'],
-        ['top', 'locate2']
-      ]);
+      assert.deepEqual(menu.style, {
+        left: 'locate1',
+        top: 'locate2'
+      });
       assert.equal(addClass.callCount, 1, 'addClass');
       assert.equal(addClass.lastCall.args[0], 'active');
       assert.equal(set.callCount, 2);

--- a/jujugui/static/gui/src/test/test_utils.js
+++ b/jujugui/static/gui/src/test/test_utils.js
@@ -23,7 +23,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     var views;
     before(function(done) {
       YUI(GlobalConfig).use(
-          'juju-view-utils', 'node-event-simulate',
+          'juju-view-utils',
           function(Y) {
             views = Y.namespace('juju.views');
             done();

--- a/jujugui/static/gui/src/test/test_viewport_module.js
+++ b/jujugui/static/gui/src/test/test_viewport_module.js
@@ -33,7 +33,7 @@ describe('views.ViewportModule (Topology module)', function() {
 
   it('aborts a resize if the canvas is not available', function() {
     var container = {
-      one: testUtils.getter({'.topology-canvas': undefined}, {})
+      querySelector: testUtils.getter({'.topology-canvas': undefined}, {})
     };
     var view = new views.ViewportModule();
     view.getContainer = function() {return container;};
@@ -45,7 +45,7 @@ describe('views.ViewportModule (Topology module)', function() {
 
   it('aborts a resize if the "svg" element is not available', function() {
     var container = {
-      one: testUtils.getter({'.the-canvas': undefined}, {})
+      querySelector: testUtils.getter({'.the-canvas': undefined}, {})
     };
     var view = new views.ViewportModule();
     view.getContainer = function() {return container;};
@@ -64,7 +64,7 @@ describe('views.ViewportModule (Topology module)', function() {
       get: function() {}
     };
     var container = {
-      one: testUtils.getter({}, {})
+      querySelector: testUtils.getter({}, {})
     };
     // Catch global custom page resize events.
     ['beforePageSizeRecalculation', 'afterPageSizeRecalculation'].forEach(

--- a/jujugui/static/gui/src/test/test_viewport_module.js
+++ b/jujugui/static/gui/src/test/test_viewport_module.js
@@ -95,12 +95,12 @@ describe('views.ViewportModule (Topology module)', function() {
 });
 
 describe('views.ViewportModule.setAllTheDimensions', function() {
-  var views, Y, testUtils, view, width, height, canvas, svg, topo, zoomPlane,
+  var views, testUtils, view, width, height, canvas, svg, topo, zoomPlane,
       eventFired, dimentions;
   before(function(done) {
     var modules = ['node', 'juju-views', 'juju-tests-utils',
       'juju-topology-viewport'];
-    Y = YUI(GlobalConfig).use(modules,
+    YUI(GlobalConfig).use(modules,
         function(Y) {
           views = Y.namespace('juju.views');
           testUtils = Y.namespace('juju-tests').utils;
@@ -129,9 +129,6 @@ describe('views.ViewportModule.setAllTheDimensions', function() {
     topo.vis.attr = testUtils.setter(topo.vis);
     view = new views.ViewportModule();
     canvas = {style: {}};
-    canvas.setStyles = function(styles) {
-      Y.mix(canvas.style, styles, true);
-    };
     zoomPlane = {};
     zoomPlane.setAttribute = testUtils.setter(zoomPlane);
     svg = {};

--- a/jujugui/static/gui/src/test/utils.js
+++ b/jujugui/static/gui/src/test/utils.js
@@ -37,22 +37,22 @@ YUI(GlobalConfig).add('juju-tests-utils', function(Y) {
             'to cleanup.');
       }
 
-      var container = Y.Node.create('<div>');
+      var container = document.createElement('div');
       if (id) {
-        container.set('id', id);
+        container.setAttribute('id', id);
       }
-      container.appendTo(document.body);
+      document.body.appendChild(container);
       if (visibleContainer !== false) {
-        container.setStyle('position', 'absolute');
-        container.setStyle('top', '-10000px');
-        container.setStyle('left', '-10000px');
+        container.style.position = 'absolute';
+        container.style.top = '-10000px';
+        container.style.left = '-10000px';
       }
 
       // Add the destroy ability to the test hook context to be run on
       // afterEach automatically.
       ctx._cleanups.push(function() {
         container.remove(true);
-        container.destroy();
+        container.remove();
       });
 
       return container;


### PR DESCRIPTION
This is a big update (necessarily, once some code was updated it would cascade breakage) to replace the YUI methods for node selecting/creating etc.

It removes all instances (where possible) of:
- Y.one
- Y.all
- Y.Node.create
- getStyle
- setSyle
- addClass
- removeClass
- simulate
- Y.bind