### PR TITLE
Fix direct deploy back to canvas and ssh-key wordwrap

### DIFF
--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -2176,7 +2176,10 @@ YUI.add('juju-gui', function(Y) {
           this._renderDeployment.bind(this),
           this._clearDeployment.bind(this)],
         // Nothing needs to be done at the top level when the hash changes.
-        ['hash']
+        ['hash'],
+        // special dd is handled by the root dispatcher as it requires /new
+        // for now.
+        ['special.dd']
       ]);
 
       return state;

--- a/jujugui/static/gui/src/app/assets/css/_components.scss
+++ b/jujugui/static/gui/src/app/assets/css/_components.scss
@@ -39,6 +39,7 @@
 @import '../../components/deployment-flow/panel/panel';
 @import '../../components/deployment-flow/services/services';
 @import '../../components/deployment-flow/signup/signup';
+@import '../../components/deployment-flow/sshkey/sshkey';
 @import '../../components/env-size-display/env-size-display';
 @import '../../components/env-switcher/env-switcher';
 @import '../../components/env-switcher/list/list';

--- a/jujugui/static/gui/src/app/components/deployment-flow/panel/panel.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/panel/panel.js
@@ -45,7 +45,8 @@ YUI.add('deployment-panel', function() {
       );
       this.props.changeState({
         gui: {deploy: null},
-        profile: null
+        profile: null,
+        special: {dd: null}
       });
     },
 

--- a/jujugui/static/gui/src/app/components/deployment-flow/panel/test-panel.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/panel/test-panel.js
@@ -81,7 +81,8 @@ describe('DeploymentPanel', function() {
     assert.equal(changeState.callCount, 1);
     assert.deepEqual(changeState.args[0][0], {
       gui: {deploy: null},
-      profile: null
+      profile: null,
+      special: {dd:null}
     });
   });
 });

--- a/jujugui/static/gui/src/app/components/deployment-flow/sshkey/_sshkey.scss
+++ b/jujugui/static/gui/src/app/components/deployment-flow/sshkey/_sshkey.scss
@@ -1,0 +1,5 @@
+.deployment-ssh-key {
+  *[contenteditable] {
+    word-wrap: break-word;
+  }
+}

--- a/jujugui/static/gui/src/app/components/deployment-flow/sshkey/sshkey.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/sshkey/sshkey.js
@@ -79,7 +79,7 @@ YUI.add('deployment-ssh-key', function() {
       }
 
       return (
-        <div>
+        <div className="deployment-ssh-key">
           {message}
           <juju.components.GenericInput
             label="SSH key"

--- a/jujugui/static/gui/src/app/components/deployment-flow/sshkey/test-sshkey.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/sshkey/test-sshkey.js
@@ -62,7 +62,7 @@ describe('DeploymentSSHKey', function() {
   it('renders with a cloud', function() {
     const comp = render('aws');
     const expectedOutput = (
-      <div>
+      <div className="deployment-ssh-key">
         <p>
           Optionally provide a SSH key (e.g. ~/.ssh/id_rsa.pub) to allow
           accessing machines provisioned on this model via "juju ssh".
@@ -86,7 +86,7 @@ describe('DeploymentSSHKey', function() {
   it('renders with azure', function() {
     const comp = render('azure');
     const expectedOutput = (
-      <div>
+      <div className="deployment-ssh-key">
         <p>
           Provide the SSH key (e.g. ~/.ssh/id_rsa.pub) that will be used to
           provision machines on Azure.


### PR DESCRIPTION
Fixes #2987 
Fixes #2988 

- When using direct deploy the "Back to canvas" button will now properly navigate back to the canvas.
- When pasting an ssh-key into the deployment flow in Firefox it will force it to wrap instead of spilling out of the container.