### PR TITLE
Initial status pane content implementation.

### DIFF
--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -1961,9 +1961,12 @@ YUI.add('juju-gui', function(Y) {
     _renderStatusView: function(state, next) {
       ReactDOM.render(
         <window.juju.components.Status
-          addNotification={
-            this.db.notifications.add.bind(this.db.notifications)} />,
-        document.getElementById('status-container'));
+          db={this.db}
+          model={this.env.getAttrs()}
+          urllib={window.jujulib.URL}
+        />,
+        document.getElementById('status-container')
+      );
       next();
     },
 

--- a/jujugui/static/gui/src/app/components/status/_status.scss
+++ b/jujugui/static/gui/src/app/components/status/_status.scss
@@ -15,5 +15,22 @@
     bottom: $deployer-bar-height;
     left: $left-panel-width + 20px;
     right: 20px;
+    margin-left: 20px;
+  }
+
+  table th {
+    padding: 3px;
+  }
+
+  table td {
+    padding: 3px;
+  }
+
+  .ok {
+    color: green;
+  }
+
+  .error {
+    color: red;
   }
 }

--- a/jujugui/static/gui/src/app/components/status/status.js
+++ b/jujugui/static/gui/src/app/components/status/status.js
@@ -5,23 +5,363 @@
 /** Status React component used to display Juju status. */
 class Status extends React.Component {
 
+  /**
+    Render the component.
+  */
   render() {
     return (
       <juju.components.Panel
         instanceName="status-view"
         visible={true}>
         <div className="status-view__content">
-          Status
+          {this.renderStatus()}
         </div>
       </juju.components.Panel>
     );
   }
 
+  /**
+    Render the current model status.
+  */
+  renderStatus() {
+    const elements = [];
+    const db = this.props.db;
+    const model = this.props.model;
+    if (!model.environmentName) {
+      // No need to go further: we are not connected to a model.
+      return 'Cannot show the status: the GUI is not connected to a model.';
+    }
+    elements.push(this._renderModel(model));
+    if (db.remoteServices.size()) {
+      elements.push(this._renderRemoteApplications(db.remoteServices));
+    }
+    if (db.services.size()) {
+      elements.push(
+        this._renderApplications(db.services),
+        this._renderUnits(db.services)
+      );
+    }
+    if (db.machines.size()) {
+      elements.push(this._renderMachines(db.machines));
+    }
+    if (db.relations.size()) {
+      elements.push(this._renderRelations(db.relations));
+    }
+    return elements;
+  }
+
+  /**
+    Render the model fragment of the status.
+    @params {Object} model The model attributes.
+  */
+  _renderModel(model) {
+    return (
+      <table key="model">
+        <thead>
+          <tr>
+            <th>Model</th>
+            <th>Cloud/Region</th>
+            <th>Version</th>
+            <th>SLA</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr key={model.environmentName}>
+            <td>{model.environmentName}</td>
+            <td>{model.cloud}/{model.region}</td>
+            <td>{model.version}</td>
+            <td>{model.sla}</td>
+          </tr>
+        </tbody>
+      </table>
+    );
+  }
+
+  /**
+    Render the remote applications fragment of the status.
+    @params {Object} remoteApplications The remote applications as included in
+      the GUI db.
+  */
+  _renderRemoteApplications(remoteApplications) {
+    const rows = remoteApplications.map(application => {
+      const app = application.getAttrs();
+      const urlParts = app.url.split(':');
+      return (
+        <tr key={app.url}>
+          <td>{app.service}</td>
+          <td>{app.status.current}</td>
+          <td>{urlParts[0]}</td>
+          <td>{urlParts[1]}</td>
+        </tr>
+      );
+    });
+    return (
+      <table key="remote-applications">
+        <thead>
+          <tr>
+            <th>SAAS</th>
+            <th>Status</th>
+            <th>Store</th>
+            <th>URL</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.sort(byKey)}
+        </tbody>
+      </table>
+    );
+  }
+
+  /**
+    Render the applications fragment of the status.
+    @params {Object} applications The applications as included in the GUI db.
+  */
+  _renderApplications(applications) {
+    const urllib = this.props.urllib;
+    const rows = applications.map(application => {
+      const app = application.getAttrs();
+      const charm = urllib.fromLegacyString(app.charm);
+      const store = charm.schema === 'cs' ? 'jujucharms' : 'local';
+      const revision = charm.revision;
+      charm.revision = null;
+      return (
+        <tr key={app.name}>
+          <td>{app.name}</td>
+          <td>{app.workloadVersion}</td>
+          <td className={getClass(app.status.current)}>
+            {app.status.current}
+          </td>
+          <td>{app.units.size()}</td>
+          <td>{charm.path()}</td>
+          <td>{store}</td>
+          <td>{revision}</td>
+        </tr>
+      );
+    });
+    return (
+      <table key="applications">
+        <thead>
+          <tr>
+            <th>Application</th>
+            <th>Version</th>
+            <th>Status</th>
+            <th>Scale</th>
+            <th>Charm</th>
+            <th>Store</th>
+            <th>Rev</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.sort(byKey)}
+        </tbody>
+      </table>
+    );
+  }
+
+  /**
+    Render the units fragment of the status.
+    @params {Object} applications The applications as included in the GUI db.
+  */
+  _renderUnits(applications) {
+    const formatPorts = ranges => {
+      if (!ranges) {
+        return '';
+      }
+      return ranges.map(range => {
+        if (range.from === range.to) {
+          return `${range.from}/${range.protocol}`;
+        }
+        return `${range.from}-${range.to}/${range.protocol}`;
+      }).join(', ');
+    };
+    const rows = [];
+    applications.each(application => {
+      application.get('units').each(unit => {
+        rows.push(
+          <tr key={unit.id}>
+            <td>{unit.displayName}</td>
+            <td className={getClass(unit.workloadStatus)}>
+              {unit.workloadStatus}
+            </td>
+            <td className={getClass(unit.agentStatus)}>
+              {unit.agentStatus}
+            </td>
+            <td>{unit.machine}</td>
+            <td>{unit.public_address}</td>
+            <td>{formatPorts(unit.portRanges)}</td>
+            <td>{unit.workloadStatusMessage}</td>
+          </tr>
+        );
+      });
+    });
+    if (!rows.length) {
+      return null;
+    }
+    return (
+      <table key="units">
+        <thead>
+          <tr>
+            <th>Unit</th>
+            <th>Workload</th>
+            <th>Agent</th>
+            <th>Machine</th>
+            <th>Public address</th>
+            <th>Ports</th>
+            <th>Message</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.sort(byKey)}
+        </tbody>
+      </table>
+    );
+  }
+
+  /**
+    Render the machines fragment of the status.
+    @params {Object} machines The machines as included in the GUI db.
+  */
+  _renderMachines(machines) {
+    const rows = machines.map(machine => {
+      return (
+        <tr key={machine.id}>
+          <td>{machine.displayName}</td>
+          <td className={getClass(machine.agent_state)}>
+            {machine.agent_state}
+          </td>
+          <td>{machine.public_address}</td>
+          <td>{machine.instance_id}</td>
+          <td>{machine.series}</td>
+          <td>{machine.agent_state_info}</td>
+        </tr>
+      );
+    });
+    return (
+      <table key="machines">
+        <thead>
+          <tr>
+            <th>Machine</th>
+            <th>State</th>
+            <th>DNS</th>
+            <th>Instance ID</th>
+            <th>Series</th>
+            <th>Message</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.sort(byKey)}
+        </tbody>
+      </table>
+    );
+  }
+
+  /**
+    Render the relations fragment of the status.
+    @params {Array} relations The relations as included in the GUI db.
+  */
+  _renderRelations(relations) {
+    const rows = relations.map(relation => {
+      const rel = relation.getAttrs();
+      let name = '';
+      let provides = '';
+      let consumes = '';
+      let scope = '';
+      rel.endpoints.forEach(endpoint => {
+        const application = endpoint[0];
+        const ep = endpoint[1];
+        switch (ep.role) {
+          case 'peer':
+            name = ep.name;
+            provides = application;
+            consumes = application;
+            scope = 'peer';
+            return;
+          case 'provider':
+            name = ep.name;
+            consumes = application;
+            scope = 'regular';
+            break;
+          case 'requirer':
+            provides = application;
+            break;
+        }
+      });
+      return (
+        <tr key={rel.id}>
+          <td>{name}</td>
+          <td>{provides}</td>
+          <td>{consumes}</td>
+          <td>{scope}</td>
+        </tr>
+      );
+    });
+    return (
+      <table key="relations">
+        <thead>
+          <tr>
+            <th>Relation</th>
+            <th>Provides</th>
+            <th>Consumes</th>
+            <th>Type</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.sort(byKey)}
+        </tbody>
+      </table>
+    );
+  }
+
 };
 
-
 Status.propTypes = {
-  addNotification: PropTypes.func.isRequired
+  db: PropTypes.shape({
+    machines: PropTypes.object.isRequired,
+    relations: PropTypes.object.isRequired,
+    remoteServices: PropTypes.object.isRequired,
+    services: PropTypes.object.isRequired
+  }).isRequired,
+  model: PropTypes.shape({
+    cloud: PropTypes.string,
+    environmentName: PropTypes.string,
+    region: PropTypes.string,
+    sla: PropTypes.string,
+    version: PropTypes.string
+  }).isRequired,
+  urllib: PropTypes.func.isRequired
+};
+
+/**
+  Return an element class name suitable for the given value.
+  @params {String} value The provided value.
+  @returns {String} The class name ('ok', 'error' or '').
+*/
+const getClass = value => {
+  switch (value) {
+    case 'active':
+    case 'idle':
+    case 'started':
+      return 'ok';
+    case 'blocked':
+    case 'down':
+    case 'error':
+      return 'error';
+  }
+  return '';
+};
+
+/**
+  A compare function for sorting an array by the key property.
+  @params {Object} a The first value.
+  @params {Object} b The second value.
+  @returns {Number} -1, 1 or 0.
+*/
+const byKey = (a, b) => {
+  if (a.key < b.key)
+    return -1;
+  if (a.key > b.key)
+    return 1;
+  return 0;
 };
 
 YUI.add('status', function() {

--- a/jujugui/static/gui/src/app/components/status/status.js
+++ b/jujugui/static/gui/src/app/components/status/status.js
@@ -22,6 +22,7 @@ class Status extends React.Component {
 
   /**
     Render the current model status.
+    @returns {Object} The resulting element.
   */
   renderStatus() {
     const elements = [];
@@ -52,7 +53,8 @@ class Status extends React.Component {
 
   /**
     Render the model fragment of the status.
-    @params {Object} model The model attributes.
+    @param {Object} model The model attributes.
+    @returns {Object} The resulting element.
   */
   _renderModel(model) {
     return (
@@ -79,8 +81,9 @@ class Status extends React.Component {
 
   /**
     Render the remote applications fragment of the status.
-    @params {Object} remoteApplications The remote applications as included in
+    @param {Object} remoteApplications The remote applications as included in
       the GUI db.
+    @returns {Object} The resulting element.
   */
   _renderRemoteApplications(remoteApplications) {
     const rows = remoteApplications.map(application => {
@@ -114,7 +117,8 @@ class Status extends React.Component {
 
   /**
     Render the applications fragment of the status.
-    @params {Object} applications The applications as included in the GUI db.
+    @param {Object} applications The applications as included in the GUI db.
+    @returns {Object} The resulting element.
   */
   _renderApplications(applications) {
     const urllib = this.props.urllib;
@@ -123,6 +127,8 @@ class Status extends React.Component {
       const charm = urllib.fromLegacyString(app.charm);
       const store = charm.schema === 'cs' ? 'jujucharms' : 'local';
       const revision = charm.revision;
+      // Set the revision to null so that it's not included when calling
+      // charm.path() below.
       charm.revision = null;
       return (
         <tr key={app.name}>
@@ -160,7 +166,8 @@ class Status extends React.Component {
 
   /**
     Render the units fragment of the status.
-    @params {Object} applications The applications as included in the GUI db.
+    @param {Object} applications The applications as included in the GUI db.
+    @returns {Object} The resulting element.
   */
   _renderUnits(applications) {
     const formatPorts = ranges => {
@@ -219,7 +226,8 @@ class Status extends React.Component {
 
   /**
     Render the machines fragment of the status.
-    @params {Object} machines The machines as included in the GUI db.
+    @param {Object} machines The machines as included in the GUI db.
+    @returns {Object} The resulting element.
   */
   _renderMachines(machines) {
     const rows = machines.map(machine => {
@@ -257,7 +265,8 @@ class Status extends React.Component {
 
   /**
     Render the relations fragment of the status.
-    @params {Array} relations The relations as included in the GUI db.
+    @param {Array} relations The relations as included in the GUI db.
+    @returns {Object} The resulting element.
   */
   _renderRelations(relations) {
     const rows = relations.map(relation => {
@@ -333,7 +342,7 @@ Status.propTypes = {
 
 /**
   Return an element class name suitable for the given value.
-  @params {String} value The provided value.
+  @param {String} value The provided value.
   @returns {String} The class name ('ok', 'error' or '').
 */
 const getClass = value => {
@@ -352,8 +361,8 @@ const getClass = value => {
 
 /**
   A compare function for sorting an array by the key property.
-  @params {Object} a The first value.
-  @params {Object} b The second value.
+  @param {Object} a The first value.
+  @param {Object} b The second value.
   @returns {Number} -1, 1 or 0.
 */
 const byKey = (a, b) => {

--- a/jujugui/static/gui/src/app/components/status/test-status.js
+++ b/jujugui/static/gui/src/app/components/status/test-status.js
@@ -5,28 +5,577 @@
 var juju = {components: {}}; // eslint-disable-line no-unused-vars
 
 describe('Status', function() {
+  let defaultModel;
+  let emptyDB;
+
   beforeAll(function(done) {
     // By loading this file it adds the component to the juju components.
-    YUI().use('status', function() {
+    YUI().use('status', () => {
       done();
     });
   });
 
-  it('can render', () => {
+  beforeEach(() => {
+    defaultModel = {
+      cloud: 'aws',
+      environmentName: 'my-model',
+      region: 'neutral zone',
+      sla: 'advanced',
+      version: '2.42.47'
+    };
+    emptyDB = {
+      machines: {size: sinon.stub().withArgs().returns(0)},
+      relations: {size: sinon.stub().withArgs().returns(0)},
+      remoteServices: {size: sinon.stub().withArgs().returns(0)},
+      services: {size: sinon.stub().withArgs().returns(0)}
+    };
+  });
+
+  // Render the component with the given db and optional model.
+  // Return an object with the instance and the output.
+  const render = (db, model=defaultModel) => {
     const renderer = jsTestUtils.shallowRender(
       <window.juju.components.Status
-        addNotification={sinon.stub()} />, true);
-    const output = renderer.getRenderOutput();
-    const expected = (
-      <juju.components.Panel
-        instanceName="status-view"
-        visible={true}>
-        <div className="status-view__content">
-          Status
-        </div>
+        db={db}
+        model={model}
+        urllib={window.jujulib.URL}
+      />, true
+    );
+    return {
+      instance: renderer.getMountedInstance(),
+      output: renderer.getRenderOutput()
+    };
+  };
+
+  // Wrap the given element into the shared component boilerplate.
+  const wrap = element => {
+    return (
+      <juju.components.Panel instanceName="status-view" visible={true}>
+        {element}
       </juju.components.Panel>
     );
-    expect(output).toEqualJSX(expected);
+  };
+
+  // Create and return a database.
+  const makeDB = () => {
+    const djangoUnits = [{
+      agentStatus: 'idle',
+      displayName: 'django/0',
+      id: 'id0',
+      machine: '1',
+      public_address: '1.2.3.4',
+      portRanges: [
+        {from: 80, to: 80, protocol: 'tcp'},
+        {from: 443, to: 443, protocol: 'tcp'}
+      ],
+      workloadStatus: 'installing',
+      workloadStatusMessage: 'these are the voyages'
+    }, {
+      agentStatus: 'executing',
+      displayName: 'django/1',
+      id: 'id1',
+      machine: '2',
+      public_address: '1.2.3.5',
+      portRanges: [
+        {from: 80, to: 88, protocol: 'udp'}
+      ],
+      workloadStatus: 'error',
+      workloadStatusMessage: 'exterminate!'
+    }];
+    const applications = [{
+      getAttrs: sinon.stub().withArgs().returns({
+        charm: '~who/xenial/django-42',
+        name: 'django',
+        status: {current: 'active'},
+        units: {size: sinon.stub().withArgs().returns(djangoUnits.length)},
+        workloadVersion: '1.10'
+      }),
+      get: sinon.stub().withArgs('units').returns({
+        each: func => djangoUnits.forEach(func)
+      })
+    }, {
+      getAttrs: sinon.stub().withArgs().returns({
+        charm: 'haproxy-47',
+        name: 'ha',
+        status: {current: 'error'},
+        units: {size: sinon.stub().withArgs().returns(0)},
+        workloadVersion: ''
+      }),
+      get: sinon.stub().withArgs('units').returns({
+        each: func => {}
+      })
+    }];
+    const machines = [{
+      agent_state: 'pending',
+      agent_state_info: '',
+      displayName: '1',
+      id: 'm1',
+      instance_id: 'machine-1',
+      public_address: '1.2.3.6',
+      series: 'zesty'
+    }, {
+      agent_state: 'started',
+      agent_state_info: 'yes, I am started',
+      displayName: '2',
+      id: 'm2',
+      instance_id: 'machine-2',
+      public_address: '1.2.3.7',
+      series: 'trusty'
+    }];
+    const relations = [{
+      getAttrs: sinon.stub().withArgs().returns({
+        endpoints: [[
+          'mysql', {name: 'cluster', role: 'peer'}
+        ]],
+        id: 'rel1'
+      })
+    }, {
+      getAttrs: sinon.stub().withArgs().returns({
+        endpoints: [[
+          'haproxy', {name: 'website', role: 'provider'}
+        ], [
+          'wordpress', {name: 'proxy', role: 'requirer'}
+        ]],
+        id: 'rel2'
+      })
+    }];
+    const remoteApplications = [{
+      getAttrs: sinon.stub().withArgs().returns({
+        service: 'haproxy',
+        status: {current: 'unknown'},
+        url: 'local:admin/saas.haproxy'
+      })
+    }, {
+      getAttrs: sinon.stub().withArgs().returns({
+        service: 'mongo',
+        status: {current: 'corrupting data'},
+        url: 'local:admin/my.mongo'
+      })
+    }];
+    return {
+      machines: {
+        size: sinon.stub().withArgs().returns(machines.length),
+        map: func => machines.map(func)
+      },
+      relations: {
+        size: sinon.stub().withArgs().returns(relations.length),
+        map: func => relations.map(func)
+      },
+      remoteServices: {
+        size: sinon.stub().withArgs().returns(remoteApplications.length),
+        map: func => remoteApplications.map(func)
+      },
+      services: {
+        size: sinon.stub().withArgs().returns(applications.length),
+        map: func => applications.map(func),
+        each: func => applications.forEach(func)
+      }
+    };
+  };
+
+  it('renders with no data', () => {
+    const model = {};
+    const comp = render(emptyDB, model);
+    const expectedOutput = wrap(
+      <div className="status-view__content">
+        Cannot show the status: the GUI is not connected to a model.
+      </div>
+    );
+    expect(comp.output).toEqualJSX(expectedOutput);
+  });
+
+  it('renders with no entities', () => {
+    const comp = render(emptyDB);
+    const expectedOutput = wrap(
+      <div className="status-view__content">
+        <table>
+          <thead>
+            <tr>
+              <th>
+                Model
+              </th>
+              <th>
+                Cloud/Region
+              </th>
+              <th>
+                Version
+              </th>
+              <th>
+                SLA
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                my-model
+              </td>
+              <td>
+                aws/neutral zone
+              </td>
+              <td>
+                2.42.47
+              </td>
+              <td>
+                advanced
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    );
+    expect(comp.output).toEqualJSX(expectedOutput);
+  });
+
+  it('renders with entities', () => {
+    const comp = render(makeDB());
+    const expectedOutput = wrap(
+      <div className="status-view__content">
+        <table>
+          <thead>
+            <tr>
+              <th>
+                Model
+              </th>
+              <th>
+                Cloud/Region
+              </th>
+              <th>
+                Version
+              </th>
+              <th>
+                SLA
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                my-model
+              </td>
+              <td>
+                aws/neutral zone
+              </td>
+              <td>
+                2.42.47
+              </td>
+              <td>
+                advanced
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <table>
+          <thead>
+            <tr>
+              <th>
+                SAAS
+              </th>
+              <th>
+                Status
+              </th>
+              <th>
+                Store
+              </th>
+              <th>
+                URL
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                mongo
+              </td>
+              <td>
+                corrupting data
+              </td>
+              <td>
+                local
+              </td>
+              <td>
+                admin/my.mongo
+              </td>
+            </tr>
+            <tr>
+              <td>
+                haproxy
+              </td>
+              <td>
+                unknown
+              </td>
+              <td>
+                local
+              </td>
+              <td>
+                admin/saas.haproxy
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <table>
+          <thead>
+            <tr>
+              <th>
+                Application
+              </th>
+              <th>
+                Version
+              </th>
+              <th>
+                Status
+              </th>
+              <th>
+                Scale
+              </th>
+              <th>
+                Charm
+              </th>
+              <th>
+                Store
+              </th>
+              <th>
+                Rev
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                django
+              </td>
+              <td>
+                1.10
+              </td>
+              <td className="ok">
+                active
+              </td>
+              <td>
+                2
+              </td>
+              <td>
+                u/who/django/xenial
+              </td>
+              <td>
+                jujucharms
+              </td>
+              <td>
+                42
+              </td>
+            </tr>
+            <tr>
+              <td>
+                ha
+              </td>
+              <td />
+              <td className="error">
+                error
+              </td>
+              <td>
+                0
+              </td>
+              <td>
+                haproxy
+              </td>
+              <td>
+                jujucharms
+              </td>
+              <td>
+                47
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <table>
+          <thead>
+            <tr>
+              <th>
+                Unit
+              </th>
+              <th>
+                Workload
+              </th>
+              <th>
+                Agent
+              </th>
+              <th>
+                Machine
+              </th>
+              <th>
+                Public address
+              </th>
+              <th>
+                Ports
+              </th>
+              <th>
+                Message
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                django/0
+              </td>
+              <td className="">
+                installing
+              </td>
+              <td className="ok">
+                idle
+              </td>
+              <td>
+                1
+              </td>
+              <td>
+                1.2.3.4
+              </td>
+              <td>
+                80/tcp, 443/tcp
+              </td>
+              <td>
+                these are the voyages
+              </td>
+            </tr>
+            <tr>
+              <td>
+                django/1
+              </td>
+              <td className="error">
+                error
+              </td>
+              <td className="">
+                executing
+              </td>
+              <td>
+                2
+              </td>
+              <td>
+                1.2.3.5
+              </td>
+              <td>
+                80-88/udp
+              </td>
+              <td>
+                exterminate!
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <table>
+          <thead>
+            <tr>
+              <th>
+                Machine
+              </th>
+              <th>
+                State
+              </th>
+              <th>
+                DNS
+              </th>
+              <th>
+                Instance ID
+              </th>
+              <th>
+                Series
+              </th>
+              <th>
+                Message
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                1
+              </td>
+              <td className="">
+                pending
+              </td>
+              <td>
+                1.2.3.6
+              </td>
+              <td>
+                machine-1
+              </td>
+              <td>
+                zesty
+              </td>
+              <td />
+            </tr>
+            <tr>
+              <td>
+                2
+              </td>
+              <td className="ok">
+                started
+              </td>
+              <td>
+                1.2.3.7
+              </td>
+              <td>
+                machine-2
+              </td>
+              <td>
+                trusty
+              </td>
+              <td>
+                yes, I am started
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <table>
+          <thead>
+            <tr>
+              <th>
+                Relation
+              </th>
+              <th>
+                Provides
+              </th>
+              <th>
+                Consumes
+              </th>
+              <th>
+                Type
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                cluster
+              </td>
+              <td>
+                mysql
+              </td>
+              <td>
+                mysql
+              </td>
+              <td>
+                peer
+              </td>
+            </tr>
+            <tr>
+              <td>
+                website
+              </td>
+              <td>
+                wordpress
+              </td>
+              <td>
+                haproxy
+              </td>
+              <td>
+                regular
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    );
+    expect(comp.output).toEqualJSX(expectedOutput);
   });
 
 });

--- a/jujugui/static/gui/src/app/init/component-renderers-mixin.js
+++ b/jujugui/static/gui/src/app/init/component-renderers-mixin.js
@@ -108,7 +108,6 @@ const ComponentRenderersMixin = (superclass) => class extends superclass {
       ReactDOM.unmountComponentAtNode(sharing);
       return;
     }
-    const db = this.db;
     const env = this.env;
     const grantRevoke = (action, username, access, callback) => {
       if (this.get('gisf') && username.indexOf('@') === -1) {
@@ -121,7 +120,7 @@ const ComponentRenderersMixin = (superclass) => class extends superclass {
     const revokeAccess = controllerAPI.revokeModelAccess.bind(controllerAPI);
     ReactDOM.render(
       <window.juju.components.Sharing
-        addNotification={db.notifications.add.bind(db.notifications)}
+        addNotification={this._bound.addNotification}
         canShareModel={this.acl.canShareModel()}
         closeHandler={this._sharingVisibility.bind(this, false)}
         getModelUserInfo={env.modelUserInfo.bind(env)}
@@ -190,8 +189,7 @@ const ComponentRenderersMixin = (superclass) => class extends superclass {
     let profile = (
       <window.juju.components.UserProfile
         acl={this.acl}
-        addNotification=
-          {this.db.notifications.add.bind(this.db.notifications)}
+        addNotification={this._bound.addNotification}
         charmstore={charmstore}
         currentModel={currentModel}
         d3={yui.d3}
@@ -381,8 +379,7 @@ const ComponentRenderersMixin = (superclass) => class extends superclass {
         charmstoreURL={
           utils.ensureTrailingSlash(window.juju_config.charmstoreURL)}
         apiVersion={window.jujulib.charmstoreAPIVersion}
-        addNotification={
-          this.db.notifications.add.bind(this.db.notifications)}
+        addNotification={this._bound.addNotification}
         makeEntityModel={yui.juju.makeEntityModel}
         setPageTitle={this.setPageTitle.bind(this)}
         showTerms={this.terms.showTerms.bind(this.terms)}
@@ -430,8 +427,7 @@ const ComponentRenderersMixin = (superclass) => class extends superclass {
           this.payment && this.payment.addAddress.bind(this.payment)}
         addBillingAddress={
           this.payment && this.payment.addBillingAddress.bind(this.payment)}
-        addNotification={
-          this.db.notifications.add.bind(this.db.notifications)}
+        addNotification={this._bound.addNotification}
         controllerIsReady={this._controllerIsReady.bind(this)}
         createCardElement={
           this.stripe && this.stripe.createCardElement.bind(this.stripe)}
@@ -556,9 +552,12 @@ const ComponentRenderersMixin = (superclass) => class extends superclass {
   _renderStatusView(state, next) {
     ReactDOM.render(
       <window.juju.components.Status
-        addNotification={
-          this.db.notifications.add.bind(this.db.notifications)} />,
-      document.getElementById('status-container'));
+        db={this.db}
+        model={this.modelAPI.getAttrs()}
+        urllib={window.jujulib.URL}
+      />,
+      document.getElementById('status-container')
+    );
     next();
   }
 
@@ -619,7 +618,7 @@ const ComponentRenderersMixin = (superclass) => class extends superclass {
           addCharm={addCharm}
           addGhostAndEcsUnits={utils.addGhostAndEcsUnits.bind(
             this, db, model, service)}
-          addNotification={db.notifications.add.bind(db.notifications)}
+          addNotification={this._bound.addNotification}
           appState={this.state}
           charm={charm}
           clearState={utils.clearState.bind(this, topo)}
@@ -759,7 +758,7 @@ const ComponentRenderersMixin = (superclass) => class extends superclass {
       <window.juju.components.DeploymentFlow
         acl={this.acl}
         addAgreement={this.terms.addAgreement.bind(this.terms)}
-        addNotification={db.notifications.add.bind(db.notifications)}
+        addNotification={this._bound.addNotification}
         addSSHKeys={modelAPI.addKeys.bind(modelAPI)}
         applications={services.toArray()}
         charmstore={charmstore}

--- a/jujugui/static/gui/src/app/models/handlers.js
+++ b/jujugui/static/gui/src/app/models/handlers.js
@@ -278,7 +278,8 @@ YUI.add('juju-delta-handlers', function(Y) {
       @return {undefined} Nothing.
      */
     applicationInfo: function(db, action, change) {
-      var data = {
+      const status = change.status || {};
+      const data = {
         id: change.name,
         // The name attribute is used to store the temporary name of ghost
         // applications. We set it here for consistency, even if the name of a
@@ -288,7 +289,14 @@ YUI.add('juju-delta-handlers', function(Y) {
         exposed: change.exposed,
         life: change.life,
         constraints: utils.convertConstraints(change.constraints),
-        subordinate: change.subordinate
+        status: {
+          current: status.current,
+          message: status.message,
+          data: status.data,
+          since: status.since
+        },
+        subordinate: change.subordinate,
+        workloadVersion: change['workload-version'] || ''
       };
       // Process the stream.
       db.services.process_delta(action, data);
@@ -316,8 +324,8 @@ YUI.add('juju-delta-handlers', function(Y) {
       @param {String} kind The delta event type.
      */
     remoteApplicationInfo: function(db, action, change) {
-      var status = change.status || {};
-      var data = {
+      const status = change.status || {};
+      const data = {
         id: change['application-url'],
         service: change.name,
         sourceId: change['model-uuid'],

--- a/jujugui/static/gui/src/app/models/models.js
+++ b/jujugui/static/gui/src/app/models/models.js
@@ -416,7 +416,34 @@ YUI.add('juju-models', function(Y) {
       life: {
         value: ALIVE
       },
+      /**
+        The application status, as an object with the following attributes:
+        - current: current status, for instance "idle" or "executing";
+        - message: arbitrary status message set by users;
+        - data: additional status data as an object, mostly unused;
+        - since: date of the last status change, for instance
+          "2015-12-16T12:35:27.873828132+01:00".
+        This info is included in the Juju mega-watcher for applications.
+
+        @attribute status
+        @type {Object}
+        @default {}
+      */
+      status: {
+        value: {}
+      },
       unit_count: {},
+
+      /**
+        The application workload version.
+        This is the optional version of the service provided by this
+        application, for  instance the postgreSQL version.
+
+        @attribute workloadVersion
+        @type {String}
+        @default ''
+      */
+      workloadVersion: {},
 
       /**
         The services current units.

--- a/jujugui/static/gui/src/app/views/utils.js
+++ b/jujugui/static/gui/src/app/views/utils.js
@@ -1409,8 +1409,13 @@ YUI.add('juju-view-utils', function(Y) {
     // Remove the switch model confirmation popup if it has been displayed to
     // the user.
     utils._hidePopup();
-    // Reset the state of the GUI ready for displaying the new model.
-    const newState = {profile: null, gui: null, root: null, hash: null};
+    const current = this.state.current;
+    const newState = {
+      profile: null,
+      gui: {status: null},
+      root: null,
+      hash: null
+    };
     let name = '';
     let uuid = '';
     if (model) {
@@ -1418,9 +1423,11 @@ YUI.add('juju-view-utils', function(Y) {
       name = model.name;
       const owner = model.owner.split('@')[0];
       newState.model = {path: `${owner}/${name}`, uuid: uuid};
+      if (current && current.gui && current.gui.status !== undefined) {
+        newState.gui.status = current.gui.status;
+      }
     } else {
       newState.model = null;
-      const current = this.state.current;
       if (!current || !current.profile) {
         newState.root = 'new';
       }

--- a/jujugui/static/gui/src/test/test_env_api.js
+++ b/jujugui/static/gui/src/test/test_env_api.js
@@ -750,6 +750,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       conn.msg({
         'request-id': 1,
         response: {
+          'agent-version': '2.42.47',
           'default-series': 'xenial',
           name: 'my-model',
           'provider-type': 'aws',
@@ -758,17 +759,20 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
           'cloud-credential-tag': 'cloudcred-aws_admin@local_aws',
           uuid: '5bea955d-7a43-47d3-89dd-tag1',
           life: 'alive',
-          'owner-tag': 'user-admin@local'
+          'owner-tag': 'user-admin@local',
+          sla: {owner: 'who', level: 'standard'}
         }
       });
-      assert.equal(env.get('defaultSeries'), 'xenial');
-      assert.equal(env.get('providerType'), 'aws');
-      assert.equal(env.get('environmentName'), 'my-model');
-      assert.equal(env.get('modelOwner'), 'admin@local');
-      assert.equal(env.get('modelUUID'), '5bea955d-7a43-47d3-89dd-tag1');
-      assert.equal(env.get('cloud'), 'aws');
-      assert.equal(env.get('region'), 'us-east-1');
-      assert.equal(env.get('credential'), 'aws_admin@local_aws');
+      assert.strictEqual(env.get('defaultSeries'), 'xenial');
+      assert.strictEqual(env.get('providerType'), 'aws');
+      assert.strictEqual(env.get('environmentName'), 'my-model');
+      assert.strictEqual(env.get('modelOwner'), 'admin@local');
+      assert.strictEqual(env.get('modelUUID'), '5bea955d-7a43-47d3-89dd-tag1');
+      assert.strictEqual(env.get('cloud'), 'aws');
+      assert.strictEqual(env.get('region'), 'us-east-1');
+      assert.strictEqual(env.get('credential'), 'aws_admin@local_aws');
+      assert.strictEqual(env.get('sla'), 'standard');
+      assert.strictEqual(env.get('version'), '2.42.47');
     });
 
     it('handles no cloud credential returned by ModelInfo', function() {

--- a/jujugui/static/gui/src/test/test_utils.js
+++ b/jujugui/static/gui/src/test/test_utils.js
@@ -922,7 +922,7 @@ describe('utilities', function() {
     it('can switch models', function() {
       const app = {
         set: sinon.stub().withArgs('modelUUID'),
-        state: {changeState: sinon.stub()}
+        state: {changeState: sinon.stub(), current: {}}
       };
       const env = {set: sinon.stub()};
       const model = {id: 'my-uuid', name: 'mymodel', 'owner': 'who'};
@@ -931,7 +931,7 @@ describe('utilities', function() {
       assert.equal(app.state.changeState.callCount, 1, 'changeState');
       assert.deepEqual(app.state.changeState.args[0], [{
         profile: null,
-        gui: null,
+        gui: {status: null},
         root: null,
         hash: null,
         model: {path: 'who/mymodel', uuid: 'my-uuid'}
@@ -945,13 +945,13 @@ describe('utilities', function() {
     it('changes to disconnected mode if model is missing', function() {
       const app = {
         set: sinon.stub().withArgs('modelUUID'),
-        state: {changeState: sinon.stub()}
+        state: {changeState: sinon.stub(), current: {}}
       };
       const env = {set: sinon.stub()};
       utils._switchModel.call(app, env, null);
       assert.deepEqual(app.state.changeState.args[0], [{
         profile: null,
-        gui: null,
+        gui: {status: null},
         root: 'new',
         hash: null,
         model: null
@@ -967,9 +967,42 @@ describe('utilities', function() {
       utils._switchModel.call(app, env, null);
       assert.deepEqual(app.state.changeState.args[0], [{
         profile: null,
-        gui: null,
+        gui: {status: null},
         hash: null,
         root: null,
+        model: null
+      }]);
+    });
+
+    it('does not close the status pane when switching to a model', function() {
+      const app = {
+        set: sinon.stub().withArgs('modelUUID'),
+        state: {current: {gui: {status: ''}}, changeState: sinon.stub()}
+      };
+      const env = {set: sinon.stub()};
+      const model = {id: 'my-uuid', name: 'mymodel', 'owner': 'who'};
+      utils._switchModel.call(app, env, model);
+      assert.deepEqual(app.state.changeState.args[0], [{
+        profile: null,
+        gui: {status: ''},
+        hash: null,
+        root: null,
+        model: {path: 'who/mymodel', uuid: 'my-uuid'}
+      }]);
+    });
+
+    it('closes the status pane when switching to a new model', function() {
+      const app = {
+        set: sinon.stub().withArgs('modelUUID'),
+        state: {current: {gui: {status: ''}}, changeState: sinon.stub()}
+      };
+      const env = {set: sinon.stub()};
+      utils._switchModel.call(app, env, null);
+      assert.deepEqual(app.state.changeState.args[0], [{
+        profile: null,
+        gui: {status: null},
+        hash: null,
+        root: 'new',
         model: null
       }]);
     });
@@ -1168,7 +1201,7 @@ describe('utilities', function() {
       assert.equal(app.state.changeState.callCount, 1);
       assert.deepEqual(app.state.changeState.args[0], [{
         profile: null,
-        gui: null,
+        gui: {status: null},
         hash: null,
         root: null,
         model: {

--- a/scripts/inspect-components
+++ b/scripts/inspect-components
@@ -244,6 +244,8 @@ def find_instantiations(path, definitions, include_tests=False):
         (definition.name.split('.')[-1], definition)
         for definition in definitions
     )
+    if not defnames:
+        return ()
     exp = _instantiation_exp(defnames.keys())
 
     def find(filepath):
@@ -297,7 +299,7 @@ def _prop_definitions_exp(name):
         \{  # Brace opening.
         ([\s\S]*?)  # Any character.
         (?=  # Until the following happens.
-            \}  # A close brace is encountered.
+            \};  # A close brace and a semicolon are encountered.
         )  # End of condition.
     """, re.VERBOSE | re.MULTILINE)
 
@@ -323,10 +325,17 @@ def _parse_prop_definitions(content):
         line for line in content.splitlines()
         if not line.strip().startswith('//'))
     collected = []
-    last_comma = 0
+    last_comma = callstack = 0
     name = ''
     for char in content:
         if char == ' ':
+            continue
+        if char == '(':
+            callstack += 1
+        if char == ')':
+            callstack -= 1
+        if callstack:
+            collected.append(char)
             continue
         if char == ':':
             if name:


### PR DESCRIPTION
This is just an example of what we can show there: we'll make it prettier, for the time being this is protected by the "status" feature flag.

In order to make required info available, some model API calls and handlers have been extended to include additional data, like workload version, app status and SLA. The SLA information should be available but it's not due to a bug in juju that I'll fix asap.

This branch also includes a fix for the inspect-component script to better handle shape fields.