### PR TITLE
Initial statsd client implementation.

### DIFF
--- a/jujugui/static/gui/src/app/utils/statsd.js
+++ b/jujugui/static/gui/src/app/utils/statsd.js
@@ -1,0 +1,79 @@
+/*
+This file is part of the Juju GUI, which lets users view and manage Juju
+environments within a graphical interface (https://launchpad.net/juju-gui).
+Copyright (C) 2017 Canonical Ltd.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU Affero General Public License version 3, as published by
+the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero
+General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along
+with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+'use strict';
+
+/**
+  A statsd client used to send application metrics.
+*/
+
+YUI.add('statsd', function(Y) {
+
+  const module = Y.namespace('juju.statsd');
+
+  /**
+    A client for sending statsd metrics.
+  */
+  const StatsClient = class StatsClient {
+
+    /**
+      Create the statsd client.
+
+      @param {String} url The URL of the statsd endpoint where to send metrics.
+      @param {String} prefix The stats prefix for all calls.
+    */
+    constructor(url, prefix='') {
+      this.url = url.replace(/\/?$/, '/');
+      this._prefix = prefix;
+    }
+
+    /**
+      Increase the counter with the given name.
+
+      @param {String} name The stats name.
+      @param {Integer} count The increment amount.
+    */
+    increase(name, count=1) {
+      this._send(`${name}:${count}|c`);
+    }
+
+    /**
+      Send the given data to the statsd endpoint.
+
+      @param {String} data The non prefixed data to send.
+    */
+    _send(data) {
+      if (this._prefix) {
+        data = `${this._prefix}.${data}`;
+      }
+      const xhr = new XMLHttpRequest({});
+      xhr.addEventListener('error', evt => {
+        console.error(`cannot send statsd data "${data}":`, evt);
+      });
+      xhr.addEventListener('load', evt => {
+        console.debug(`statsd data "${data}" correctly sent`);
+      });
+      xhr.open('POST', this.url);
+      xhr.send(data);
+    }
+
+  };
+
+  module.StatsClient = StatsClient;
+
+}, '0.1.0', {requires: []});

--- a/jujugui/static/gui/src/app/utils/statsd.js
+++ b/jujugui/static/gui/src/app/utils/statsd.js
@@ -1,79 +1,57 @@
-/*
-This file is part of the Juju GUI, which lets users view and manage Juju
-environments within a graphical interface (https://launchpad.net/juju-gui).
-Copyright (C) 2017 Canonical Ltd.
-
-This program is free software: you can redistribute it and/or modify it under
-the terms of the GNU Affero General Public License version 3, as published by
-the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful, but WITHOUT
-ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
-SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero
-General Public License for more details.
-
-You should have received a copy of the GNU Affero General Public License along
-with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
+/* Copyright (C) 2017 Canonical Ltd. */
 
 'use strict';
+
+if (typeof this.jujugui === 'undefined') {
+  this.jujugui = {};
+}
 
 /**
   A statsd client used to send application metrics.
 */
-
-YUI.add('statsd', function(Y) {
-
-  const module = Y.namespace('juju.statsd');
+const StatsClient = class StatsClient {
 
   /**
-    A client for sending statsd metrics.
+    Create the statsd client.
+
+    @param {String} url The URL of the statsd endpoint where to send metrics.
+    @param {String} prefix The stats prefix for all calls.
   */
-  const StatsClient = class StatsClient {
+  constructor(url, prefix='') {
+    this.url = url.replace(/\/?$/, '/');
+    this._prefix = prefix;
+  }
 
-    /**
-      Create the statsd client.
+  /**
+    Increase the counter with the given name.
 
-      @param {String} url The URL of the statsd endpoint where to send metrics.
-      @param {String} prefix The stats prefix for all calls.
-    */
-    constructor(url, prefix='') {
-      this.url = url.replace(/\/?$/, '/');
-      this._prefix = prefix;
+    @param {String} name The stats name.
+    @param {Integer} count The increment amount.
+  */
+  increase(name, count=1) {
+    this._send(`${name}:${count}|c`);
+  }
+
+  /**
+    Send the given data to the statsd endpoint.
+
+    @param {String} data The non prefixed data to send.
+  */
+  _send(data) {
+    if (this._prefix) {
+      data = `${this._prefix}.${data}`;
     }
+    const xhr = new XMLHttpRequest({});
+    xhr.addEventListener('error', evt => {
+      console.error(`cannot send statsd data "${data}":`, evt);
+    });
+    xhr.addEventListener('load', evt => {
+      console.debug(`statsd data "${data}" correctly sent`);
+    });
+    xhr.open('POST', this.url);
+    xhr.send(data);
+  }
 
-    /**
-      Increase the counter with the given name.
+};
 
-      @param {String} name The stats name.
-      @param {Integer} count The increment amount.
-    */
-    increase(name, count=1) {
-      this._send(`${name}:${count}|c`);
-    }
-
-    /**
-      Send the given data to the statsd endpoint.
-
-      @param {String} data The non prefixed data to send.
-    */
-    _send(data) {
-      if (this._prefix) {
-        data = `${this._prefix}.${data}`;
-      }
-      const xhr = new XMLHttpRequest({});
-      xhr.addEventListener('error', evt => {
-        console.error(`cannot send statsd data "${data}":`, evt);
-      });
-      xhr.addEventListener('load', evt => {
-        console.debug(`statsd data "${data}" correctly sent`);
-      });
-      xhr.open('POST', this.url);
-      xhr.send(data);
-    }
-
-  };
-
-  module.StatsClient = StatsClient;
-
-}, '0.1.0', {requires: []});
+this.jujugui.StatsClient = StatsClient;

--- a/jujugui/static/gui/src/app/utils/test-statsd.js
+++ b/jujugui/static/gui/src/app/utils/test-statsd.js
@@ -1,20 +1,4 @@
-/*
-This file is part of the Juju GUI, which lets users view and manage Juju
-environments within a graphical interface (https://launchpad.net/juju-gui).
-Copyright (C) 2017 Canonical Ltd.
-
-This program is free software: you can redistribute it and/or modify it under
-the terms of the GNU Affero General Public License version 3, as published by
-the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful, but WITHOUT
-ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
-SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero
-General Public License for more details.
-
-You should have received a copy of the GNU Affero General Public License along
-with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
+/* Copyright (C) 2017 Canonical Ltd. */
 
 'use strict';
 
@@ -23,14 +7,7 @@ chai.config.includeStack = true;
 chai.config.truncateThreshold = 0;
 
 describe('StatsClient', () => {
-  let mockXHR, statsd;
-
-  beforeAll((done) => {
-    YUI().use('statsd', Y => {
-      statsd = Y.juju.statsd;
-      done();
-    });
-  });
+  let mockXHR;
 
   beforeEach(() => {
     const proto = XMLHttpRequest.prototype;
@@ -69,27 +46,27 @@ describe('StatsClient', () => {
 
   it('increases a counter', () => {
     const url = 'https://example.com/stats/';
-    const client = new statsd.StatsClient(url);
+    const client = new window.jujugui.StatsClient(url);
     client.increase('foo');
     assertXHRSent(url, 'foo:1|c');
   });
 
   it('adds the trailing slash to the URL', () => {
-    const client = new statsd.StatsClient('https://example.com');
+    const client = new window.jujugui.StatsClient('https://example.com');
     client.increase('bar');
     assertXHRSent('https://example.com/', 'bar:1|c');
   });
 
-  it('increases a counter more than one', () => {
+  it('increases a counter by more than one', () => {
     const url = 'https://example.com/stats/';
-    const client = new statsd.StatsClient(url);
+    const client = new window.jujugui.StatsClient(url);
     client.increase('my-key', 42);
     assertXHRSent(url, 'my-key:42|c');
   });
 
   it('can include a prefix', () => {
     const url = 'https://example.com/stats/';
-    const client = new statsd.StatsClient(url, 'gui');
+    const client = new window.jujugui.StatsClient(url, 'gui');
     client.increase('awesome');
     assertXHRSent(url, 'gui.awesome:1|c');
   });

--- a/jujugui/static/gui/src/app/utils/test-statsd.js
+++ b/jujugui/static/gui/src/app/utils/test-statsd.js
@@ -1,0 +1,96 @@
+/*
+This file is part of the Juju GUI, which lets users view and manage Juju
+environments within a graphical interface (https://launchpad.net/juju-gui).
+Copyright (C) 2017 Canonical Ltd.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU Affero General Public License version 3, as published by
+the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero
+General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along
+with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+'use strict';
+
+var juju = {components: {}}; // eslint-disable-line no-unused-vars
+chai.config.includeStack = true;
+chai.config.truncateThreshold = 0;
+
+describe('StatsClient', () => {
+  let mockXHR, statsd;
+
+  beforeAll((done) => {
+    YUI().use('statsd', Y => {
+      statsd = Y.juju.statsd;
+      done();
+    });
+  });
+
+  beforeEach(() => {
+    const proto = XMLHttpRequest.prototype;
+    mockXHR = {
+      addEventListener: sinon.stub(proto, 'addEventListener'),
+      open: sinon.stub(proto, 'open'),
+      send: sinon.stub(proto, 'send')
+    };
+  });
+
+  afterEach(() => {
+    Object.keys(mockXHR).forEach(key => {
+      mockXHR[key].restore();
+    });
+  });
+
+  // Ensure the XHR request has been sent to the URL with the provided value.
+  const assertXHRSent = (url, value) => {
+    // Both success and error event listeners are added.
+    assert.equal(mockXHR.addEventListener.callCount, 2, 'addEventListener');
+    let args = mockXHR.addEventListener.args;
+    assert.strictEqual(args[0][0], 'error');
+    assert.strictEqual(args[1][0], 'load');
+    // The XHR is properly opened.
+    assert.equal(mockXHR.open.callCount, 1, 'open');
+    args = mockXHR.open.args[0];
+    assert.equal(args.length, 2, 'open args');
+    assert.strictEqual(args[0], 'POST');
+    assert.strictEqual(args[1], url);
+    // The data has been correctly sent.
+    assert.equal(mockXHR.send.callCount, 1, 'send');
+    args = mockXHR.send.args[0];
+    assert.equal(args.length, 1, 'send args');
+    assert.strictEqual(args[0], value);
+  };
+
+  it('increases a counter', () => {
+    const url = 'https://example.com/stats/';
+    const client = new statsd.StatsClient(url);
+    client.increase('foo');
+    assertXHRSent(url, 'foo:1|c');
+  });
+
+  it('adds the trailing slash to the URL', () => {
+    const client = new statsd.StatsClient('https://example.com');
+    client.increase('bar');
+    assertXHRSent('https://example.com/', 'bar:1|c');
+  });
+
+  it('increases a counter more than one', () => {
+    const url = 'https://example.com/stats/';
+    const client = new statsd.StatsClient(url);
+    client.increase('my-key', 42);
+    assertXHRSent(url, 'my-key:42|c');
+  });
+
+  it('can include a prefix', () => {
+    const url = 'https://example.com/stats/';
+    const client = new statsd.StatsClient(url, 'gui');
+    client.increase('awesome');
+    assertXHRSent(url, 'gui.awesome:1|c');
+  });
+});

--- a/jujugui/templates/index.html.go
+++ b/jujugui/templates/index.html.go
@@ -340,6 +340,9 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
         };
 
         YUI(GlobalConfig).use(['juju-gui', 'yui-patches'], function(Y) {
+          if (!juju_config.flags) {
+            juju_config.flags = {};
+          }
           app = new Y.juju.App(juju_config);
           // We need to activate the hotkeys when running the application
           // in production. Unit tests should call it manually.

--- a/jujugui/templates/index.html.mako
+++ b/jujugui/templates/index.html.mako
@@ -346,6 +346,9 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
         };
 
         YUI(GlobalConfig).use(['juju-gui', 'yui-patches'], function(Y) {
+          if (!juju_config.flags) {
+            juju_config.flags = {};
+          }
           app = new Y.juju.App(juju_config); // comment out for init.js
           // const JujuGUI = require('init');
           // window.JujuGUI = new JujuGUI(juju_config);

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -70,7 +70,9 @@ module.exports = function(config) {
       'jujugui/static/gui/build/app/utils/net-utils.js',
       'jujugui/static/gui/build/app/utils/test-net-utils.js',
       'jujugui/static/gui/build/app/utils/analytics.js',
-      'jujugui/static/gui/build/app/utils/test-analytics.js'
+      'jujugui/static/gui/build/app/utils/test-analytics.js',
+      'jujugui/static/gui/build/app/utils/statsd.js',
+      'jujugui/static/gui/build/app/utils/test-statsd.js'
     ],
 
     // list of files to exclude


### PR DESCRIPTION
This branch implements the increase statsd call. It will be used to send event metrics from the GUI to prometheus.
Also ensure that the flags object is always present as part of the configuration: it will be used to propagate flags from the store front to the GUI.