### PR TITLE
Do not generate ugly deploy urls

### DIFF
--- a/jujugui/static/gui/src/app/state/state.js
+++ b/jujugui/static/gui/src/app/state/state.js
@@ -679,7 +679,12 @@ const State = class State {
               path.push(localType);
             }
           } else {
-            path.push(value);
+            // The deploy key is used for the direct deploy which will also
+            // contain a complex object. We do not want to push that object
+            // stringified into the url.
+            if (key !== 'deploy') {
+              path.push(value);
+            }
           }
         }
       });

--- a/jujugui/static/gui/src/app/state/test-state.js
+++ b/jujugui/static/gui/src/app/state/test-state.js
@@ -192,9 +192,9 @@ describe('State', () => {
     error: null
   }, {
     path:
-      'http://abc.com:123/i/inspector/apache2/machines/3/lxc-0/deploy/foo',
+      'http://abc.com:123/i/inspector/apache2/machines/3/lxc-0/deploy',
     state: {
-      gui: { inspector: {id: 'apache2'}, machines: '3/lxc-0', deploy: 'foo'}
+      gui: { inspector: {id: 'apache2'}, machines: '3/lxc-0', deploy: ''}
     },
     error: null
   }, {


### PR DESCRIPTION
Fixes #2828

When using Direct Deploy the url generated when entering the deployment flow should no longer contain the direct deploy json data.