### PR TITLE
Improve handling of account page in the case of uncommitted changes.

### DIFF
--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -998,7 +998,6 @@ YUI.add('juju-gui', function(Y) {
           this.state.changeState.bind(this.state),
           auth.rootUserName);
       };
-
       const navigateUserAccount = () => {
         const auth = this._getAuth();
         if (!auth) {
@@ -1008,6 +1007,7 @@ YUI.add('juju-gui', function(Y) {
           this.env && this.env.get('ecs'),
           this.state.changeState.bind(this.state));
       };
+
       ReactDOM.render(<window.juju.components.UserMenu
         controllerAPI={controllerAPI}
         LogoutLink={LogoutLink}
@@ -1156,6 +1156,9 @@ YUI.add('juju-gui', function(Y) {
         // If the controller isn't ready yet then don't render anything.
         return;
       }
+      // When going to the account view, we are theoretically no longer
+      // connected to any model.
+      this.set('modelUUID', null);
       ReactDOM.render(
         <window.juju.components.Account
           acl={this.acl}
@@ -1502,8 +1505,17 @@ YUI.add('juju-gui', function(Y) {
       const providerDetails = cloudProvider ?
         views.utils.getCloudProviderDetails(cloudProvider) :
         {};
-      const isProfile = this.state.current.profile;
-      const isDisabled = !cloudProvider || !providerDetails || isProfile;
+      const currentState = this.state.current || {};
+      const isDisabled = (
+        // There is no provider.
+        !cloudProvider ||
+        // It's not possible to get provider details.
+        !providerDetails ||
+        // We are in the profile page.
+        currentState.profile ||
+        // We are in the account page.
+        currentState.root === 'account'
+      );
       const classes = classNames(
         'provider-logo',
         {

--- a/jujugui/static/gui/src/app/components/header-breadcrumb/header-breadcrumb.js
+++ b/jujugui/static/gui/src/app/components/header-breadcrumb/header-breadcrumb.js
@@ -54,12 +54,9 @@ YUI.add('header-breadcrumb', function() {
       @returns {String} The collection of class names.
     */
     _generateClasses: function() {
-      return classNames(
-        'header-breadcrumb',
-        {
-          'header-breadcrumb--loading-model': this.props.loadingModel
-        }
-      );
+      return classNames('header-breadcrumb', {
+        'header-breadcrumb--loading-model': this.props.loadingModel
+      });
     },
 
     /**
@@ -70,7 +67,12 @@ YUI.add('header-breadcrumb', function() {
     */
     _renderEnvSwitcher: function() {
       const props = this.props;
-      if (!props.showEnvSwitcher || props.appState.current.profile) {
+      const currentState = props.appState.current;
+      if (
+        !props.showEnvSwitcher ||
+        currentState.profile ||
+        currentState.root === 'account'
+      ) {
         return null;
       }
       return (

--- a/jujugui/static/gui/src/app/components/header-breadcrumb/test-header-breadcrumb.js
+++ b/jujugui/static/gui/src/app/components/header-breadcrumb/test-header-breadcrumb.js
@@ -198,6 +198,18 @@ describe('HeaderBreadcrumb', () => {
       null);
   });
 
+  it('does not render the model switcher when in the account page', () => {
+    appState.current.root = 'account';
+    const comp = render({
+      authDetails: {user: 'who@external', rootUserName: 'who'},
+      modelName: 'mymodel',
+      modelOwner: '',
+      showEnvSwitcher: true
+    });
+    const switcher = comp.output.props.children[1].props.children[1];
+    assert.strictEqual(switcher, null);
+  });
+
   it('does not make the username linkable if we hide model switcher', () => {
     const comp = render({
       authDetails: {user: 'who@external', rootUserName: 'who'},

--- a/jujugui/static/gui/src/app/components/model-actions/model-actions.js
+++ b/jujugui/static/gui/src/app/components/model-actions/model-actions.js
@@ -88,13 +88,14 @@ YUI.add('model-actions', function() {
     */
     _generateClasses: function() {
       const props = this.props;
-      return classNames(
-        'model-actions',
-        {
-          'model-actions--loading-model': props.appState.current.profile ||
-            props.loadingModel
-        }
+      const currentState = props.appState.current;
+      const isDisabled = (
+        currentState.profile ||
+        currentState.root === 'account' ||
+        props.loadingModel
       );
+      return classNames(
+        'model-actions', {'model-actions--loading-model': isDisabled});
     },
 
     render: function() {

--- a/jujugui/static/gui/src/app/components/model-actions/test-model-actions.js
+++ b/jujugui/static/gui/src/app/components/model-actions/test-model-actions.js
@@ -335,4 +335,24 @@ describe('ModelActions', function() {
     const classFound = output.props.className.indexOf(className) >= 0;
     assert.isTrue(classFound);
   });
+
+  it('applies the correct class when on a user account page', function() {
+    const renderer = jsTestUtils.shallowRender(
+      <juju.components.ModelActions
+        acl={acl}
+        appState={{current: {root: 'account'}}}
+        changeState={sinon.stub()}
+        exportEnvironmentFile={sinon.stub()}
+        hideDragOverNotification={sinon.stub()}
+        importBundleFile={sinon.stub()}
+        loadingModel={false}
+        userIsAuthenticated={false}
+        renderDragOverNotification={sinon.stub()}
+        sharingVisibility={sinon.stub()}
+      />, true);
+    const output = renderer.getRenderOutput();
+    const className = 'model-actions--loading-model';
+    const classFound = output.props.className.indexOf(className) >= 0;
+    assert.strictEqual(classFound, true);
+  });
 });

--- a/jujugui/static/gui/src/app/components/user-menu/test-user-menu.js
+++ b/jujugui/static/gui/src/app/components/user-menu/test-user-menu.js
@@ -93,6 +93,10 @@ describe('UserMenu', () => {
 
   describe('menu', () => {
     it('opens a menu when clicked', () => {
+      // TODO frankban: remove juju_config handling when deleting the flag.
+      const jujuConfig = window.juju_config;
+      window.juju_config = {accountFlag: true};
+
       const userMenu = createEle({
         LogoutLink: LogoutLink,
         controllerAPI: {
@@ -106,7 +110,10 @@ describe('UserMenu', () => {
       assert.deepEqual(output.props.children[0].props.className,
         'header-menu__button header-menu__show-menu');
 
-      const expected = (<juju.components.Panel
+      // TODO frankban: remove juju_config handling when deleting the flag.
+      window.juju_config = jujuConfig;
+
+      const expectedOutput = (<juju.components.Panel
         instanceName="header-menu__menu"
         visible={true}>
           <ul className="header-menu__menu-list" role="menubar">
@@ -129,7 +136,7 @@ describe('UserMenu', () => {
             </li>
           </ul>
         </juju.components.Panel>);
-      assert.deepEqual(output.props.children[1], expected);
+      expect(output.props.children[1]).toEqualJSX(expectedOutput);
     });
 
     it('closes when handleClickOutside is called', () => {

--- a/jujugui/static/gui/src/app/components/user-menu/user-menu.js
+++ b/jujugui/static/gui/src/app/components/user-menu/user-menu.js
@@ -70,43 +70,51 @@ YUI.add('user-menu', function() {
     },
 
     /**
-     Generate menu based on whether the button has been clicked.
+      Generate menu based on whether the button has been clicked.
 
       @method generateUserMenu
     */
     _generateUserMenu: function() {
-      if (this.state.showUserMenu) {
-        const logoutLink = this.props.LogoutLink;
-        return (
-          <juju.components.Panel
-            instanceName="header-menu__menu"
-            visible={true}>
-              <ul className="header-menu__menu-list" role="menubar">
-                <li className="header-menu__menu-list-item
-                  header-menu__menu-list-item-with-link"
-                  role="menuitem" tabIndex="0">
-                  <a role="button"
-                    onClick={this._handleProfileClick}>Pofile</a>
-                </li>
-                <li className="header-menu__menu-list-item
-                  header-menu__menu-list-item-with-link"
-                  role="menuitem" tabIndex="0">
-                  <a role="button"
-                    onClick={this._handleAccountClick}>Account</a>
-                </li>
-                <li className="header-menu__menu-list-item
-                  header-menu__menu-list-item-with-link"
-                  role="menuitem" tabIndex="0">
-                    {logoutLink}
-                  </li>
-              </ul>
-            </juju.components.Panel>);
+      if (!this.state.showUserMenu) {
+        return '';
       }
-      return '';
+      const logoutLink = this.props.LogoutLink;
+      let accountEntry = null;
+      // For the time being, weakly protect the account page via a flag.
+      // The account page can still be accessed directly by people knowing its
+      // "/account" path. Otherwise, the user menu voice can be activated, for
+      // instance, by running the following guiproxy command:
+      //   guiproxy -config 'gisf: true, jujuEnvUUID: "", accountFlag: true'
+      if (window.juju_config && window.juju_config.accountFlag) {
+        accountEntry = (
+          <li className="header-menu__menu-list-item
+            header-menu__menu-list-item-with-link"
+            role="menuitem" tabIndex="0">
+            <a role="button" onClick={this._handleAccountClick}>Account</a>
+          </li>
+        );
+      }
+      return (
+        <juju.components.Panel instanceName="header-menu__menu" visible={true}>
+          <ul className="header-menu__menu-list" role="menubar">
+            <li className="header-menu__menu-list-item
+              header-menu__menu-list-item-with-link"
+              role="menuitem" tabIndex="0">
+              <a role="button" onClick={this._handleProfileClick}>Pofile</a>
+            </li>
+            {accountEntry}
+            <li className="header-menu__menu-list-item
+              header-menu__menu-list-item-with-link"
+              role="menuitem" tabIndex="0">
+              {logoutLink}
+            </li>
+          </ul>
+        </juju.components.Panel>
+      );
     },
 
     /**
-     Get class names based on whether the menu is shown.
+      Get class names based on whether the menu is shown.
 
       @method _getClassNames
     */

--- a/jujugui/static/gui/src/app/views/utils.js
+++ b/jujugui/static/gui/src/app/views/utils.js
@@ -1408,13 +1408,12 @@ YUI.add('juju-view-utils', function(Y) {
     Navigate to the profile, displaying a confirmation if there are
     uncommitted changes.
 
-    @method showProfile
     @param {Object} ecs Reference to the ecs.
     @param {Function} changeState The method for changing the app state.
     @param {String} username The username of the profile to display.
   */
   utils.showProfile = function(ecs, changeState, username) {
-    var currentChangeSet = ecs.getCurrentChangeSet();
+    const currentChangeSet = ecs.getCurrentChangeSet();
     // If there are uncommitted changes then show a confirmation popup.
     if (Object.keys(currentChangeSet).length > 0) {
       utils._showUncommittedConfirm(
@@ -1426,10 +1425,8 @@ YUI.add('juju-view-utils', function(Y) {
   };
 
   /**
-    Navigate to the profile, displaying a confirmation if there are
-    uncommitted changes.
+    Navigate to the profile, hiding the uncommitted confirmation if necessary.
 
-    @method _showProfile
     @param {Object} ecs Reference to the ecs.
     @param {Function} changeState The method for changing the app state.
     @param {String} username The username of the profile to display.
@@ -1454,19 +1451,35 @@ YUI.add('juju-view-utils', function(Y) {
     Navigate to the account, displaying a confirmation if there are
     uncommitted changes.
 
-    @method showAccount
     @param {Object} ecs Reference to the ecs.
     @param {Function} changeState The method for changing the app state.
   */
   utils.showAccount = function(ecs, changeState) {
-    var currentChangeSet = ecs.getCurrentChangeSet();
+    const currentChangeSet = ecs.getCurrentChangeSet();
     // If there are uncommitted changes then show a confirmation popup.
     if (Object.keys(currentChangeSet).length > 0) {
       utils._showUncommittedConfirm(
         utils._showAccount.bind(this, ecs, changeState, true));
       return;
     }
+    // If there are no uncommitted changes then switch right away.
+    utils._showAccount(ecs, changeState, false);
+  };
+
+  /**
+    Navigate to the account, hiding the uncommitted confirmation if necessary.
+
+    @param {Object} ecs Reference to the ecs.
+    @param {Function} changeState The method for changing the app state.
+    @param {Boolean} clear Whether to clear the ecs.
+  */
+  utils._showAccount = function(ecs, changeState, clear=false) {
     utils._hidePopup();
+    if (clear) {
+      // Have to go ahead and clear the ECS otherwise future navigation will
+      // pop up the uncommitted changes confirmation again.
+      ecs.clear();
+    }
     changeState({
       profile: null,
       model: null,


### PR DESCRIPTION
Now it works and it does not throw an error.

Also hide the menu item for the time being, the accountFlag must be active to see the account menu entry.
Also correctly hide the model switcher, cloud logo and model actions when in the account page, as technically we are not in a model at that point, and practically could not be in a model (for instance if /account is accessed directly or from the profile page).

Fixes https://github.com/juju/juju-gui/issues/2730

