### PR TITLE
Model API: properly send the charm configuration.

### DIFF
--- a/jujugui/static/gui/src/app/store/env/api.js
+++ b/jujugui/static/gui/src/app/store/env/api.js
@@ -1353,20 +1353,15 @@ YUI.add('juju-env-api', function(Y) {
       const params = {
         application: args.applicationName,
         'charm-url': args.charmURL,
-        // In order to maintain backwards compatibility, the Juju API
-        // implemented a new param, configYAML, so that an empty configuration
-        // value does not 'unset' keys. This value is parsed by the Go yaml2
-        // package So as long as we pass a key/value JSON map it will be able
-        // to parse it as YAML.
-        // In the event that making this modification causes issues setting
-        // configuration values due to the JSON>YAML conversion and needs to be
-        // reverted the key can simply be changed to 'config'.
-        configYAML: stringifyObjectValues(args.config || {}),
-        'config-yaml': args.configRaw || '',
         constraints: constraints,
         'num-units': args.numUnits || 0,
         resources: args.resources || {}
       };
+      if (args.configRaw) {
+        params['config-yaml'] = args.configRaw;
+      } else if (args.config) {
+        params.config = stringifyObjectValues(args.config);
+      }
       if (args.series) {
         // If series is defined then set it, do not send an undefined series
         // field as Juju core will not successfully deploy the application.

--- a/jujugui/static/gui/src/test/test_env_api.js
+++ b/jujugui/static/gui/src/test/test_env_api.js
@@ -1703,8 +1703,6 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
         version: 7,
         params: {applications: [{
           application: 'mysql',
-          'config-yaml': '',
-          configYAML: {},
           constraints: {},
           'charm-url': 'precise/mysql',
           'num-units': 1,
@@ -1725,8 +1723,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
         params: {applications: [{
           application: 'wiki',
           // Configuration values are sent as strings.
-          configYAML: {debug: 'true', logo: 'example.com/mylogo.png'},
-          'config-yaml': '',
+          config: {debug: 'true', logo: 'example.com/mylogo.png'},
           constraints: {},
           'charm-url': 'precise/mediawiki',
           'num-units': 0,
@@ -1751,7 +1748,6 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
         version: 7,
         params: {applications: [{
           application: 'mysql',
-          configYAML: {},
           constraints: {},
           'config-yaml': configRaw,
           'charm-url': 'precise/mysql',
@@ -1763,6 +1759,33 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       env.deploy({
         charmURL: 'precise/mysql',
         applicationName: 'mysql',
+        configRaw: configRaw
+      }, null, {immediate: true});
+      msg = conn.last_message();
+      assert.deepEqual(expected, msg);
+    });
+
+    it('the raw config takes precedence over the config object', function() {
+      const config = {debug: true, logo: 'example.com/mylogo.png'};
+      const configRaw = 'tuning-level: \nexpert-mojo';
+      const expected = {
+        type: 'Application',
+        request: 'Deploy',
+        version: 7,
+        params: {applications: [{
+          application: 'wiki',
+          'config-yaml': configRaw,
+          constraints: {},
+          'charm-url': 'precise/mediawiki',
+          'num-units': 0,
+          resources: {}
+        }]},
+        'request-id': 1
+      };
+      env.deploy({
+        charmURL: 'precise/mediawiki',
+        applicationName: 'wiki',
+        config: config,
         configRaw: configRaw
       }, null, {immediate: true});
       msg = conn.last_message();
@@ -1803,9 +1826,6 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
         version: 7,
         params: {applications: [{
           application: 'wiki',
-          // Configuration values are sent as strings.
-          configYAML: {},
-          'config-yaml': '',
           constraints: {},
           'charm-url': 'precise/mediawiki',
           'num-units': 7,


### PR DESCRIPTION
Fixes https://github.com/juju/juju-gui/issues/2845 by correctly sending the right config fields to the Application.Deploy API call.