### PR TITLE
Deployment flow: SSH key no longer mandatory for azure cloud.

### DIFF
--- a/jujugui/static/gui/src/app/components/deployment-flow/deployment-flow.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/deployment-flow.js
@@ -999,13 +999,6 @@ YUI.add('deployment-flow', function() {
       if (this.props.modelCommitted) {
         return true;
       }
-      // When a new model will be created, check that the SSH key, if required,
-      // has been provided.
-      // TODO frankban: avoid duplicating the logic already implemented in the
-      // DeploymentSSHKey component.
-      if (this.state.cloud.cloudType === 'azure' && !this.state.sshKey) {
-        return false;
-      }
       // A new model is ready to be created.
       return true;
     },

--- a/jujugui/static/gui/src/app/components/deployment-flow/sshkey/sshkey.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/sshkey/sshkey.js
@@ -27,10 +27,8 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 YUI.add('deployment-ssh-key', function() {
 
-  // Define the Azure cloud type.
-  const AZURE_CLOUD_TYPE = 'azure';
-
   juju.components.DeploymentSSHKey = React.createClass({
+    displayName: 'DeploymentSSHKey',
     propTypes: {
       cloud: React.PropTypes.object,
       setSSHKey: React.PropTypes.func.isRequired
@@ -57,41 +55,21 @@ YUI.add('deployment-ssh-key', function() {
       if (!cloud) {
         return null;
       }
-      const isAzure = cloud.cloudType === AZURE_CLOUD_TYPE;
-
-      let message = (
-        <p>
-          Optionally provide a SSH key (e.g. ~/.ssh/id_rsa.pub) to allow
-          accessing machines provisioned on this model via "juju ssh".
-          <br/> SSH keys can be added at any time using "juju add-ssh-key" or
-          "juju import-ssh-key".
-        </p>
-      );
-      if (isAzure) {
-        message = (
-          <p>
-            Provide the SSH key (e.g. ~/.ssh/id_rsa.pub) that will be used to
-            provision machines on Azure.
-            <br/> Additional keys can be added at any time using
-            "juju add-ssh-key" or "juju import-ssh-key".
-          </p>
-        );
-      }
-
       return (
         <div>
-          {message}
+          <p>
+            Optionally provide a SSH key (e.g. ~/.ssh/id_rsa.pub) to allow
+            accessing machines provisioned on this model via "juju ssh".
+            <br/> SSH keys can be added at any time using "juju add-ssh-key" or
+            "juju import-ssh-key".
+          </p>
           <juju.components.GenericInput
             label="SSH key"
             key="sshKey"
             ref="sshKey"
             multiLine={true}
             onBlur={this._onSSHKeyInputBlur}
-            required={isAzure}
-            validate={isAzure ? [{
-              regex: /\S+/,
-              error: 'This field is required.'
-            }] : undefined}
+            required={false}
           />
         </div>
       );

--- a/jujugui/static/gui/src/app/components/deployment-flow/sshkey/test-sshkey.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/sshkey/test-sshkey.js
@@ -76,34 +76,6 @@ describe('DeploymentSSHKey', function() {
           multiLine={true}
           onBlur={comp.instance._onSSHKeyInputBlur}
           required={false}
-          validate={undefined}
-        />
-      </div>
-    );
-    assert.deepEqual(comp.output, expectedOutput);
-  });
-
-  it('renders with azure', function() {
-    const comp = render('azure');
-    const expectedOutput = (
-      <div>
-        <p>
-          Provide the SSH key (e.g. ~/.ssh/id_rsa.pub) that will be used to
-          provision machines on Azure.
-          <br/> Additional keys can be added at any time using
-          "juju add-ssh-key" or "juju import-ssh-key".
-        </p>
-        <juju.components.GenericInput
-          label="SSH key"
-          key="sshKey"
-          ref="sshKey"
-          multiLine={true}
-          onBlur={comp.instance._onSSHKeyInputBlur}
-          required={true}
-          validate={[{
-            regex: /\S+/,
-            error: 'This field is required.'
-          }]}
         />
       </div>
     );


### PR DESCRIPTION
Do not land for now, just a proposal. We could need to do a Juju version check in order to enable/disable th eoptional SSH key. I'd rather avoid that.