### PR TITLE
Fix lint-component errors.

### DIFF
--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -1018,7 +1018,6 @@ YUI.add('juju-gui', function(Y) {
             this.controllerAPI.destroyModels.bind(this.controllerAPI)}
           getAgreements={this.terms.getAgreements.bind(this.terms)}
           getDiagramURL={charmstore.getDiagramURL.bind(charmstore)}
-          gisf={this.get('gisf')}
           interactiveLogin={this.get('interactiveLogin')}
           pluralize={utils.pluralize.bind(this)}
           setPageTitle={this.setPageTitle}
@@ -1188,7 +1187,6 @@ YUI.add('juju-gui', function(Y) {
     _renderHeaderSearch: function() {
       ReactDOM.render(
         <window.juju.components.HeaderSearch
-          changeState={this.state.changeState.bind(this.state)}
           appState={this.state} />,
         document.getElementById('header-search-container'));
     },

--- a/jujugui/static/gui/src/app/components/inspector/inspector.js
+++ b/jujugui/static/gui/src/app/components/inspector/inspector.js
@@ -425,7 +425,6 @@ YUI.add('inspector-component', function() {
             backCallback={this._backCallback}
             activeComponent={this.state.activeComponent}
             type={this.state.activeChild.headerType}
-            count={this.state.activeChild.count}
             title={this.state.activeChild.title}
             icon={this.state.activeChild.icon} />
           <div className="inspector-content">

--- a/jujugui/static/gui/src/app/components/inspector/relate-to/endpoint/endpoint.js
+++ b/jujugui/static/gui/src/app/components/inspector/relate-to/endpoint/endpoint.js
@@ -70,12 +70,9 @@ YUI.add('inspector-relate-to-endpoint', function() {
       }
       return relations.map((relation, index) => {
         return (<juju.components.CheckListItem
-          index={index}
           key={index}
           ref={`InspectorRelateToEndpoint-${index}`}
           label={`${relation[0].name} → ${relation[1].name}`}
-          relation={relation}
-          changeState={this.props.changeState}
           whenChanged={this._updateActiveCount} />);
       });
     },

--- a/jujugui/static/gui/src/app/components/inspector/relate-to/endpoint/test-endpoint.js
+++ b/jujugui/static/gui/src/app/components/inspector/relate-to/endpoint/test-endpoint.js
@@ -51,12 +51,9 @@ describe('InspectorRelateToEndpoint', () => {
       <div className="inspector-relate-to-endpoint">
         <ul className="inspector-relate-to-endpoint__list">
           {[<juju.components.CheckListItem
-            index={0}
             key={0}
             ref="InspectorRelateToEndpoint-0"
             label="db → db"
-            relation={endpoints[0]}
-            changeState={changeState}
             whenChanged={output.props.children[0].props.children[0]
               .props.whenChanged} />]}
         </ul>
@@ -68,7 +65,7 @@ describe('InspectorRelateToEndpoint', () => {
             disabled: true
           }]} />
       </div>);
-    assert.deepEqual(output, expected);
+    expect(output).toEqualJSX(expected);
   });
 
   it('can render when there are no relatable endpoints', () => {

--- a/jujugui/static/gui/src/app/components/inspector/relations/relations.js
+++ b/jujugui/static/gui/src/app/components/inspector/relations/relations.js
@@ -129,8 +129,6 @@ YUI.add('inspector-relations', function() {
           key={relation.id}
           ref={ref}
           label={this._generateRelationLabel(relation)}
-          relation={relation}
-          changeState={this.props.changeState}
           whenChanged={this._updateActiveCount} />);
       }, this);
       return components;

--- a/jujugui/static/gui/src/app/components/inspector/relations/test-relations.js
+++ b/jujugui/static/gui/src/app/components/inspector/relations/test-relations.js
@@ -111,8 +111,6 @@ describe('InspectorRelations', function() {
           label={'django:django'}
           key={relations[0].id}
           ref='CheckListItem-mysql'
-          relation={relations[0]}
-          changeState={changeState}
           whenChanged={instance._updateActiveCount} />
         <juju.components.CheckListItem
           action={output.props.children[1].props.children[2].props.action}
@@ -120,14 +118,12 @@ describe('InspectorRelations', function() {
           label={'django:django'}
           key={relations[1].id}
           ref='CheckListItem-postgresql'
-          relation={relations[1]}
-          changeState={changeState}
           whenChanged={instance._updateActiveCount} />
       </ul>
       <juju.components.ButtonRow
         buttons={buttons} />
     </div>);
-    assert.deepEqual(output, expected);
+    expect(output).toEqualJSX(expected);
   });
 
   it('can show relation details on click', function() {
@@ -227,8 +223,6 @@ describe('InspectorRelations', function() {
             label={'django:django'}
             key={relations[0].id}
             ref='CheckListItem-mysql'
-            relation={relations[0]}
-            changeState={changeState}
             whenChanged={instance._updateActiveCount} />
           <juju.components.CheckListItem
             action={output.props.children[1].props.children[2].props.action}
@@ -236,14 +230,12 @@ describe('InspectorRelations', function() {
             label={'django:django'}
             key={relations[1].id}
             ref='CheckListItem-postgresql'
-            relation={relations[1]}
-            changeState={changeState}
             whenChanged={instance._updateActiveCount} />
         </ul>
         <juju.components.ButtonRow
           buttons={buttons} />
     </div>);
-    assert.deepEqual(output, expected);
+    expect(output).toEqualJSX(expected);
   });
 
   it('renders if there are no relations', () => {

--- a/jujugui/static/gui/src/app/components/inspector/test-inspector.js
+++ b/jujugui/static/gui/src/app/components/inspector/test-inspector.js
@@ -112,12 +112,10 @@ describe('Inspector', function() {
         backCallback={instance._backCallback}
         activeComponent={undefined}
         type={undefined}
-        count={undefined}
         title={title}
         icon={icon} />
     );
-    assert.deepEqual(header, expectedHeader,
-                     'Header is not rendered as expected');
+    expect(header).toEqualJSX(expectedHeader);
     const overview = output.props.children[1].props.children;
     var expectedOverview = (
         <juju.components.ServiceOverview
@@ -132,8 +130,7 @@ describe('Inspector', function() {
           service={service}
           serviceRelations={serviceRelations}
           showActivePlan={showActivePlan} />);
-    assert.deepEqual(overview, expectedOverview,
-                     'Overview is not rendered as expected');
+    expect(overview).toEqualJSX(expectedOverview);
   });
 
   it('displays the unit list when the app state calls for it', function() {
@@ -199,13 +196,10 @@ describe('Inspector', function() {
         backCallback={instance._backCallback}
         activeComponent='units'
         type={unitStatus}
-        count={0}
         title='Units'
         icon={icon} />
     );
-    assert.deepEqual(header, expectedHeader,
-                     'Header is not rendered as expected');
-
+    expect(header).toEqualJSX(expectedHeader);
 
     var children = output.props.children[1].props.children;
     assert.deepEqual(children,
@@ -282,12 +276,10 @@ describe('Inspector', function() {
         backCallback={instance._backCallback}
         activeComponent="config"
         type={undefined}
-        count={undefined}
         title='Configure'
         icon={icon} />
     );
-    assert.deepEqual(header, expectedHeader,
-                     'Header is not rendered as expected');
+    expect(header).toEqualJSX(expectedHeader);
 
     var children = output.props.children[1].props.children;
     assert.deepEqual(children,
@@ -373,12 +365,11 @@ describe('Inspector', function() {
         backCallback={instance._backCallback}
         activeComponent='unit'
         type={headerType}
-        count={undefined}
         title={title}
         icon={icon} />
     );
-    assert.deepEqual(header, expectedHeader,
-                     'Header is not rendered as expected');
+    expect(header).toEqualJSX(expectedHeader);
+
     var children = output.props.children[1].props.children;
     var expectedChildren = (
       <juju.components.UnitDetails
@@ -762,13 +753,11 @@ describe('Inspector', function() {
         backCallback={instance._backCallback}
         activeComponent="scale"
         type={undefined}
-        count={undefined}
         title='Scale'
         icon={icon}
       />
     );
-    assert.deepEqual(header, expectedHeader,
-                     'Header is not rendered as expected');
+    expect(header).toEqualJSX(expectedHeader);
     var children = output.props.children[1].props.children;
     assert.deepEqual(children,
         <juju.components.ScaleService
@@ -842,12 +831,10 @@ describe('Inspector', function() {
         backCallback={instance._backCallback}
         activeComponent="expose"
         type={undefined}
-        count={undefined}
         title='Expose'
         icon={icon} />
     );
-    assert.deepEqual(header, expectedHeader,
-                     'Header is not rendered as expected');
+    expect(header).toEqualJSX(expectedHeader);
     var children = output.props.children[1].props.children;
     assert.deepEqual(children,
         <juju.components.InspectorExpose
@@ -918,12 +905,10 @@ describe('Inspector', function() {
         backCallback={instance._backCallback}
         activeComponent="relations"
         type={undefined}
-        count={undefined}
         title='Relations'
         icon={icon} />
     );
-    assert.deepEqual(header, expectedHeader,
-                     'Header is not rendered as expected');
+    expect(header).toEqualJSX(expectedHeader);
     var children = output.props.children[1].props.children;
     assert.deepEqual(children,
         <juju.components.InspectorRelations
@@ -990,12 +975,10 @@ describe('Inspector', function() {
         backCallback={instance._backCallback}
         activeComponent="relate-to"
         type={undefined}
-        count={undefined}
         title='Relate to'
         icon={icon} />
     );
-    assert.deepEqual(header, expectedHeader,
-                     'Header is not rendered as expected');
+    expect(header).toEqualJSX(expectedHeader);
     var children = output.props.children[1].props.children;
     assert.deepEqual(children,
       <juju.components.InspectorRelateTo
@@ -1066,12 +1049,10 @@ describe('Inspector', function() {
         backCallback={instance._backCallback}
         activeComponent="relate-to"
         type={undefined}
-        count={undefined}
         title='spouse-name'
         icon={icon} />
     );
-    assert.deepEqual(header, expectedHeader,
-                     'Header is not rendered as expected');
+    expect(header).toEqualJSX(expectedHeader);
     var children = output.props.children[1].props.children;
     assert.deepEqual(children,
       <juju.components.InspectorRelateToEndpoint
@@ -1146,12 +1127,10 @@ describe('Inspector', function() {
         backCallback={instance._backCallback}
         activeComponent='plan'
         type={undefined}
-        count={undefined}
         title='Plan'
         icon={icon} />
     );
-    assert.deepEqual(header, expectedHeader,
-                     'Header is not rendered as expected');
+    expect(header).toEqualJSX(expectedHeader);
     var children = output.props.children[1].props.children;
     assert.deepEqual(children,
         <juju.components.InspectorPlan
@@ -1220,12 +1199,10 @@ describe('Inspector', function() {
         backCallback={instance._backCallback}
         activeComponent="change-version"
         type={undefined}
-        count={undefined}
         title='Change version'
         icon={icon} />
     );
-    assert.deepEqual(header, expectedHeader,
-                     'Header is not rendered as expected');
+    expect(header).toEqualJSX(expectedHeader);
     var children = output.props.children[1].props.children;
     expect(children).toEqualJSX(
       <juju.components.InspectorChangeVersion
@@ -1302,12 +1279,10 @@ describe('Inspector', function() {
         backCallback={instance._backCallback}
         activeComponent='resources'
         type={undefined}
-        count={undefined}
         title='Resources'
         icon={icon} />
     );
-    assert.deepEqual(header, expectedHeader,
-                     'Header is not rendered as expected');
+    expect(header).toEqualJSX(expectedHeader);
     const children = output.props.children[1].props.children;
     assert.deepEqual(children,
       <juju.components.InspectorResourcesList

--- a/jujugui/static/gui/src/app/components/sharing/sharing.js
+++ b/jujugui/static/gui/src/app/components/sharing/sharing.js
@@ -283,13 +283,11 @@ YUI.add('sharing', function() {
                 placeholder="Username"
                 ref="username"
                 onKeyUp={this._handleUsernameInputChange}
-                errors={!!this.state.inviteError}
                 required={true} />
             </div>
             <div className="sharing__invite--access">
               <juju.components.InsetSelect
                 label="Access"
-                defaultValue="read"
                 ref="access"
                 options={accessOptions} />
             </div>

--- a/jujugui/static/gui/src/app/components/sharing/test-sharing.js
+++ b/jujugui/static/gui/src/app/components/sharing/test-sharing.js
@@ -229,14 +229,12 @@ describe('Sharing', () => {
               label="Username"
               placeholder="Username"
               onKeyUp={instance._handleUsernameInputChange}
-              errors={false}
               ref="username"
               required={true} />
           </div>
           <div className="sharing__invite--access">
             <juju.components.InsetSelect
               label="Access"
-              defaultValue="read"
               ref="access"
               options={expectedOptions} />
           </div>
@@ -254,7 +252,7 @@ describe('Sharing', () => {
       </div>
     );
     const actualMarkup = output.props.children[0];
-    assert.deepEqual(actualMarkup, expectedMarkup);
+    expect(actualMarkup).toEqualJSX(expectedMarkup);
   });
 
   it('can grant user access', () => {

--- a/jujugui/static/gui/src/app/components/user-profile/entity/entity.js
+++ b/jujugui/static/gui/src/app/components/user-profile/entity/entity.js
@@ -398,7 +398,6 @@ YUI.add('user-profile-entity', function() {
     _showMetrics: function() {
       return (
         <juju.components.UserProfileEntityKPI
-          charmId={this.props.entity.id}
           d3={this.props.d3}
           metrics={this.state.metrics}
           metricTypes={this.state.metricTypes} />);

--- a/jujugui/static/gui/src/app/components/user-profile/entity/test-entity.js
+++ b/jujugui/static/gui/src/app/components/user-profile/entity/test-entity.js
@@ -440,7 +440,6 @@ describe('UserProfileEntity', () => {
           action={function noRefCheck() {}}
           title="Show KPI Metrics" />
         <juju.components.UserProfileEntityKPI
-          charmId="cs:django"
           d3={{}}
           metricTypes={['bad-wolf']}
           metrics={[{count: 10, metric: 'bad-wolf', sum: 10, time: {}}]} />

--- a/scripts/inspect-components
+++ b/scripts/inspect-components
@@ -12,6 +12,17 @@ import re
 import sys
 
 
+# Define React internally defined properties.
+_REACT_PROPS = ('key', 'ref')
+# Define per-component properties that are usually injected and therefore must
+# be excluded from validation when required but apparently not provided.
+_WHITELISTED_PROPS = {
+    'MachineViewHeader': ('canDrop', 'connectDropTarget', 'isOver'),
+    'MachineViewMachine': ('canDrop', 'connectDropTarget', 'isOver'),
+    'MachineViewMachineUnit': ('canDrag', 'connectDragSource', 'isDragging'),
+    'MachineViewUnplacedUnit': ('connectDragSource', 'isDragging'),
+}
+
 # Define global regular expressions.
 _definition_exp = re.compile(r"""
     ([\w\._]+)\s*  # Component name.
@@ -33,10 +44,9 @@ _fields_exp = re.compile(r"""
     =\s*  # Assignment.
     [^>=]  # Not an arrow function or equality operator..
 """, re.VERBOSE)
+
 # Define the number of workers.
 _MAX_WORKERS = 10
-# Define React internally defined properties.
-_REACT_PROPS = ('key', 'ref')
 
 
 class Definition(namedtuple('Definition', 'name path line props')):
@@ -113,9 +123,10 @@ class Instantiation(namedtuple('Instantiation', 'definition path line props')):
         errors = []
         definition = self.definition
         defined = dict((prop.name, prop.required) for prop in definition.props)
-        provided = self.props
+        provided = tuple(self.props)
+        all_provided = provided + _WHITELISTED_PROPS.get(definition.name, ())
         for name, required in defined.items():
-            if required and name not in provided:
+            if required and name not in all_provided:
                 errors.append('{} required but not provided'.format(name))
         errors.extend(
             '{} provided but not declared'.format(name)
@@ -346,7 +357,7 @@ def _execute_validate(options):
         if not options.short:
             output(instantiation, errors)
     if not error_summary:
-        print(green('validation succeeded'))
+        print(green('component validation succeeded'))
         return
     if not options.short:
         print(red('{big}\n{short} VALIDATION ERRORS {short}\n{big}\n'.format(
@@ -357,7 +368,8 @@ def _execute_validate(options):
         output(instantiation, errors)
     label = 'error' if error_count == 1 else 'errors'
     raise ValidationError(
-        red('validation failed: {} {} found'.format(error_count, label)))
+        red('component validation failed: {} {} found'.format(
+            error_count, label)))
 
 
 def _execute_tree(options):


### PR DESCRIPTION
This fixes all the "provided but not declared" errors.
Fortunately, after further inspection, the "required but nor provided" failures where due to some properties indirectly provided to the component with injection rather than when the instance is created. So I updated the inspect-component script to reflect these exceptions.