### PR TITLE
Improvements on the charm/bundle detail pages.

### DIFF
--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -1763,7 +1763,9 @@ YUI.add('juju-gui', function(Y) {
           addNotification={
             this.db.notifications.add.bind(this.db.notifications)}
           makeEntityModel={Y.juju.makeEntityModel}
-          setPageTitle={this.setPageTitle.bind(this)} />,
+          setPageTitle={this.setPageTitle.bind(this)}
+          urllib={window.jujulib.URL}
+        />,
         document.getElementById('charmbrowser-container'));
       next();
     },

--- a/jujugui/static/gui/src/app/components/charmbrowser/charmbrowser.js
+++ b/jujugui/static/gui/src/app/components/charmbrowser/charmbrowser.js
@@ -42,6 +42,7 @@ YUI.add('charmbrowser-component', function() {
       series: React.PropTypes.object.isRequired,
       setPageTitle: React.PropTypes.func.isRequired,
       staticURL: React.PropTypes.string,
+      urllib: React.PropTypes.object.isRequired,
       utils: React.PropTypes.object.isRequired
     },
 
@@ -161,6 +162,8 @@ YUI.add('charmbrowser-component', function() {
           );
           break;
         case 'entity-details':
+          // TODO frankban: do we still really need this?
+          const id = currentState.store || `~${currentState.user}`;
           activeChild = (
               <juju.components.EntityDetails
                 acl={this.props.acl}
@@ -176,11 +179,17 @@ YUI.add('charmbrowser-component', function() {
                 getFile={this.props.getFile}
                 scrollPosition={this.state.scrollPosition}
                 renderMarkdown={this.props.renderMarkdown}
-                id={currentState.store || `~${currentState.user}`}
+                id={id}
+                // This is used to force a component remount when the entity
+                // changes, for instance a charm detail page has a link to
+                // another charm detail page.
+                key={id}
                 pluralize={utils.pluralize}
                 listPlansForCharm={this.props.listPlansForCharm}
                 makeEntityModel={this.props.makeEntityModel}
-                setPageTitle={this.props.setPageTitle} />
+                setPageTitle={this.props.setPageTitle}
+                urllib={this.props.urllib}
+              />
           );
           break;
       }

--- a/jujugui/static/gui/src/app/components/charmbrowser/test-charmbrowser.js
+++ b/jujugui/static/gui/src/app/components/charmbrowser/test-charmbrowser.js
@@ -164,6 +164,7 @@ describe('Charmbrowser', function() {
       pluralize: sinon.spy()
     };
     const setPageTitle = sinon.spy();
+    const urllib = {fromLegacyString: sinon.stub()};
     const renderer = jsTestUtils.shallowRender(
       <juju.components.Charmbrowser
         acl={acl}
@@ -185,10 +186,12 @@ describe('Charmbrowser', function() {
         utils={utils}
         renderMarkdown={renderMarkdown}
         series={{}}
-        setPageTitle={setPageTitle} />, true);
+        setPageTitle={setPageTitle}
+        urllib={urllib}
+      />, true);
     const instance = renderer.getMountedInstance();
     const output = renderer.getRenderOutput();
-    const expected = (
+    const expectedOutput = (
         <juju.components.Panel
           instanceName="white-box"
           clickAction={instance._close}
@@ -215,10 +218,12 @@ describe('Charmbrowser', function() {
               id={id}
               addNotification={addNotification}
               pluralize={utils.pluralize}
-              setPageTitle={setPageTitle} />
+              setPageTitle={setPageTitle}
+              urllib={urllib}
+            />
           </div>
         </juju.components.Panel>);
-    assert.deepEqual(output, expected);
+    expect(output).toEqualJSX(expectedOutput);
   });
 
   it('displays entity details when the state has a user path', function() {
@@ -239,6 +244,7 @@ describe('Charmbrowser', function() {
       pluralize: sinon.stub()
     };
     const setPageTitle = sinon.stub();
+    const urllib = {fromLegacyString: sinon.stub()};
     const renderer = jsTestUtils.shallowRender(
       <juju.components.Charmbrowser
         acl={acl}
@@ -260,10 +266,12 @@ describe('Charmbrowser', function() {
         utils={utils}
         renderMarkdown={renderMarkdown}
         series={{}}
-        setPageTitle={setPageTitle} />, true);
+        setPageTitle={setPageTitle}
+        urllib={urllib}
+      />, true);
     const instance = renderer.getMountedInstance();
     const output = renderer.getRenderOutput();
-    const expected = (
+    const expectedOutput = (
         <juju.components.Panel
           instanceName="white-box"
           clickAction={instance._close}
@@ -290,10 +298,12 @@ describe('Charmbrowser', function() {
               id='~spinch/koala'
               addNotification={addNotification}
               pluralize={utils.pluralize}
-              setPageTitle={setPageTitle} />
+              setPageTitle={setPageTitle}
+              urllib={urllib}
+            />
           </div>
         </juju.components.Panel>);
-    assert.deepEqual(output, expected);
+    expect(output).toEqualJSX(expectedOutput);
   });
 
   it('closes when clicked outside', function() {

--- a/jujugui/static/gui/src/app/components/entity-details/entity-details.js
+++ b/jujugui/static/gui/src/app/components/entity-details/entity-details.js
@@ -42,7 +42,8 @@ YUI.add('entity-details', function() {
       pluralize: React.PropTypes.func.isRequired,
       renderMarkdown: React.PropTypes.func.isRequired,
       scrollPosition: React.PropTypes.number.isRequired,
-      setPageTitle: React.PropTypes.func.isRequired
+      setPageTitle: React.PropTypes.func.isRequired,
+      urllib: React.PropTypes.object.isRequired
     },
 
     /**
@@ -90,7 +91,9 @@ YUI.add('entity-details', function() {
                   deployService={this.props.deployService}
                   plans={this.state.plans}
                   pluralize={this.props.pluralize}
-                  scrollPosition={this.props.scrollPosition} />
+                  scrollPosition={this.props.scrollPosition}
+                  urllib={this.props.urllib}
+                />
                 {this._generateDiagram(entityModel)}
                 <juju.components.EntityContent
                   apiUrl={this.props.apiUrl}
@@ -100,7 +103,8 @@ YUI.add('entity-details', function() {
                   renderMarkdown={this.props.renderMarkdown}
                   entityModel={entityModel}
                   plans={this.state.plans}
-                  pluralize={this.props.pluralize} />
+                  pluralize={this.props.pluralize}
+                />
               </div>
           );
           break;

--- a/jujugui/static/gui/src/app/components/entity-details/header/test-header.js
+++ b/jujugui/static/gui/src/app/components/entity-details/header/test-header.js
@@ -25,7 +25,7 @@ chai.config.includeStack = true;
 chai.config.truncateThreshold = 0;
 
 describe('EntityHeader', function() {
-  let acl, mockEntity;
+  let acl, mockEntity, urllib;
 
   beforeAll(function(done) {
     // By loading these files it makes their classes available in the tests.
@@ -35,6 +35,10 @@ describe('EntityHeader', function() {
   beforeEach(function() {
     acl = {isReadOnly: sinon.stub().returns(false)};
     mockEntity = jsTestUtils.makeEntity();
+    urllib = {fromLegacyString: sinon.stub().returns({
+      revision: 42,
+      path: sinon.stub().returns('u/who/django/42')
+    })};
   });
 
   afterEach(function() {
@@ -55,10 +59,11 @@ describe('EntityHeader', function() {
           importBundleYAML={sinon.stub()}
           pluralize={sinon.stub()}
           scrollPosition={0}
+          urllib={urllib}
         />, true);
     const instance = renderer.getMountedInstance();
     const output = renderer.getRenderOutput();
-    const expected = (
+    const expectedOutput = (
       <div className="row-hero"
         ref="headerWrapper"
         style={{}}>
@@ -78,10 +83,14 @@ describe('EntityHeader', function() {
               </h1>
               <ul className="bullets inline entity-header__properties">
                 <li className="entity-header__by">
-                  By{' '}
-                  <a href="https://launchpad.net/~test-owner"
-                    className="link"
-                    target="_blank">test-owner</a>
+                  By&nbsp;
+                  <span className="link" onClick={instance._onOwnerClick}>
+                    test-owner
+                  </span>
+                </li>
+                <li className="entity-header__series link"
+                    onClick={instance._onLastRevisionClick}>
+                  Latest revision (42)
                 </li>
                 {[<li key="trusty" className="entity-header__series">
                   trusty
@@ -131,7 +140,7 @@ describe('EntityHeader', function() {
           </div>
         </header>
       </div>);
-    assert.deepEqual(output, expected);
+    expect(output).toEqualJSX(expectedOutput);
   });
 
   it('renders an old entity properly', function() {
@@ -148,9 +157,10 @@ describe('EntityHeader', function() {
           hasPlans={false}
           importBundleYAML={sinon.stub()}
           pluralize={sinon.stub()}
-          scrollPosition={0} />, true);
+          scrollPosition={0}
+          urllib={urllib}
+        />, true);
     const output = renderer.getRenderOutput();
-
     assert.deepEqual(
       output.props.children.props.children.props.children[0].
       props.children[1].props.children[2].props.children[1],
@@ -159,10 +169,8 @@ describe('EntityHeader', function() {
   });
 
   it('can display plans', function() {
-    var plans = [{
-      url: 'test'
-    }];
-    var renderer = jsTestUtils.shallowRender(
+    const plans = [{url: 'test'}];
+    const renderer = jsTestUtils.shallowRender(
         <juju.components.EntityHeader
           acl={acl}
           addNotification={sinon.stub()}
@@ -175,9 +183,11 @@ describe('EntityHeader', function() {
           plans={plans}
           importBundleYAML={sinon.stub()}
           pluralize={sinon.stub()}
-          scrollPosition={0} />, true);
-    var output = renderer.getRenderOutput();
-    var expected = (
+          scrollPosition={0}
+          urllib={urllib}
+        />, true);
+    const output = renderer.getRenderOutput();
+    const expectedOutput = (
       <select className="entity-header__select"
         ref="plan">
         <option key="default">Choose a plan</option>
@@ -186,13 +196,13 @@ describe('EntityHeader', function() {
           test
         </option>]}
       </select>);
-    assert.deepEqual(
-      output.props.children.props.children.props.children[1].props.children[0],
-      expected);
+    expect(
+      output.props.children.props.children.props.children[1].props.children[0]
+    ).toEqualJSX(expectedOutput);
   });
 
   it('displays correctly when loading plans', function() {
-    var renderer = jsTestUtils.shallowRender(
+    const renderer = jsTestUtils.shallowRender(
         <juju.components.EntityHeader
           acl={acl}
           addNotification={sinon.stub()}
@@ -205,21 +215,23 @@ describe('EntityHeader', function() {
           plans={null}
           importBundleYAML={sinon.stub()}
           pluralize={sinon.stub()}
-          scrollPosition={0} />, true);
-    var output = renderer.getRenderOutput();
-    var expected = (
+          scrollPosition={0}
+          urllib={urllib}
+        />, true);
+    const output = renderer.getRenderOutput();
+    const expectedOutput = (
       <select className="entity-header__select"
         ref="plan">
         <option key="default">Loading plans...</option>
         {null}
       </select>);
-    assert.deepEqual(
-      output.props.children.props.children.props.children[1].props.children[0],
-      expected);
+    expect(
+      output.props.children.props.children.props.children[1].props.children[0]
+    ).toEqualJSX(expectedOutput);
   });
 
   it('displays correctly when there are no plans', function() {
-    var renderer = jsTestUtils.shallowRender(
+    const renderer = jsTestUtils.shallowRender(
         <juju.components.EntityHeader
           acl={acl}
           addNotification={sinon.stub()}
@@ -232,21 +244,23 @@ describe('EntityHeader', function() {
           plans={[]}
           importBundleYAML={sinon.stub()}
           pluralize={sinon.stub()}
-          scrollPosition={0} />, true);
-    var output = renderer.getRenderOutput();
-    var expected = (undefined);
+          scrollPosition={0}
+          urllib={urllib}
+        />, true);
+    const output = renderer.getRenderOutput();
     assert.deepEqual(
       output.props.children.props.children.props.children[1].props.children[0],
-      expected);
+      (undefined)
+    );
   });
 
   it('displays the counts for a bundle', function() {
-    var pluralize = sinon.stub();
+    const pluralize = sinon.stub();
     pluralize.withArgs('application').returns('applications');
     pluralize.withArgs('machine').returns('machines');
     pluralize.withArgs('unit').returns('units');
-    var entity = jsTestUtils.makeEntity(true);
-    var renderer = jsTestUtils.shallowRender(
+    const entity = jsTestUtils.makeEntity(true);
+    const renderer = jsTestUtils.shallowRender(
         <juju.components.EntityHeader
           acl={acl}
           addNotification={sinon.stub()}
@@ -258,9 +272,11 @@ describe('EntityHeader', function() {
           hasPlans={false}
           importBundleYAML={sinon.stub()}
           pluralize={pluralize}
-          scrollPosition={0} />, true);
-    var output = renderer.getRenderOutput();
-    var expected = (
+          scrollPosition={0}
+          urllib={urllib}
+        />, true);
+    const output = renderer.getRenderOutput();
+    const expectedOutput = (
       <li>
         {3} {'applications'},
         &nbsp;
@@ -269,12 +285,14 @@ describe('EntityHeader', function() {
         {5} {'units'}
       </li>);
     assert.deepEqual(
-      output.props.children.props.children.props.children[0]
-        .props.children[2].props.children[2], expected);
+      output.props.children.props.children.props.children[0].props.children[2]
+      .props.children[3],
+      expectedOutput
+    );
   });
 
   it('displays an add to model button', function() {
-    var output = testUtils.renderIntoDocument(
+    const output = testUtils.renderIntoDocument(
       <juju.components.EntityHeader
         acl={acl}
         addNotification={sinon.stub()}
@@ -286,8 +304,10 @@ describe('EntityHeader', function() {
         hasPlans={false}
         importBundleYAML={sinon.stub()}
         pluralize={sinon.stub()}
-        scrollPosition={0} />);
-    var deployAction = output.refs.deployAction;
+        scrollPosition={0}
+        urllib={urllib}
+      />);
+    const deployAction = output.refs.deployAction;
     assert.equal(deployAction.props.type, 'positive');
     assert.equal(deployAction.props.title, 'Add to model');
   });
@@ -305,7 +325,9 @@ describe('EntityHeader', function() {
         hasPlans={false}
         importBundleYAML={sinon.stub()}
         pluralize={sinon.stub()}
-        scrollPosition={0} />);
+        scrollPosition={0}
+        urllib={urllib}
+      />);
     const deployAction = output.refs.deployAction;
     assert.equal(deployAction.props.type, 'positive');
     assert.equal(deployAction.props.title, 'Add to porkchop');
@@ -313,7 +335,7 @@ describe('EntityHeader', function() {
 
   it('displays an unsupported message for multi-series charms', function() {
     mockEntity.set('series', undefined);
-    var output = testUtils.renderIntoDocument(
+    const output = testUtils.renderIntoDocument(
       <juju.components.EntityHeader
         acl={acl}
         addNotification={sinon.stub()}
@@ -325,18 +347,20 @@ describe('EntityHeader', function() {
         hasPlans={false}
         importBundleYAML={sinon.stub()}
         pluralize={sinon.stub()}
-        scrollPosition={0} />);
-    var textContent = output.refs.deployAction.innerText;
+        scrollPosition={0}
+        urllib={urllib}
+      />);
+    const textContent = output.refs.deployAction.innerText;
     assert.equal(textContent, 'This type of charm can only be deployed from ' +
       'the command line.');
   });
 
   it('adds a charm when the add button is clicked', function() {
-    var deployService = sinon.stub();
-    var changeState = sinon.stub();
-    var importBundleYAML = sinon.stub();
-    var getBundleYAML = sinon.stub();
-    var output = testUtils.renderIntoDocument(
+    const deployService = sinon.stub();
+    const changeState = sinon.stub();
+    const importBundleYAML = sinon.stub();
+    const getBundleYAML = sinon.stub();
+    const output = testUtils.renderIntoDocument(
       <juju.components.EntityHeader
         acl={acl}
         addNotification={sinon.stub()}
@@ -348,8 +372,10 @@ describe('EntityHeader', function() {
         changeState={changeState}
         entityModel={mockEntity}
         pluralize={sinon.stub()}
-        scrollPosition={0}/>);
-    var deployAction = output.refs.deployAction;
+        scrollPosition={0}
+        urllib={urllib}
+      />);
+    const deployAction = output.refs.deployAction;
     // Simulate a click.
     deployAction.props.action();
     assert.equal(deployService.callCount, 1);
@@ -357,12 +383,12 @@ describe('EntityHeader', function() {
   });
 
   it('can include a plan when deploying a charm', function() {
-    var deployService = sinon.stub();
-    var changeState = sinon.stub();
-    var importBundleYAML = sinon.stub();
-    var getBundleYAML = sinon.stub();
-    var plans = [{url: 'test-plan'}];
-    var output = testUtils.renderIntoDocument(
+    const deployService = sinon.stub();
+    const changeState = sinon.stub();
+    const importBundleYAML = sinon.stub();
+    const getBundleYAML = sinon.stub();
+    const plans = [{url: 'test-plan'}];
+    const output = testUtils.renderIntoDocument(
       <juju.components.EntityHeader
         acl={acl}
         addNotification={sinon.stub()}
@@ -375,9 +401,11 @@ describe('EntityHeader', function() {
         entityModel={mockEntity}
         plans={plans}
         pluralize={sinon.stub()}
-        scrollPosition={0}/>);
-    var refs = output.refs;
-    var deployAction = refs.deployAction;
+        scrollPosition={0}
+        urllib={urllib}
+      />);
+    const refs = output.refs;
+    const deployAction = refs.deployAction;
     // Change the select value to a plan.
     refs.plan.value = 'test-plan';
     // Simulate a click.
@@ -388,12 +416,12 @@ describe('EntityHeader', function() {
   });
 
   it('can set the plans when deploying a charm without selecing one', () => {
-    var deployService = sinon.stub();
-    var changeState = sinon.stub();
-    var importBundleYAML = sinon.stub();
-    var getBundleYAML = sinon.stub();
-    var plans = [{url: 'test-plan'}];
-    var output = testUtils.renderIntoDocument(
+    const deployService = sinon.stub();
+    const changeState = sinon.stub();
+    const importBundleYAML = sinon.stub();
+    const getBundleYAML = sinon.stub();
+    const plans = [{url: 'test-plan'}];
+    const output = testUtils.renderIntoDocument(
       <juju.components.EntityHeader
         acl={acl}
         addNotification={sinon.stub()}
@@ -406,9 +434,11 @@ describe('EntityHeader', function() {
         entityModel={mockEntity}
         plans={plans}
         pluralize={sinon.stub()}
-        scrollPosition={0}/>);
-    var refs = output.refs;
-    var deployAction = refs.deployAction;
+        scrollPosition={0}
+        urllib={urllib}
+      />);
+    const refs = output.refs;
+    const deployAction = refs.deployAction;
     // Simulate a click.
     deployAction.props.action();
     assert.equal(deployService.callCount, 1);
@@ -417,12 +447,12 @@ describe('EntityHeader', function() {
   });
 
   it('adds a bundle when the add button is clicked', function() {
-    var deployService = sinon.stub();
-    var changeState = sinon.stub();
-    var getBundleYAML = sinon.stub().callsArgWith(1, null, 'mock yaml');
-    var importBundleYAML = sinon.stub();
-    var entity = jsTestUtils.makeEntity(true);
-    var output = testUtils.renderIntoDocument(
+    const deployService = sinon.stub();
+    const changeState = sinon.stub();
+    const getBundleYAML = sinon.stub().callsArgWith(1, null, 'mock yaml');
+    const importBundleYAML = sinon.stub();
+    const entity = jsTestUtils.makeEntity(true);
+    const output = testUtils.renderIntoDocument(
       <juju.components.EntityHeader
         acl={acl}
         addNotification={sinon.stub()}
@@ -434,8 +464,10 @@ describe('EntityHeader', function() {
         changeState={changeState}
         entityModel={entity}
         pluralize={sinon.stub()}
-        scrollPosition={0} />);
-    var deployAction = output.refs.deployAction;
+        scrollPosition={0}
+        urllib={urllib}
+      />);
+    const deployAction = output.refs.deployAction;
     // Simulate a click.
     deployAction.props.action();
     assert.equal(getBundleYAML.callCount, 1);
@@ -445,13 +477,13 @@ describe('EntityHeader', function() {
   });
 
   it('displays a notification if there is a bundle deploy error', function() {
-    var deployService = sinon.stub();
-    var changeState = sinon.stub();
-    var getBundleYAML = sinon.stub().callsArgWith(1, 'error');
-    var importBundleYAML = sinon.stub();
-    var addNotification = sinon.stub();
-    var entity = jsTestUtils.makeEntity(true);
-    var output = testUtils.renderIntoDocument(
+    const deployService = sinon.stub();
+    const changeState = sinon.stub();
+    const getBundleYAML = sinon.stub().callsArgWith(1, 'error');
+    const importBundleYAML = sinon.stub();
+    const addNotification = sinon.stub();
+    const entity = jsTestUtils.makeEntity(true);
+    const output = testUtils.renderIntoDocument(
       <juju.components.EntityHeader
         acl={acl}
         importBundleYAML={importBundleYAML}
@@ -463,8 +495,10 @@ describe('EntityHeader', function() {
         entityModel={entity}
         addNotification={addNotification}
         pluralize={sinon.stub()}
-        scrollPosition={0} />);
-    var deployAction = output.refs.deployAction;
+        scrollPosition={0}
+        urllib={urllib}
+      />);
+    const deployAction = output.refs.deployAction;
     // Simulate a click.
     deployAction.props.action();
     assert.equal(addNotification.callCount, 1);
@@ -473,13 +507,13 @@ describe('EntityHeader', function() {
   });
 
   it('can display as sticky', function() {
-    var deployService = sinon.stub();
-    var changeState = sinon.stub();
-    var getBundleYAML = sinon.stub().callsArgWith(1, 'error');
-    var importBundleYAML = sinon.stub();
-    var addNotification = sinon.stub();
-    var entity = jsTestUtils.makeEntity(true);
-    var renderer = jsTestUtils.shallowRender(
+    const deployService = sinon.stub();
+    const changeState = sinon.stub();
+    const getBundleYAML = sinon.stub().callsArgWith(1, 'error');
+    const importBundleYAML = sinon.stub();
+    const addNotification = sinon.stub();
+    const entity = jsTestUtils.makeEntity(true);
+    const renderer = jsTestUtils.shallowRender(
       <juju.components.EntityHeader
         acl={acl}
         importBundleYAML={importBundleYAML}
@@ -491,29 +525,94 @@ describe('EntityHeader', function() {
         entityModel={entity}
         addNotification={addNotification}
         pluralize={sinon.stub()}
-        scrollPosition={100} />, true);
-    var instance = renderer.getMountedInstance();
+        scrollPosition={100}
+        urllib={urllib}
+      />, true);
+    const instance = renderer.getMountedInstance();
     instance.refs = {
       headerWrapper: {
         clientHeight: 99
       }
     };
     instance.componentDidMount();
-    var output = renderer.getRenderOutput();
-    assert.deepEqual(
-      output,
-        <div className="row-hero"
-          ref="headerWrapper"
-          style={{height: '99px'}}>
-          <header className="entity-header entity-header--sticky">
-            {output.props.children.props.children}
-          </header>
-        </div>);
+    const output = renderer.getRenderOutput();
+    const expectedOutput = (
+      <div className="row-hero"
+        ref="headerWrapper"
+        style={{height: '99px'}}>
+        <header className="entity-header entity-header--sticky">
+          {output.props.children.props.children}
+        </header>
+      </div>
+    );
+    expect(output).toEqualJSX(expectedOutput);
+  });
+
+  it('goes to the profile page when the owner is clicked', function() {
+    const changeState = sinon.stub();
+    const evt = {
+      preventDefault: sinon.stub().withArgs(),
+      stopPropagation: sinon.stub().withArgs()
+    };
+    const renderer = jsTestUtils.shallowRender(
+      <juju.components.EntityHeader
+        acl={acl}
+        addNotification={sinon.stub()}
+        entityModel={mockEntity}
+        changeState={changeState}
+        deployService={sinon.spy()}
+        getBundleYAML={sinon.stub()}
+        getModelName={sinon.stub()}
+        hasPlans={false}
+        importBundleYAML={sinon.stub()}
+        pluralize={sinon.stub()}
+        scrollPosition={0}
+        urllib={urllib}
+      />, true);
+    const instance = renderer.getMountedInstance();
+    instance._onOwnerClick(evt);
+    assert.strictEqual(evt.preventDefault.callCount, 1, 'preventDefault');
+    assert.strictEqual(evt.stopPropagation.callCount, 1, 'stopPropagation');
+    assert.strictEqual(changeState.callCount, 1, 'changeState');
+    const args = changeState.args[0];
+    assert.strictEqual(args.length, 1, 'changeState args');
+    assert.deepEqual(args[0], {store: null, profile: 'test-owner'});
+  });
+
+  it('goes to the last revision when present', function() {
+    const changeState = sinon.stub();
+    const evt = {
+      preventDefault: sinon.stub().withArgs(),
+      stopPropagation: sinon.stub().withArgs()
+    };
+    const renderer = jsTestUtils.shallowRender(
+      <juju.components.EntityHeader
+        acl={acl}
+        addNotification={sinon.stub()}
+        entityModel={mockEntity}
+        changeState={changeState}
+        deployService={sinon.spy()}
+        getBundleYAML={sinon.stub()}
+        getModelName={sinon.stub()}
+        hasPlans={false}
+        importBundleYAML={sinon.stub()}
+        pluralize={sinon.stub()}
+        scrollPosition={0}
+        urllib={urllib}
+      />, true);
+    const instance = renderer.getMountedInstance();
+    instance._onLastRevisionClick(evt);
+    assert.strictEqual(evt.preventDefault.callCount, 1, 'preventDefault');
+    assert.strictEqual(evt.stopPropagation.callCount, 1, 'stopPropagation');
+    assert.strictEqual(changeState.callCount, 1, 'changeState');
+    const args = changeState.args[0];
+    assert.strictEqual(args.length, 1, 'changeState args');
+    assert.deepEqual(args[0], {store: 'u/who/django/42'});
   });
 
   it('can disable the deploy button when read only', function() {
     acl.isReadOnly = sinon.stub().returns(true);
-    var renderer = jsTestUtils.shallowRender(
+    const renderer = jsTestUtils.shallowRender(
         <juju.components.EntityHeader
           acl={acl}
           addNotification={sinon.stub()}
@@ -525,17 +624,20 @@ describe('EntityHeader', function() {
           hasPlans={false}
           importBundleYAML={sinon.stub()}
           pluralize={sinon.stub()}
-          scrollPosition={0} />, true);
-    var instance = renderer.getMountedInstance();
-    var output = renderer.getRenderOutput();
-    var expected = (
+          scrollPosition={0}
+          urllib={urllib}
+        />, true);
+    const instance = renderer.getMountedInstance();
+    const output = renderer.getRenderOutput();
+    const expectedOutput = (
       <juju.components.GenericButton
         ref="deployAction"
         action={instance._handleDeployClick}
         disabled={true}
         type="positive"
         title="Add to model" />);
-    assert.deepEqual(output.props.children.props.children.props.children[1]
-      .props.children[2], expected);
+    expect(
+      output.props.children.props.children.props.children[1].props.children[2]
+    ).toEqualJSX(expectedOutput);
   });
 });

--- a/jujugui/static/gui/src/app/components/entity-details/test-entity-details.js
+++ b/jujugui/static/gui/src/app/components/entity-details/test-entity-details.js
@@ -24,7 +24,7 @@ chai.config.includeStack = true;
 chai.config.truncateThreshold = 0;
 
 describe('EntityDetails', function() {
-  var acl, mockEntity;
+  var acl, mockEntity, urllib;
 
   beforeAll(function(done) {
     // By loading these files it makes their classes available in the tests.
@@ -34,6 +34,7 @@ describe('EntityDetails', function() {
   beforeEach(function() {
     acl = {isReadOnly: sinon.stub().returns(false)};
     mockEntity = jsTestUtils.makeEntity();
+    urllib = {fromLegacyString: sinon.stub()};
   });
 
   afterEach(function() {
@@ -59,7 +60,9 @@ describe('EntityDetails', function() {
         pluralize={sinon.spy()}
         renderMarkdown={sinon.stub()}
         scrollPosition={0}
-        setPageTitle={sinon.stub()} />);
+        setPageTitle={sinon.stub()}
+        urllib={urllib}
+      />);
     assert.equal(output.props.className, 'entity-details');
   });
 
@@ -97,7 +100,9 @@ describe('EntityDetails', function() {
           pluralize={pluralize}
           addNotification={addNotification}
           makeEntityModel={makeEntityModel}
-          setPageTitle={sinon.stub()} />, true);
+          setPageTitle={sinon.stub()}
+          urllib={urllib}
+        />, true);
     const instance = shallowRenderer.getMountedInstance();
     instance.refs = {content: {focus: sinon.stub()}};
     instance.componentDidMount();
@@ -106,7 +111,7 @@ describe('EntityDetails', function() {
                   'getEntity function not called');
     assert.equal(getEntity.args[0][0], id,
                  'getEntity not called with the entity ID');
-    const expected = (
+    const expectedOutput = (
       <div className={'entity-details charm'}
         ref="content"
         tabIndex="0">
@@ -123,7 +128,9 @@ describe('EntityDetails', function() {
             deployService={deployService}
             plans={null}
             pluralize={pluralize}
-            scrollPosition={100} />
+            scrollPosition={100}
+            urllib={urllib}
+          />
           {undefined}
           <juju.components.EntityContent
             apiUrl={apiUrl}
@@ -133,11 +140,12 @@ describe('EntityDetails', function() {
             hasPlans={false}
             plans={null}
             pluralize={pluralize}
-            renderMarkdown={renderMarkdown} />
+            renderMarkdown={renderMarkdown}
+          />
           </div>
       </div>
     );
-    assert.deepEqual(output, expected);
+    expect(output).toEqualJSX(expectedOutput);
   });
 
   it('can display a message if there is a loading error', function() {
@@ -168,12 +176,14 @@ describe('EntityDetails', function() {
           id={id}
           pluralize={pluralize}
           scrollPosition={0}
-          setPageTitle={sinon.stub()} />, true);
+          setPageTitle={sinon.stub()}
+          urllib={urllib}
+        />, true);
     const instance = shallowRenderer.getMountedInstance();
     instance.refs = {content: {focus: sinon.stub()}};
     instance.componentDidMount();
     const output = shallowRenderer.getRenderOutput();
-    const expected = (
+    const expectedOutput = (
       <div className="entity-details"
         ref="content"
         tabIndex="0">
@@ -186,7 +196,7 @@ describe('EntityDetails', function() {
           </span>.
         </p>
       </div>);
-    assert.deepEqual(output, expected);
+    expect(output).toEqualJSX(expectedOutput);
   });
 
   it('can display a bundle diagram', function() {
@@ -224,7 +234,9 @@ describe('EntityDetails', function() {
           pluralize={pluralize}
           addNotification={addNotification}
           makeEntityModel={makeEntityModel}
-          setPageTitle={sinon.stub()} />, true);
+          setPageTitle={sinon.stub()}
+          urllib={urllib}
+        />, true);
     const instance = shallowRenderer.getMountedInstance();
     instance.refs = {content: {focus: sinon.stub()}};
     instance.componentDidMount();
@@ -233,7 +245,7 @@ describe('EntityDetails', function() {
                   'getEntity function not called');
     assert.equal(getEntity.args[0][0], id,
                  'getEntity not called with the entity ID');
-    const expected = (
+    const expectedOutput = (
       <div className={'entity-details bundle'}
         ref="content"
         tabIndex="0">
@@ -250,10 +262,13 @@ describe('EntityDetails', function() {
             addNotification={addNotification}
             plans={null}
             pluralize={pluralize}
-            scrollPosition={100} />
+            scrollPosition={100}
+            urllib={urllib}
+          />
           <juju.components.EntityContentDiagram
             getDiagramURL={getDiagramURL}
-            id={id} />
+            id={id}
+          />
           <juju.components.EntityContent
             apiUrl={apiUrl}
             changeState={changeState}
@@ -262,10 +277,11 @@ describe('EntityDetails', function() {
             hasPlans={false}
             plans={null}
             pluralize={pluralize}
-            renderMarkdown={renderMarkdown} />
+            renderMarkdown={renderMarkdown}
+          />
           </div>
       </div>);
-    assert.deepEqual(output, expected);
+    expect(output).toEqualJSX(expectedOutput);
   });
 
   it('will abort the request when unmounting', function() {
@@ -297,7 +313,9 @@ describe('EntityDetails', function() {
           id={id}
           pluralize={pluralize}
           scrollPosition={0}
-          setPageTitle={sinon.stub()} />, true);
+          setPageTitle={sinon.stub()}
+          urllib={urllib}
+        />, true);
     const instance = shallowRenderer.getMountedInstance();
     instance.refs = {content: {focus: sinon.stub()}};
     instance.componentDidMount();
@@ -325,7 +343,9 @@ describe('EntityDetails', function() {
         pluralize={sinon.spy()}
         renderMarkdown={sinon.stub()}
         scrollPosition={0}
-        setPageTitle={sinon.stub()} />, true);
+        setPageTitle={sinon.stub()}
+        urllib={urllib}
+      />, true);
     const instance = shallowRenderer.getMountedInstance();
     instance.refs = {content: {focus: focus}};
     instance.componentDidMount();
@@ -368,7 +388,9 @@ describe('EntityDetails', function() {
         pluralize={pluralize}
         renderMarkdown={renderMarkdown}
         scrollPosition={100}
-        setPageTitle={sinon.stub()} />, true);
+        setPageTitle={sinon.stub()}
+        urllib={urllib}
+      />, true);
     const instance = shallowRenderer.getMountedInstance();
     instance.refs = {content: {focus: sinon.stub()}};
     instance.componentDidMount();
@@ -377,7 +399,7 @@ describe('EntityDetails', function() {
                   'getEntity function not called');
     assert.equal(getEntity.args[0][0], id,
                  'getEntity not called with the entity ID');
-    const expected = (
+    const expectedOutput = (
       <div className={'entity-details charm'}
         ref="content"
         tabIndex="0">
@@ -394,7 +416,9 @@ describe('EntityDetails', function() {
             deployService={deployService}
             plans={plans}
             pluralize={pluralize}
-            scrollPosition={100} />
+            scrollPosition={100}
+            urllib={urllib}
+          />
           {undefined}
           <juju.components.EntityContent
             apiUrl={apiUrl}
@@ -404,10 +428,11 @@ describe('EntityDetails', function() {
             hasPlans={true}
             plans={plans}
             pluralize={pluralize}
-            renderMarkdown={renderMarkdown} />
+            renderMarkdown={renderMarkdown}
+          />
           </div>
       </div>);
-    assert.deepEqual(output, expected);
+    expect(output).toEqualJSX(expectedOutput);
     assert.equal(listPlansForCharm.callCount, 1);
     assert.equal(listPlansForCharm.args[0][0], 'cs:django');
   });
@@ -447,7 +472,9 @@ describe('EntityDetails', function() {
         pluralize={pluralize}
         renderMarkdown={renderMarkdown}
         scrollPosition={100}
-        setPageTitle={sinon.stub()} />, true);
+        setPageTitle={sinon.stub()}
+        urllib={urllib}
+      />, true);
     const instance = shallowRenderer.getMountedInstance();
     instance.refs = {content: {focus: sinon.stub()}};
     instance.componentDidMount();
@@ -456,7 +483,7 @@ describe('EntityDetails', function() {
                   'getEntity function not called');
     assert.equal(getEntity.args[0][0], id,
                  'getEntity not called with the entity ID');
-    const expected = (
+    const expectedOutput = (
       <div className={'entity-details charm'}
         ref="content"
         tabIndex="0">
@@ -473,7 +500,9 @@ describe('EntityDetails', function() {
             deployService={deployService}
             plans={[]}
             pluralize={pluralize}
-            scrollPosition={100} />
+            scrollPosition={100}
+            urllib={urllib}
+          />
           {undefined}
           <juju.components.EntityContent
             apiUrl={apiUrl}
@@ -483,10 +512,11 @@ describe('EntityDetails', function() {
             hasPlans={true}
             plans={[]}
             pluralize={pluralize}
-            renderMarkdown={renderMarkdown} />
+            renderMarkdown={renderMarkdown}
+          />
           </div>
       </div>);
-    assert.deepEqual(output, expected);
+    expect(output).toEqualJSX(expectedOutput);
     assert.equal(listPlansForCharm.callCount, 1);
   });
 });


### PR DESCRIPTION
Specifically, include a link to the last revision of a charm/bundle (if not already on the latest one) and modify the charm/bundle owner link to point to the GUI profile page itself, not externally on some launchpad page.

The latest revision part of this branch fixes part of https://github.com/juju/juju-gui/issues/2726