### PR TITLE
Fix removing SSH keys.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -314,8 +314,7 @@ lint-css: $(NODE_MODULES)
 
 .PHONY: lint-components
 lint-components:
-	 @./scripts/inspect-components validate --path jujugui/static/gui/src/ --short || \
-	 	echo "^^^ Open an issue or ping frankban if those are not actual errors.\n"
+	 @./scripts/inspect-components validate --path jujugui/static/gui/src/ --short
 
 .PHONY: test
 test: test-python test-js test-js-old

--- a/jujugui/static/gui/src/app/components/deployment-flow/deployment-flow.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/deployment-flow.js
@@ -336,14 +336,25 @@ class DeploymentFlow extends React.Component {
       region: this.state.region
     };
     if (this.state.sshKeys.length) {
+      const sshKeys = this.state.sshKeys.slice();
       // Attempt to provide at least one key in case the addSSHKeys call fails.
-      args.config['authorized-keys'] = this.state.sshKeys[0].text;
-      // Also add to change set - adding keys twice is a no-op.
+      args.config['authorized-keys'] = sshKeys.shift().text;
+      // Then add the remaining ones to the change set.
+      const ecsOptions = {};
       this.props.addSSHKeys(
         this.props.getUserName(),
-        this.state.sshKeys.map(key => key.text),
-        (error, data) => { console.log(error, data); },
-        {});
+        sshKeys.map(key => key.text),
+        (error, data) => {
+          if (!error) {
+            return;
+          }
+          this.props.addNotification({
+            title: 'Cannot add SSH keys',
+            message: `Cannot add SSH keys: ${error}`,
+            level: 'error'
+          });
+        },
+        ecsOptions);
     }
     if (this.state.vpcId) {
       args.config['vpc-id'] = this.state.vpcId;

--- a/jujugui/static/gui/src/app/components/deployment-flow/sshkey/sshkey.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/sshkey/sshkey.js
@@ -164,13 +164,10 @@ class DeploymentSSHKey extends React.Component {
     const newSSHkeyList = this.state.SSHkeys.filter(key => {
       return key.id !== keyId;
     });
-
-    this.setState({
-      SSHkeys: newSSHkeyList
-    });
-
+    this.setState({SSHkeys: newSSHkeyList});
+    // For now, we only support import all or none.
     if (!newSSHkeyList.length) {
-      this.props.setSSHKeys(null);
+      this.props.setSSHKeys([]);
     }
   }
 

--- a/jujugui/static/gui/src/app/init/component-renderers-mixin.js
+++ b/jujugui/static/gui/src/app/init/component-renderers-mixin.js
@@ -898,6 +898,7 @@ const ComponentRenderersMixin = (superclass) => class extends superclass {
     };
     ReactDOM.render(
       <window.juju.components.Login
+        addNotification={this._bound.addNotification}
         controllerIsConnected={controllerIsConnected}
         errorMessage={err}
         gisf={this.applicationConfig.gisf}
@@ -933,6 +934,7 @@ const ComponentRenderersMixin = (superclass) => class extends superclass {
     const bakery = this.bakery;
     const USSOLoginLink = (
       <window.juju.components.USSOLoginLink
+        addNotification={this._bound.addNotification}
         displayType="text"
         loginToController={
           controllerAPI.loginWithMacaroon.bind(controllerAPI, bakery)} />);
@@ -1014,6 +1016,7 @@ const ComponentRenderersMixin = (superclass) => class extends superclass {
     ReactDOM.render(
       <juju.components.HeaderBreadcrumb
         acl={this.acl}
+        addNotification={this._bound.addNotification}
         appState={this.state}
         user={this.user}
         changeState={this.state.changeState.bind(this.state)}


### PR DESCRIPTION
Additionally, do not pass the same key used when creating the model to the addSSHKey ECS: while it's true that it's a noop, an error is still returned and we can easily avoid that.

Also fix some component errors (props required but not provided) and make lint-components block CI in the case of errors so that this won't happen again.

Fixes https://github.com/juju/juju-gui/issues/3106
