### PR TITLE
Add charms and bundles list to new profile

### DIFF
--- a/jujugui/static/gui/src/app/app.js
+++ b/jujugui/static/gui/src/app/app.js
@@ -629,7 +629,7 @@ YUI.add('juju-gui', function(Y) {
             });
             return;
           }
-          this.storeUser('charmstore', true);
+          this.storeUser('charmstore');
           console.log('logged into charmstore');
         });
       }
@@ -1073,6 +1073,7 @@ YUI.add('juju-gui', function(Y) {
             addNotification={this._bound.addNotification}
             baseURL={window.juju_config.baseUrl}
             changeState={this._bound.changeState}
+            charmstore={charmstore}
             facadesExist={facadesExist}
             listModelsWithInfo={this._bound.listModelsWithInfo}
             destroyModels={this._bound.destroyModels}
@@ -2481,7 +2482,7 @@ YUI.add('juju-gui', function(Y) {
         // Store away the charmstore auth info.
         if (this.bakery.storage.get(jujuConfig.charmstoreURL)) {
           this.get('users')['charmstore'] = {loading: true};
-          this.storeUser('charmstore', false, true);
+          this.storeUser('charmstore', true);
         }
       }
     },
@@ -3147,15 +3148,11 @@ YUI.add('juju-gui', function(Y) {
     },
 
     /**
-      Takes a macaroon and stores the user info (if any) in the app.
-
-      @method storeUser
+      Stores the user information returned from the whoami charmstore call.
       @param {String} service The service the macaroon comes from.
-      @param {String} macaroon The base64 encoded macaroon.
-      @param {Boolean} rerenderProfile Rerender the user profile.
       @param {Boolean} rerenderBreadcrumb Rerender the breadcrumb.
      */
-    storeUser: function(service, rerenderProfile, rerenderBreadcrumb) {
+    storeUser: function(service, rerenderBreadcrumb) {
       var callback = function(error, auth) {
         if (error) {
           const message = 'Unable to query user information';
@@ -3169,15 +3166,11 @@ YUI.add('juju-gui', function(Y) {
         }
         if (auth) {
           this.get('users')[service] = auth;
-          // If the profile is visible then we want to rerender it with the
-          // updated username.
-          if (rerenderProfile) {
-            this._renderUserProfile(this.state.current, ()=>{});
-          }
         }
         if (rerenderBreadcrumb) {
           this._renderBreadcrumb();
         }
+        this.state.dispatch();
       };
       if (service === 'charmstore') {
         this.get('charmstore').whoami(callback.bind(this));

--- a/jujugui/static/gui/src/app/assets/css/_components.scss
+++ b/jujugui/static/gui/src/app/assets/css/_components.scss
@@ -106,6 +106,7 @@
 @import '../../components/profile/header/header';
 @import '../../components/profile/navigation/navigation';
 @import '../../components/profile/model-list/model-list';
+@import '../../components/profile/charm-list/charm-list';
 @import '../../components/search-results/search-results';
 @import '../../components/sharing/sharing';
 @import '../../components/spinner/spinner';

--- a/jujugui/static/gui/src/app/assets/css/_components.scss
+++ b/jujugui/static/gui/src/app/assets/css/_components.scss
@@ -107,6 +107,7 @@
 @import '../../components/profile/navigation/navigation';
 @import '../../components/profile/model-list/model-list';
 @import '../../components/profile/charm-list/charm-list';
+@import '../../components/profile/bundle-list/bundle-list';
 @import '../../components/search-results/search-results';
 @import '../../components/sharing/sharing';
 @import '../../components/spinner/spinner';

--- a/jujugui/static/gui/src/app/components/profile/bundle-list/_bundle-list.scss
+++ b/jujugui/static/gui/src/app/components/profile/bundle-list/_bundle-list.scss
@@ -1,0 +1,27 @@
+.profile-bundle-list {
+  width: 766px;
+
+  &__table-header {
+    border-bottom: 1px solid $mid-grey;
+    padding-bottom: 10px;
+  }
+
+  &__row {
+    border-bottom: 1px solid $mid-grey;
+    padding-bottom: 10px;
+  }
+
+  &__row,
+  &__table-header {
+    display: grid;
+    grid-template-columns: 225px 200px 150px auto;
+  }
+
+  &__icon {
+    border-radius: 50%;
+    width: 20px;
+    float: left;
+    margin-right: 15px;
+  }
+
+}

--- a/jujugui/static/gui/src/app/components/profile/bundle-list/_bundle-list.scss
+++ b/jujugui/static/gui/src/app/components/profile/bundle-list/_bundle-list.scss
@@ -1,18 +1,10 @@
 .profile-bundle-list {
   width: 766px;
 
-  &__table-header {
-    border-bottom: 1px solid $mid-grey;
-    padding-bottom: 10px;
-  }
-
-  &__row {
-    border-bottom: 1px solid $mid-grey;
-    padding-bottom: 10px;
-  }
-
   &__row,
   &__table-header {
+    border-bottom: 1px solid $mid-grey;
+    padding-bottom: 10px;
     display: grid;
     grid-template-columns: 225px 200px 150px auto;
   }

--- a/jujugui/static/gui/src/app/components/profile/bundle-list/bundle-list.js
+++ b/jujugui/static/gui/src/app/components/profile/bundle-list/bundle-list.js
@@ -78,7 +78,7 @@ class ProfileBundleList extends React.Component {
     @param {String} key The key that stores the data in the bundle object.
     @return {String} The string value to display in the table.
   */
-  procesData(bundle, key) {
+  _processData(bundle, key) {
     switch(key) {
       case 'name':
         const name = bundle[key];
@@ -127,7 +127,8 @@ class ProfileBundleList extends React.Component {
           {this.state.data
             .map((bundle, idx) =>
               <li className="profile-bundle-list__row" key={idx}>
-                {bundleKeys.map(key => <span key={key}>{this.procesData(bundle, key)}</span>)}
+                {bundleKeys.map(key =>
+                  <span key={key}>{this._processData(bundle, key)}</span>)}
               </li>
             )}
         </ul>

--- a/jujugui/static/gui/src/app/components/profile/bundle-list/bundle-list.js
+++ b/jujugui/static/gui/src/app/components/profile/bundle-list/bundle-list.js
@@ -1,0 +1,154 @@
+/* Copyright (C) 2017 Canonical Ltd. */
+
+'use strict';
+
+/**
+  Charm list React component used to display a list of the users bundles in
+  their profile.
+*/
+class ProfileBundleList extends React.Component {
+  constructor() {
+    super();
+    this.xhrs = [];
+    this.state = {
+      data: []
+    };
+  }
+
+  componentWillMount() {
+    const user = this.props.user;
+    if (user) {
+      this._fetchBundles(user);
+    }
+  }
+
+  componentWillUnmount() {
+    this.xhrs.forEach((xhr) => {
+      xhr && xhr.abort && xhr.abort();
+    });
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const props = this.props;
+    if (props.user !== nextProps.user) {
+      this._fetchBundles(nextProps.user);
+    }
+  }
+
+  /**
+    Fetch the users bundles from the charmstore.
+    @param {String} user The external user name in the format "user@external".
+  */
+  _fetchBundles(user) {
+    const props = this.props;
+    this.xhrs.push(
+      props.charmstore.list(
+        user,
+        (error, data) => {
+          if (error) {
+            const message = 'Unable to retrieve bundles';
+            console.error(message, error);
+            this.props.addNotification({
+              title: message,
+              message: `${message}: ${error}`,
+              level: 'error'
+            });
+            return;
+          }
+          this.setState({data});
+        },
+        'bundle'));
+  }
+
+  /**
+    Prevents the default actions on the link and navigates to the charmstore
+    for the supplied id via changeState.
+    @param {String} path The GUI bundle path to navigate to.
+    @param {Object} e The click event.
+  */
+  _navigateToBundle(path, e) {
+    e.preventDefault();
+    e.stopPropagation();
+    this.props.changeState({profile: null, store: path, hash: null});
+  }
+
+  /**
+    Process the data required for the bundle table.
+    @param {Object} bundle The bundle data.
+    @param {String} key The key that stores the data in the bundle object.
+    @return {String} The string value to display in the table.
+  */
+  procesData(bundle, key) {
+    switch(key) {
+      case 'name':
+        const name = bundle[key];
+        // To get the icon for the bundle we take the first application in the
+        // list and then use its icon as the icon for the bundle
+        let src = '';
+        const applications = bundle.applications;
+        for (let key in applications) {
+          const app = applications[key];
+          src = `${this.props.charmstore.url}/${app.charm.replace('cs:', '')}/icon.svg`;
+          break;
+        }
+        console.log(src);
+        const path = window.jujulib.URL.fromLegacyString(bundle.id).path();
+        return [
+          <img key="img" className="profile-bundle-list__icon" src={src} title={name} />,
+          <a
+            key="link"
+            href={`${this.props.baseURL}${path}`}
+            onClick={this._navigateToBundle.bind(this, path)}>{name}</a>
+        ];
+        return;
+        break;
+      case 'owner':
+        return bundle[key] || this.props.user;
+      case 'perm':
+        const perms = bundle[key];
+        if (perms && perms.read.includes('everyone')) {
+          return 'public';
+        }
+        return 'private';
+      default:
+        return bundle[key];
+    }
+    return '';
+  }
+
+  render() {
+    const labels = ['Name', 'Units', 'Owner', 'Visibility'];
+    const bundleKeys = ['name', 'unitCount', 'owner', 'perm'];
+    return (
+      <div className="profile-bundle-list">
+        <ul>
+          <li className="profile-bundle-list__table-header">
+            {labels.map(label => <span key={label}>{label}</span>)}
+          </li>
+          {this.state.data
+            .map((bundle, idx) =>
+              <li className="profile-bundle-list__row" key={idx}>
+                {bundleKeys.map(key => <span key={key}>{this.procesData(bundle, key)}</span>)}
+              </li>
+            )}
+        </ul>
+      </div>);
+  }
+};
+
+ProfileBundleList.propTypes = {
+  addNotification: PropTypes.func.isRequired,
+  baseURL: PropTypes.string.isRequired,
+  changeState: PropTypes.func.isRequired,
+  charmstore: shapeup.shape({
+    list: PropTypes.func.isRequired,
+    url: PropTypes.string.isRequired
+  }).isRequired,
+  user: PropTypes.string
+};
+
+YUI.add('profile-bundle-list', function() {
+  juju.components.ProfileBundleList = ProfileBundleList;
+}, '', {
+  requires: []
+});

--- a/jujugui/static/gui/src/app/components/profile/bundle-list/bundle-list.js
+++ b/jujugui/static/gui/src/app/components/profile/bundle-list/bundle-list.js
@@ -91,7 +91,6 @@ class ProfileBundleList extends React.Component {
           src = `${this.props.charmstore.url}/${app.charm.replace('cs:', '')}/icon.svg`;
           break;
         }
-        console.log(src);
         const path = window.jujulib.URL.fromLegacyString(bundle.id).path();
         return [
           <img key="img" className="profile-bundle-list__icon" src={src} title={name} />,

--- a/jujugui/static/gui/src/app/components/profile/bundle-list/test-bundle-list.js
+++ b/jujugui/static/gui/src/app/components/profile/bundle-list/test-bundle-list.js
@@ -1,0 +1,122 @@
+/* Copyright (C) 2017 Canonical Ltd. */
+
+'use strict';
+
+var juju = {components: {}}; // eslint-disable-line no-unused-vars
+
+describe('Profile Bundle List', function() {
+
+  const rawBundleData = `[{
+    "id": "cs:~lazypower/bundle/logstash-core-1",
+    "perm": {
+      "read": ["everyone"],
+      "write": ["lazypower"]
+    },
+    "applications": {
+      "elasticsearch": {
+        "charm": "cs:~lazypower/trusty/elasticsearch"
+      },
+      "kibana": {
+        "charm": "cs:trusty/kibana-10"
+      },
+      "logstash": {
+        "charm": "cs:~lazypower/trusty/logstash-20"
+      },
+      "openjdk": {
+        "charm": "cs:~kwmonroe/trusty/openjdk"
+      }
+    },
+    "name": "logstash-core",
+    "unitCount": 3
+  }, {
+    "id": "cs:~lazypower/bundle/swarm-core-1",
+    "perm": {
+      "read": ["lazypower", "everyone"],
+      "write": ["lazypower"]
+    },
+    "applications": {
+      "consul": {
+        "charm": "cs:~containers/trusty/consul"
+      },
+      "swarm": {
+        "charm": "cs:~lazypower/swarm"
+      }
+    },
+    "name": "swarm-core",
+    "unitCount": 5
+  }]`;
+
+  beforeAll(function(done) {
+    // By loading this file it adds the component to the juju components.
+    YUI().use('profile-bundle-list', function() {
+      done();
+    });
+  });
+
+  function renderComponent(options={}) {
+    const charmstoreList = (user, cb) => {
+      assert.equal(user, 'lazypower@external');
+      cb(null, JSON.parse(rawBundleData));
+    };
+    return jsTestUtils.shallowRender(
+      <juju.components.ProfileBundleList
+        addNotification={sinon.stub()}
+        baseURL="/gui/"
+        changeState={options.changeState || sinon.stub()}
+        charmstore={{
+          list: charmstoreList,
+          url: '/charmstore'
+        }}
+        user="lazypower@external" />, true);
+  }
+
+  it('can render', () => {
+    const renderer = renderComponent();
+    const output = renderer.getRenderOutput();
+    const list = output.props.children.props.children[1];
+    const expected = (
+      <div className="profile-bundle-list">
+        <ul>
+          <li className="profile-bundle-list__table-header">
+            <span>Name</span>
+            <span>Units</span>
+            <span>Owner</span>
+            <span>Visibility</span>
+          </li>
+          <li className="profile-bundle-list__row">
+            <span>
+              <img
+                className="profile-bundle-list__icon"
+                src="/charmstore/~lazypower/trusty/elasticsearch/icon.svg"
+                title="logstash-core"/>
+              <a
+                href="/gui/u/lazypower/logstash-core/bundle/1"
+                onClick={list[0].props.children[0].props.children[1].props.onClick}>
+                logstash-core
+              </a>
+            </span>
+            <span>3</span>
+            <span>lazypower@external</span>
+            <span>public</span>
+          </li>
+          <li className="profile-bundle-list__row">
+            <span>
+              <img
+                className="profile-bundle-list__icon"
+                src="/charmstore/~containers/trusty/consul/icon.svg"
+                title="swarm-core"/>
+              <a
+                href="/gui/u/lazypower/swarm-core/bundle/1"
+                onClick={list[1].props.children[0].props.children[1].props.onClick}>
+                swarm-core
+              </a>
+            </span>
+            <span>5</span>
+            <span>lazypower@external</span>
+            <span>public</span>
+          </li>
+        </ul>
+      </div>);
+    expect(output).toEqualJSX(expected);
+  });
+});

--- a/jujugui/static/gui/src/app/components/profile/charm-list/_charm-list.scss
+++ b/jujugui/static/gui/src/app/components/profile/charm-list/_charm-list.scss
@@ -1,0 +1,20 @@
+.profile-charm-list {
+  width: 766px;
+
+  &__table-header {
+    border-bottom: 1px solid $mid-grey;
+    padding-bottom: 10px;
+  }
+
+  &__row {
+    border-bottom: 1px solid $mid-grey;
+    padding-bottom: 10px;
+  }
+
+  &__row,
+  &__table-header {
+    display: grid;
+    grid-template-columns: 225px 200px 150px auto;
+  }
+
+}

--- a/jujugui/static/gui/src/app/components/profile/charm-list/_charm-list.scss
+++ b/jujugui/static/gui/src/app/components/profile/charm-list/_charm-list.scss
@@ -17,4 +17,11 @@
     grid-template-columns: 225px 200px 150px auto;
   }
 
+  &__icon {
+    border-radius: 50%;
+    width: 20px;
+    margin-right: 10px;
+    float: left;
+  }
+
 }

--- a/jujugui/static/gui/src/app/components/profile/charm-list/_charm-list.scss
+++ b/jujugui/static/gui/src/app/components/profile/charm-list/_charm-list.scss
@@ -1,20 +1,12 @@
 .profile-charm-list {
   width: 766px;
 
-  &__table-header {
-    border-bottom: 1px solid $mid-grey;
-    padding-bottom: 10px;
-  }
-
-  &__row {
-    border-bottom: 1px solid $mid-grey;
-    padding-bottom: 10px;
-  }
-
   &__row,
   &__table-header {
     display: grid;
     grid-template-columns: 225px 200px 150px auto;
+    border-bottom: 1px solid $mid-grey;
+    padding-bottom: 10px;
   }
 
   &__icon {

--- a/jujugui/static/gui/src/app/components/profile/charm-list/charm-list.js
+++ b/jujugui/static/gui/src/app/components/profile/charm-list/charm-list.js
@@ -68,6 +68,15 @@ class ProfileCharmList extends React.Component {
   */
   procesData(charm, key) {
     switch(key) {
+      case 'name':
+        const name = charm[key];
+        const src = `${this.props.charmstore.url}/${charm.id.replace('cs:', '')}/icon.svg`;
+        return [
+          <img key="img" className="profile-charm-list__icon" src={src} title={name} />,
+          name
+        ];
+        return;
+        break;
       case 'series':
         return charm[key].reduce((list, val) => `${list} ${val}`, '');
         break;
@@ -108,7 +117,8 @@ class ProfileCharmList extends React.Component {
 ProfileCharmList.propTypes = {
   addNotification: PropTypes.func.isRequired,
   charmstore: shapeup.shape({
-    list: PropTypes.func.isRequired
+    list: PropTypes.func.isRequired,
+    url: PropTypes.string.isRequired
   }).isRequired,
   user: PropTypes.string
 };

--- a/jujugui/static/gui/src/app/components/profile/charm-list/charm-list.js
+++ b/jujugui/static/gui/src/app/components/profile/charm-list/charm-list.js
@@ -76,7 +76,7 @@ class ProfileCharmList extends React.Component {
     Process the data required for the charm table.
     @param {Object} charm The charm data.
     @param {String} key The key that stores the data in the charm object.
-    @return {String} THe string value to display in the table.
+    @return {String} The string value to display in the table.
   */
   procesData(charm, key) {
     switch(key) {

--- a/jujugui/static/gui/src/app/components/profile/charm-list/charm-list.js
+++ b/jujugui/static/gui/src/app/components/profile/charm-list/charm-list.js
@@ -1,0 +1,120 @@
+/* Copyright (C) 2017 Canonical Ltd. */
+
+'use strict';
+
+/**
+  Charm list React component used to display a list of the users charms in
+  their profile.
+*/
+class ProfileCharmList extends React.Component {
+  constructor() {
+    super();
+    this.xhrs = [];
+    this.state = {
+      data: []
+    };
+  }
+
+  componentWillMount() {
+    const user = this.props.user;
+    if (user) {
+      this._fetchCharms(user);
+    }
+  }
+
+  componentWillUnmount() {
+    this.xhrs.forEach((xhr) => {
+      xhr && xhr.abort && xhr.abort();
+    });
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const props = this.props;
+    if (props.user !== nextProps.user) {
+      this._fetchCharms(nextProps.user);
+    }
+  }
+
+  /**
+    Fetch the users charms from the charmstore.
+    @param {String} user The external user name in the format "user@external".
+  */
+  _fetchCharms(user) {
+    const props = this.props;
+    this.xhrs.push(
+      props.charmstore.list(
+        user,
+        (error, data) => {
+          if (error) {
+            const message = 'Unable to retrieve charms';
+            console.error(message, error);
+            this.props.addNotification({
+              title: message,
+              message: `${message}: ${error}`,
+              level: 'error'
+            });
+            return;
+          }
+          this.setState({data});
+        },
+        'charm'));
+  }
+
+  /**
+    Process the data required for the charm table.
+    @param {Object} charm The charm data.
+    @param {String} key The key that stores the data in the charm object.
+    @return {String} THe string value to display in the table.
+  */
+  procesData(charm, key) {
+    switch(key) {
+      case 'series':
+        return charm[key].reduce((list, val) => `${list} ${val}`, '');
+        break;
+      case 'owner':
+        return charm[key] || this.props.user;
+      case 'perm':
+        const perms = charm[key];
+        if (perms && perms.read.includes('everyone')) {
+          return 'public';
+        }
+        return 'private';
+      default:
+        return charm[key];
+    }
+    return '';
+  }
+
+  render() {
+    const labels = ['Name', 'Series', 'Owner', 'Visibility'];
+    const charmKeys = ['name', 'series', 'owner', 'perm'];
+    return (
+      <div className="profile-charm-list">
+        <ul>
+          <li className="profile-charm-list__table-header">
+            {labels.map(label => <span key={label}>{label}</span>)}
+          </li>
+          {this.state.data
+            .map((charm, idx) =>
+              <li className="profile-charm-list__row" key={idx}>
+                {charmKeys.map(key => <span key={key}>{this.procesData(charm, key)}</span>)}
+              </li>
+            )}
+        </ul>
+      </div>);
+  }
+};
+
+ProfileCharmList.propTypes = {
+  addNotification: PropTypes.func.isRequired,
+  charmstore: shapeup.shape({
+    list: PropTypes.func.isRequired
+  }).isRequired,
+  user: PropTypes.string
+};
+
+YUI.add('profile-charm-list', function() {
+  juju.components.ProfileCharmList = ProfileCharmList;
+}, '', {
+  requires: []
+});

--- a/jujugui/static/gui/src/app/components/profile/charm-list/charm-list.js
+++ b/jujugui/static/gui/src/app/components/profile/charm-list/charm-list.js
@@ -61,6 +61,18 @@ class ProfileCharmList extends React.Component {
   }
 
   /**
+    Prevents the default actions on the link and navigates to the charmstore
+    for the supplied id via changeState.
+    @param {String} path The GUI charm path to navigate to.
+    @param {Object} e The click event.
+  */
+  _navigateToCharm(path, e) {
+    e.preventDefault();
+    e.stopPropagation();
+    this.props.changeState({profile: null, store: path, hash: null});
+  }
+
+  /**
     Process the data required for the charm table.
     @param {Object} charm The charm data.
     @param {String} key The key that stores the data in the charm object.
@@ -70,10 +82,15 @@ class ProfileCharmList extends React.Component {
     switch(key) {
       case 'name':
         const name = charm[key];
-        const src = `${this.props.charmstore.url}/${charm.id.replace('cs:', '')}/icon.svg`;
+        const id = charm.id;
+        const src = `${this.props.charmstore.url}/${id.replace('cs:', '')}/icon.svg`;
+        const path = window.jujulib.URL.fromLegacyString(id).path();
         return [
           <img key="img" className="profile-charm-list__icon" src={src} title={name} />,
-          name
+          <a
+            key="link"
+            href={`${this.props.baseURL}${path}`}
+            onClick={this._navigateToCharm.bind(this, path)}>{name}</a>
         ];
         return;
         break;
@@ -116,6 +133,8 @@ class ProfileCharmList extends React.Component {
 
 ProfileCharmList.propTypes = {
   addNotification: PropTypes.func.isRequired,
+  baseURL: PropTypes.string.isRequired,
+  changeState: PropTypes.func.isRequired,
   charmstore: shapeup.shape({
     list: PropTypes.func.isRequired,
     url: PropTypes.string.isRequired

--- a/jujugui/static/gui/src/app/components/profile/charm-list/charm-list.js
+++ b/jujugui/static/gui/src/app/components/profile/charm-list/charm-list.js
@@ -95,7 +95,7 @@ class ProfileCharmList extends React.Component {
         return;
         break;
       case 'series':
-        return charm[key].reduce((list, val) => `${list} ${val}`, '');
+        return charm[key].reduce((list, val) => `${list} ${val}`, '').trim();
         break;
       case 'owner':
         return charm[key] || this.props.user;

--- a/jujugui/static/gui/src/app/components/profile/charm-list/charm-list.js
+++ b/jujugui/static/gui/src/app/components/profile/charm-list/charm-list.js
@@ -78,7 +78,7 @@ class ProfileCharmList extends React.Component {
     @param {String} key The key that stores the data in the charm object.
     @return {String} The string value to display in the table.
   */
-  procesData(charm, key) {
+  _processData(charm, key) {
     switch(key) {
       case 'name':
         const name = charm[key];
@@ -123,7 +123,7 @@ class ProfileCharmList extends React.Component {
           {this.state.data
             .map((charm, idx) =>
               <li className="profile-charm-list__row" key={idx}>
-                {charmKeys.map(key => <span key={key}>{this.procesData(charm, key)}</span>)}
+                {charmKeys.map(key => <span key={key}>{this._processData(charm, key)}</span>)}
               </li>
             )}
         </ul>

--- a/jujugui/static/gui/src/app/components/profile/charm-list/test-charm-list.js
+++ b/jujugui/static/gui/src/app/components/profile/charm-list/test-charm-list.js
@@ -1,0 +1,124 @@
+/* Copyright (C) 2017 Canonical Ltd. */
+
+'use strict';
+
+var juju = {components: {}}; // eslint-disable-line no-unused-vars
+
+describe('Profile Charm List', function() {
+
+  const rawCharmData = `[{
+    "id": "cs:~hatch/precise/failtester-7",
+    "series": ["precise"],
+    "perm": {
+      "read": ["everyone", "hatch"],
+      "write": ["hatch"]
+    },
+    "name": "failtester"
+  }, {
+    "id": "cs:~hatch/xenial/ghost-3",
+    "series": ["xenial"],
+    "perm": {
+      "read": ["everyone", "hatch"],
+      "write": ["hatch"]
+    },
+    "name": "ghost"
+  }, {
+    "id": "cs:~hatch/privghost-1",
+    "series": ["xenial", "trusty"],
+    "perm": {
+      "read": ["hatch"],
+      "write": ["hatch"]
+    },
+    "name": "privghost"
+  }]`;
+
+  beforeAll(function(done) {
+    // By loading this file it adds the component to the juju components.
+    YUI().use('profile-charm-list', function() {
+      done();
+    });
+  });
+
+  function renderComponent(options={}) {
+    const charmstoreList = (user, cb) => {
+      assert.equal(user, 'hatch@external');
+      cb(null, JSON.parse(rawCharmData));
+    };
+    return jsTestUtils.shallowRender(
+      <juju.components.ProfileCharmList
+        addNotification={sinon.stub()}
+        baseURL="/gui/"
+        changeState={options.changeState || sinon.stub()}
+        charmstore={{
+          list: charmstoreList,
+          url: '/charmstore'
+        }}
+        user="hatch@external" />, true);
+  }
+
+  it('can render', () => {
+    const renderer = renderComponent();
+    const output = renderer.getRenderOutput();
+    const list = output.props.children.props.children[1];
+    const expected = (
+      <div className="profile-charm-list">
+        <ul>
+          <li className="profile-charm-list__table-header">
+            <span>Name</span>
+            <span>Series</span>
+            <span>Owner</span>
+            <span>Visibility</span>
+          </li>
+          <li className="profile-charm-list__row">
+            <span>
+              <img
+                className="profile-charm-list__icon"
+                src="/charmstore/~hatch/precise/failtester-7/icon.svg"
+                title="failtester"/>
+              <a
+                href="/gui/u/hatch/failtester/precise/7"
+                onClick={list[0].props.children[0].props.children[1].props.onClick}>
+                failtester
+              </a>
+            </span>
+            <span>precise</span>
+            <span>hatch@external</span>
+            <span>public</span>
+          </li>
+          <li className="profile-charm-list__row">
+            <span>
+              <img
+                className="profile-charm-list__icon"
+                src="/charmstore/~hatch/xenial/ghost-3/icon.svg"
+                title="ghost"/>
+              <a
+                href="/gui/u/hatch/ghost/xenial/3"
+                onClick={list[1].props.children[0].props.children[1].props.onClick}>
+                ghost
+              </a>
+            </span>
+            <span>xenial</span>
+            <span>hatch@external</span>
+            <span>public</span>
+          </li>
+          <li className="profile-charm-list__row">
+            <span>
+              <img
+                className="profile-charm-list__icon"
+                src="/charmstore/~hatch/privghost-1/icon.svg"
+                title="privghost"/>
+              <a
+                href="/gui/u/hatch/privghost/1"
+                onClick={list[2].props.children[0].props.children[1].props.onClick}>
+                privghost
+              </a>
+            </span>
+            <span>xenial trusty</span>
+            <span>hatch@external</span>
+            <span>private</span>
+          </li>
+        </ul>
+      </div>);
+    expect(output).toEqualJSX(expected);
+  });
+});

--- a/jujugui/static/gui/src/app/components/profile/profile.js
+++ b/jujugui/static/gui/src/app/components/profile/profile.js
@@ -28,7 +28,7 @@ class Profile extends React.Component {
             activeSection={this.props.activeSection || mapEntry[0]}
             changeState={this.props.changeState}
             sectionsMap={sectionsMap}/>
-          {section.getComponent(this)}
+          {section.getComponent.call(this, this)}
         </div>
       </juju.components.Panel>
     );
@@ -55,7 +55,15 @@ Profile.sectionsMap = new Map([
   }],
   ['charms', {
     label: 'Charms',
-    getComponent: context => 'Charms'
+    getComponent: component => {
+      const fromShape = window.shapeup.fromShape;
+      const propTypes = juju.components.ProfileCharmList.propTypes;
+      return (
+        <juju.components.ProfileCharmList
+          addNotification={component.props.addNotification}
+          charmstore={fromShape(component.props.charmstore, propTypes.charmstore)}
+          user={component.props.userInfo.external} />);
+    }
   }],
   ['bundles', {
     label: 'Bundles',
@@ -73,6 +81,7 @@ Profile.propTypes = {
   addNotification: PropTypes.func.isRequired,
   baseURL: PropTypes.string.isRequired,
   changeState: PropTypes.func.isRequired,
+  charmstore: PropTypes.object.isRequired,
   destroyModels: PropTypes.func.isRequired,
   facadesExist: PropTypes.bool.isRequired,
   listModelsWithInfo: PropTypes.func.isRequired,
@@ -95,6 +104,7 @@ YUI.add('profile', function() {
     'panel-component',
     'profile-navigation',
     'profile-header',
-    'profile-model-list'
+    'profile-model-list',
+    'profile-charm-list'
   ]
 });

--- a/jujugui/static/gui/src/app/components/profile/profile.js
+++ b/jujugui/static/gui/src/app/components/profile/profile.js
@@ -61,6 +61,8 @@ Profile.sectionsMap = new Map([
       return (
         <juju.components.ProfileCharmList
           addNotification={component.props.addNotification}
+          baseURL={component.props.baseURL}
+          changeState={component.props.changeState}
           charmstore={fromShape(component.props.charmstore, propTypes.charmstore)}
           user={component.props.userInfo.external} />);
     }

--- a/jujugui/static/gui/src/app/components/profile/profile.js
+++ b/jujugui/static/gui/src/app/components/profile/profile.js
@@ -69,7 +69,17 @@ Profile.sectionsMap = new Map([
   }],
   ['bundles', {
     label: 'Bundles',
-    getComponent: context => 'Bundles'
+    getComponent: component => {
+      const fromShape = window.shapeup.fromShape;
+      const propTypes = juju.components.ProfileBundleList.propTypes;
+      return (
+        <juju.components.ProfileBundleList
+          addNotification={component.props.addNotification}
+          baseURL={component.props.baseURL}
+          changeState={component.props.changeState}
+          charmstore={fromShape(component.props.charmstore, propTypes.charmstore)}
+          user={component.props.userInfo.external} />);
+    }
   }],
   ['credentials', {
     label: 'Cloud Credentials',
@@ -107,6 +117,7 @@ YUI.add('profile', function() {
     'profile-navigation',
     'profile-header',
     'profile-model-list',
-    'profile-charm-list'
+    'profile-charm-list',
+    'profile-bundle-list'
   ]
 });

--- a/jujugui/static/gui/src/app/components/profile/test-profile.js
+++ b/jujugui/static/gui/src/app/components/profile/test-profile.js
@@ -23,6 +23,10 @@ describe('Profile', function() {
         addNotification={sinon.stub()}
         baseURL="/gui/"
         changeState={options.changeState || sinon.stub()}
+        charmstore={{
+          list: sinon.stub(),
+          url: '/charmstore'
+        }}
         facadesExist={true}
         listModelsWithInfo={sinon.stub()}
         destroyModels={sinon.stub()}

--- a/jujugui/static/gui/src/app/components/user-profile/user-profile.js
+++ b/jujugui/static/gui/src/app/components/user-profile/user-profile.js
@@ -60,7 +60,7 @@ class UserProfile extends React.Component {
         console.log('cannot retrieve charm store macaroon:', err);
         return;
       }
-      props.storeUser('charmstore', true);
+      props.storeUser('charmstore');
     };
     // TODO frankban: should pass an user object as prop here instead.
     const macaroon = props.charmstore.bakery.storage.get('charmstore');

--- a/jujugui/static/gui/src/app/init/component-renderers-mixin.js
+++ b/jujugui/static/gui/src/app/init/component-renderers-mixin.js
@@ -221,6 +221,7 @@ const ComponentRenderersMixin = (superclass) => class extends superclass {
           addNotification={this._bound.addNotification}
           baseURL={this.applicationConfig.baseUrl}
           changeState={this._bound.changeState}
+          charmstore={charmstore}
           facadesExist={facadesExist}
           listModelsWithInfo={this._bound.listModelsWithInfo}
           destroyModels={this._bound.destroyModels}

--- a/jujugui/static/gui/src/app/jujulib/charmstore.js
+++ b/jujugui/static/gui/src/app/jujulib/charmstore.js
@@ -201,6 +201,10 @@ var module = module;
           return {name: info.Channel, current: info.Current};
         });
       }
+      if (meta.perm) {
+        processed.perm = {};
+        this._lowerCaseKeys(meta.perm || {}, processed.perm);
+      }
 
       // Convert the options keys to lowercase.
       if (charmConfig && typeof charmConfig.Options === 'object') {
@@ -421,7 +425,8 @@ var module = module;
         'include=bundle-unit-count',
         'include=extra-info',
         'include=supported-series',
-        'include=stats'
+        'include=stats',
+        'include=perm'
       ];
       const url = this._generatePath('list', qs.join('&'));
       const headers = null;

--- a/jujugui/static/gui/src/app/jujulib/test-charmstore.js
+++ b/jujugui/static/gui/src/app/jujulib/test-charmstore.js
@@ -365,7 +365,8 @@ describe('jujulib charmstore', function() {
             'include=bundle-unit-count&' +
             'include=extra-info&' +
             'include=supported-series&' +
-            'include=stats']);
+            'include=stats&' +
+            'include=perm']);
     });
 
     it('can list bundles', function() {

--- a/jujugui/static/gui/src/test/test_app.js
+++ b/jujugui/static/gui/src/test/test_app.js
@@ -1143,6 +1143,7 @@ describe('App', function() {
         jujuCoreVersion: '2.0.0',
         user: userClass
       });
+      app.state.dispatch = sinon.stub();
       var charmstore = app.get('charmstore');
       csStub = sinon.stub(charmstore, 'whoami');
       this._cleanups.push(csStub);
@@ -1162,19 +1163,16 @@ describe('App', function() {
       assert.deepEqual(users['charmstore'], user);
     });
 
-    it('re-renders the user profile & breadcrumb if told to', function() {
+    it('re-dispatches the app & renders the breadcrumb if told to', function() {
       const user = {user: 'test'};
       const state = {test: 'state'};
       app.state._appStateHistory.push(state);
-      app._renderUserProfile = sinon.stub();
       app._renderBreadcrumb = sinon.stub();
-      app.storeUser('charmstore', true, true);
+      app.storeUser('charmstore', true);
       assert.equal(csStub.callCount, 1);
       csStub.lastCall.args[0](null, user);
-      assert.equal(app._renderUserProfile.callCount, 1);
-      assert.equal(app._renderUserProfile.args[0][0], state);
-      assert.equal(typeof app._renderUserProfile.args[0][1], 'function');
       assert.equal(app._renderBreadcrumb.callCount, 1);
+      assert.equal(app.state.dispatch.callCount, 1);
       assert.deepEqual(app.get('users')['charmstore'], user);
     });
   });


### PR DESCRIPTION
Create a new charms list and bundles list component for the new profile. This is the first pass at it and it will likely require a number of design changes in the near future.

This also contains a driveby to fix a profile dispatching issue after logging into the charmstore around the `storeUser` method.