### PR TITLE
Add domain to ACL canRemoveModel check

### DIFF
--- a/jujugui/static/gui/src/app/store/env/acl.js
+++ b/jujugui/static/gui/src/app/store/env/acl.js
@@ -87,7 +87,13 @@ YUI.add('acl', function(Y) {
       */
       canRemoveModel: model => {
         const currentUser = getUser();
-        if (model.owner !== currentUser) {
+        // model.owner does not have the domain compoent in gijoe. So if one
+        // is missing we can assume that the domain is @local.
+        let modelOwner = model.owner;
+        if (modelOwner.indexOf('@') < 0) {
+          modelOwner = `${modelOwner}@local`;
+        }
+        if (modelOwner !== currentUser) {
           return false;
         }
         for (let user of model.users) {

--- a/jujugui/static/gui/src/app/store/env/acl.js
+++ b/jujugui/static/gui/src/app/store/env/acl.js
@@ -87,7 +87,7 @@ YUI.add('acl', function(Y) {
       */
       canRemoveModel: model => {
         const currentUser = getUser();
-        // model.owner does not have the domain compoent in gijoe. So if one
+        // model.owner does not have the domain component in gijoe. So if one
         // is missing we can assume that the domain is @local.
         let modelOwner = model.owner;
         if (modelOwner.indexOf('@') < 0) {

--- a/jujugui/static/gui/src/app/store/env/test-acl.js
+++ b/jujugui/static/gui/src/app/store/env/test-acl.js
@@ -120,10 +120,10 @@ describe('ACL', function() {
 
   it('canRemoveModel', () => {
     const model = makeModel('who', {
-      who: 'admin',
-      dalek: 'admin',
-      rose: 'write',
-      cyberman: 'read'
+      'who@local': 'admin',
+      'dalek@local': 'admin',
+      'rose@local': 'write',
+      'cyberman@local': 'read'
     });
     let acl = makeACL({});
     assert.strictEqual(acl.canRemoveModel(model), false);
@@ -135,7 +135,7 @@ describe('ACL', function() {
     assert.strictEqual(acl.canRemoveModel(model), false);
     acl = makeACL({user: 'dalek'});
     assert.strictEqual(acl.canRemoveModel(model), false);
-    acl = makeACL({user: 'who'});
+    acl = makeACL({user: 'who@local'});
     assert.strictEqual(acl.canRemoveModel(model), true);
     acl = makeACL({user: 'who'});
     const model2 = makeModel('who', {who: 'read'});

--- a/jujugui/static/gui/src/app/store/env/test-acl.js
+++ b/jujugui/static/gui/src/app/store/env/test-acl.js
@@ -137,6 +137,9 @@ describe('ACL', function() {
     assert.strictEqual(acl.canRemoveModel(model), false);
     acl = makeACL({user: 'who@local'});
     assert.strictEqual(acl.canRemoveModel(model), true);
+    const model1 = makeModel('who@external', {'who@external': 'admin'});
+    acl = makeACL({user: 'who@external'});
+    assert.strictEqual(acl.canRemoveModel(model1), true);
     acl = makeACL({user: 'who'});
     const model2 = makeModel('who', {who: 'read'});
     assert.strictEqual(acl.canRemoveModel(model2), false);


### PR DESCRIPTION
In gijoe the model owner tag is in the format `user-hatch` instead of the jaas version of `user-hatch@external` so we have to add a domain to the model owner when making the check.