### PR TITLE
Provide the charm store API instance to remaining addCharm calls.

### DIFF
--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -1610,10 +1610,13 @@ YUI.add('juju-gui', function(Y) {
         const relatableApplications = relationUtils.getRelatableApplications(
           db, models.getEndpoints(service, this.endpointsController));
         const ecs = model.get('ecs');
+        const addCharm = (url, callback, options) => {
+          model.addCharm(url, charmstore, callback, options);
+        };
         inspector = (
           <window.juju.components.Inspector
             acl={this.acl}
-            addCharm={model.addCharm.bind(model)}
+            addCharm={addCharm}
             addGhostAndEcsUnits={utils.addGhostAndEcsUnits.bind(
               this, db, model, service)}
             addNotification={db.notifications.add.bind(db.notifications)}

--- a/jujugui/static/gui/src/app/components/inspector/change-version/change-version.js
+++ b/jujugui/static/gui/src/app/components/inspector/change-version/change-version.js
@@ -80,16 +80,10 @@ YUI.add('inspector-change-version', function() {
         @param {Object} e The click event.
     */
     _versionButtonAction: function(charmId, e) {
-      // In Juju 2.0+ we have to add the charm before we set it. This is just
-      // good practice for 1.25.
-      // TODO frankban: provide the charm store API instance as second
-      // argument, so that it can be used to retrieve a delegatable macaroon.
-      this.props.addCharm(charmId, null,
-        this._addCharmCallback.bind(this, charmId), {
-          // XXX hatch: the ecs doesn't yet support addCharm so we are going to
-          // send the command to juju immedaitely.
-          immediate: true
-        });
+      const callback = this._addCharmCallback.bind(this, charmId);
+      // XXX hatch: the ecs doesn't yet support addCharm so we are going to
+      // send the command to juju immediately.
+      this.props.addCharm(charmId, callback, {immediate: true});
     },
 
     /**

--- a/jujugui/static/gui/src/app/components/inspector/change-version/test-change-version.js
+++ b/jujugui/static/gui/src/app/components/inspector/change-version/test-change-version.js
@@ -292,29 +292,28 @@ describe('InspectorChangeVersion', function() {
     // The charm needs to be added to the model first.
     assert.equal(addCharm.callCount, 1);
     assert.equal(addCharm.args[0][0], 'cs:django-4');
-    assert.equal(addCharm.args[0][1], null);
-    // Call the callback
-    addCharm.args[0][2]({});
+    // Call the callback.
+    addCharm.args[0][1]({});
     assert.equal(serviceSet.callCount, 1);
     assert.equal(serviceSet.args[0][1], 'cs:django-4');
   });
 
   it('adds a notification if it can not add a charm', function() {
-    var addNotification = sinon.stub();
-    var changeState = sinon.stub();
-    var serviceSet = sinon.stub();
-    var getMacaroon = sinon.stub().returns('macaroon');
-    var setCharm = sinon.stub();
-    var service = {
+    const addNotification = sinon.stub();
+    const changeState = sinon.stub();
+    const serviceSet = sinon.stub();
+    const getMacaroon = sinon.stub().returns('macaroon');
+    const setCharm = sinon.stub();
+    const service = {
       get: sinon.stub().returns('django'),
       set: serviceSet
     };
-    var addCharm = sinon.stub().callsArgWith(2, {err: 'error'});
-    var getCharm = sinon.stub();
-    var getAvailableVersions = sinon.stub().callsArgWith(1, null, [
+    const addCharm = sinon.stub().callsArgWith(1, {err: 'error'});
+    const getCharm = sinon.stub();
+    const getAvailableVersions = sinon.stub().callsArgWith(1, null, [
       'cs:django-4', 'cs:django-5', 'cs:django-6'
     ]);
-    var shallowRenderer = jsTestUtils.shallowRender(
+    const shallowRenderer = jsTestUtils.shallowRender(
         <juju.components.InspectorChangeVersion
           acl={acl}
           changeState={changeState}
@@ -327,7 +326,7 @@ describe('InspectorChangeVersion', function() {
           getCharm={getCharm}
           getAvailableVersions={getAvailableVersions} />, true);
     shallowRenderer.getMountedInstance().componentDidMount();
-    var output = shallowRenderer.getRenderOutput();
+    const output = shallowRenderer.getRenderOutput();
     output.props.children[1].props.children[0].props.buttonAction();
     assert.equal(addNotification.callCount, 1);
   });
@@ -362,8 +361,8 @@ describe('InspectorChangeVersion', function() {
     shallowRenderer.getMountedInstance().componentDidMount();
     var output = shallowRenderer.getRenderOutput();
     output.props.children[1].props.children[0].props.buttonAction();
-    // call the addCharm callback
-    addCharm.args[0][2]({});
+    // Call the addCharm callback.
+    addCharm.args[0][1]({});
     assert.equal(addNotification.callCount, 1);
   });
 
@@ -397,8 +396,8 @@ describe('InspectorChangeVersion', function() {
     shallowRenderer.getMountedInstance().componentDidMount();
     var output = shallowRenderer.getRenderOutput();
     output.props.children[1].props.children[0].props.buttonAction();
-    // call the addCharm callback
-    addCharm.args[0][2]({});
+    // Call the addCharm callback.
+    addCharm.args[0][1]({});
     assert.equal(addNotification.callCount, 1);
   });
 

--- a/jujugui/static/gui/src/app/utils/bundle-importer.js
+++ b/jujugui/static/gui/src/app/utils/bundle-importer.js
@@ -561,10 +561,7 @@ YUI.add('bundle-importer', function(Y) {
             charm.loaded = true;
             db.charms.add(charm);
           }
-          // TODO frankban: provide the charm store API instance as second
-          // argument, so that it can be used to retrieve a delegatable
-          // macaroon.
-          this.modelAPI.addCharm(charmId, null, () => {});
+          this.modelAPI.addCharm(charmId, charmstore, () => {});
           this._saveModelToRequires(record.id, charm);
           next();
         });


### PR DESCRIPTION
So that it is possible to upgrade/downgrade charms for existing applications, and also deploy bundles with non-public charms or, charms with terms.