### PR TITLE
Correctly fetch application names in deployment flow changelog.

### DIFF
--- a/jujugui/static/gui/src/app/utils/changes-utils.js
+++ b/jujugui/static/gui/src/app/utils/changes-utils.js
@@ -105,7 +105,8 @@ YUI.add('changes-utils', function(Y) {
   */
   ChangesUtils.sortDescriptionsByApplication = (getServiceById, changeset, descriptions) => { // eslint-disable-line max-len
     // ECS methods to blacklist for description sorting.
-    const methodBlacklist = ['addCharm', 'addMachines', 'addSSHKeys', 'importSSHKeys'];
+    const methodBlacklist = [
+      'addCharm', 'addMachines', 'addSSHKeys', 'importSSHKeys', 'destroyMachines'];
     const grouped = {};
     // If the application name is a temporary ID (contains $)
     // then fetch its real name and return that or return the original name.
@@ -113,18 +114,22 @@ YUI.add('changes-utils', function(Y) {
       name.includes('$') ? getServiceById(name).get('name') : name;
     // Not all api calls have the same call signature so this normalizes the
     // application that the command is for.
+    const relationAppNames = args => {
+      const appNames = [args[0][0]];
+      // Relations will typically have another remote endpoint but sometimes
+      // they won't, like with peer relations between the same app.
+      if (args[1]) {
+        appNames.push(args[1][0]);
+      }
+      return appNames;
+    };
     const nameFetchers = {
-      '_addPendingResources': args => args[0].applicationName,
-      '_deploy': args => args[0].applicationName,
-      '_add_relation': args => {
-        const appNames = [args[0][0]];
-        // Relations will typically have another remote endpoint but sometimes
-        // they won't, like with peer relations between the same app.
-        if (args[1]) {
-          appNames.push(args[1][0]);
-        }
-        return appNames;
-      },
+      _addPendingResources: args => args[0].applicationName,
+      _deploy: args => args[0].applicationName,
+      _add_relation: relationAppNames,
+      // These unit calls will be grouped by application already.
+      _remove_units: args => args[0][0].split('/')[0],
+      _remove_relation: relationAppNames,
       default: args => args[0]
     };
     // Adds the supplied item to the supplied name.

--- a/jujugui/static/gui/src/app/utils/changes-utils.js
+++ b/jujugui/static/gui/src/app/utils/changes-utils.js
@@ -112,8 +112,7 @@ YUI.add('changes-utils', function(Y) {
     // then fetch its real name and return that or return the original name.
     const getRealAppName = name =>
       name.includes('$') ? getServiceById(name).get('name') : name;
-    // Not all api calls have the same call signature so this normalizes the
-    // application that the command is for.
+    // Fetch the names of a relation.
     const relationAppNames = args => {
       const appNames = [args[0][0]];
       // Relations will typically have another remote endpoint but sometimes
@@ -123,6 +122,8 @@ YUI.add('changes-utils', function(Y) {
       }
       return appNames;
     };
+    // Not all api calls have the same call signature so this normalizes the
+    // application that the command is for.
     const nameFetchers = {
       _addPendingResources: args => args[0].applicationName,
       _deploy: args => args[0].applicationName,

--- a/jujugui/static/gui/src/test/test_changes_utils.js
+++ b/jujugui/static/gui/src/test/test_changes_utils.js
@@ -292,7 +292,6 @@ describe('ChangesUtils', function() {
 
   describe('sortDescriptionsByApplication', function() {
     const getServiceById = sinon.stub();
-
     const descriptionsJSON = '[{"id":"addPendingResources-458","icon":"https://api.jujucharms.com/charmstore/v5/~containers/easyrsa-12/icon.svg","description":" easyrsa resources will be added.","time":"8:49 am"},{"id":"service-220","icon":"https://api.jujucharms.com/charmstore/v5/~containers/kubernetes-master-35/icon.svg","description":" kubernetes-master will be added to the model.","time":"8:49 am"},{"id":"expose-102","icon":"exposed_16","description":"kubernetes-master will be exposed","time":"8:49 am"},{"id":"addRelation-83","icon":"changes-relation-added","description":"kube-api-endpoint relation will be added between kubernetes-master and kubernetes-worker.","time":"8:49 am"},{"id":"addUnits-256","icon":"changes-units-added","description":" 1 easyrsa unit will be added.","time":"8:49 am"}]'; // eslint-disable-line max-len
 
     it('sorts additive descriptions by application', function() {
@@ -322,20 +321,17 @@ describe('ChangesUtils', function() {
       const sorted = changesUtils.sortDescriptionsByApplication(
         getServiceById, changeSet, descriptions);
       const expected = {
-        easyrsa: [
-          {
-            id: 'addPendingResources-458',
-            icon: 'https://api.jujucharms.com/charmstore/v5/~containers/easyrsa-12/icon.svg', // eslint-disable-line max-len
-            description: ' easyrsa resources will be added.',
-            time: '8:49 am'
-          },
-          {
-            id: 'addUnits-256',
-            icon: 'changes-units-added',
-            description: ' 1 easyrsa unit will be added.',
-            time: '8:49 am'
-          }
-        ],
+        easyrsa: [{
+          id: 'addPendingResources-458',
+          icon: 'https://api.jujucharms.com/charmstore/v5/~containers/easyrsa-12/icon.svg', // eslint-disable-line max-len
+          description: ' easyrsa resources will be added.',
+          time: '8:49 am'
+        }, {
+          id: 'addUnits-256',
+          icon: 'changes-units-added',
+          description: ' 1 easyrsa unit will be added.',
+          time: '8:49 am'
+        }],
         'kubernetes-master': [{
           id: 'service-220',
           icon: 'https://api.jujucharms.com/charmstore/v5/~containers/kubernetes-master-35/icon.svg', // eslint-disable-line max-len
@@ -397,28 +393,23 @@ describe('ChangesUtils', function() {
       const sorted = changesUtils.sortDescriptionsByApplication(
         getServiceById, changeSet, descriptions);
       const expected = {
-        elasticsearch: [
-          {
-            id: 'removeUnit-376',
-            icon: 'changes-units-removed',
-            description: '1 unit will be removed from elasticsearch',
-            time: '3:18 pm'
-          },
-          {
-            id: 'removeRelation-281',
-            icon: 'changes-relation-removed',
-            description: 'rest relation will be removed between kibana and elasticsearch.', // eslint-disable-line max-len
-            time: '3:21 pm'
-          }
-        ],
-        kibana: [
-          {
-            id: 'removeRelation-281',
-            icon: 'changes-relation-removed',
-            description: 'rest relation will be removed between kibana and elasticsearch.', // eslint-disable-line max-len
-            time: '3:21 pm'
-          }
-        ]
+        elasticsearch: [{
+          id: 'removeUnit-376',
+          icon: 'changes-units-removed',
+          description: '1 unit will be removed from elasticsearch',
+          time: '3:18 pm'
+        }, {
+          id: 'removeRelation-281',
+          icon: 'changes-relation-removed',
+          description: 'rest relation will be removed between kibana and elasticsearch.', // eslint-disable-line max-len
+          time: '3:21 pm'
+        }],
+        kibana: [{
+          id: 'removeRelation-281',
+          icon: 'changes-relation-removed',
+          description: 'rest relation will be removed between kibana and elasticsearch.', // eslint-disable-line max-len
+          time: '3:21 pm'
+        }]
       };
       assert.deepEqual(sorted, expected);
     });

--- a/jujugui/static/gui/src/test/test_changes_utils.js
+++ b/jujugui/static/gui/src/test/test_changes_utils.js
@@ -289,4 +289,138 @@ describe('ChangesUtils', function() {
       three: {parents: ['parent1', 'parent2']}
     });
   });
+
+  describe('sortDescriptionsByApplication', function() {
+    const getServiceById = sinon.stub();
+
+    const descriptionsJSON = '[{"id":"addPendingResources-458","icon":"https://api.jujucharms.com/charmstore/v5/~containers/easyrsa-12/icon.svg","description":" easyrsa resources will be added.","time":"8:49 am"},{"id":"service-220","icon":"https://api.jujucharms.com/charmstore/v5/~containers/kubernetes-master-35/icon.svg","description":" kubernetes-master will be added to the model.","time":"8:49 am"},{"id":"expose-102","icon":"exposed_16","description":"kubernetes-master will be exposed","time":"8:49 am"},{"id":"addRelation-83","icon":"changes-relation-added","description":"kube-api-endpoint relation will be added between kubernetes-master and kubernetes-worker.","time":"8:49 am"},{"id":"addUnits-256","icon":"changes-units-added","description":" 1 easyrsa unit will be added.","time":"8:49 am"}]'; // eslint-disable-line max-len
+
+    it('sorts additive descriptions by application', function() {
+      const descriptions = JSON.parse(descriptionsJSON);
+      const changeSet = {
+        'addPendingResources-458': {
+          command: {
+            method: '_addPendingResources',
+            args: [{applicationName: 'easyrsa'}]}},
+        'service-220': {
+          command: {
+            method: '_deploy',
+            args: [{applicationName: 'kubernetes-master'}]}},
+        'expose-102': {
+          command: {
+            method: '_expose',
+            args: ['kubernetes-master']}},
+        'addRelation-83': {
+          command: {
+            method: '_add_relation',
+            args: [['kubernetes-worker'], ['kubernetes-master']]}},
+        'addUnits-256': {
+          command: {
+            method: '_add_unit',
+            args: ['easyrsa']}}
+      };
+      const sorted = changesUtils.sortDescriptionsByApplication(
+        getServiceById, changeSet, descriptions);
+      const expected = {
+        easyrsa: [
+          {
+            id: 'addPendingResources-458',
+            icon: 'https://api.jujucharms.com/charmstore/v5/~containers/easyrsa-12/icon.svg', // eslint-disable-line max-len
+            description: ' easyrsa resources will be added.',
+            time: '8:49 am'
+          },
+          {
+            id: 'addUnits-256',
+            icon: 'changes-units-added',
+            description: ' 1 easyrsa unit will be added.',
+            time: '8:49 am'
+          }
+        ],
+        'kubernetes-master': [{
+          id: 'service-220',
+          icon: 'https://api.jujucharms.com/charmstore/v5/~containers/kubernetes-master-35/icon.svg', // eslint-disable-line max-len
+          description: ' kubernetes-master will be added to the model.',
+          time: '8:49 am'
+        }, {
+          id: 'expose-102',
+          icon: 'exposed_16',
+          description: 'kubernetes-master will be exposed',
+          time: '8:49 am'
+        }, {
+          id: 'addRelation-83',
+          icon: 'changes-relation-added',
+          description: 'kube-api-endpoint relation will be added between kubernetes-master and kubernetes-worker.', // eslint-disable-line max-len
+          time: '8:49 am'
+        }],
+        'kubernetes-worker': [{
+          id: 'addRelation-83',
+          icon: 'changes-relation-added',
+          description: 'kube-api-endpoint relation will be added between kubernetes-master and kubernetes-worker.', //eslint-disable-line max-len
+          time: '8:49 am'
+        }]
+      };
+      assert.deepEqual(sorted, expected);
+    });
+
+    it('skips methods in the blacklist', function() {
+      const descriptions = [
+        {id: 'addCharm-123'},
+        {id: 'addMachines-123'},
+        {id: 'addSSHKeys-123'},
+        {id: 'importSSHKeys-123'},
+        {id: 'destroyMachines-123'}
+      ];
+      const changeSet = {};
+      const sorted = changesUtils.sortDescriptionsByApplication(
+        getServiceById, changeSet, descriptions);
+      assert.deepEqual(sorted, {});
+    });
+
+    it('does not error for removal commands', function() {
+      const descriptions = [
+        JSON.parse('{"id":"removeUnit-376","icon":"changes-units-removed","description":"1 unit will be removed from elasticsearch","time":"3:18 pm"}'), // eslint-disable-line max-len
+        JSON.parse('{"id":"removeRelation-281","icon":"changes-relation-removed","description":"rest relation will be removed between kibana and elasticsearch.","time":"3:21 pm"}') // eslint-disable-line max-len
+      ];
+
+      const changeSet = {
+        'removeUnit-376': {
+          command: {
+            method: '_remove_units',
+            args: [['elasticsearch/0']]}},
+        'removeRelation-281': {
+          command: {
+            method: '_remove_relation',
+            args: [['kibana'],['elasticsearch']]
+          }
+        }
+      };
+      const sorted = changesUtils.sortDescriptionsByApplication(
+        getServiceById, changeSet, descriptions);
+      const expected = {
+        elasticsearch: [
+          {
+            id: 'removeUnit-376',
+            icon: 'changes-units-removed',
+            description: '1 unit will be removed from elasticsearch',
+            time: '3:18 pm'
+          },
+          {
+            id: 'removeRelation-281',
+            icon: 'changes-relation-removed',
+            description: 'rest relation will be removed between kibana and elasticsearch.', // eslint-disable-line max-len
+            time: '3:21 pm'
+          }
+        ],
+        kibana: [
+          {
+            id: 'removeRelation-281',
+            icon: 'changes-relation-removed',
+            description: 'rest relation will be removed between kibana and elasticsearch.', // eslint-disable-line max-len
+            time: '3:21 pm'
+          }
+        ]
+      };
+      assert.deepEqual(sorted, expected);
+    });
+  });
 });


### PR DESCRIPTION
Fixes #3109

Different api methods have different call signatures so if the application name isn't in the correct spot the displaying of the changelog could fail. 