### PR TITLE
Dedupe tags on charm model creation.

### DIFF
--- a/jujugui/static/gui/src/app/models/charm.js
+++ b/jujugui/static/gui/src/app/models/charm.js
@@ -698,6 +698,9 @@ YUI.add('juju-charm-models', function(Y) {
       series: {},
 
       summary: {},
+      tags: {
+        setter: val => [...new Set(val)]
+      },
       tested_providers: {},
       url: {},
       iconPath: {

--- a/jujugui/static/gui/src/test/test_model.js
+++ b/jujugui/static/gui/src/test/test_model.js
@@ -41,6 +41,14 @@ describe('test_model.js', function() {
           '~alt-bac/precise/openstack-dashboard');
     });
 
+    it('must dedupe tags', () => {
+      const charm = new models.Charm({
+        id: 'cs:precise/openstack-dashboard-0',
+        tags:['bar', 'bar', 'foo', 'foo']
+      });
+      assert.deepEqual(charm.get('tags'), ['bar', 'foo']);
+    });
+
     it('must not set "owner" for promulgated charms', function() {
       var charm = new models.Charm({
         id: 'cs:precise/openstack-dashboard-0'


### PR DESCRIPTION
Charmstore doesn't dedupe tags so when a charm has multiples listed in their metadata we were displaying them multiple times. 