### PR TITLE
Fixes to display names and charm owner links.

### DIFF
--- a/jujugui/static/gui/src/app/components/search-results/item/item.js
+++ b/jujugui/static/gui/src/app/components/search-results/item/item.js
@@ -183,25 +183,15 @@ YUI.add('search-results-item', function(Y) {
     },
 
     /**
-      Show search results for the given owner.
+      Navigate to the profile page of the given owner.
 
       @method _handleOwnerClick
       @param {String} owner The owner's name.
-      @param {Object} e The click event.
+      @param {Object} evt The click event.
     */
-    _handleOwnerClick: function(owner, e) {
-      e.stopPropagation();
-      this.props.changeState({
-        search: {
-          owner: owner,
-          provides: null,
-          requires: null,
-          series: null,
-          tags: null,
-          text: '',
-          type: null
-        }
-      });
+    _handleOwnerClick: function(owner, evt) {
+      evt.stopPropagation();
+      this.props.changeState({search: null, profile: owner});
     },
 
     /**

--- a/jujugui/static/gui/src/app/components/search-results/item/test-item.js
+++ b/jujugui/static/gui/src/app/components/search-results/item/test-item.js
@@ -412,9 +412,9 @@ describe('SearchResultsItem', function() {
   });
 
   it('can handle clicking on an owner', function() {
-    var changeState = sinon.stub();
-    var stopPropagation = sinon.stub();
-    var item = {
+    const changeState = sinon.stub();
+    const stopPropagation = sinon.stub();
+    const item = {
       name: 'mysql',
       displayName: 'mysql',
       special: true,
@@ -428,7 +428,7 @@ describe('SearchResultsItem', function() {
       tags: ['tag1', 'tag2'],
       series: [{name: 'vivid'}, {name: 'wily'}]
     };
-    var output = jsTestUtils.shallowRender(
+    const output = jsTestUtils.shallowRender(
         <juju.components.SearchResultsItem
           changeState={changeState}
           key={item.storeId}
@@ -438,15 +438,8 @@ describe('SearchResultsItem', function() {
     assert.equal(changeState.callCount, 1);
     assert.equal(stopPropagation.callCount, 1);
     assert.deepEqual(changeState.args[0][0], {
-      search: {
-        owner: 'test-owner',
-        provides: null,
-        requires: null,
-        series: null,
-        tags: null,
-        text: '',
-        type: null
-      }
+      search: null,
+      profile: 'test-owner'
     });
   });
 

--- a/jujugui/static/gui/src/app/models/entity-extension.js
+++ b/jujugui/static/gui/src/app/models/entity-extension.js
@@ -60,7 +60,7 @@ YUI.add('entity-extension', function(Y) {
       if (attrs.name === 'canonical-kubernetes') {
         displayName = 'The Canonical Distribution Of Kubernetes';
       } else {
-        displayName = attrs.name.replace('-', ' ');
+        displayName = attrs.name.split('-').join(' ');
       }
       const entity = {
         description: attrs.description,

--- a/jujugui/static/gui/src/test/test_entity_extension.js
+++ b/jujugui/static/gui/src/test/test_entity_extension.js
@@ -40,7 +40,7 @@ describe('Entity Extension', function() {
     var attrs = {
       id: '~owner/foobar',
       storeId: 'cs:~owner/foobar-132',
-      name: 'foo-bar',
+      name: 'foo-bar-entity',
       description: 'A test description.',
       revision_id: 132,
       downloads: '0',
@@ -79,12 +79,12 @@ describe('Entity Extension', function() {
     var entity = entityModel.toEntity();
     var expected = {
       description: 'A test description.',
-      displayName: 'foo bar',
+      displayName: 'foo bar entity',
       downloads: '0',
       id: '~owner/foobar',
       revision_id: 132,
       storeId: 'cs:~owner/foobar-132',
-      name: 'foo-bar',
+      name: 'foo-bar-entity',
       owner: 'owner',
       promulgated: false,
       revisions: [],
@@ -116,13 +116,13 @@ describe('Entity Extension', function() {
     var entity = entityModel.toEntity();
     var expected = {
       description: 'A test description.',
-      displayName: 'foo bar',
+      displayName: 'foo bar entity',
       downloads: '0',
       id: 'foobar',
       revision_id: '132',
       storeId: 'cs:~owner/foobar-132',
       machineCount: 2,
-      name: 'foo-bar',
+      name: 'foo-bar-entity',
       owner: 'foobar-charmers',
       promulgated: false,
       revisions: [],


### PR DESCRIPTION
Clicking on the user in search results points to the corresponding profile page (fixes https://github.com/juju/juju-gui/issues/2760).
Properly generate the charm/bundle display names (fixes https://github.com/juju/juju-gui/issues/2758).