### PR TITLE
Gracefully fail when charmstore requests return no data

### DIFF
--- a/jujugui/static/gui/src/app/components/entity-details/entity-details.js
+++ b/jujugui/static/gui/src/app/components/entity-details/entity-details.js
@@ -150,7 +150,7 @@ class EntityDetails extends React.Component {
     @param {Array} models A list of the entity models found.
   */
   _fetchCallback(error, data) {
-    if (error) {
+    if (error || !data) {
       this._changeActiveComponent('error');
       console.error('cannot fetch the entity:' + error);
       return;

--- a/jujugui/static/gui/src/app/jujulib/charmstore.js
+++ b/jujugui/static/gui/src/app/jujulib/charmstore.js
@@ -83,6 +83,10 @@ var module = module;
     _transformQueryResults: function(callback, error, data) {
       if (error !== null) {
         callback(error, data);
+      } else if (!data) {
+        // The only time there should be no data and no error is if the
+        // request to the charmstore times out, or is blocked by a vpn.
+        callback('no entity data returned, can you access the charmstore?');
       } else {
         // If there is a single charm or bundle being requested then we need
         // to wrap it in an array so we can use the same map code.

--- a/jujugui/static/gui/src/app/jujulib/index.js
+++ b/jujugui/static/gui/src/app/jujulib/index.js
@@ -72,7 +72,7 @@ var module = module;
   };
 
   const _transformAuthObject = function(callback, error, data) {
-    if (error !== null) {
+    if (error !== null || !data) {
       callback(error, data);
     } else {
       const auth = {};

--- a/jujugui/static/gui/src/app/jujulib/test-charmstore.js
+++ b/jujugui/static/gui/src/app/jujulib/test-charmstore.js
@@ -92,6 +92,13 @@ describe('jujulib charmstore', function() {
       assert.equal(models[2], 'It\'s a charm.');
       assert.equal(models[3], 'It\'s a bundle.');
     });
+
+    it('errors when no data is provided even if there is no error', function() {
+      charmstore._transformQueryResults(cb, null, null);
+      assert.equal(
+        cb.args[0][0],
+        'no entity data returned, can you access the charmstore?');
+    });
   });
 
   describe('_lowerCaseKeys', function() {

--- a/jujugui/static/gui/src/app/jujulib/test-index.js
+++ b/jujugui/static/gui/src/app/jujulib/test-index.js
@@ -80,6 +80,12 @@ describe('jujulib utility functions', () => {
       assert.deepEqual(stub.args, [['error', 'data']]);
     });
 
+    it('calls the supplied callback if no data', () => {
+      const cb = sinon.stub();
+      transform(cb, null, null);
+      assert.deepEqual(cb.args[0], [null, null]);
+    });
+
     it('lowercases data keys and calls supplied callback', () => {
       const stub = sinon.stub();
       transform(stub, null, {Upper: 'case', Keys: 'here'});


### PR DESCRIPTION
Fixes #3086

If the API is functioning properly this only happens when the host is blocked by a VPN. This also allows the GUI to display model information even if the user cannot access the charmstore.