### PR TITLE
Update login events to prevent model login loop

### DIFF
--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -2536,9 +2536,6 @@ YUI.add('juju-gui', function(Y) {
       document.removeEventListener(
         'ecs.currentCommitFinished', this.renderDeploymentBarListener);
       document.removeEventListener('login', this.onLoginHandler);
-      if (this.boundOnLogin) {
-        document.removeEventListener('login', this.boundOnLogin);
-      }
       document.removeEventListener('login', this.controllerLoginHandler);
       document.removeEventListener('delta', this.onDeltaBound);
     },
@@ -2686,11 +2683,6 @@ YUI.add('juju-gui', function(Y) {
       @private
     */
     onLogin: function(evt) {
-      if (this.boundOnLoginFired) {
-        // We want this event to only fire once, so if it exists then remove it
-        // so it can't get fired again.
-        document.removeEventListener('login', this.boundOnLogin);
-      }
       if (evt.detail && evt.detail.err) {
         this._renderLogin(evt.detail.err);
         return;
@@ -2781,7 +2773,6 @@ YUI.add('juju-gui', function(Y) {
       };
       const credentials = this.user.model;
       const onLogin = callback => {
-        this.boundOnLoginFired = true;
         this.env.loading = false;
         if (callback) {
           callback(this.env);
@@ -2789,9 +2780,8 @@ YUI.add('juju-gui', function(Y) {
       };
       // Delay the callback until after the env login as everything should be
       // set up by then.
-      this.boundOnLoginFired = false;
-      this.boundOnLogin = onLogin.bind(this, callback);
-      document.addEventListener('login', this.boundOnLogin);
+      document.addEventListener(
+        'model.login', onLogin.bind(this, callback), {once: true});
       if (clearDB) {
         // Clear uncommitted state.
         this.env.get('ecs').clear();

--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -2664,32 +2664,6 @@ YUI.add('juju-gui', function(Y) {
     },
 
     /**
-      Hide the login mask and redispatch the router.
-
-      When the environment gets a response from a login attempt,
-      it fires a login event, to which this responds.
-
-      @method onLogin
-      @param {Object} evt An event object that includes an "err" attribute
-        with an error if the authentication failed.
-      @private
-    */
-    onLogin: function(evt) {
-      if (evt.detail && evt.detail.err) {
-        this._renderLogin(evt.detail.err);
-        return;
-      }
-      // The login was a success.
-      console.log('successfully logged into controller');
-      this.maskVisibility(false);
-      this._clearLogin();
-      this.set('loggedIn', true);
-      if (this.state.current.root === 'login') {
-        this.state.changeState({root: null});
-      }
-    },
-
-    /**
       Create the new socket URL based on the socket template and model details.
 
       @method createSocketURL

--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -466,10 +466,6 @@ YUI.add('juju-gui', function(Y) {
           this.onEnvironmentNameChange, this);
       this.env.after('defaultSeriesChange', this.onDefaultSeriesChange, this);
 
-      // Once the user logs in, we need to redraw.
-      this.onLoginHandler = this.onLogin.bind(this);
-      document.addEventListener('login', this.onLoginHandler);
-
       // Once we know about MAAS server, update the header accordingly.
       let maasServer = this.env.get('maasServer');
       if (!maasServer && this.controllerAPI) {
@@ -2535,7 +2531,6 @@ YUI.add('juju-gui', function(Y) {
         'ecs.changeSetModified', this.renderDeploymentBarListener);
       document.removeEventListener(
         'ecs.currentCommitFinished', this.renderDeploymentBarListener);
-      document.removeEventListener('login', this.onLoginHandler);
       document.removeEventListener('login', this.controllerLoginHandler);
       document.removeEventListener('delta', this.onDeltaBound);
     },
@@ -2648,18 +2643,15 @@ YUI.add('juju-gui', function(Y) {
       // authenticated. If we aren't then display the login screen.
       const shouldDisplayLogin = apis.some(api => {
         // Legacy Juju won't have a controller API.
-        if (!api) {
+        // If we do not have an api instance or if we are not connected with
+        // it then we don't need to concern ourselves with being
+        // authenticated to it.
+        if (!api || !api.get('connected')) {
           return false;
         }
         // If the api is connecting then we can't know if they are properly
         // logged in yet.
         if (api.get('connecting')) {
-          return true;
-        }
-        if (!api || !api.get('connected')) {
-          // If we do not have an api instance or if we are not connected with
-          // it then we don't need to concern ourselves with being
-          // authenticated to it.
           return false;
         }
         return !api.userIsAuthenticated && !this.get('gisf');
@@ -2688,7 +2680,7 @@ YUI.add('juju-gui', function(Y) {
         return;
       }
       // The login was a success.
-      console.log('successfully logged into model');
+      console.log('successfully logged into controller');
       this.maskVisibility(false);
       this._clearLogin();
       this.set('loggedIn', true);

--- a/jujugui/static/gui/src/app/state/state.js
+++ b/jujugui/static/gui/src/app/state/state.js
@@ -524,6 +524,7 @@ const State = class State {
       if (parts.length > 1 && parts[0] !== 'store') {
         error = invalidRootPath;
       }
+      return {error, state};
     }
     // The order of the PATH_DELIMETERS is important so we can assume the
     // order for easy parsing of the path.
@@ -758,7 +759,6 @@ const State = class State {
     ROOT_RESERVED.some(key => {
       if (urlParts && urlParts[0] === key) {
         state.root = key;
-        urlParts.splice(0, 1);
         return true;
       }
     });

--- a/jujugui/static/gui/src/app/state/state.js
+++ b/jujugui/static/gui/src/app/state/state.js
@@ -524,7 +524,6 @@ const State = class State {
       if (parts.length > 1 && parts[0] !== 'store') {
         error = invalidRootPath;
       }
-      return {error, state};
     }
     // The order of the PATH_DELIMETERS is important so we can assume the
     // order for easy parsing of the path.
@@ -759,6 +758,7 @@ const State = class State {
     ROOT_RESERVED.some(key => {
       if (urlParts && urlParts[0] === key) {
         state.root = key;
+        urlParts.splice(0, 1);
         return true;
       }
     });

--- a/jujugui/static/gui/src/app/store/env/api.js
+++ b/jujugui/static/gui/src/app/store/env/api.js
@@ -612,7 +612,7 @@ YUI.add('juju-env-api', function(Y) {
     login: function() {
       // If the user is already authenticated there is nothing to do.
       if (this.userIsAuthenticated) {
-        document.dispatchEvent(new CustomEvent('login', {
+        document.dispatchEvent(new CustomEvent('model.login', {
           detail: {err: null}
         }));
         return;
@@ -622,7 +622,7 @@ YUI.add('juju-env-api', function(Y) {
       }
       const credentials = this.get('user').model;
       if (!credentials.user || !credentials.password) {
-        document.dispatchEvent(new CustomEvent('login', {
+        document.dispatchEvent(new CustomEvent('model.login', {
           detail: {err: 'invalid username or password'}
         }));
         return;
@@ -954,7 +954,7 @@ YUI.add('juju-env-api', function(Y) {
     uploadLocalCharm: function(file, series, progress, callback) {
       // Ensure that they are logged in and authenticated before uploading.
       if (!this.userIsAuthenticated) {
-        document.dispatchEvent(new CustomEvent('login', {
+        document.dispatchEvent(new CustomEvent('model.login', {
           detail: {err: 'cannot upload files anonymously'}
         }));
         return;

--- a/jujugui/static/gui/src/app/store/env/api.js
+++ b/jujugui/static/gui/src/app/store/env/api.js
@@ -569,7 +569,7 @@ YUI.add('juju-env-api', function(Y) {
       // Only fire login if this is not a redirect error as we will come back
       // here once the redirection is made.
       if (!utils.isRedirectError(data.error)) {
-        document.dispatchEvent(new CustomEvent('login', {
+        document.dispatchEvent(new CustomEvent('model.login', {
           detail: {err: data.error || null}
         }));
       }

--- a/jujugui/static/gui/src/test/test_app.js
+++ b/jujugui/static/gui/src/test/test_app.js
@@ -311,11 +311,11 @@ describe('App', function() {
 
         assert.equal(stub.callCount >= 3, true);
         var args = stub.args;
-        assert.equal(args[6][0], 'dragenter');
+        assert.equal(args[5][0], 'dragenter');
         assert.isFunction(args[0][1]);
-        assert.equal(args[7][0], 'dragover');
+        assert.equal(args[6][0], 'dragover');
         assert.isFunction(args[1][1]);
-        assert.equal(args[8][0], 'dragleave');
+        assert.equal(args[7][0], 'dragleave');
         assert.isFunction(args[2][1]);
       });
 
@@ -594,45 +594,6 @@ describe('App', function() {
       assert.deepEqual(
         app.user.controller, {user: '', password: '', macaroons: null});
       assert.equal(conn.messages.length, 0);
-    });
-
-    it('displays the login view if credentials are not valid', function() {
-      env.connect();
-      var loginStub = sinon.stub(app, '_renderLogin');
-      app.env.login();
-      // Mimic a login failed response assuming login is the first request.
-      conn.msg({'request-id': 1, error: 'bad wolf'});
-      assert.equal(1, conn.messages.length);
-      assertIsLogin(conn.last_message());
-      assert.equal(loginStub.callCount, 2);
-      assert.equal(loginStub.args[0][0], 'bad wolf');
-      assert.equal(loginStub.args[1][0], 'bad wolf');
-    });
-
-    it('login method handler is called after successful login', function(done) {
-      let localApp = {};
-      const oldOnLogin = Y.juju.App.prototype.onLogin;
-      Y.juju.App.prototype.onLogin = evt => {
-        assert.equal(conn.messages.length, 1);
-        assertIsLogin(conn.last_message());
-        assert.strictEqual(evt.detail.err, null);
-        localApp.on('destroy', () => done());
-        localApp.destroy();
-      };
-      this._cleanups.push(() => {
-        Y.juju.App.prototype.onLogin = oldOnLogin;
-      });
-      localApp = new Y.juju.App({
-        baseUrl: 'http://example.com/',
-        controllerAPI: controller,
-        env: env,
-        controllerSocketTemplate: '/api',
-        viewContainer: container,
-        jujuCoreVersion: '2.0.0'
-      });
-      env.connect();
-      localApp.env.userIsAuthenticated = true;
-      localApp.env.login();
     });
 
     it('tries to log in on first connection', function() {
@@ -1512,12 +1473,12 @@ describe('App', function() {
       checkNext({root: 'store'});
     });
 
-    it('displays login if one of the apis is still connecting', () => {
+    it('does not display login if one of the apis is still connecting', () => {
       app.controllerAPI.set('connecting', true);
       const next = sinon.stub();
       const displayStub = sinon.stub(app, '_displayLogin');
       app.checkUserCredentials({}, next);
-      assert.equal(displayStub.callCount, 1);
+      assert.equal(displayStub.callCount, 0);
     });
 
     it('does not login if all apis are not connected', () => {

--- a/jujugui/static/gui/src/test/test_env_api.js
+++ b/jujugui/static/gui/src/test/test_env_api.js
@@ -386,7 +386,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
           assert.strictEqual(evt.detail.err, null);
           done();
         };
-        document.addEventListener('login', listener);
+        document.addEventListener('model.login', listener);
         env.login();
         // Assume login to be the first request.
         conn.msg({
@@ -397,7 +397,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
             facades: [{name: 'ModelManager', versions: [2]}]
           }
         });
-        document.removeEventListener('login', listener);
+        document.removeEventListener('model.login', listener);
       });
 
       it('resets failed markers on successful login', function() {
@@ -420,11 +420,11 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
           assert.strictEqual(evt.detail.err, 'Invalid user or password');
           done();
         };
-        document.addEventListener('login', listener);
+        document.addEventListener('model.login', listener);
         env.login();
         // Assume login to be the first request.
         conn.msg({'request-id': 1, error: 'Invalid user or password'});
-        document.removeEventListener('login', listener);
+        document.removeEventListener('model.login', listener);
       });
 
       it('avoids sending login requests without credentials', function() {
@@ -1097,9 +1097,9 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
           assert.deepEqual(evt.detail.err, 'cannot upload files anonymously');
           done();
         };
-        document.addEventListener('login', listener);
+        document.addEventListener('model.login', listener);
         env.uploadLocalCharm();
-        document.removeEventListener('login', listener);
+        document.removeEventListener('model.login', listener);
       });
 
       it('uses the stored webHandler to perform requests', function() {


### PR DESCRIPTION
Fixes #2968

We were relying on non-namespaced events when the controller and model logged in which was causing a race condition when logging in. This would mean that sometimes the login state would be re-instated because it would get the login event from the controller but then check the model and it would still be connecting which would cause it to loop back to logging in.