### PR TITLE
Deployment flow: only get agreements on mount when user is logged in.

### DIFF
--- a/jujugui/static/gui/src/app/components/deployment-flow/deployment-flow.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/deployment-flow.js
@@ -104,7 +104,9 @@ YUI.add('deployment-flow', function() {
     },
 
     componentWillMount: function() {
-      this._getAgreements();
+      if (this.state.loggedIn) {
+        this._getAgreements();
+      }
     },
 
     componentDidMount: function() {
@@ -647,6 +649,7 @@ YUI.add('deployment-flow', function() {
       const callback = err => {
         if (!err) {
           this.setState({loggedIn: true});
+          this._getAgreements();
         }
       };
       return (


### PR DESCRIPTION
This way, no popup is opened when an anonymus user opens the deployment flow having a charm with terms in the canvas.