### PR TITLE
Fix credential cancel

### DIFF
--- a/jujugui/static/gui/src/app/components/deployment-flow/credential/add/_add.scss
+++ b/jujugui/static/gui/src/app/components/deployment-flow/credential/add/_add.scss
@@ -15,6 +15,16 @@
     }
   }
 
+  &__buttons {
+    text-align: right;
+
+    .button-row button {
+      width: auto;
+      padding-left: 20px;
+      padding-right: 20px;
+    }
+  }
+
   .string-config {
     margin: 0;
 

--- a/jujugui/static/gui/src/app/components/deployment-flow/credential/add/add.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/credential/add/add.js
@@ -32,6 +32,7 @@ YUI.add('deployment-credential-add', function() {
       generateCloudCredentialName: React.PropTypes.func.isRequired,
       getCloudProviderDetails: React.PropTypes.func.isRequired,
       getCredentials: React.PropTypes.func.isRequired,
+      hideCancel: React.PropTypes.bool,
       sendAnalytics: React.PropTypes.func.isRequired,
       setCredential: React.PropTypes.func.isRequired,
       updateCloudCredential: React.PropTypes.func.isRequired,
@@ -249,16 +250,19 @@ YUI.add('deployment-credential-add', function() {
     },
 
     render: function() {
-      var buttons = [{
-        action: () => { this.props.close(true); },
-        title: 'Cancel',
-        type: 'neutral'
-      }, {
+      let buttons = [{
         action: this._handleAddCredentials,
         submit: true,
         title: 'Add cloud credential',
-        type: 'positive'
+        type: 'inline-positive'
       }];
+      if (!this.props.hideCancel) {
+        buttons.unshift({
+          action: () => { this.props.close(true); },
+          title: 'Cancel',
+          type: 'inline-neutral'
+        });
+      }
       // If no cloud has been selected we set a default so that the disabled
       // form will display correctly as the next step.
       var isReadOnly = this.props.acl.isReadOnly();
@@ -311,7 +315,8 @@ YUI.add('deployment-credential-add', function() {
             </h3>
             {this._generateCredentialsFields()}
           </form>
-          <div className="prepend-six six-col last-col">
+          <div className={
+            'deployment-credential-add__buttons twelve-col last-col'}>
             <juju.components.ButtonRow
               buttons={buttons} />
           </div>

--- a/jujugui/static/gui/src/app/components/deployment-flow/credential/add/test-add.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/credential/add/test-add.js
@@ -247,7 +247,6 @@ describe('DeploymentCredentialAdd', function() {
   });
 
   it('can render without a cancel button', function() {
-    var cloud = getCloudProviderDetails('gce');
     var renderer = jsTestUtils.shallowRender(
       <juju.components.DeploymentCredentialAdd
           acl={acl}

--- a/jujugui/static/gui/src/app/components/deployment-flow/credential/add/test-add.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/credential/add/test-add.js
@@ -237,12 +237,42 @@ describe('DeploymentCredentialAdd', function() {
             </div>
           </div>
         </form>
-        <div className="prepend-six six-col last-col">
+        <div className={
+          'deployment-credential-add__buttons twelve-col last-col'}>
           <juju.components.ButtonRow
             buttons={buttons} />
         </div>
       </div>);
     expect(output).toEqualJSX(expected);
+  });
+
+  it('can render without a cancel button', function() {
+    var cloud = getCloudProviderDetails('gce');
+    var renderer = jsTestUtils.shallowRender(
+      <juju.components.DeploymentCredentialAdd
+          acl={acl}
+          addNotification={sinon.stub()}
+          updateCloudCredential={sinon.stub()}
+          close={sinon.stub()}
+          cloud={null}
+          credentials={[]}
+          getCloudProviderDetails={getCloudProviderDetails}
+          generateCloudCredentialName={sinon.stub()}
+          getCredentials={sinon.stub()}
+          hideCancel={true}
+          sendAnalytics={sendAnalytics}
+          setCredential={sinon.stub()}
+          user="user-admin"
+          validateForm={sinon.stub()} />, true);
+    var instance = renderer.getMountedInstance();
+    var output = renderer.getRenderOutput();
+    const buttons = output.props.children[3].props.children.props.buttons;
+    assert.deepEqual(buttons, [{
+      action: instance._handleAddCredentials,
+      submit: true,
+      title: 'Add cloud credential',
+      type: 'inline-positive'
+    }]);
   });
 
   it('can update to a new cloud', function() {
@@ -359,7 +389,8 @@ describe('DeploymentCredentialAdd', function() {
             </div>
           </div>
         </form>
-        <div className="prepend-six six-col last-col">
+        <div className={
+          'deployment-credential-add__buttons twelve-col last-col'}>
           <juju.components.ButtonRow
             buttons={buttons} />
         </div>
@@ -512,7 +543,8 @@ describe('DeploymentCredentialAdd', function() {
             </div>
           </div>
         </form>
-        <div className="prepend-six six-col last-col">
+        <div className={
+          'deployment-credential-add__buttons twelve-col last-col'}>
           <juju.components.ButtonRow
             buttons={buttons} />
         </div>
@@ -613,7 +645,8 @@ describe('DeploymentCredentialAdd', function() {
             </div>
           </div>
         </form>
-        <div className="prepend-six six-col last-col">
+        <div className={
+          'deployment-credential-add__buttons twelve-col last-col'}>
           <juju.components.ButtonRow
             buttons={buttons} />
         </div>
@@ -764,7 +797,8 @@ describe('DeploymentCredentialAdd', function() {
             </div>
           </div>
         </form>
-        <div className="prepend-six six-col last-col">
+        <div className={
+          'deployment-credential-add__buttons twelve-col last-col'}>
           <juju.components.ButtonRow
             buttons={buttons} />
         </div>

--- a/jujugui/static/gui/src/app/components/deployment-flow/credential/credential.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/credential/credential.js
@@ -293,6 +293,7 @@ YUI.add('deployment-credential', function() {
           getCloudProviderDetails={this.props.getCloudProviderDetails}
           generateCloudCredentialName={this.props.generateCloudCredentialName}
           getCredentials={this._getCredentials}
+          hideCancel={!this.state.credentials.length}
           sendAnalytics={this.props.sendAnalytics}
           setCredential={this.props.setCredential}
           updateCloudCredential={this.props.updateCloudCredential}

--- a/jujugui/static/gui/src/app/components/deployment-flow/credential/test-credential.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/credential/test-credential.js
@@ -117,6 +117,7 @@ describe('DeploymentCredential', function() {
             generateCloudCredentialName={generateCloudCredentialName}
             getCredentials={instance._getCredentials}
             getCloudProviderDetails={getCloudProviderDetails}
+            hideCancel={true}
             sendAnalytics={sendAnalytics}
             setCredential={setCredential}
             user={user}
@@ -238,6 +239,7 @@ describe('DeploymentCredential', function() {
             generateCloudCredentialName={generateCloudCredentialName}
             getCredentials={instance._getCredentials}
             getCloudProviderDetails={getCloudProviderDetails}
+            hideCancel={true}
             sendAnalytics={sendAnalytics}
             setCredential={setCredential}
             user={user}
@@ -516,6 +518,7 @@ describe('DeploymentCredential', function() {
             generateCloudCredentialName={generateCloudCredentialName}
             getCredentials={instance._getCredentials}
             getCloudProviderDetails={getCloudProviderDetails}
+            hideCancel={false}
             sendAnalytics={sendAnalytics}
             setCredential={setCredential}
             user={user}


### PR DESCRIPTION
Fixes: #2643. We shouldn't show the credentials selection if there are none (the user has not taken an action that they can cancel).