### PR TITLE
Adds a flags setting to jujugui config

### DIFF
--- a/jujugui/options.py
+++ b/jujugui/options.py
@@ -28,6 +28,7 @@ def update(settings):
     _update(settings, 'jujugui.stripe_key', default='')
     _update(settings, 'jujugui.user', default=None)
     _update(settings, 'jujugui.static_url', default='')
+    _update(settings, 'jujugui.flags', default={})
 
     _update_url(settings, 'jujugui.plans_url', default=DEFAULT_PLANS_URL)
     _update_url(settings, 'jujugui.payment_url', default=DEFAULT_PAYMENT_URL)

--- a/jujugui/tests/test_options.py
+++ b/jujugui/tests/test_options.py
@@ -31,6 +31,7 @@ class TestUpdate(unittest.TestCase):
         'jujugui.terms_url': options.DEFAULT_TERMS_URL,
         'jujugui.payment_url': options.DEFAULT_PAYMENT_URL,
         'jujugui.user': None,
+        'jujugui.flags': {},
     }
 
     def test_default_values(self):
@@ -62,6 +63,7 @@ class TestUpdate(unittest.TestCase):
             'jujugui.payment_url': 'https://1.2.3.4/payment-api/',
             'jujugui.terms_url': 'https://1.2.3.4/terms-api/',
             'jujugui.user': 'who',
+            'jujugui.flags': {'foo': True}
         }
         settings = {
             'jujugui.auth': 'blob',
@@ -85,6 +87,7 @@ class TestUpdate(unittest.TestCase):
             'jujugui.payment_url': 'https://1.2.3.4/payment-api/',
             'jujugui.terms_url': 'https://1.2.3.4/terms-api/',
             'jujugui.user': 'who',
+            'jujugui.flags': {'foo': True}
         }
         options.update(settings)
         self.assertEqual(expected_settings, settings)

--- a/jujugui/views.py
+++ b/jujugui/views.py
@@ -88,6 +88,7 @@ def config(request):
     options = {
         # Base YUI options.
         'auth': settings['jujugui.auth'],
+        'flags': settings['jujugui.flags'],
         'serverRouting': False,
         'container': '#main',
         'viewContainer': '#main',


### PR DESCRIPTION
This is primarily for the gui in gisf context, in which case the storefront
passes along active switches as flags.