### PR TITLE
Add url hash support to state.js

### DIFF
--- a/jujugui/static/gui/src/app/state/state.js
+++ b/jujugui/static/gui/src/app/state/state.js
@@ -105,28 +105,35 @@ const State = class State {
 
   /**
     Takes the complete URL and runs it through various process methods and
-    returns an object with the processed url parts and query string.
+    returns an object with the processed url parts, query, and hash.
     @param {String} url - The URL to process.
     @return {Object} The processed url.
   */
   _processURL(url) {
+    const processed = {};
     const stripLRSlashes = path => path.replace(/^\/*/, '').replace(/\/*$/, '');
     // Strip the baseURL before parsing the sections.
     const cleanURL = stripLRSlashes(url.replace(this.baseURL, ''));
-    const splitURL = cleanURL.split('?');
-    const processed = {};
-    if (splitURL[1]) {
+    // The following regex splits a supplied url into its three parts, path,
+    // query, and hash.
+    const urlSplitRegex = /([^?#]+)?(?:\?([^#]+))?(?:#(.*))?/;
+    const splitURL = urlSplitRegex.exec(cleanURL);
+    const path = splitURL[1];
+    if (path) {
+      processed.parts = stripLRSlashes(path).split('/');
+    }
+    const query = splitURL[2];
+    if (query) {
       processed.query = {};
-      splitURL[1].split('&')
+      query.split('&')
            .forEach(section => {
              const parts = section.split('=');
              processed.query[parts[0]] = parts[1];
            });
     }
-    // The url parts without the query split on the / delimeter.
-    const cleanParts = stripLRSlashes(splitURL[0]);
-    if (cleanParts.length > 0) {
-      processed.parts = cleanParts.split('/');
+    const hash = splitURL[3];
+    if (hash) {
+      processed.hash = hash;
     }
     return processed;
   }

--- a/jujugui/static/gui/src/app/state/state.js
+++ b/jujugui/static/gui/src/app/state/state.js
@@ -499,6 +499,10 @@ const State = class State {
     const splitURL = this._processURL(url);
     let parts = splitURL.parts;
     const query = splitURL.query;
+    const hash = splitURL.hash;
+    if (hash) {
+      state.hash = hash;
+    }
     state = this._parseSpecial(query, state, allowStateModifications);
     // If we have an invalid parts or invalid query then we can return early.
     if (invalidParts(parts) && !query) {

--- a/jujugui/static/gui/src/app/state/state.js
+++ b/jujugui/static/gui/src/app/state/state.js
@@ -591,6 +591,8 @@ const State = class State {
   */
   generatePath(stateObj = this.current) {
     let path = [];
+    let hash = stateObj.hash;
+    let hashAdded = false;
     const root = stateObj.root;
     if (root) {
       path.push(root);
@@ -615,7 +617,15 @@ const State = class State {
           }
         });
         if (querystrings.length > 0) {
-          path.push(`?${querystrings.join('&')}`);
+          // If there is a hash with a query string them we do not want the
+          // join at the end of the fn to put a slash between the query and
+          // the hash.
+          let queryHash = '';
+          if (hash) {
+            queryHash = `#${stateObj.hash}`;
+            hashAdded = true;
+          }
+          path.push(`?${querystrings.join('&')}${queryHash}`);
         }
       }
     }
@@ -661,6 +671,9 @@ const State = class State {
           }
         }
       });
+    }
+    if (hash && !hashAdded) {
+      path.push(`#${hash}`);
     }
     return `${this.baseURL}${path.join('/')}`;
   }

--- a/jujugui/static/gui/src/app/state/test-state.js
+++ b/jujugui/static/gui/src/app/state/test-state.js
@@ -70,7 +70,7 @@ describe('State', () => {
     state: { store: 'u/frankban/django/bundle/0' },
     error: null
   }, {
-    path: 'http://abc.com:123/u/frankban/django/bundle/0#jam',
+    path: 'http://abc.com:123/u/frankban/django/bundle/0/#jam',
     state: { hash: 'jam', store: 'u/frankban/django/bundle/0' },
     error: null
   }];
@@ -100,7 +100,7 @@ describe('State', () => {
     state: { root: 'login' },
     error: null
   }, {
-    path: 'http://abc.com:123/login#honey',
+    path: 'http://abc.com:123/login/#honey',
     state: {root: 'login', hash: 'honey'},
     error: null
   }];
@@ -191,7 +191,7 @@ describe('State', () => {
     },
     error: null
   }, {
-    path: 'http://abc.com:123/i/inspector/local/update#ketchup',
+    path: 'http://abc.com:123/i/inspector/local/update/#ketchup',
     state: {
       hash: 'ketchup',
       gui: {inspector: {localType: 'update'}}
@@ -216,7 +216,7 @@ describe('State', () => {
     state: { store: 'django/bundle/47' },
     error: null
   }, {
-    path: 'http://abc.com:123/django/bundle/47#relish',
+    path: 'http://abc.com:123/django/bundle/47/#relish',
     state: { hash: 'relish', store: 'django/bundle/47' },
     error: null
   }];
@@ -257,7 +257,7 @@ describe('State', () => {
     error: null
   }, {
     path:
-      'http://abc.com:123/u/frankban/production/u/frankban/django/bundle/0#ham',
+      'http://abc.com:123/u/frankban/production/u/frankban/django/bundle/0/#ham', // eslint-disable-line max-len
     state: {
       hash: 'ham',
       user: 'frankban/production', store: 'u/frankban/django/bundle/0' },
@@ -284,7 +284,7 @@ describe('State', () => {
     error: null
   }, {
     path:
-      'http://abc.com:123/u/hatch/staging/i/applications/inspector/ghost#mayo',
+      'http://abc.com:123/u/hatch/staging/i/applications/inspector/ghost/#mayo',
     state: {
       hash: 'mayo',
       user: 'hatch/staging', gui: {applications: '', inspector: {id:'ghost' }}},
@@ -389,7 +389,7 @@ describe('State', () => {
     },
     error: null
   }, {
-    path: 'http://abc.com:123/u/frankban/production/u/frankban/django/bundle/0/i/applications#turkey', // eslint-disable-line max-len
+    path: 'http://abc.com:123/u/frankban/production/u/frankban/django/bundle/0/i/applications/#turkey', // eslint-disable-line max-len
     state: {
       hash: 'turkey',
       user: 'frankban/production',

--- a/jujugui/static/gui/src/app/state/test-state.js
+++ b/jujugui/static/gui/src/app/state/test-state.js
@@ -476,6 +476,20 @@ describe('State', () => {
         state._processURL(
           'http://abc.com:123/a/b/c/?deploy-target=cs:trusty/ceph45'),
         {parts: ['a', 'b', 'c'], query: {'deploy-target': 'cs:trusty/ceph45'}});
+      assert.deepEqual(
+        state._processURL('http://abc.com:123/#apple-sauce'),
+        {hash: 'apple-sauce'});
+      assert.deepEqual(
+        state._processURL('http://abc.com:123/a/b/#granola'),
+        {parts: ['a', 'b'], hash: 'granola'});
+      assert.deepEqual(
+        state._processURL(
+          'http://abc.com:123/a/b/?deploy-target=cs:trusty/ceph45#gummybear'),
+        {
+          parts: ['a', 'b'],
+          query: {'deploy-target': 'cs:trusty/ceph45'},
+          hash: 'gummybear'
+        });
     });
   });
 

--- a/jujugui/static/gui/src/app/state/test-state.js
+++ b/jujugui/static/gui/src/app/state/test-state.js
@@ -39,6 +39,14 @@ describe('State', () => {
       special: {
         next: '/u/frankban/prod', deployTarget: 'cs:trusty/kibana-15'}},
     error: null
+  }, {
+    path: 'http://abc.com:123/login?next=/u/frankban/prod&deploy-target=cs:trusty/kibana-15#peanut-butter', // eslint-disable-line max-len
+    state: {
+      root: 'login',
+      hash: 'peanut-butter',
+      special: {
+        next: '/u/frankban/prod', deployTarget: 'cs:trusty/kibana-15'}},
+    error: null
   }];
 
   const userStateTests = [{
@@ -61,6 +69,10 @@ describe('State', () => {
     path: 'http://abc.com:123/u/frankban/django/bundle/0',
     state: { store: 'u/frankban/django/bundle/0' },
     error: null
+  }, {
+    path: 'http://abc.com:123/u/frankban/django/bundle/0#jam',
+    state: { hash: 'jam', store: 'u/frankban/django/bundle/0' },
+    error: null
   }];
 
   const rootStateTests = [{
@@ -71,21 +83,25 @@ describe('State', () => {
     path: 'http://abc.com:123/new',
     state: { root: 'new' },
     error: null
-  },{
+  }, {
     path: 'http://abc.com:123/store',
     state: { root: 'store' },
     error: null
-  },{
+  }, {
     path: 'http://abc.com:123/about',
     state: { root: 'about' },
     error: null
-  },{
+  }, {
     path: 'http://abc.com:123/docs',
     state: { root: 'docs' },
     error: null
-  },{
+  }, {
     path: 'http://abc.com:123/login',
     state: { root: 'login' },
+    error: null
+  }, {
+    path: 'http://abc.com:123/login#honey',
+    state: {root: 'login', hash: 'honey'},
     error: null
   }];
 
@@ -118,6 +134,15 @@ describe('State', () => {
   }, {
     path: 'http://abc.com:123/q/?series=yakkety',
     state: {
+      search: {
+        series: 'yakkety'
+      }
+    },
+    error: null
+  }, {
+    path: 'http://abc.com:123/q/?series=yakkety#mustard',
+    state: {
+      hash: 'mustard',
       search: {
         series: 'yakkety'
       }
@@ -165,6 +190,13 @@ describe('State', () => {
       gui: {inspector: {localType: 'update'}}
     },
     error: null
+  }, {
+    path: 'http://abc.com:123/i/inspector/local/update#ketchup',
+    state: {
+      hash: 'ketchup',
+      gui: {inspector: {localType: 'update'}}
+    },
+    error: null
   }];
 
   const storeStateTests = [{
@@ -182,6 +214,10 @@ describe('State', () => {
   }, {
     path: 'http://abc.com:123/django/bundle/47',
     state: { store: 'django/bundle/47' },
+    error: null
+  }, {
+    path: 'http://abc.com:123/django/bundle/47#relish',
+    state: { hash: 'relish', store: 'django/bundle/47' },
     error: null
   }];
 
@@ -219,6 +255,13 @@ describe('State', () => {
     state: {
       user: 'frankban/production', store: 'u/frankban/django/bundle/0' },
     error: null
+  }, {
+    path:
+      'http://abc.com:123/u/frankban/production/u/frankban/django/bundle/0#ham',
+    state: {
+      hash: 'ham',
+      user: 'frankban/production', store: 'u/frankban/django/bundle/0' },
+    error: null
   }];
 
   const modelGuiStateTests = [{
@@ -237,6 +280,13 @@ describe('State', () => {
     path:
       'http://abc.com:123/u/hatch/staging/i/applications/inspector/ghost',
     state: {
+      user: 'hatch/staging', gui: {applications: '', inspector: {id:'ghost' }}},
+    error: null
+  }, {
+    path:
+      'http://abc.com:123/u/hatch/staging/i/applications/inspector/ghost#mayo',
+    state: {
+      hash: 'mayo',
       user: 'hatch/staging', gui: {applications: '', inspector: {id:'ghost' }}},
     error: null
   }];
@@ -333,6 +383,15 @@ describe('State', () => {
   }, {
     path: 'http://abc.com:123/u/frankban/production/u/frankban/django/bundle/0/i/applications', // eslint-disable-line max-len
     state: {
+      user: 'frankban/production',
+      store: 'u/frankban/django/bundle/0',
+      gui: { applications: '' }
+    },
+    error: null
+  }, {
+    path: 'http://abc.com:123/u/frankban/production/u/frankban/django/bundle/0/i/applications#turkey', // eslint-disable-line max-len
+    state: {
+      hash: 'turkey',
       user: 'frankban/production',
       store: 'u/frankban/django/bundle/0',
       gui: { applications: '' }

--- a/karma-mocha-old.conf.js.tmpl
+++ b/karma-mocha-old.conf.js.tmpl
@@ -128,7 +128,10 @@ module.exports = function(config) {
     // test results reporter to use
     // possible values: 'dots', 'progress'
     // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-    reporters: ['mocha'],
+    reporters: ['spec'],
+    specReporter : {
+      suppressSkipped: true
+    },
 
     // web server and port
     hostname: '0.0.0.0',

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -87,9 +87,11 @@ module.exports = function(config) {
     },
 
     // test results reporter to use
-    // possible values: 'dots', 'progress'
     // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-    reporters: ['jasmine-expect-jsx', 'mocha'],
+    reporters: ['spec'],
+    specReporter : {
+      suppressSkipped: true
+    },
 
     // web server and port
     hostname: '0.0.0.0',

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "juju-gui",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "dependencies": {
     "accepts": {
       "version": "1.3.3",
@@ -1722,7 +1722,7 @@
       "dependencies": {
         "mime": {
           "version": "1.2.11",
-          "from": "mime@>=1.2.2 <1.3.0",
+          "from": "mime@~1.2.2",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
           "dev": true
         }
@@ -2635,7 +2635,7 @@
     },
     "karma": {
       "version": "1.5.0",
-      "from": "karma@>=1.5.0 <2.0.0",
+      "from": "karma@1.5.0",
       "resolved": "https://registry.npmjs.org/karma/-/karma-1.5.0.tgz",
       "dev": true,
       "dependencies": {
@@ -2673,13 +2673,13 @@
     },
     "karma-chrome-launcher": {
       "version": "2.0.0",
-      "from": "karma-chrome-launcher@>=2.0.0 <3.0.0",
+      "from": "karma-chrome-launcher@2.0.0",
       "resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-2.0.0.tgz",
       "dev": true
     },
     "karma-jasmine": {
       "version": "1.1.0",
-      "from": "karma-jasmine@>=1.1.0 <2.0.0",
+      "from": "karma-jasmine@1.1.0",
       "resolved": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-1.1.0.tgz",
       "dev": true
     },
@@ -2711,10 +2711,10 @@
         }
       }
     },
-    "karma-mocha-reporter": {
-      "version": "2.2.3",
-      "from": "karma-mocha-reporter@>=2.2.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/karma-mocha-reporter/-/karma-mocha-reporter-2.2.3.tgz",
+    "karma-spec-reporter": {
+      "version": "0.0.31",
+      "from": "karma-spec-reporter@latest",
+      "resolved": "https://registry.npmjs.org/karma-spec-reporter/-/karma-spec-reporter-0.0.31.tgz",
       "dev": true
     },
     "kew": {
@@ -3012,7 +3012,7 @@
     },
     "mocha": {
       "version": "3.2.0",
-      "from": "mocha@>=3.2.0 <4.0.0",
+      "from": "mocha@3.2.0",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.2.0.tgz",
       "dev": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "karma-jasmine": "^1.1.0",
     "karma-jasmine-expect-jsx": "^1.0.2",
     "karma-mocha": "^1.0.1",
-    "karma-mocha-reporter": "^2.2.2",
+    "karma-spec-reporter": "0.0.31",
     "keysim": "^2.0.0",
     "mocha": "^3.2.0",
     "should": "^11.2.1",

--- a/scripts/test-js-old.sh
+++ b/scripts/test-js-old.sh
@@ -39,4 +39,4 @@ sleep 2
 # Capture ctrl-c
 trap 'finished' SIGINT SIGQUIT SIGTERM SIGCHLD
 
-DISPLAY=:99 CHROME_BIN='/usr/bin/chromium-browser' node_modules/.bin/karma start karma-mocha-old.conf.js --single-run --browsers Chrome --log-level warn --reporters mocha
+DISPLAY=:99 CHROME_BIN='/usr/bin/chromium-browser' node_modules/.bin/karma start karma-mocha-old.conf.js --single-run --browsers Chrome --log-level warn

--- a/scripts/test-js.sh
+++ b/scripts/test-js.sh
@@ -24,4 +24,4 @@ if [ -n "$MULTI_RUN" ]; then
   SINGLE_RUN=""
 fi
 
-DISPLAY=:99 CHROME_BIN='/usr/bin/chromium-browser' node_modules/.bin/karma start karma.conf.js $SINGLE_RUN --browsers Chrome --log-level warn --reporters mocha
+DISPLAY=:99 CHROME_BIN='/usr/bin/chromium-browser' node_modules/.bin/karma start karma.conf.js $SINGLE_RUN --browsers Chrome --log-level warn


### PR DESCRIPTION
In order to support anchor tag linking the state system first needed to support having the hash parsed and generated from state.

As a drive-by I changed the karma reporter so that skipped tests are no longer printed so that it makes debugging easier