### PR TITLE
Add Direct Deploy functionality

### DIFF
--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -1367,7 +1367,6 @@ YUI.add('juju-gui', function(Y) {
       const controllerIsAvailable = () =>
         this.controllerAPI &&
         this.controllerAPI.get('connected') &&
-        !this.controllerAPI.pendingLoginResponse &&
         this.controllerAPI.userIsAuthenticated;
       const loginToController =
         controllerAPI.loginWithMacaroon.bind(

--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -1360,6 +1360,10 @@ YUI.add('juju-gui', function(Y) {
         const credentials = this.user.controller;
         return credentials ? credentials.user : undefined;
       };
+      const controllerIsAvailable = () =>
+        this.controllerAPI &&
+        this.controllerAPI.get('connected') &&
+        !this.controllerAPI.pendingLoginResponse;
       const loginToController =
         controllerAPI.loginWithMacaroon.bind(
           controllerAPI, this.bakeryFactory.get('juju'));
@@ -1379,6 +1383,7 @@ YUI.add('juju-gui', function(Y) {
             changesUtils.filterByParent.bind(changesUtils, currentChangeSet)}
           changeState={this.state.changeState.bind(this.state)}
           cloud={cloud}
+          controllerIsAvailable={controllerIsAvailable}
           createToken={this.stripe && this.stripe.createToken.bind(this.stripe)}
           createCardElement={
             this.stripe && this.stripe.createCardElement.bind(this.stripe)}

--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -731,7 +731,7 @@ YUI.add('juju-gui', function(Y) {
 
         if (state.current.root === 'login') {
           if (dd) {
-            console.log('Initiating Direct Deploy.');
+            console.log('initiating direct deploy');
             this.maskVisibility(false);
             this._directDeploy(dd);
             return;
@@ -2284,15 +2284,15 @@ YUI.add('juju-gui', function(Y) {
       Calls the necessary methods to setup the GUI and put the user in the
       Deployment Flow when they have used Direct Deploy.
 
-      @param {Object} dd - The Direct Deploy data from state.
+      @param {Object} ddData - The Direct Deploy data from state.
     */
     _directDeploy: function(ddData) {
       this.state.changeState({
         special: {dd: null}
       });
-      // Reusing deployTarget state method so faking request signature
+      // The deployTarget method is called directly by state. We're reusing it
+      // here so the state call signature needs to be replicated.
       this._deployTarget({special: {deployTarget: ddData.id}}, ()=>{});
-      // The user must log in first
       this._renderDeployment(this.state, ()=>{}, ddData);
     },
 

--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -1328,7 +1328,8 @@ YUI.add('juju-gui', function(Y) {
       const connected = this.env.get('connected');
       const modelName = env.get('environmentName') || 'mymodel';
       const utils = views.utils;
-      const currentChangeSet = env.get('ecs').getCurrentChangeSet();
+      const ecs = env.get('ecs');
+      const currentChangeSet = ecs.getCurrentChangeSet();
       if (Object.keys(currentChangeSet).length === 0 && !ddData) {
         // If there are no changes then close the deployment flow. This is to
         // prevent showing the deployment flow if the user clicks back in the
@@ -1401,6 +1402,7 @@ YUI.add('juju-gui', function(Y) {
           getCloudCredentialNames={
             controllerAPI.getCloudCredentialNames.bind(controllerAPI)}
           getCloudProviderDetails={utils.getCloudProviderDetails.bind(utils)}
+          getCurrentChangeSet={ecs.getCurrentChangeSet.bind(ecs)}
           getCountries={
               this.payment && this.payment.getCountries.bind(this.payment)}
           getDiagramURL={charmstore.getDiagramURL.bind(charmstore)}

--- a/jujugui/static/gui/src/app/components/deployment-flow/_deployment-flow.scss
+++ b/jujugui/static/gui/src/app/components/deployment-flow/_deployment-flow.scss
@@ -23,6 +23,10 @@
     .button--neutral {
       background-color: $white;
     }
+
+    .entity-content__diagram-image {
+      width: 950px;
+    }
   }
 
   &__notice {

--- a/jujugui/static/gui/src/app/components/deployment-flow/changes/changes.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/changes/changes.js
@@ -21,38 +21,49 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 YUI.add('deployment-changes', function() {
 
   juju.components.DeploymentChanges = React.createClass({
+    displayName: 'DeploymentChanges',
+
     propTypes: {
-      changes: React.PropTypes.object.isRequired,
-      generateAllChangeDescriptions: React.PropTypes.func.isRequired
+      generateAllChangeDescriptions: React.PropTypes.func.isRequired,
+      getCurrentChangeSet: React.PropTypes.func.isRequired
     },
 
-    /**
-      Generate the list of change items.
+    getInitialState: function() {
+      this.interval = null;
+      return {
+        changes: this.props.getCurrentChangeSet()
+      };
+    },
 
-      @method _generateChanges
-      @returns {Array} A list of change elements.
-    */
-    _generateChanges: function() {
-      const descriptions = this.props.generateAllChangeDescriptions(
-        this.props.changes);
-      return descriptions.map(change => (
-        <juju.components.DeploymentChangeItem
-          change={change}
-          key={change.id}
-          showTime={false} />));
+    componentDidMount: function() {
+      // poll the changeset every second for updates as there is no way that
+      // we can be sure when a bundle import will be complete.
+      this.interval = setInterval(() => {
+        this.setState({changes: this.props.getCurrentChangeSet()});
+      }, 1000);
+    },
+
+    componentWillUnmount: function() {
+      clearInterval(this.interval);
     },
 
     render: function() {
+      const state = this.state;
       return (
         <juju.components.ExpandingRow
           classes={{'twelve-col': true}}
           clickable={true}>
           <div>
-            Show changes ({Object.keys(this.props.changes).length})
+            Show changes ({Object.keys(state.changes).length})
             &rsaquo;
           </div>
           <ul className="deployment-changes">
-            {this._generateChanges()}
+            {this.props.generateAllChangeDescriptions(state.changes)
+              .map(change => (
+                <juju.components.DeploymentChangeItem
+                  change={change}
+                  key={change.id}
+                  showTime={false} />))}
           </ul>
         </juju.components.ExpandingRow>
       );

--- a/jujugui/static/gui/src/app/components/deployment-flow/changes/changes.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/changes/changes.js
@@ -29,22 +29,9 @@ YUI.add('deployment-changes', function() {
     },
 
     getInitialState: function() {
-      this.interval = null;
       return {
         changes: this.props.getCurrentChangeSet()
       };
-    },
-
-    componentDidMount: function() {
-      // poll the changeset every second for updates as there is no way that
-      // we can be sure when a bundle import will be complete.
-      this.interval = setInterval(() => {
-        this.setState({changes: this.props.getCurrentChangeSet()});
-      }, 1000);
-    },
-
-    componentWillUnmount: function() {
-      clearInterval(this.interval);
     },
 
     render: function() {

--- a/jujugui/static/gui/src/app/components/deployment-flow/changes/test-changes.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/changes/test-changes.js
@@ -37,7 +37,7 @@ describe('DeploymentChanges', function() {
     ];
     var renderer = jsTestUtils.shallowRender(
       <juju.components.DeploymentChanges
-        changes={{one: 1, two: 2}}
+        getCurrentChangeSet={sinon.stub().returns({one: 1, two: 2})}
         generateAllChangeDescriptions={sinon.stub().returns(changes)} />, true);
     var output = renderer.getRenderOutput();
     var expected = (

--- a/jujugui/static/gui/src/app/components/deployment-flow/cloud/cloud.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/cloud/cloud.js
@@ -49,7 +49,7 @@ YUI.add('deployment-cloud', function() {
         }
         this.props.listClouds((error, clouds) => {
           if (error) {
-            console.error('Unable to list clouds', error);
+            console.error('unable to list clouds:', error);
             return;
           }
           let cloudList = [];

--- a/jujugui/static/gui/src/app/components/deployment-flow/cloud/cloud.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/cloud/cloud.js
@@ -21,9 +21,12 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 YUI.add('deployment-cloud', function() {
 
   juju.components.DeploymentCloud = React.createClass({
+    displayName: 'DeploymentCloud',
+
     propTypes: {
       acl: React.PropTypes.object.isRequired,
       cloud: React.PropTypes.object,
+      controllerIsAvailable: React.PropTypes.func.isRequired,
       getCloudProviderDetails: React.PropTypes.func.isRequired,
       listClouds: React.PropTypes.func.isRequired,
       setCloud: React.PropTypes.func.isRequired
@@ -37,28 +40,37 @@ YUI.add('deployment-cloud', function() {
     },
 
     componentWillMount: function() {
-      this.props.listClouds((error, clouds) => {
-        if (error) {
-          console.error('Unable to list clouds', error);
+      const listClouds = () => {
+        // It is possible that the controller hasn't yet connected so
+        // bounce until it's connected then fetch the clouds list.
+        if (!this.props.controllerIsAvailable()) {
+          setTimeout(listClouds, 500);
           return;
         }
-        let cloudList = [];
-        if (clouds) {
-          cloudList = Object.keys(clouds).map(name => {
-            const cloud = clouds[name];
-            cloud.name = name;
-            return cloud;
+        this.props.listClouds((error, clouds) => {
+          if (error) {
+            console.error('Unable to list clouds', error);
+            return;
+          }
+          let cloudList = [];
+          if (clouds) {
+            cloudList = Object.keys(clouds).map(name => {
+              const cloud = clouds[name];
+              cloud.name = name;
+              return cloud;
+            });
+          }
+          this.setState({
+            clouds: cloudList,
+            cloudsLoading: false
           });
-        }
-        this.setState({
-          clouds: cloudList,
-          cloudsLoading: false
+          // If there is only one cloud then automatically select it.
+          if (cloudList.length === 1) {
+            this.props.setCloud(cloudList[0]);
+          }
         });
-        // If there is only one cloud then automatically select it.
-        if (cloudList.length === 1) {
-          this.props.setCloud(cloudList[0]);
-        }
-      });
+      };
+      listClouds();
     },
 
     /**

--- a/jujugui/static/gui/src/app/components/deployment-flow/cloud/test-cloud.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/cloud/test-cloud.js
@@ -80,6 +80,7 @@ describe('DeploymentCloud', function() {
       <juju.components.DeploymentCloud
         acl={acl}
         cloud={null}
+        controllerIsAvailable={sinon.stub().returns(true)}
         getCloudProviderDetails={getCloudProviderDetails}
         listClouds={sinon.stub().callsArgWith(0, null, cloudList)}
         setCloud={sinon.stub()} />, true);
@@ -135,6 +136,7 @@ describe('DeploymentCloud', function() {
       <juju.components.DeploymentCloud
         acl={acl}
         cloud={null}
+        controllerIsAvailable={sinon.stub().returns(true)}
         getCloudProviderDetails={getCloudProviderDetails}
         listClouds={sinon.stub()}
         setCloud={sinon.stub()} />, true);
@@ -154,6 +156,7 @@ describe('DeploymentCloud', function() {
       <juju.components.DeploymentCloud
         acl={acl}
         cloud={{name: 'google', cloudType: 'gce'}}
+        controllerIsAvailable={sinon.stub().returns(true)}
         getCloudProviderDetails={getCloudProviderDetails}
         listClouds={sinon.stub().callsArgWith(0, null, {})}
         setCloud={sinon.stub()} />, true);
@@ -180,6 +183,7 @@ describe('DeploymentCloud', function() {
       <juju.components.DeploymentCloud
         acl={acl}
         cloud={null}
+        controllerIsAvailable={sinon.stub().returns(true)}
         getCloudProviderDetails={getCloudProviderDetails}
         listClouds={sinon.stub().callsArgWith(0, null, cloudList)}
         setCloud={setCloud} />);
@@ -195,6 +199,7 @@ describe('DeploymentCloud', function() {
       <juju.components.DeploymentCloud
         acl={acl}
         cloud={null}
+        controllerIsAvailable={sinon.stub().returns(true)}
         getCloudProviderDetails={getCloudProviderDetails}
         listClouds={sinon.stub().callsArgWith(0, null, cloudList)}
         setCloud={setCloud} />, true);

--- a/jujugui/static/gui/src/app/components/deployment-flow/credential/credential.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/credential/credential.js
@@ -27,6 +27,7 @@ YUI.add('deployment-credential', function() {
       acl: React.PropTypes.object.isRequired,
       addNotification: React.PropTypes.func.isRequired,
       cloud: React.PropTypes.object,
+      controllerIsAvailable: React.PropTypes.func.isRequired,
       credential: React.PropTypes.string,
       editable: React.PropTypes.bool,
       generateCloudCredentialName: React.PropTypes.func.isRequired,
@@ -72,7 +73,7 @@ YUI.add('deployment-credential', function() {
     _getCredentials: function(credential) {
       const cloud = this.props.cloud && this.props.cloud.name;
       const user = this.props.user;
-      if (user) {
+      if (user && this.props.controllerIsAvailable()) {
         this.setState({credentialsLoading: true}, () => {
           this.props.getCloudCredentialNames(
             [[user, cloud]],

--- a/jujugui/static/gui/src/app/components/deployment-flow/credential/test-credential.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/credential/test-credential.js
@@ -51,6 +51,7 @@ describe('DeploymentCredential', function() {
         acl={acl}
         addNotification={sinon.stub()}
         updateCloudCredential={sinon.stub()}
+        controllerIsAvailable={sinon.stub().returns(true)}
         cloud={cloud}
         editable={true}
         getCloudCredentials={sinon.stub()}
@@ -84,6 +85,7 @@ describe('DeploymentCredential', function() {
         addNotification={sinon.stub()}
         updateCloudCredential={updateCloudCredential}
         cloud={cloud}
+        controllerIsAvailable={sinon.stub().returns(true)}
         editable={true}
         generateCloudCredentialName={generateCloudCredentialName}
         getCloudCredentials={sinon.stub().callsArgWith(1, null, [])}
@@ -135,6 +137,7 @@ describe('DeploymentCredential', function() {
         addNotification={sinon.stub()}
         updateCloudCredential={updateCloudCredential}
         cloud={cloud}
+        controllerIsAvailable={sinon.stub().returns(true)}
         credential="lxd_admin@local_default"
         editable={false}
         generateCloudCredentialName={sinon.stub()}
@@ -203,6 +206,7 @@ describe('DeploymentCredential', function() {
         addNotification={sinon.stub()}
         updateCloudCredential={updateCloudCredential}
         cloud={null}
+        controllerIsAvailable={sinon.stub().returns(true)}
         editable={true}
         generateCloudCredentialName={generateCloudCredentialName}
         getCloudCredentials={sinon.stub().callsArgWith(1, null, {})}
@@ -252,6 +256,7 @@ describe('DeploymentCredential', function() {
         addNotification={sinon.stub()}
         updateCloudCredential={sinon.stub()}
         cloud={cloud}
+        controllerIsAvailable={sinon.stub().returns(true)}
         editable={true}
         generateCloudCredentialName={sinon.stub()}
         getCloudCredentials={sinon.stub().callsArgWith(1, null, credentials)}
@@ -314,6 +319,7 @@ describe('DeploymentCredential', function() {
         addNotification={sinon.stub()}
         updateCloudCredential={sinon.stub()}
         cloud={cloud}
+        controllerIsAvailable={sinon.stub().returns(true)}
         editable={true}
         generateCloudCredentialName={sinon.stub()}
         getCloudCredentials={sinon.stub().callsArgWith(1, null, credentials)}
@@ -341,6 +347,7 @@ describe('DeploymentCredential', function() {
         addNotification={sinon.stub()}
         updateCloudCredential={sinon.stub()}
         cloud={cloud}
+        controllerIsAvailable={sinon.stub().returns(true)}
         editable={true}
         generateCloudCredentialName={sinon.stub()}
         getCloudCredentials={sinon.stub().callsArgWith(1, null, credentials)}
@@ -371,6 +378,7 @@ describe('DeploymentCredential', function() {
         addNotification={sinon.stub()}
         updateCloudCredential={sinon.stub()}
         cloud={cloud}
+        controllerIsAvailable={sinon.stub().returns(true)}
         editable={true}
         generateCloudCredentialName={sinon.stub()}
         getCloudCredentials={sinon.stub().callsArgWith(1, null, credentials)}
@@ -434,6 +442,7 @@ describe('DeploymentCredential', function() {
         addNotification={sinon.stub()}
         updateCloudCredential={sinon.stub()}
         cloud={cloud}
+        controllerIsAvailable={sinon.stub().returns(true)}
         editable={true}
         generateCloudCredentialName={sinon.stub()}
         getCloudCredentials={sinon.stub().callsArgWith(1, null, credentials)}
@@ -474,6 +483,7 @@ describe('DeploymentCredential', function() {
         addNotification={sinon.stub()}
         updateCloudCredential={updateCloudCredential}
         cloud={cloud}
+        controllerIsAvailable={sinon.stub().returns(true)}
         editable={true}
         generateCloudCredentialName={generateCloudCredentialName}
         getCloudCredentials={sinon.stub().callsArgWith(1, null, credentials)}
@@ -528,6 +538,7 @@ describe('DeploymentCredential', function() {
         addNotification={sinon.stub()}
         updateCloudCredential={updateCloudCredential}
         cloud={cloud}
+        controllerIsAvailable={sinon.stub().returns(true)}
         editable={true}
         generateCloudCredentialName={generateCloudCredentialName}
         getCloudCredentials={sinon.stub().callsArgWith(1, null, credentials)}
@@ -554,6 +565,7 @@ describe('DeploymentCredential', function() {
         addNotification={sinon.stub()}
         updateCloudCredential={sinon.stub()}
         cloud={cloud}
+        controllerIsAvailable={sinon.stub().returns(true)}
         credential={credential}
         editable={true}
         generateCloudCredentialName={sinon.stub()}

--- a/jujugui/static/gui/src/app/components/deployment-flow/deployment-flow.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/deployment-flow.js
@@ -1075,6 +1075,7 @@ YUI.add('deployment-flow', function() {
           <juju.components.DeploymentPanel
             changeState={this.props.changeState}
             title={this.props.modelName}>
+            {this._generateOneClickDeploy()}
             {this._generateLogin()}
           </juju.components.DeploymentPanel>
         );

--- a/jujugui/static/gui/src/app/components/deployment-flow/deployment-flow.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/deployment-flow.js
@@ -968,7 +968,11 @@ YUI.add('deployment-flow', function() {
         </div>);
     },
 
-    _generateOneClickDeploy: function() {
+    /**
+      Generates the Direct Deploy component if necessary
+      @returns {Object} The React elements.
+    */
+    _generateDirectDeploy: function() {
       const props = this.props;
       const ddEntityId = props.ddData && props.ddData.id;
       if (!ddEntityId) {
@@ -1050,7 +1054,7 @@ YUI.add('deployment-flow', function() {
           <juju.components.DeploymentPanel
             changeState={this.props.changeState}
             title={this.props.modelName}>
-            {this._generateOneClickDeploy()}
+            {this._generateDirectDeploy()}
             {this._generateModelNameSection()}
             {this._generateCloudSection()}
             {this._generateCredentialSection()}
@@ -1080,7 +1084,7 @@ YUI.add('deployment-flow', function() {
           <juju.components.DeploymentPanel
             changeState={this.props.changeState}
             title={this.props.modelName}>
-            {this._generateOneClickDeploy()}
+            {this._generateDirectDeploy()}
             {this._generateLogin()}
           </juju.components.DeploymentPanel>
         );
@@ -1102,6 +1106,7 @@ YUI.add('deployment-flow', function() {
     'deployment-services',
     'deployment-ssh-key',
     'deployment-vpc',
+    'entity-content-diagram',
     'generic-button',
     'generic-input',
     'usso-login-link'

--- a/jujugui/static/gui/src/app/components/deployment-flow/deployment-flow.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/deployment-flow.js
@@ -24,6 +24,8 @@ YUI.add('deployment-flow', function() {
   const INITIAL_VPC_ID = null;
 
   juju.components.DeploymentFlow = React.createClass({
+    displayName: 'DeploymentFlow',
+
     propTypes: {
       acl: React.PropTypes.object.isRequired,
       addAgreement: React.PropTypes.func.isRequired,
@@ -35,6 +37,7 @@ YUI.add('deployment-flow', function() {
       charmsGetById: React.PropTypes.func.isRequired,
       charmstore: React.PropTypes.object.isRequired,
       cloud: React.PropTypes.object,
+      controllerIsAvailable: React.PropTypes.func.isRequired,
       createCardElement: React.PropTypes.func,
       createToken: React.PropTypes.func,
       createUser: React.PropTypes.func,
@@ -735,6 +738,7 @@ YUI.add('deployment-flow', function() {
           <juju.components.DeploymentCloud
             acl={this.props.acl}
             cloud={cloud}
+            controllerIsAvailable={this.props.controllerIsAvailable}
             listClouds={this.props.listClouds}
             getCloudProviderDetails={this.props.getCloudProviderDetails}
             setCloud={this._setCloud} />

--- a/jujugui/static/gui/src/app/components/deployment-flow/deployment-flow.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/deployment-flow.js
@@ -599,7 +599,7 @@ YUI.add('deployment-flow', function() {
         <juju.components.DeploymentSection
           instance="deployment-model-name"
           showCheck={false}
-          title="Model name">
+          title="Set your model name">
           <div className="six-col">
             <juju.components.GenericInput
               disabled={this.props.acl.isReadOnly()}

--- a/jujugui/static/gui/src/app/components/deployment-flow/deployment-flow.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/deployment-flow.js
@@ -768,6 +768,7 @@ YUI.add('deployment-flow', function() {
             addNotification={this.props.addNotification}
             credential={this.state.credential}
             cloud={cloud}
+            controllerIsAvailable={this.props.controllerIsAvailable}
             getCloudProviderDetails={this.props.getCloudProviderDetails}
             editable={!this.props.modelCommitted}
             generateCloudCredentialName={this.props.generateCloudCredentialName}

--- a/jujugui/static/gui/src/app/components/deployment-flow/deployment-flow.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/deployment-flow.js
@@ -49,6 +49,7 @@ YUI.add('deployment-flow', function() {
       getCloudCredentials: React.PropTypes.func,
       getCloudProviderDetails: React.PropTypes.func.isRequired,
       getCountries: React.PropTypes.func.isRequired,
+      getCurrentChangeSet: React.PropTypes.func.isRequired,
       getDiagramURL: React.PropTypes.func,
       getDischargeToken: React.PropTypes.func,
       getUser: React.PropTypes.func,
@@ -916,7 +917,7 @@ YUI.add('deployment-flow', function() {
           showCheck={false}
           title="Model changes">
           <juju.components.DeploymentChanges
-            changes={this.props.changes}
+            getCurrentChangeSet={this.props.getCurrentChangeSet}
             generateAllChangeDescriptions={
               this.props.generateAllChangeDescriptions} />
         </juju.components.DeploymentSection>);

--- a/jujugui/static/gui/src/app/components/deployment-flow/deployment-flow.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/deployment-flow.js
@@ -969,7 +969,7 @@ YUI.add('deployment-flow', function() {
     },
 
     /**
-      Generates the Direct Deploy component if necessary
+      Generates the Direct Deploy component if necessary.
       @returns {Object} The React elements.
     */
     _generateDirectDeploy: function() {
@@ -978,7 +978,7 @@ YUI.add('deployment-flow', function() {
       if (!ddEntityId) {
         return;
       };
-      let diagram = undefined;
+      let diagram = null;
       if (ddEntityId.indexOf('bundle') !== -1) {
         diagram = <juju.components.EntityContentDiagram
           getDiagramURL={this.props.getDiagramURL}

--- a/jujugui/static/gui/src/app/components/deployment-flow/deployment-flow.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/deployment-flow.js
@@ -910,7 +910,10 @@ YUI.add('deployment-flow', function() {
     */
     _generateChangeSection: function() {
       var status = this._getSectionStatus('changes');
-      if (!status.visible) {
+      // Do not show the changes if we're performing a Direct Deploy.
+      const ddData = this.props.ddData;
+      const inDD = !!(ddData && Object.keys(ddData).length);
+      if (!status.visible || inDD) {
         return;
       }
       return (

--- a/jujugui/static/gui/src/app/components/deployment-flow/deployment-flow.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/deployment-flow.js
@@ -39,6 +39,7 @@ YUI.add('deployment-flow', function() {
       createToken: React.PropTypes.func,
       createUser: React.PropTypes.func,
       credential: React.PropTypes.string,
+      ddData: React.PropTypes.object,
       deploy: React.PropTypes.func.isRequired,
       generateAllChangeDescriptions: React.PropTypes.func.isRequired,
       generateCloudCredentialName: React.PropTypes.func.isRequired,
@@ -48,6 +49,7 @@ YUI.add('deployment-flow', function() {
       getCloudCredentials: React.PropTypes.func,
       getCloudProviderDetails: React.PropTypes.func.isRequired,
       getCountries: React.PropTypes.func.isRequired,
+      getDiagramURL: React.PropTypes.func,
       getDischargeToken: React.PropTypes.func,
       getUser: React.PropTypes.func,
       getUserName: React.PropTypes.func.isRequired,
@@ -961,6 +963,30 @@ YUI.add('deployment-flow', function() {
         </div>);
     },
 
+    _generateOneClickDeploy: function() {
+      const props = this.props;
+      const ddEntityId = props.ddData && props.ddData.id;
+      if (!ddEntityId) {
+        return;
+      };
+      let diagram = undefined;
+      if (ddEntityId.indexOf('bundle') !== -1) {
+        diagram = <juju.components.EntityContentDiagram
+          getDiagramURL={this.props.getDiagramURL}
+          id={ddEntityId} />;
+      }
+      return (
+        <juju.components.DeploymentSection
+          instance="deployment-one-click"
+          showCheck={false}
+          title="Direct Deploy">
+          <p>
+            The following steps will guide you through deploying {ddEntityId}
+          </p>
+          {diagram}
+        </juju.components.DeploymentSection>);
+    },
+
     /**
       Report whether going forward with the deployment is currently allowed.
 
@@ -1019,6 +1045,7 @@ YUI.add('deployment-flow', function() {
           <juju.components.DeploymentPanel
             changeState={this.props.changeState}
             title={this.props.modelName}>
+            {this._generateOneClickDeploy()}
             {this._generateModelNameSection()}
             {this._generateCloudSection()}
             {this._generateCredentialSection()}

--- a/jujugui/static/gui/src/app/components/deployment-flow/test-deployment-flow.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/test-deployment-flow.js
@@ -69,8 +69,10 @@ const createDeploymentFlow = (props = {}) => {
     changesFilterByParent: sinon.stub(),
     charmsGetById: charmsGetById,
     charmstore: {},
+    controllerIsAvailable: sinon.stub(),
     createToken: sinon.stub(),
     createUser: sinon.stub(),
+    ddData: {},
     deploy: sinon.stub().callsArg(0),
     generateAllChangeDescriptions: sinon.stub(),
     generateCloudCredentialName: sinon.stub(),
@@ -78,6 +80,8 @@ const createDeploymentFlow = (props = {}) => {
     getAuth: sinon.stub().returns({}),
     getCloudProviderDetails: sinon.stub(),
     getCountries: sinon.stub(),
+    getCurrentChangeSet: sinon.stub(),
+    getDiagramURL:sinon.stub(),
     getUser: sinon.stub(),
     getUserName: sinon.stub().returns('dalek'),
     groupedChanges: groupedChanges,
@@ -141,10 +145,11 @@ describe('DeploymentFlow', function() {
       <juju.components.DeploymentPanel
         changeState={props.changeState}
         title="Pavlova">
+        {undefined}
         <juju.components.DeploymentSection
           instance="deployment-model-name"
           showCheck={false}
-          title="Model name">
+          title="Set your model name">
           <div className="six-col">
             <juju.components.GenericInput
               disabled={false}
@@ -175,6 +180,7 @@ describe('DeploymentFlow', function() {
           <juju.components.DeploymentCloud
             acl={props.acl}
             cloud={null}
+            controllerIsAvailable={props.controllerIsAvailable}
             listClouds={props.listClouds}
             getCloudProviderDetails={props.getCloudProviderDetails}
             setCloud={instance._setCloud} />
@@ -270,7 +276,7 @@ describe('DeploymentFlow', function() {
           showCheck={false}
           title="Model changes">
           <juju.components.DeploymentChanges
-            changes={props.changes}
+            getCurrentChangeSet={props.getCurrentChangeSet}
             generateAllChangeDescriptions={
               props.generateAllChangeDescriptions}/>
         </juju.components.DeploymentSection>
@@ -288,7 +294,52 @@ describe('DeploymentFlow', function() {
           </div>
         </div>
       </juju.components.DeploymentPanel>);
-    assert.deepEqual(output, expected);
+    expect(output).toEqualJSX(expected);
+  });
+
+  it('renders the Direct Deploy for a charm', () => {
+    const id = 'cs:apache-21';
+    const renderer = createDeploymentFlow({
+      ddData: {id},
+      modelCommitted: false
+    });
+    const dd = renderer.getRenderOutput().props.children[0];
+    const expected = (
+      <juju.components.DeploymentSection
+        instance="deployment-one-click"
+        showCheck={false}
+        title="Direct Deploy">
+        <p>
+          The following steps will guide you through deploying {id}
+        </p>
+        {undefined}
+      </juju.components.DeploymentSection>
+    );
+    expect(dd).toEqualJSX(expected);
+  });
+
+  it('renders the Direct Deploy for a bundle', () => {
+    const id = 'cs:bundles/kubernetes-core-8';
+    const renderer = createDeploymentFlow({
+      ddData: {id},
+      modelCommitted: false
+    });
+    const instance = renderer.getMountedInstance();
+    const dd = renderer.getRenderOutput().props.children[0];
+    const expected = (
+      <juju.components.DeploymentSection
+        instance="deployment-one-click"
+        showCheck={false}
+        title="Direct Deploy">
+        <p>
+          The following steps will guide you through deploying {id}
+        </p>
+        <juju.components.EntityContentDiagram
+          getDiagramURL={instance.props.getDiagramURL}
+          id={id} />
+      </juju.components.DeploymentSection>
+    );
+    expect(dd).toEqualJSX(expected);
   });
 
   it('can display the cloud section as complete', function() {
@@ -299,7 +350,7 @@ describe('DeploymentFlow', function() {
     const instance = renderer.getMountedInstance();
     instance.setState({cloud: {name: 'cloud'}});
     const output = renderer.getRenderOutput();
-    assert.strictEqual(output.props.children[1].props.completed, true);
+    assert.strictEqual(output.props.children[2].props.completed, true);
   });
 
   it('does not display the cloud section if complete + committed', function() {
@@ -324,7 +375,7 @@ describe('DeploymentFlow', function() {
     const renderer = createDeploymentFlow();
     const output = renderer.getRenderOutput();
     assert.equal(
-      output.props.children[1].props.title, 'Choose cloud to deploy to');
+      output.props.children[2].props.title, 'Choose cloud to deploy to');
   });
 
   it('can clear the cloud and credential when changing clouds', function() {
@@ -338,7 +389,7 @@ describe('DeploymentFlow', function() {
     const output = renderer.getRenderOutput();
     assert.isNotNull(instance.state.cloud);
     assert.isNotNull(instance.state.credential);
-    output.props.children[1].props.buttons[0].action();
+    output.props.children[2].props.buttons[0].action();
     assert.isNull(instance.state.cloud);
     assert.isNull(instance.state.credential);
     assert.equal(instance.props.sendAnalytics.callCount, 1);
@@ -354,7 +405,7 @@ describe('DeploymentFlow', function() {
     const instance = renderer.getMountedInstance();
     instance.setState({cloud: {name: 'cloud'}});
     const output = renderer.getRenderOutput();
-    assert.strictEqual(output.props.children[2].props.disabled, false);
+    assert.strictEqual(output.props.children[3].props.disabled, false);
   });
 
   it('can hide the credential section', function() {
@@ -364,7 +415,7 @@ describe('DeploymentFlow', function() {
     const instance = renderer.getMountedInstance();
     instance.setState({cloud: {name: 'cloud'}});
     const output = renderer.getRenderOutput();
-    assert.strictEqual(output.props.children[2], undefined);
+    assert.strictEqual(output.props.children[3], undefined);
   });
 
   it('can enable the machines section', function() {
@@ -374,7 +425,7 @@ describe('DeploymentFlow', function() {
       modelCommitted: true
     });
     const output = renderer.getRenderOutput();
-    assert.strictEqual(output.props.children[5].props.disabled, false);
+    assert.strictEqual(output.props.children[6].props.disabled, false);
   });
 
   it('can enable the services section', function() {
@@ -401,7 +452,7 @@ describe('DeploymentFlow', function() {
         <juju.components.DeploymentVPC setVPCId={instance._setVPCId} />
       </juju.components.DeploymentSection>
     );
-    assert.deepEqual(output.props.children[4], expectedOutput);
+    assert.deepEqual(output.props.children[5], expectedOutput);
   });
 
   it('can enable the budget section', function() {
@@ -461,7 +512,7 @@ describe('DeploymentFlow', function() {
           username="spinach"
           validateForm={validateForm} />
       </juju.components.DeploymentSection>);
-    assert.deepEqual(output.props.children[9], expected);
+    assert.deepEqual(output.props.children[10], expected);
   });
 
   it('can hide the agreements section', function() {
@@ -470,7 +521,7 @@ describe('DeploymentFlow', function() {
     });
     const output = renderer.getRenderOutput();
     assert.isUndefined(
-      output.props.children[10].props.children.props.children[0]);
+      output.props.children[11].props.children.props.children[0]);
   });
 
   it('can handle the agreements when there are no added apps', function() {
@@ -482,7 +533,7 @@ describe('DeploymentFlow', function() {
     });
     const output = renderer.getRenderOutput();
     assert.isUndefined(
-      output.props.children[10].props.children.props.children[0]);
+      output.props.children[11].props.children.props.children[0]);
   });
 
   it('can display the agreements section', function() {
@@ -497,7 +548,7 @@ describe('DeploymentFlow', function() {
     });
     const output = renderer.getRenderOutput();
     const instance = renderer.getMountedInstance();
-    const agreements = output.props.children[10].props.children
+    const agreements = output.props.children[11].props.children
       .props.children[0];
     const expected = (
       <div className="deployment-flow__deploy-option">
@@ -519,7 +570,7 @@ describe('DeploymentFlow', function() {
       modelCommitted: false
     });
     const output = renderer.getRenderOutput();
-    const agreements = output.props.children[10].props.children
+    const agreements = output.props.children[11].props.children
       .props.children[0];
     const className = agreements.props.className;
     const expectedClass = 'deployment-flow__deploy-option--disabled';
@@ -537,7 +588,7 @@ describe('DeploymentFlow', function() {
     });
     const output = renderer.getRenderOutput();
     const instance = renderer.getMountedInstance();
-    const loginLink = output.props.children.props.children.props.children[2]
+    const loginLink = output.props.children[1].props.children.props.children[2]
       .props.children;
     const expected = (
       <juju.components.DeploymentSection
@@ -601,7 +652,7 @@ describe('DeploymentFlow', function() {
         </div>
       </juju.components.DeploymentSection>
     );
-    assert.deepEqual(output.props.children, expected);
+    expect(output.props.children[1]).toEqualJSX(expected);
   });
 
   // Click log in and pass the given error string to the login callback used by
@@ -622,7 +673,7 @@ describe('DeploymentFlow', function() {
       }
     };
     const output = renderer.getRenderOutput();
-    const loginSection = output.props.children.props.children;
+    const loginSection = output.props.children[1].props.children;
     const loginButton = loginSection.props.children[2].props.children;
     const loginToController = instance.props.loginToController;
     // Call the supplied callback function which is called after the user
@@ -664,7 +715,7 @@ describe('DeploymentFlow', function() {
     instance._updateModelName();
     const props = instance.props;
     const output = renderer.getRenderOutput();
-    output.props.children[10].props.children.props.children[1].props.children
+    output.props.children[11].props.children.props.children[1].props.children
       .props.action();
     assert.equal(props.deploy.callCount, 1);
     assert.strictEqual(props.deploy.args[0].length, 4);
@@ -701,7 +752,7 @@ describe('DeploymentFlow', function() {
     instance._handleTermsAgreement({target: {checked: true}});
     const props = instance.props;
     const output = renderer.getRenderOutput();
-    output.props.children[10].props.children.props.children[1].props.children
+    output.props.children[11].props.children.props.children[1].props.children
       .props.action();
     assert.equal(props.deploy.callCount, 0,
       'The deploy function should not be called');
@@ -898,13 +949,13 @@ describe('DeploymentFlow', function() {
       }
     };
     let output = renderer.getRenderOutput();
-    let deployButton = output.props.children[10].props.children.props
+    let deployButton = output.props.children[11].props.children.props
       .children[1].props.children;
     deployButton.props.action();
 
     // .action() rerenders the component so we need to get it again
     output = renderer.getRenderOutput();
-    deployButton = output.props.children[10].props.children.props
+    deployButton = output.props.children[11].props.children.props
       .children[1].props.children;
 
     assert.equal(deployButton.props.disabled, true);
@@ -925,7 +976,7 @@ describe('DeploymentFlow', function() {
     const instance = renderer.getMountedInstance();
     instance.refs = {};
     const output = renderer.getRenderOutput();
-    output.props.children[10].props.children.props.children[1].props.children
+    output.props.children[11].props.children.props.children[1].props.children
       .props.action();
     const deploy = instance.props.deploy;
     assert.equal(deploy.callCount, 1);
@@ -955,7 +1006,7 @@ describe('DeploymentFlow', function() {
     const instance = renderer.getMountedInstance();
     instance._setSSHKey('my SSH key');
     const output = renderer.getRenderOutput();
-    output.props.children[10].props.children.props.children[1].props.children
+    output.props.children[11].props.children.props.children[1].props.children
       .props.action();
     const deploy = instance.props.deploy;
     assert.equal(deploy.callCount, 1);
@@ -985,7 +1036,7 @@ describe('DeploymentFlow', function() {
     const instance = renderer.getMountedInstance();
     instance._setVPCId('my VPC id');
     const output = renderer.getRenderOutput();
-    output.props.children[10].props.children.props.children[1].props.children
+    output.props.children[11].props.children.props.children[1].props.children
       .props.action();
     const deploy = instance.props.deploy;
     assert.equal(deploy.callCount, 1);
@@ -1015,7 +1066,7 @@ describe('DeploymentFlow', function() {
     const instance = renderer.getMountedInstance();
     instance._setVPCId('my VPC id', true);
     const output = renderer.getRenderOutput();
-    output.props.children[10].props.children.props.children[1].props.children
+    output.props.children[11].props.children.props.children[1].props.children
       .props.action();
     const deploy = instance.props.deploy;
     assert.equal(deploy.callCount, 1);

--- a/jujugui/static/gui/src/app/components/deployment-flow/test-deployment-flow.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/test-deployment-flow.js
@@ -195,6 +195,7 @@ describe('DeploymentFlow', function() {
             addNotification={props.addNotification}
             credential={undefined}
             cloud={null}
+            controllerIsAvailable={props.controllerIsAvailable}
             getCloudProviderDetails={props.getCloudProviderDetails}
             editable={true}
             generateCloudCredentialName={props.generateCloudCredentialName}

--- a/jujugui/static/gui/src/app/components/entity-details/content/diagram/diagram.js
+++ b/jujugui/static/gui/src/app/components/entity-details/content/diagram/diagram.js
@@ -21,6 +21,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 YUI.add('entity-content-diagram', function() {
 
   juju.components.EntityContentDiagram = React.createClass({
+    displayName: 'EntityContentDiagram',
 
     /* Define and validate the properites available on this component. */
     propTypes: {

--- a/jujugui/static/gui/src/app/state/state.js
+++ b/jujugui/static/gui/src/app/state/state.js
@@ -699,14 +699,28 @@ const State = class State {
     @return {Object} The updated state to contain the root value, if any.
   */
   _parseSpecial(query, state, allowStateModifications = true) {
-    if (!query) {
-      return state;
-    }
-    let deployTarget = query['deploy-target'];
-    if (deployTarget) {
+    const setupSpecial = state => {
       if (!state.special) {
         state.special = {};
       }
+    };
+    if (!query) {
+      return state;
+    }
+    let dd = query['dd'];
+    if (dd) {
+      // XXX The spec calls for additional query parameters which directly
+      // relate to the direct deploy. These will also need to be extracted and
+      // setup here. The dd state is an object in preparation for these
+      // additional values.
+      setupSpecial(state);
+      state.special.dd = {
+        id: dd
+      };
+    }
+    let deployTarget = query['deploy-target'];
+    if (deployTarget) {
+      setupSpecial(state);
       state.special.deployTarget = deployTarget;
       // Push the state so that any special query string is removed now,
       // therefore avoiding multiple dispatches of the same special callback.
@@ -716,9 +730,7 @@ const State = class State {
     }
     let next = query.next;
     if (next) {
-      if (!state.special) {
-        state.special = {};
-      }
+      setupSpecial(state);
       state.special.next = next;
     }
     return state;

--- a/jujugui/static/gui/src/app/state/test-state.js
+++ b/jujugui/static/gui/src/app/state/test-state.js
@@ -29,6 +29,10 @@ describe('State', () => {
     state: {special: {deployTarget: 'cs:trusty/kibana-15'}},
     error: null
   }, {
+    path: 'http://abc.com:123/new/?dd=trusty/kibana-15',
+    state: {root: 'new', special: {dd: {id: 'trusty/kibana-15'}}},
+    error: null
+  }, {
     path: 'http://abc.com:123/login?next=/u/frankban/prod',
     state: {root: 'login', special: {next: '/u/frankban/prod'}},
     error: null

--- a/jujugui/static/gui/src/app/views/utils.js
+++ b/jujugui/static/gui/src/app/views/utils.js
@@ -1546,6 +1546,18 @@ YUI.add('juju-view-utils', function(Y) {
         });
         callback(null);
       };
+      const current = app.state.current;
+      const rootState = current.root;
+      if (rootState && rootState === 'new') {
+        // If root is set to new then set it to null otherwise when the app
+        // dispatches again it'll disconnect the model being deployed to.
+        app.state.changeState({root: null});
+      }
+      const special = current.special;
+      if (special && special.dd) {
+        // Cleanup the direct deploy state so that we don't dispatch it again.
+        app.state.changeState({special: {dd: null}});
+      }
       app.set('modelUUID', model.uuid);
       const socketUrl = app.createSocketURL(
         app.get('socketTemplate'), model.uuid);

--- a/jujugui/static/gui/src/test/test_utils.js
+++ b/jujugui/static/gui/src/test/test_utils.js
@@ -1082,6 +1082,7 @@ describe('utilities', function() {
         get: sinon.stub().returns('wss://socket-url'),
         switchEnv: sinon.stub(),
         state: {
+          current: {},
           changeState: sinon.stub()
         },
         user: userClass,
@@ -1171,6 +1172,33 @@ describe('utilities', function() {
           uuid: 'the-uuid'
         }
       }]);
+    });
+
+    it('calls changeState when deploying if state matches rules', () => {
+      const modelData = {
+        id: 'abc123',
+        name: 'model-name',
+        owner: 'foo@external',
+        uuid: 'the-uuid'
+      };
+      app.state.current = {
+        root: 'new',
+        special: {dd: {id: 'cs:apache'}}
+      };
+      const args = {model: 'args'};
+      envGet.withArgs('connected').returns(false);
+      const commit = sinon.stub();
+      envGet.withArgs('ecs').returns({commit});
+      sinon.stub(utils, '_switchModel');
+      utils.deploy(app, callback, false, 'my-model', args);
+      // Call the handler for the createModel callCount
+      app.controllerAPI.createModel.args[0][3](null, modelData);
+      // Check to make sure that the state was changed.
+      assert.equal(app.state.changeState.callCount, 2);
+      assert.deepEqual(app.state.changeState.args, [
+        [{root: null}],
+        [{special: {dd: null}}]
+      ]);
     });
 
     it('can display an error notification', function() {


### PR DESCRIPTION
If visiting the GUI with the url `{host}/new/?dd={entityId}` the GUI will now immediately open the deployment flow with the appropriate entity added to the canvas. This is the first step towards a much quicker deploy experience. 