### PR TITLE
Use shapeup on the machine view component tree.

### DIFF
--- a/jujugui/static/gui/src/app/components/machine-view/add-machine/test-add-machine.js
+++ b/jujugui/static/gui/src/app/components/machine-view/add-machine/test-add-machine.js
@@ -22,7 +22,7 @@ var juju = {components: {}}; // eslint-disable-line no-unused-vars
 var testUtils = React.addons.TestUtils;
 
 describe('MachineViewAddMachine', function() {
-  var acl;
+  let acl;
 
   beforeAll(function(done) {
     // By loading this file it adds the component to the juju components.
@@ -30,22 +30,24 @@ describe('MachineViewAddMachine', function() {
   });
 
   beforeEach(() => {
-    acl = {isReadOnly: sinon.stub().returns(false)};
+    acl = shapeup.deepFreeze({isReadOnly: () => false});
   });
 
   it('can render for creating a machine', function() {
-    var close = sinon.stub();
-    var createMachine = sinon.stub();
+    const close = sinon.stub();
+    const createMachine = sinon.stub();
     const renderer = jsTestUtils.shallowRender(
       <juju.components.MachineViewAddMachine
         acl={acl}
         close={close}
-        createMachine={createMachine}
-        providerType={'ec2'}
+        modelAPI={{
+          createMachine: createMachine,
+          providerType: 'ec2'
+        }}
       />, true);
-    var instance = renderer.getMountedInstance();
-    var output = renderer.getRenderOutput();
-    var buttons = [{
+    const instance = renderer.getMountedInstance();
+    const output = renderer.getRenderOutput();
+    const buttons = [{
       title: 'Cancel',
       type: 'base',
       action: close
@@ -55,7 +57,7 @@ describe('MachineViewAddMachine', function() {
       type: 'neutral',
       disabled: undefined
     }];
-    var expected = (
+    const expected = (
       <div className="add-machine">
         <div className="add-machine__constraints" key="constraints">
           <h4 className="add-machine__title">
@@ -76,19 +78,20 @@ describe('MachineViewAddMachine', function() {
   });
 
   it('can disable the controls when read only', function() {
-    acl.isReadOnly = sinon.stub().returns(true);
-    var close = sinon.stub();
-    var createMachine = sinon.stub();
+    const close = sinon.stub();
+    const createMachine = sinon.stub();
     const renderer = jsTestUtils.shallowRender(
       <juju.components.MachineViewAddMachine
-        acl={acl}
+        acl={shapeup.deepFreeze({isReadOnly: () => true})}
         close={close}
-        createMachine={createMachine}
-        providerType={'lxd'}
+        modelAPI={{
+          createMachine: createMachine,
+          providerType: 'lxd'
+        }}
       />, true);
-    var instance = renderer.getMountedInstance();
-    var output = renderer.getRenderOutput();
-    var buttons = [{
+    const instance = renderer.getMountedInstance();
+    const output = renderer.getRenderOutput();
+    const buttons = [{
       title: 'Cancel',
       type: 'base',
       action: close
@@ -98,7 +101,7 @@ describe('MachineViewAddMachine', function() {
       type: 'neutral',
       disabled: true
     }];
-    var expected = (
+    const expected = (
       <div className="add-machine">
         <div className="add-machine__constraints" key="constraints">
           <h4 className="add-machine__title">
@@ -125,7 +128,9 @@ describe('MachineViewAddMachine', function() {
       <juju.components.MachineViewAddMachine
         acl={acl}
         close={close}
-        createMachine={createMachine}
+        modelAPI={{
+          createMachine: createMachine
+        }}
         parentId="new0" />, true);
     const instance = renderer.getMountedInstance();
     const output = renderer.getRenderOutput();
@@ -148,10 +153,10 @@ describe('MachineViewAddMachine', function() {
   });
 
   it('can render for selecting a machine', function() {
-    var close = sinon.stub();
-    var createMachine = sinon.stub();
-    var unit = {};
-    var machines = {
+    const close = sinon.stub();
+    const createMachine = sinon.stub();
+    const unit = {};
+    const machines = {
       filterByParent: sinon.stub().returns([{
         id: 'new0',
         displayName: 'new0'
@@ -165,17 +170,21 @@ describe('MachineViewAddMachine', function() {
         displayName: 'new2'
       }])
     };
-    var renderer = jsTestUtils.shallowRender(
+    const renderer = jsTestUtils.shallowRender(
       <juju.components.MachineViewAddMachine
         acl={acl}
         close={close}
-        createMachine={createMachine}
-        machines={machines}
+        dbAPI={{
+          machines: machines
+        }}
+        modelAPI={{
+          createMachine: createMachine
+        }}
         parentId="new0"
         unit={unit} />, true);
-    var instance = renderer.getMountedInstance();
-    var output = renderer.getRenderOutput();
-    var expected = (
+    const instance = renderer.getMountedInstance();
+    const output = renderer.getRenderOutput();
+    const expected = (
       <select
         defaultValue=""
         disabled={false}
@@ -204,28 +213,34 @@ describe('MachineViewAddMachine', function() {
   });
 
   it('can call the cancel method', function() {
-    var close = sinon.stub();
-    var createMachine = sinon.stub();
-    var renderer = jsTestUtils.shallowRender(
+    const close = sinon.stub();
+    const createMachine = sinon.stub();
+    const renderer = jsTestUtils.shallowRender(
       <juju.components.MachineViewAddMachine
         acl={acl}
         close={close}
-        createMachine={createMachine} />, true);
-    var output = renderer.getRenderOutput();
+        modelAPI={{
+          createMachine: createMachine
+        }}
+      />, true);
+    const output = renderer.getRenderOutput();
     output.props.children[1].props.buttons[0].action();
     assert.equal(close.callCount, 1);
   });
 
   it('can create a machine', function() {
-    var close = sinon.stub();
-    var createMachine = sinon.stub();
-    var renderer = jsTestUtils.shallowRender(
+    const close = sinon.stub();
+    const createMachine = sinon.stub();
+    const renderer = jsTestUtils.shallowRender(
       <juju.components.MachineViewAddMachine
         acl={acl}
         close={close}
-        createMachine={createMachine} />, true);
-    var instance = renderer.getMountedInstance();
-    var output = renderer.getRenderOutput();
+        modelAPI={{
+          createMachine: createMachine
+        }}
+      />, true);
+    const instance = renderer.getMountedInstance();
+    const output = renderer.getRenderOutput();
     output.props.children[1].props.buttons[1].action();
     assert.equal(createMachine.callCount, 1);
     assert.equal(createMachine.args[0][0], null);
@@ -234,16 +249,18 @@ describe('MachineViewAddMachine', function() {
   });
 
   it('can create a container', function() {
-    var close = sinon.stub();
-    var createMachine = sinon.stub();
-    var output = testUtils.renderIntoDocument(
+    const close = sinon.stub();
+    const createMachine = sinon.stub();
+    const output = testUtils.renderIntoDocument(
       <juju.components.MachineViewAddMachine
         acl={acl}
         close={close}
-        createMachine={createMachine}
+        modelAPI={{
+          createMachine: createMachine
+        }}
         parentId="new0" />);
-    var outputNode = ReactDOM.findDOMNode(output);
-    var selectNode = outputNode.querySelector('.add-machine__container');
+    const outputNode = ReactDOM.findDOMNode(output);
+    const selectNode = outputNode.querySelector('.add-machine__container');
     selectNode.value = 'lxd';
     testUtils.Simulate.change(selectNode);
     testUtils.Simulate.click(outputNode.querySelector(
@@ -254,23 +271,28 @@ describe('MachineViewAddMachine', function() {
   });
 
   it('can place a unit on a new machine', function() {
-    var close = sinon.stub();
-    var createMachine = sinon.stub().returns({id: 'new0'});
-    var machines = {
+    const close = sinon.stub();
+    const createMachine = sinon.stub().returns({id: 'new0'});
+    const machines = {
       filterByParent: sinon.stub().returns([])
     };
-    var placeUnit = sinon.stub();
-    var unit = {id: 'unit1'};
-    var renderer = jsTestUtils.shallowRender(
+    const placeUnit = sinon.stub();
+    const unit = {id: 'unit1'};
+    const renderer = jsTestUtils.shallowRender(
       <juju.components.MachineViewAddMachine
         acl={acl}
         close={close}
-        createMachine={createMachine}
-        machines={machines}
+        dbAPI={{
+          machines: machines
+        }}
+        modelAPI={{
+          createMachine: createMachine,
+          placeUnit: placeUnit
+        }}
         parentId="new0"
-        placeUnit={placeUnit}
-        unit={unit} />, true);
-    var instance = renderer.getMountedInstance();
+        unit={unit}
+      />, true);
+    const instance = renderer.getMountedInstance();
     instance.state = {selectedMachine: 'new'};
     instance._submitForm();
     assert.equal(createMachine.callCount, 1);
@@ -283,23 +305,27 @@ describe('MachineViewAddMachine', function() {
   });
 
   it('can place a unit on a new container', function() {
-    var close = sinon.stub();
-    var createMachine = sinon.stub().returns({id: 'new0/lxc/new1'});
-    var machines = {
+    const close = sinon.stub();
+    const createMachine = sinon.stub().returns({id: 'new0/lxc/new1'});
+    const machines = {
       filterByParent: sinon.stub().returns([])
     };
-    var placeUnit = sinon.stub();
-    var unit = {id: 'unit1'};
-    var renderer = jsTestUtils.shallowRender(
+    const placeUnit = sinon.stub();
+    const unit = {id: 'unit1'};
+    const renderer = jsTestUtils.shallowRender(
       <juju.components.MachineViewAddMachine
         acl={acl}
         close={close}
-        createMachine={createMachine}
-        machines={machines}
+        dbAPI={{
+          machines: machines
+        }}
+        modelAPI={{
+          createMachine: createMachine,
+          placeUnit: placeUnit
+        }}
         parentId="new0"
-        placeUnit={placeUnit}
         unit={unit} />, true);
-    var instance = renderer.getMountedInstance();
+    const instance = renderer.getMountedInstance();
     instance.state = {
       selectedContainer: 'lxc'
     };
@@ -314,23 +340,28 @@ describe('MachineViewAddMachine', function() {
   });
 
   it('can place a unit on an existing machine', function() {
-    var close = sinon.stub();
-    var createMachine = sinon.stub().returns({id: 'new0'});
-    var machines = {
+    const close = sinon.stub();
+    const createMachine = sinon.stub().returns({id: 'new0'});
+    const machines = {
       filterByParent: sinon.stub().returns([])
     };
-    var placeUnit = sinon.stub();
-    var unit = {id: 'unit1'};
-    var renderer = jsTestUtils.shallowRender(
+    const placeUnit = sinon.stub();
+    const unit = {id: 'unit1'};
+    const renderer = jsTestUtils.shallowRender(
       <juju.components.MachineViewAddMachine
         acl={acl}
         close={close}
-        createMachine={createMachine}
-        machines={machines}
+        dbAPI={{
+          machines: machines
+        }}
+        modelAPI={{
+          createMachine: createMachine,
+          placeUnit: placeUnit
+        }}
         parentId="new0"
-        placeUnit={placeUnit}
-        unit={unit} />, true);
-    var instance = renderer.getMountedInstance();
+        unit={unit}
+      />, true);
+    const instance = renderer.getMountedInstance();
     instance.state = {
       selectedMachine: 'new0',
       selectedContainer: 'new0'
@@ -343,23 +374,28 @@ describe('MachineViewAddMachine', function() {
   });
 
   it('can place a unit on an existing container', function() {
-    var close = sinon.stub();
-    var createMachine = sinon.stub().returns({id: 'new0'});
-    var machines = {
+    const close = sinon.stub();
+    const createMachine = sinon.stub().returns({id: 'new0'});
+    const machines = {
       filterByParent: sinon.stub().returns([])
     };
-    var placeUnit = sinon.stub();
-    var unit = {id: 'unit1'};
-    var renderer = jsTestUtils.shallowRender(
+    const placeUnit = sinon.stub();
+    const unit = {id: 'unit1'};
+    const renderer = jsTestUtils.shallowRender(
       <juju.components.MachineViewAddMachine
         acl={acl}
         close={close}
-        createMachine={createMachine}
-        machines={machines}
+        dbAPI={{
+          machines: machines
+        }}
+        modelAPI={{
+          createMachine: createMachine,
+          placeUnit: placeUnit
+        }}
         parentId="new0"
-        placeUnit={placeUnit}
-        unit={unit} />, true);
-    var instance = renderer.getMountedInstance();
+        unit={unit}
+      />, true);
+    const instance = renderer.getMountedInstance();
     instance.state = {
       selectedMachine: 'new0',
       selectedContainer: 'new0/lxc/new0'
@@ -372,25 +408,30 @@ describe('MachineViewAddMachine', function() {
   });
 
   it('can select a machine when created', function() {
-    var close = sinon.stub();
-    var createMachine = sinon.stub().returns({id: 'new0'});
-    var machines = {
+    const close = sinon.stub();
+    const createMachine = sinon.stub().returns({id: 'new0'});
+    const machines = {
       filterByParent: sinon.stub().returns([])
     };
-    var placeUnit = sinon.stub();
-    var selectMachine = sinon.stub();
-    var unit = {id: 'unit1'};
-    var renderer = jsTestUtils.shallowRender(
+    const placeUnit = sinon.stub();
+    const selectMachine = sinon.stub();
+    const unit = {id: 'unit1'};
+    const renderer = jsTestUtils.shallowRender(
       <juju.components.MachineViewAddMachine
         acl={acl}
         close={close}
-        createMachine={createMachine}
-        machines={machines}
+        dbAPI={{
+          machines: machines
+        }}
+        modelAPI={{
+          createMachine: createMachine,
+          placeUnit: placeUnit
+        }}
         parentId="new0"
-        placeUnit={placeUnit}
         selectMachine={selectMachine}
-        unit={unit} />, true);
-    var instance = renderer.getMountedInstance();
+        unit={unit}
+      />, true);
+    const instance = renderer.getMountedInstance();
     instance.state = {selectedMachine: 'new'};
     instance._submitForm();
     assert.equal(selectMachine.callCount, 1);
@@ -398,25 +439,30 @@ describe('MachineViewAddMachine', function() {
   });
 
   it('does not select a container when created', function() {
-    var close = sinon.stub();
-    var createMachine = sinon.stub().returns({id: 'new0/lxc/new1'});
-    var machines = {
+    const close = sinon.stub();
+    const createMachine = sinon.stub().returns({id: 'new0/lxc/new1'});
+    const machines = {
       filterByParent: sinon.stub().returns([])
     };
-    var placeUnit = sinon.stub();
-    var selectMachine = sinon.stub();
-    var unit = {id: 'unit1'};
-    var renderer = jsTestUtils.shallowRender(
+    const placeUnit = sinon.stub();
+    const selectMachine = sinon.stub();
+    const unit = {id: 'unit1'};
+    const renderer = jsTestUtils.shallowRender(
       <juju.components.MachineViewAddMachine
         acl={acl}
         close={close}
-        createMachine={createMachine}
-        machines={machines}
+        dbAPI={{
+          machines: machines
+        }}
+        modelAPI={{
+          createMachine: createMachine,
+          placeUnit: placeUnit
+        }}
         parentId="new0"
-        placeUnit={placeUnit}
         selectMachine={selectMachine}
-        unit={unit} />, true);
-    var instance = renderer.getMountedInstance();
+        unit={unit}
+      />, true);
+    const instance = renderer.getMountedInstance();
     instance.state = {
       selectedContainer: 'lxc'
     };

--- a/jujugui/static/gui/src/app/components/machine-view/column/column.js
+++ b/jujugui/static/gui/src/app/components/machine-view/column/column.js
@@ -85,11 +85,13 @@ class MachineViewColumn extends React.Component {
   }
 
   render() {
-    var props = this.props;
-    return this.props.connectDropTarget(
+    const props = this.props;
+    const propTypes = (
+      juju.components.MachineViewHeader.DecoratedComponent.propTypes);
+    return props.connectDropTarget(
       <div className={this._generateClasses()}>
         <juju.components.MachineViewHeader
-          acl={this.props.acl}
+          acl={props.acl.reshape(propTypes.acl)}
           activeMenuItem={props.activeMenuItem}
           droppable={props.droppable}
           dropUnit={props.dropUnit}
@@ -110,7 +112,10 @@ class MachineViewColumn extends React.Component {
 };
 
 MachineViewColumn.propTypes = {
-  acl: PropTypes.object.isRequired,
+  acl: shapeup.shape({
+    isReadOnly: PropTypes.func.isRequired,
+    reshape: shapeup.reshapeFunc
+  }).frozen.isRequired,
   activeMenuItem: PropTypes.string,
   canDrop: PropTypes.bool.isRequired,
   children: PropTypes.oneOfType([

--- a/jujugui/static/gui/src/app/components/machine-view/column/test-column.js
+++ b/jujugui/static/gui/src/app/components/machine-view/column/test-column.js
@@ -21,7 +21,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 var juju = {components: {}}; // eslint-disable-line no-unused-vars
 
 describe('MachineViewColumn', function() {
-  var acl;
+  let acl;
 
   beforeAll(function(done) {
     // By loading this file it adds the component to the juju components.
@@ -29,16 +29,16 @@ describe('MachineViewColumn', function() {
   });
 
   beforeEach(() => {
-    acl = {isReadOnly: sinon.stub().returns(false)};
+    acl = shapeup.deepFreeze(shapeup.addReshape({isReadOnly: () => false}));
   });
 
   it('can render', function() {
-    var menuItems = [];
-    var toggle = {};
-    var dropUnit = sinon.stub();
+    const menuItems = [];
+    const toggle = {};
+    const dropUnit = sinon.stub();
     // The component is wrapped to handle drag and drop, but we just want to
     // test the internal component so we access it via DecoratedComponent.
-    var output = jsTestUtils.shallowRender(
+    const output = jsTestUtils.shallowRender(
       <juju.components.MachineViewColumn.DecoratedComponent
         acl={acl}
         activeMenuItem="name"
@@ -53,10 +53,12 @@ describe('MachineViewColumn', function() {
         type="machine">
         <div>contents</div>
       </juju.components.MachineViewColumn.DecoratedComponent>);
-    var expected = (
+    const expected = (
       <div className="machine-view__column">
         <juju.components.MachineViewHeader
-          acl={acl}
+          acl={acl.reshape(
+            juju.components.MachineViewHeader.DecoratedComponent.propTypes.acl
+          )}
           activeMenuItem="name"
           droppable={true}
           dropUnit={dropUnit}
@@ -72,11 +74,11 @@ describe('MachineViewColumn', function() {
           </div>
         </div>
       </div>);
-    assert.deepEqual(output, expected);
+    expect(output).toEqualJSX(expected);
   });
 
   it('can render in droppable mode', function() {
-    var output = jsTestUtils.shallowRender(
+    const output = jsTestUtils.shallowRender(
       <juju.components.MachineViewColumn.DecoratedComponent
         acl={acl}
         canDrop={false}
@@ -85,15 +87,15 @@ describe('MachineViewColumn', function() {
         isOver={true}
         title="Sandbox"
         type="machine" />);
-    var expected = (
+    const expected = (
       <div className="machine-view__column machine-view__column--drop">
         {output.props.children}
       </div>);
-    assert.deepEqual(output, expected);
+    expect(output).toEqualJSX(expected);
   });
 
   it('can render in drop mode', function() {
-    var output = jsTestUtils.shallowRender(
+    const output = jsTestUtils.shallowRender(
       <juju.components.MachineViewColumn.DecoratedComponent
         acl={acl}
         canDrop={true}
@@ -102,10 +104,10 @@ describe('MachineViewColumn', function() {
         isOver={false}
         title="Sandbox"
         type="machine" />);
-    var expected = (
+    const expected = (
       <div className="machine-view__column machine-view__column--droppable">
         {output.props.children}
       </div>);
-    assert.deepEqual(output, expected);
+    expect(output).toEqualJSX(expected);
   });
 });

--- a/jujugui/static/gui/src/app/components/machine-view/header/header.js
+++ b/jujugui/static/gui/src/app/components/machine-view/header/header.js
@@ -124,7 +124,9 @@ class MachineViewHeader extends React.Component {
 };
 
 MachineViewHeader.propTypes = {
-  acl: PropTypes.object.isRequired,
+  acl: shapeup.shape({
+    isReadOnly: PropTypes.func.isRequired
+  }).frozen.isRequired,
   activeMenuItem: PropTypes.string,
   canDrop: PropTypes.bool.isRequired,
   connectDropTarget: PropTypes.func.isRequired,

--- a/jujugui/static/gui/src/app/components/machine-view/header/test-header.js
+++ b/jujugui/static/gui/src/app/components/machine-view/header/test-header.js
@@ -21,7 +21,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 var juju = {components: {}}; // eslint-disable-line no-unused-vars
 
 describe('MachineViewHeader', function() {
-  var acl;
+  let acl;
 
   beforeAll(function(done) {
     // By loading this file it adds the component to the juju components.
@@ -29,13 +29,13 @@ describe('MachineViewHeader', function() {
   });
 
   beforeEach(() => {
-    acl = {isReadOnly: sinon.stub().returns(false)};
+    acl = shapeup.deepFreeze({isReadOnly: () => false});
   });
 
   it('can render', function() {
     // The component is wrapped to handle drag and drop, but we just want to
     // test the internal component so we access it via DecoratedComponent.
-    var output = jsTestUtils.shallowRender(
+    const output = jsTestUtils.shallowRender(
       <juju.components.MachineViewHeader.DecoratedComponent
         acl={acl}
         canDrop={false}
@@ -44,7 +44,7 @@ describe('MachineViewHeader', function() {
         isOver={false}
         title="Sandbox"
         type="machine" />);
-    var expected = (
+    const expected = (
       <div className="machine-view__header">
           Sandbox
         {undefined}
@@ -58,7 +58,7 @@ describe('MachineViewHeader', function() {
   });
 
   it('can render in droppable mode', function() {
-    var output = jsTestUtils.shallowRender(
+    const output = jsTestUtils.shallowRender(
       <juju.components.MachineViewHeader.DecoratedComponent
         acl={acl}
         canDrop={false}
@@ -67,7 +67,7 @@ describe('MachineViewHeader', function() {
         isOver={true}
         title="Sandbox"
         type="machine" />);
-    var expected = (
+    const expected = (
       <div className="machine-view__header machine-view__header--drop">
         {output.props.children}
       </div>);
@@ -75,7 +75,7 @@ describe('MachineViewHeader', function() {
   });
 
   it('can render in drop mode', function() {
-    var output = jsTestUtils.shallowRender(
+    const output = jsTestUtils.shallowRender(
       <juju.components.MachineViewHeader.DecoratedComponent
         acl={acl}
         canDrop={true}
@@ -84,7 +84,7 @@ describe('MachineViewHeader', function() {
         isOver={false}
         title="Sandbox"
         type="machine" />);
-    var expected = (
+    const expected = (
       <div className="machine-view__header machine-view__header--droppable">
         {output.props.children}
       </div>);
@@ -92,8 +92,8 @@ describe('MachineViewHeader', function() {
   });
 
   it('can render with a menu', function() {
-    var menuItems = [];
-    var output = jsTestUtils.shallowRender(
+    const menuItems = [];
+    const output = jsTestUtils.shallowRender(
       <juju.components.MachineViewHeader.DecoratedComponent
         acl={acl}
         activeMenuItem="name"
@@ -104,7 +104,7 @@ describe('MachineViewHeader', function() {
         menuItems={menuItems}
         title="Sandbox"
         type="machine" />);
-    var expected = (
+    const expected = (
       <div className="machine-view__header">
           Sandbox
         <juju.components.MoreMenu
@@ -120,8 +120,8 @@ describe('MachineViewHeader', function() {
   });
 
   it('can render with a toggle', function() {
-    var action = sinon.stub();
-    var output = jsTestUtils.shallowRender(
+    const action = sinon.stub();
+    const output = jsTestUtils.shallowRender(
       <juju.components.MachineViewHeader.DecoratedComponent
         acl={acl}
         canDrop={false}
@@ -135,7 +135,7 @@ describe('MachineViewHeader', function() {
         }}
         title="Sandbox"
         type="machine" />);
-    var expected = (
+    const expected = (
       <div className="machine-view__header">
           Sandbox
         <juju.components.GenericButton

--- a/jujugui/static/gui/src/app/components/machine-view/machine-unit/machine-unit.js
+++ b/jujugui/static/gui/src/app/components/machine-view/machine-unit/machine-unit.js
@@ -114,7 +114,9 @@ class MachineViewMachineUnit extends React.Component {
 };
 
 MachineViewMachineUnit.propTypes = {
-  acl: PropTypes.object.isRequired,
+  acl: shapeup.shape({
+    isReadOnly: PropTypes.func.isRequired
+  }).frozen.isRequired,
   canDrag: PropTypes.bool.isRequired,
   connectDragSource: PropTypes.func.isRequired,
   isDragging: PropTypes.bool.isRequired,

--- a/jujugui/static/gui/src/app/components/machine-view/machine-unit/test-machine-unit.js
+++ b/jujugui/static/gui/src/app/components/machine-view/machine-unit/test-machine-unit.js
@@ -21,7 +21,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 var juju = {components: {}}; // eslint-disable-line no-unused-vars
 
 describe('MachineViewMachineUnit', function() {
-  var acl, service, unit;
+  let acl, service, unit;
 
   beforeAll(function(done) {
     // By loading this file it adds the component to the juju components.
@@ -29,7 +29,7 @@ describe('MachineViewMachineUnit', function() {
   });
 
   beforeEach(function () {
-    acl = {isReadOnly: sinon.stub().returns(false)};
+    acl = shapeup.deepFreeze({isReadOnly: () => false});
     service = {
       get: function(val) {
         switch (val) {
@@ -52,8 +52,8 @@ describe('MachineViewMachineUnit', function() {
   });
 
   it('can render a machine', function() {
-    var removeUnit = sinon.stub();
-    var renderer = jsTestUtils.shallowRender(
+    const removeUnit = sinon.stub();
+    const renderer = jsTestUtils.shallowRender(
       // The component is wrapped to handle drag and drop, but we just want to
       // test the internal component so we access it via DecoratedComponent.
       <juju.components.MachineViewMachineUnit.DecoratedComponent
@@ -65,8 +65,8 @@ describe('MachineViewMachineUnit', function() {
         removeUnit={removeUnit}
         service={service}
         unit={unit} />, true);
-    var output = renderer.getRenderOutput();
-    var expected = (
+    const output = renderer.getRenderOutput();
+    const expected = (
       <li className={'machine-view__machine-unit ' +
         'machine-view__machine-unit--started'}>
         <span className="machine-view__machine-unit-icon">
@@ -83,8 +83,8 @@ describe('MachineViewMachineUnit', function() {
   });
 
   it('can render a container', function() {
-    var removeUnit = sinon.stub();
-    var output = jsTestUtils.shallowRender(
+    const removeUnit = sinon.stub();
+    const output = jsTestUtils.shallowRender(
       <juju.components.MachineViewMachineUnit.DecoratedComponent
         acl={acl}
         canDrag={false}
@@ -94,7 +94,7 @@ describe('MachineViewMachineUnit', function() {
         removeUnit={removeUnit}
         service={service}
         unit={unit} />);
-    var expected = (
+    const expected = (
       <li className={'machine-view__machine-unit ' +
         'machine-view__machine-unit--started'}>
         <span className="machine-view__machine-unit-icon">
@@ -115,9 +115,9 @@ describe('MachineViewMachineUnit', function() {
   });
 
   it('can disable the destroy when read only', function() {
-    acl.isReadOnly = sinon.stub().returns(true);
-    var removeUnit = sinon.stub();
-    var output = jsTestUtils.shallowRender(
+    acl = shapeup.deepFreeze({isReadOnly: () => true});
+    const removeUnit = sinon.stub();
+    const output = jsTestUtils.shallowRender(
       <juju.components.MachineViewMachineUnit.DecoratedComponent
         acl={acl}
         canDrag={false}
@@ -127,7 +127,7 @@ describe('MachineViewMachineUnit', function() {
         removeUnit={removeUnit}
         service={service}
         unit={unit} />);
-    var expected = (
+    const expected = (
       <juju.components.MoreMenu
         items={[{
           label: 'Destroy',
@@ -137,8 +137,8 @@ describe('MachineViewMachineUnit', function() {
   });
 
   it('can display in dragged mode', function() {
-    var removeUnit = sinon.stub();
-    var output = jsTestUtils.shallowRender(
+    const removeUnit = sinon.stub();
+    const output = jsTestUtils.shallowRender(
       <juju.components.MachineViewMachineUnit.DecoratedComponent
         acl={acl}
         canDrag={false}
@@ -148,7 +148,7 @@ describe('MachineViewMachineUnit', function() {
         removeUnit={removeUnit}
         service={service}
         unit={unit} />);
-    var expected = (
+    const expected = (
       <li className={'machine-view__machine-unit ' +
         'machine-view__machine-unit--dragged ' +
         'machine-view__machine-unit--started'}>
@@ -159,8 +159,8 @@ describe('MachineViewMachineUnit', function() {
 
   it('can display as uncommitted', function() {
     unit.deleted = true;
-    var removeUnit = sinon.stub();
-    var output = jsTestUtils.shallowRender(
+    const removeUnit = sinon.stub();
+    const output = jsTestUtils.shallowRender(
       <juju.components.MachineViewMachineUnit.DecoratedComponent
         acl={acl}
         canDrag={false}
@@ -170,7 +170,7 @@ describe('MachineViewMachineUnit', function() {
         removeUnit={removeUnit}
         service={service}
         unit={unit} />);
-    var expected = (
+    const expected = (
       <li className={'machine-view__machine-unit ' +
         'machine-view__machine-unit--uncommitted'}>
         {output.props.children}
@@ -179,8 +179,8 @@ describe('MachineViewMachineUnit', function() {
   });
 
   it('can display in draggable mode', function() {
-    var removeUnit = sinon.stub();
-    var output = jsTestUtils.shallowRender(
+    const removeUnit = sinon.stub();
+    const output = jsTestUtils.shallowRender(
       <juju.components.MachineViewMachineUnit.DecoratedComponent
         acl={acl}
         connectDragSource={jsTestUtils.connectDragSource}
@@ -190,7 +190,7 @@ describe('MachineViewMachineUnit', function() {
         removeUnit={removeUnit}
         service={service}
         unit={unit} />);
-    var expected = (
+    const expected = (
       <li className={'machine-view__machine-unit ' +
         'machine-view__machine-unit--draggable ' +
         'machine-view__machine-unit--started'}>
@@ -200,8 +200,8 @@ describe('MachineViewMachineUnit', function() {
   });
 
   it('can remove a unit', function() {
-    var removeUnit = sinon.stub();
-    var output = jsTestUtils.shallowRender(
+    const removeUnit = sinon.stub();
+    const output = jsTestUtils.shallowRender(
       <juju.components.MachineViewMachineUnit.DecoratedComponent
         acl={acl}
         canDrag={false}

--- a/jujugui/static/gui/src/app/components/machine-view/machine/machine.js
+++ b/jujugui/static/gui/src/app/components/machine-view/machine/machine.js
@@ -32,7 +32,7 @@ MachineViewMachineGlobals.dropTarget = {
   */
   drop: function (props, monitor, component) {
     var item = monitor.getItem();
-    props.dropUnit(item.unit, props.machine.id);
+    props.dropUnit(item.unit, props.machineAPI.machine.id);
   },
 
   /**
@@ -43,7 +43,7 @@ MachineViewMachineGlobals.dropTarget = {
     @param {Object} monitor A DropTargetMonitor.
   */
   canDrop: function (props, monitor) {
-    return !props.acl.isReadOnly() && !props.machine.deleted;
+    return !props.acl.isReadOnly() && !props.machineAPI.machine.deleted;
   }
 };
 
@@ -96,9 +96,10 @@ class MachineViewMachine extends React.Component {
     // The series is updated separately from the constraints, so remove it
     // from the object that is passed to the update constraints method.
     delete constraints.series;
-    const id = this.props.machine.id;
-    this.props.updateMachineConstraints(id, constraints);
-    this.props.updateMachineSeries(id, series);
+    const id = this.props.machineAPI.machine.id;
+    const modelAPI = this.props.modelAPI;
+    modelAPI.updateMachineConstraints(id, constraints);
+    modelAPI.updateMachineSeries(id, series);
     this._toggleForm();
   }
 
@@ -111,9 +112,9 @@ class MachineViewMachine extends React.Component {
     if (!this.state.showForm) {
       return null;
     }
-    const machine = this.props.machine;
+    const machine = this.props.machineAPI.machine;
     const disabled = this.props.acl.isReadOnly();
-    const units = this.props.units.filterByMachine(
+    const units = this.props.dbAPI.units.filterByMachine(
       machine.id, this.props.type === 'machine');
     const buttons = [{
       title: 'Cancel',
@@ -135,8 +136,8 @@ class MachineViewMachine extends React.Component {
           currentSeries={machine.series}
           disabled={disabled}
           hasUnit={!!units.length}
-          providerType={this.props.providerType}
-          series={this.props.series}
+          providerType={this.props.modelAPI.providerType}
+          series={this.props.machineAPI.series}
           valuesChanged={this._updateConstraints.bind(this)} />
         <juju.components.ButtonRow
           buttons={buttons}
@@ -151,13 +152,15 @@ class MachineViewMachine extends React.Component {
     @returns {Object} the machine hardware elements.
   */
   _generateHardware() {
-    if (this.props.type === 'container' || !this.props.showConstraints ||
+    const props = this.props;
+    if (props.type === 'container' || !props.showConstraints ||
         this.state.showForm) {
       return;
     }
+    const machineAPI = props.machineAPI;
     return (
       <div className="machine-view__machine-hardware">
-        {this.props.generateMachineDetails(this.props.machine)}
+        {machineAPI.generateMachineDetails(machineAPI.machine)}
       </div>);
   }
 
@@ -171,25 +174,28 @@ class MachineViewMachine extends React.Component {
     if (this.state.showForm) {
       return null;
     }
-    var includeChildren = this.props.type === 'machine';
-    var units = this.props.units.filterByMachine(
-      this.props.machine.id, includeChildren);
+    const props = this.props;
+    const includeChildren = props.type === 'machine';
+    const units = props.dbAPI.units.filterByMachine(
+      props.machineAPI.machine.id, includeChildren);
     if (units.length === 0) {
       return;
     }
-    var components = [];
+    const components = [];
     units.forEach((unit) => {
-      var service = this.props.services.getById(unit.service);
-      if (this.props.type === 'machine' && (service.get('hide')
+      const service = props.dbAPI.applications.getById(unit.service);
+      if (props.type === 'machine' && (service.get('hide')
         || service.get('fade'))) {
         return;
       }
+      const propTypes = (
+        juju.components.MachineViewMachineUnit.DecoratedComponent.propTypes);
       components.push(
         <juju.components.MachineViewMachineUnit
-          acl={this.props.acl}
+          acl={props.acl.reshape(propTypes.acl)}
           key={unit.id}
-          machineType={this.props.type}
-          removeUnit={this.props.removeUnit}
+          machineType={props.type}
+          removeUnit={props.machineAPI.removeUnit}
           service={service}
           unit={unit} />);
     });
@@ -205,7 +211,8 @@ class MachineViewMachine extends React.Component {
     @method _destroyMachine
   */
   _destroyMachine() {
-    this.props.destroyMachines([this.props.machine.id], true);
+    const props = this.props;
+    props.modelAPI.destroyMachines([props.machineAPI.machine.id], true);
   }
 
   /**
@@ -214,9 +221,9 @@ class MachineViewMachine extends React.Component {
     @method _handleSelectMachine
   */
   _handleSelectMachine() {
-    var selectMachine = this.props.selectMachine;
+    const selectMachine = this.props.machineAPI.selectMachine;
     if (selectMachine) {
-      selectMachine(this.props.machine.id);
+      selectMachine(this.props.machineAPI.machine.id);
     }
   }
 
@@ -227,10 +234,10 @@ class MachineViewMachine extends React.Component {
     @returns {String} The collection of class names.
   */
   _generateClasses() {
-    var machine = this.props.machine;
+    var machine = this.props.machineAPI.machine;
     var classes = {
       'machine-view__machine--drop': this.props.isOver && this.props.canDrop,
-      'machine-view__machine--selected': this.props.selected,
+      'machine-view__machine--selected': this.props.machineAPI.selected,
       'machine-view__machine--uncommitted': machine.deleted ||
         machine.commitStatus === 'uncommitted',
       'machine-view__machine--root': machine.root
@@ -243,7 +250,7 @@ class MachineViewMachine extends React.Component {
   }
 
   render() {
-    var machine = this.props.machine;
+    var machine = this.props.machineAPI.machine;
     var menuItems = [{
       label: 'Destroy',
       action: !this.props.acl.isReadOnly() && this._destroyMachine.bind(this)
@@ -264,14 +271,14 @@ class MachineViewMachine extends React.Component {
         <juju.components.MoreMenu
           items={menuItems} />
         <div className="machine-view__machine-name">
-          {this.props.machine.displayName}
+          {this.props.machineAPI.machine.displayName}
         </div>
         {this._generateHardware()}
         {this._generateUnits()}
         {this._generateConstraintsForm()}
         <div className="machine-view__machine-drop-target">
           <div className="machine-view__machine-drop-message">
-            Add to {this.props.machine.displayName}
+            Add to {this.props.machineAPI.machine.displayName}
           </div>
         </div>
       </div>
@@ -280,27 +287,35 @@ class MachineViewMachine extends React.Component {
 };
 
 MachineViewMachine.propTypes = {
-  acl: PropTypes.object.isRequired,
+  acl: shapeup.shape({
+    isReadOnly: PropTypes.func.isRequired,
+    reshape: shapeup.reshapeFunc
+  }).frozen.isRequired,
   canDrop: PropTypes.bool.isRequired,
   connectDropTarget: PropTypes.func.isRequired,
-  destroyMachines: PropTypes.func.isRequired,
+  dbAPI: shapeup.shape({
+    applications: PropTypes.object.isRequired,
+    units: PropTypes.object.isRequired
+  }).isRequired,
   dropUnit: PropTypes.func.isRequired,
-  generateMachineDetails: PropTypes.func,
   isOver: PropTypes.bool.isRequired,
-  machine: PropTypes.object.isRequired,
-  machineModel: PropTypes.object,
-  parseConstraints: PropTypes.func,
-  providerType: PropTypes.string,
-  removeUnit: PropTypes.func,
-  selectMachine: PropTypes.func,
-  selected: PropTypes.bool,
-  series: PropTypes.array,
-  services: PropTypes.object.isRequired,
+  machineAPI: shapeup.shape({
+    generateMachineDetails: PropTypes.func,
+    machine: PropTypes.object.isRequired,
+    removeUnit: PropTypes.func,
+    series: PropTypes.array,
+    selectMachine: PropTypes.func,
+    selected: PropTypes.bool
+  }).isRequired,
+  modelAPI: shapeup.shape({
+    destroyMachines: PropTypes.func.isRequired,
+    providerType: PropTypes.string,
+    updateMachineConstraints: PropTypes.func,
+    updateMachineSeries: PropTypes.func
+  }).isRequired,
+  parseConstraints: PropTypes.func.isRequired,
   showConstraints: PropTypes.bool,
-  type: PropTypes.string.isRequired,
-  units: PropTypes.object.isRequired,
-  updateMachineConstraints: PropTypes.func,
-  updateMachineSeries: PropTypes.func
+  type: PropTypes.string.isRequired
 };
 
 YUI.add('machine-view-machine', function() {

--- a/jujugui/static/gui/src/app/components/machine-view/scale-up/scale-up.js
+++ b/jujugui/static/gui/src/app/components/machine-view/scale-up/scale-up.js
@@ -20,15 +20,15 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 class MachineViewScaleUp extends React.Component {
   /**
-    Display a list of services.
+    Display a list of applications.
 
     @method _generateServices
     @returns {Object} A unit list or onboarding.
   */
   _generateServices() {
-    var components = [];
-    var services = this.props.services.toArray();
-    services.forEach((service) => {
+    const components = [];
+    const applications = this.props.dbAPI.applications.toArray();
+    applications.forEach((service) => {
       if (service.get('subordinate')) {
         return;
       }
@@ -59,24 +59,25 @@ class MachineViewScaleUp extends React.Component {
   }
 
   /**
-    Add units to the services.
+    Add units to the applications.
 
     @method _handleAddUnits
-    @param {Object} e An event object.
+    @param {Object} evt An event object.
   */
-  _handleAddUnits(e) {
-    if (e) {
-      e.preventDefault();
+  _handleAddUnits(evt) {
+    if (evt) {
+      evt.preventDefault();
     }
-    var re = /(scaleUpUnit-)(.*)/;
+    const re = /(scaleUpUnit-)(.*)/;
+    const props = this.props;
     Object.keys(this.refs).forEach((ref) => {
-      var parts = re.exec(ref);
+      const parts = re.exec(ref);
       if (parts) {
-        var service = this.props.services.getById(parts[2]);
-        this.props.addGhostAndEcsUnits(service, this.refs[ref].value);
+        const application = props.dbAPI.applications.getById(parts[2]);
+        props.dbAPI.addGhostAndEcsUnits(application, this.refs[ref].value);
       }
     });
-    this.props.toggleScaleUp();
+    props.toggleScaleUp();
   }
 
   render() {
@@ -101,9 +102,13 @@ class MachineViewScaleUp extends React.Component {
 };
 
 MachineViewScaleUp.propTypes = {
-  acl: PropTypes.object.isRequired,
-  addGhostAndEcsUnits: PropTypes.func.isRequired,
-  services: PropTypes.object.isRequired,
+  acl: shapeup.shape({
+    isReadOnly: PropTypes.func.isRequired
+  }).frozen.isRequired,
+  dbAPI: shapeup.shape({
+    addGhostAndEcsUnits: PropTypes.func.isRequired,
+    applications: PropTypes.object.isRequired
+  }).isRequired,
   toggleScaleUp: PropTypes.func.isRequired
 };
 

--- a/jujugui/static/gui/src/app/components/machine-view/scale-up/test-scale-up.js
+++ b/jujugui/static/gui/src/app/components/machine-view/scale-up/test-scale-up.js
@@ -21,7 +21,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 var juju = {components: {}}; // eslint-disable-line no-unused-vars
 
 describe('MachineViewScaleUp', function() {
-  var acl, services;
+  let acl, applications;
 
   beforeAll(function(done) {
     // By loading this file it adds the component to the juju components.
@@ -29,8 +29,8 @@ describe('MachineViewScaleUp', function() {
   });
 
   beforeEach(() => {
-    acl = {isReadOnly: sinon.stub().returns(false)};
-    services = {
+    acl = shapeup.deepFreeze({isReadOnly: () => false});
+    applications = {
       toArray: sinon.stub().returns([{
         get: function (val) {
           switch (val) {
@@ -60,7 +60,7 @@ describe('MachineViewScaleUp', function() {
           }
         }
       }, {
-        // Subordinate services should not appear in the list.
+        // Subordinate applications should not appear in the list.
         get: function (val) {
           switch (val) {
             case 'id':
@@ -92,17 +92,19 @@ describe('MachineViewScaleUp', function() {
   });
 
   it('can render', function() {
-    var addGhostAndEcsUnits = sinon.stub();
-    var toggleScaleUp = sinon.stub();
-    var renderer = jsTestUtils.shallowRender(
+    const addGhostAndEcsUnits = sinon.stub();
+    const toggleScaleUp = sinon.stub();
+    const renderer = jsTestUtils.shallowRender(
       <juju.components.MachineViewScaleUp
         acl={acl}
-        addGhostAndEcsUnits={addGhostAndEcsUnits}
-        services={services}
+        dbAPI={{
+          addGhostAndEcsUnits: addGhostAndEcsUnits,
+          applications: applications
+        }}
         toggleScaleUp={toggleScaleUp} />, true);
-    var instance = renderer.getMountedInstance();
-    var output = renderer.getRenderOutput();
-    var expected = (
+    const instance = renderer.getMountedInstance();
+    const output = renderer.getRenderOutput();
+    const expected = (
       <form className="machine-view__scale-up"
         onSubmit={instance._handleAddUnits}>
         <ul className="machine-view__scale-up-units">
@@ -158,18 +160,21 @@ describe('MachineViewScaleUp', function() {
   });
 
   it('can disable controls when read only', function() {
-    acl.isReadOnly = sinon.stub().returns(true);
-    var addGhostAndEcsUnits = sinon.stub();
-    var toggleScaleUp = sinon.stub();
-    var renderer = jsTestUtils.shallowRender(
+    acl = shapeup.deepFreeze({isReadOnly: () => true});
+
+    const addGhostAndEcsUnits = sinon.stub();
+    const toggleScaleUp = sinon.stub();
+    const renderer = jsTestUtils.shallowRender(
       <juju.components.MachineViewScaleUp
         acl={acl}
-        addGhostAndEcsUnits={addGhostAndEcsUnits}
-        services={services}
+        dbAPI={{
+          addGhostAndEcsUnits: addGhostAndEcsUnits,
+          applications: applications
+        }}
         toggleScaleUp={toggleScaleUp} />, true);
-    var instance = renderer.getMountedInstance();
-    var output = renderer.getRenderOutput();
-    var expected = (
+    const instance = renderer.getMountedInstance();
+    const output = renderer.getRenderOutput();
+    const expected = (
       <form className="machine-view__scale-up"
         onSubmit={instance._handleAddUnits}>
         <ul className="machine-view__scale-up-units">
@@ -207,7 +212,8 @@ describe('MachineViewScaleUp', function() {
               ref="scaleUpUnit-222222$"
               type="number"
               min="0"
-              step="1" />
+              step="1"
+            />
           </li>
         </ul>
         <juju.components.ButtonRow buttons={[{
@@ -224,20 +230,23 @@ describe('MachineViewScaleUp', function() {
     expect(output).toEqualJSX(expected);
   });
 
-  it('can scale services', function() {
-    var addGhostAndEcsUnits = sinon.stub();
-    var toggleScaleUp = sinon.stub();
-    var output = testUtils.renderIntoDocument(
+  it('can scale applications', function() {
+    const addGhostAndEcsUnits = sinon.stub();
+    const toggleScaleUp = sinon.stub();
+    const output = testUtils.renderIntoDocument(
       <juju.components.MachineViewScaleUp
         acl={acl}
-        addGhostAndEcsUnits={addGhostAndEcsUnits}
-        services={services}
-        toggleScaleUp={toggleScaleUp} />, true);
-    var confirm = ReactDOM.findDOMNode(output).querySelector(
+        dbAPI={{
+          addGhostAndEcsUnits: addGhostAndEcsUnits,
+          applications: applications
+        }}
+        toggleScaleUp={toggleScaleUp}
+      />, true);
+    const confirm = ReactDOM.findDOMNode(output).querySelector(
       '.button--neutral');
-    var input1 = output.refs['scaleUpUnit-111111$'];
+    const input1 = output.refs['scaleUpUnit-111111$'];
     input1.value = '5';
-    var input2 = output.refs['scaleUpUnit-222222$'];
+    const input2 = output.refs['scaleUpUnit-222222$'];
     input2.value = '9';
     testUtils.Simulate.click(confirm);
     assert.equal(addGhostAndEcsUnits.callCount, 2);
@@ -247,10 +256,10 @@ describe('MachineViewScaleUp', function() {
     assert.equal(addGhostAndEcsUnits.args[1][1], '9');
   });
 
-  it('can scale services with dashes in the name', () => {
-    var addGhostAndEcsUnits = sinon.stub();
-    var toggleScaleUp = sinon.stub();
-    var services = {
+  it('can scale applications with dashes in the name', () => {
+    const addGhostAndEcsUnits = sinon.stub();
+    const toggleScaleUp = sinon.stub();
+    const applications = {
       toArray: sinon.stub().returns([{
         get: function (val) {
           switch (val) {
@@ -270,15 +279,18 @@ describe('MachineViewScaleUp', function() {
         return 'juju-gui';
       }
     };
-    var output = testUtils.renderIntoDocument(
+    const output = testUtils.renderIntoDocument(
       <juju.components.MachineViewScaleUp
         acl={acl}
-        addGhostAndEcsUnits={addGhostAndEcsUnits}
-        services={services}
-        toggleScaleUp={toggleScaleUp} />, true);
-    var confirm = ReactDOM.findDOMNode(output).querySelector(
+        dbAPI={{
+          addGhostAndEcsUnits: addGhostAndEcsUnits,
+          applications: applications
+        }}
+        toggleScaleUp={toggleScaleUp}
+      />, true);
+    const confirm = ReactDOM.findDOMNode(output).querySelector(
       '.button--neutral');
-    var input1 = output.refs['scaleUpUnit-juju-gui'];
+    const input1 = output.refs['scaleUpUnit-juju-gui'];
     input1.value = '5';
     testUtils.Simulate.click(confirm);
     assert.equal(addGhostAndEcsUnits.callCount, 1);

--- a/jujugui/static/gui/src/app/components/machine-view/test-machine-view.js
+++ b/jujugui/static/gui/src/app/components/machine-view/test-machine-view.js
@@ -29,7 +29,7 @@ describe('MachineView', function() {
   });
 
   beforeEach(function() {
-    acl = {isReadOnly: sinon.stub().returns(false)};
+    acl = shapeup.deepFreeze(shapeup.addReshape({isReadOnly: () => false}));
     parseConstraints = sinon.stub();
     generateMachineDetails = sinon.stub();
     machines = {
@@ -56,7 +56,7 @@ describe('MachineView', function() {
     const units = {
       filterByMachine: sinon.stub().returns([])
     };
-    const services = {
+    const applications = {
       size: sinon.stub().returns(0)
     };
     const placeUnit = sinon.stub();
@@ -65,21 +65,28 @@ describe('MachineView', function() {
       // test the internal component so we access it via DecoratedComponent.
       <juju.components.MachineView.DecoratedComponent
         acl={acl}
-        addGhostAndEcsUnits={sinon.stub()}
-        autoPlaceUnits={sinon.stub()}
         changeState={sinon.stub()}
-        createMachine={sinon.stub()}
-        destroyMachines={sinon.stub()}
-        environmentName="My Env"
+        dbAPI={{
+          addGhostAndEcsUnits: sinon.stub(),
+          applications: applications,
+          machines: machines,
+          modelName: 'My Model',
+          reshape: sinon.stub(),
+          units: units
+        }}
         generateMachineDetails={generateMachineDetails}
-        machines={machines}
+        modelAPI={{
+          autoPlaceUnits: sinon.stub(),
+          createMachine: sinon.stub(),
+          destroyMachines: sinon.stub(),
+          placeUnit: placeUnit,
+          removeUnits: sinon.stub(),
+          reshape: shapeup.reshapeFunc,
+          updateMachineConstraints: sinon.stub(),
+          updateMachineSeries: sinon.stub()
+        }}
         parseConstraints={parseConstraints}
-        placeUnit={placeUnit}
-        removeUnits={sinon.stub()}
-        services={services}
-        units={units}
-        updateMachineConstraints={sinon.stub()}
-        updateMachineSeries={sinon.stub()} />, true);
+      />, true);
     const instance = renderer.getMountedInstance();
     const output = renderer.getRenderOutput();
     const machineMenuItems = output.props.children.props.children[1]
@@ -150,7 +157,7 @@ describe('MachineView', function() {
               id: 'cpu',
               action: machineMenuItems[8].action
             }]}
-            title="My Env (0)"
+            title="My Model (0)"
             type="machine">
             {undefined}
             <div className="machine-view__column-onboarding">
@@ -208,7 +215,7 @@ describe('MachineView', function() {
     const units = {
       filterByMachine: sinon.stub().returns([])
     };
-    const services = {
+    const applications = {
       size: sinon.stub().returns(0)
     };
     const renderer = jsTestUtils.shallowRender(
@@ -216,21 +223,26 @@ describe('MachineView', function() {
       // test the internal component so we access it via DecoratedComponent.
       <juju.components.MachineView.DecoratedComponent
         acl={acl}
-        addGhostAndEcsUnits={sinon.stub()}
-        autoPlaceUnits={sinon.stub()}
         changeState={sinon.stub()}
-        createMachine={sinon.stub()}
-        destroyMachines={sinon.stub()}
-        environmentName="My Env"
+        dbAPI={shapeup.addReshape({
+          addGhostAndEcsUnits: sinon.stub(),
+          applications: applications,
+          machines: machines,
+          modelName: 'My Model',
+          units: units
+        })}
         generateMachineDetails={generateMachineDetails}
-        machines={machines}
+        modelAPI={shapeup.addReshape({
+          autoPlaceUnits: sinon.stub(),
+          createMachine: sinon.stub(),
+          destroyMachines: sinon.stub(),
+          placeUnit: sinon.stub(),
+          removeUnits: sinon.stub(),
+          updateMachineConstraints: sinon.stub(),
+          updateMachineSeries: sinon.stub()
+        })}
         parseConstraints={parseConstraints}
-        placeUnit={sinon.stub()}
-        removeUnits={sinon.stub()}
-        services={services}
-        units={units}
-        updateMachineConstraints={sinon.stub()}
-        updateMachineSeries={sinon.stub()} />, true);
+      />, true);
     const instance = renderer.getMountedInstance();
     const output = renderer.getRenderOutput();
     const expected = (
@@ -255,7 +267,7 @@ describe('MachineView', function() {
     const units = {
       filterByMachine: sinon.stub().returns([])
     };
-    const services = {
+    const applications = {
       size: sinon.stub().returns(0)
     };
     const changeState = sinon.stub();
@@ -264,21 +276,26 @@ describe('MachineView', function() {
       // test the internal component so we access it via DecoratedComponent.
       <juju.components.MachineView.DecoratedComponent
         acl={acl}
-        addGhostAndEcsUnits={sinon.stub()}
-        autoPlaceUnits={sinon.stub()}
         changeState={changeState}
-        createMachine={sinon.stub()}
-        destroyMachines={sinon.stub()}
-        environmentName="My Env"
+        dbAPI={shapeup.addReshape({
+          addGhostAndEcsUnits: sinon.stub(),
+          applications: applications,
+          machines: machines,
+          modelName: 'My Model',
+          units: units
+        })}
         generateMachineDetails={generateMachineDetails}
-        machines={machines}
+        modelAPI={shapeup.addReshape({
+          autoPlaceUnits: sinon.stub(),
+          createMachine: sinon.stub(),
+          destroyMachines: sinon.stub(),
+          placeUnit: sinon.stub(),
+          removeUnits: sinon.stub(),
+          updateMachineConstraints: sinon.stub(),
+          updateMachineSeries: sinon.stub()
+        })}
         parseConstraints={parseConstraints}
-        placeUnit={sinon.stub()}
-        removeUnits={sinon.stub()}
-        services={services}
-        units={units}
-        updateMachineConstraints={sinon.stub()}
-        updateMachineSeries={sinon.stub()} />, true);
+      />, true);
     const output = renderer.getRenderOutput();
     output.props.children.props.children[0].props.children[1].props.children[1]
       .props.children[1].props.onClick();
@@ -290,7 +307,7 @@ describe('MachineView', function() {
     const units = {
       filterByMachine: sinon.stub().returns([])
     };
-    const services = {
+    const applications = {
       size: sinon.stub().returns(1)
     };
     const output = jsTestUtils.shallowRender(
@@ -298,21 +315,26 @@ describe('MachineView', function() {
       // test the internal component so we access it via DecoratedComponent.
       <juju.components.MachineView.DecoratedComponent
         acl={acl}
-        addGhostAndEcsUnits={sinon.stub()}
-        autoPlaceUnits={sinon.stub()}
         changeState={sinon.stub()}
-        createMachine={sinon.stub()}
-        destroyMachines={sinon.stub()}
-        environmentName="My Env"
+        dbAPI={shapeup.addReshape({
+          addGhostAndEcsUnits: sinon.stub(),
+          applications: applications,
+          machines: machines,
+          modelName: 'My Model',
+          units: units
+        })}
         generateMachineDetails={generateMachineDetails}
-        machines={machines}
+        modelAPI={shapeup.addReshape({
+          autoPlaceUnits: sinon.stub(),
+          createMachine: sinon.stub(),
+          destroyMachines: sinon.stub(),
+          placeUnit: sinon.stub(),
+          removeUnits: sinon.stub(),
+          updateMachineConstraints: sinon.stub(),
+          updateMachineSeries: sinon.stub()
+        })}
         parseConstraints={parseConstraints}
-        placeUnit={sinon.stub()}
-        removeUnits={sinon.stub()}
-        services={services}
-        units={units}
-        updateMachineConstraints={sinon.stub()}
-        updateMachineSeries={sinon.stub()} />);
+      />);
     const expected = (
       <div className="machine-view__column-onboarding">
         <juju.components.SvgIcon name="task-done_16"
@@ -325,42 +347,48 @@ describe('MachineView', function() {
   });
 
   it('can display a service scale up form', function() {
-    const addGhostAndEcsUnits = sinon.stub();
     const units = {
       filterByMachine: sinon.stub().returns([])
     };
-    const services = {
+    const applications = {
       size: sinon.stub().returns(1)
     };
+    const dbAPI = shapeup.addReshape({
+      addGhostAndEcsUnits: sinon.stub(),
+      applications: applications,
+      machines: machines,
+      modelName: 'My Model',
+      units: units
+    });
     const renderer = jsTestUtils.shallowRender(
       // The component is wrapped to handle drag and drop, but we just want to
       // test the internal component so we access it via DecoratedComponent.
       <juju.components.MachineView.DecoratedComponent
         acl={acl}
-        addGhostAndEcsUnits={addGhostAndEcsUnits}
-        autoPlaceUnits={sinon.stub()}
         changeState={sinon.stub()}
-        createMachine={sinon.stub()}
-        destroyMachines={sinon.stub()}
-        environmentName="My Env"
+        dbAPI={dbAPI}
         generateMachineDetails={generateMachineDetails}
-        machines={machines}
+        modelAPI={shapeup.addReshape({
+          autoPlaceUnits: sinon.stub(),
+          createMachine: sinon.stub(),
+          destroyMachines: sinon.stub(),
+          placeUnit: sinon.stub(),
+          removeUnits: sinon.stub(),
+          updateMachineConstraints: sinon.stub(),
+          updateMachineSeries: sinon.stub()
+        })}
         parseConstraints={parseConstraints}
-        placeUnit={sinon.stub()}
-        removeUnits={sinon.stub()}
-        services={services}
-        units={units}
-        updateMachineConstraints={sinon.stub()}
-        updateMachineSeries={sinon.stub()} />, true);
+      />, true);
     const instance = renderer.getMountedInstance();
     instance._toggleScaleUp();
     const output = renderer.getRenderOutput();
+    const propTypes = juju.components.MachineViewScaleUp.propTypes;
     const expected = (
       <juju.components.MachineViewScaleUp
-        acl={acl}
-        addGhostAndEcsUnits={addGhostAndEcsUnits}
-        services={services}
-        toggleScaleUp={instance._toggleScaleUp} />);
+        acl={acl.reshape(propTypes.acl)}
+        dbAPI={dbAPI.reshape(propTypes.dbAPI)}
+        toggleScaleUp={instance._toggleScaleUp}
+      />);
     expect(
       output.props.children.props.children[0].props.children[0]).toEqualJSX(
       expected);
@@ -384,62 +412,73 @@ describe('MachineView', function() {
     const getStub = sinon.stub();
     getStub.withArgs('icon').returns('django.svg');
     getStub.withArgs('subordinate').returns(false);
-    const services = {
+    const applications = {
       size: sinon.stub().returns(1),
       getById: sinon.stub().returns({
         get: getStub
       })
     };
+    const dbAPI = shapeup.addReshape({
+      addGhostAndEcsUnits: sinon.stub(),
+      applications: applications,
+      machines: machines,
+      modelName: 'My Model',
+      units: units
+    });
+    const modelAPI = shapeup.addReshape({
+      autoPlaceUnits: autoPlaceUnits,
+      createMachine: createMachine,
+      destroyMachines: sinon.stub(),
+      placeUnit: placeUnit,
+      providerType: 'azure',
+      removeUnits: removeUnits,
+      updateMachineConstraints: sinon.stub(),
+      updateMachineSeries: sinon.stub()
+    });
     const renderer = jsTestUtils.shallowRender(
       // The component is wrapped to handle drag and drop, but we just want to
       // test the internal component so we access it via DecoratedComponent.
       <juju.components.MachineView.DecoratedComponent
         acl={acl}
-        addGhostAndEcsUnits={sinon.stub()}
-        autoPlaceUnits={autoPlaceUnits}
         changeState={sinon.stub()}
-        createMachine={createMachine}
-        destroyMachines={sinon.stub()}
-        environmentName="My Env"
+        dbAPI={dbAPI}
         generateMachineDetails={generateMachineDetails}
-        machines={machines}
+        modelAPI={modelAPI}
         parseConstraints={parseConstraints}
-        placeUnit={placeUnit}
-        providerType={'azure'}
-        removeUnits={removeUnits}
         series={['trusty', 'xenial']}
-        services={services}
-        units={units}
-        updateMachineConstraints={sinon.stub()}
-        updateMachineSeries={sinon.stub()} />, true);
+      />, true);
     const instance = renderer.getMountedInstance();
     const output = renderer.getRenderOutput();
+    const propTypes = (
+      juju.components.MachineViewUnplacedUnit.DecoratedComponent.propTypes);
     const expected = (
       <ul className="machine-view__list">
         <juju.components.MachineViewUnplacedUnit
-          acl={acl}
-          createMachine={createMachine}
-          icon="django.svg"
+          acl={acl.reshape(propTypes.acl)}
+          dbAPI={dbAPI.reshape(propTypes.dbAPI)}
           key="django/0"
-          machines={machines}
-          removeUnit={instance._removeUnit}
-          placeUnit={placeUnit}
-          providerType={'azure'}
-          selectMachine={instance.selectMachine}
+          modelAPI={modelAPI.reshape(propTypes.modelAPI)}
           series={['trusty', 'xenial']}
-          unit={unitList[0]} />
+          unitAPI={{
+            icon: 'django.svg',
+            removeUnit: instance._removeUnit,
+            selectMachine: instance.selectMachine,
+            unit: unitList[0]
+          }}
+        />
         <juju.components.MachineViewUnplacedUnit
-          acl={acl}
-          createMachine={createMachine}
-          icon="django.svg"
+          acl={acl.reshape(propTypes.acl)}
+          dbAPI={dbAPI.reshape(propTypes.dbAPI)}
           key="django/1"
-          machines={machines}
-          placeUnit={placeUnit}
-          providerType={'azure'}
-          removeUnit={instance._removeUnit}
-          selectMachine={instance.selectMachine}
+          modelAPI={modelAPI.reshape(propTypes.modelAPI)}
           series={['trusty', 'xenial']}
-          unit={unitList[1]} />
+          unitAPI={{
+            icon: 'django.svg',
+            removeUnit: instance._removeUnit,
+            selectMachine: instance.selectMachine,
+            unit: unitList[1]
+          }}
+        />
       </ul>);
     expect(
       output.props.children.props.children[0].props.children[1]
@@ -465,50 +504,60 @@ describe('MachineView', function() {
     getStub.withArgs('icon').returns('django.svg');
     getStub.withArgs('subordinate').onFirstCall().returns(false)
       .onSecondCall().returns(true);
-    const services = {
+    const applications = {
       size: sinon.stub().returns(1),
       getById: sinon.stub().returns({
         get: getStub
       })
     };
+    const dbAPI = shapeup.addReshape({
+      addGhostAndEcsUnits: sinon.stub(),
+      applications: applications,
+      machines: machines,
+      modelName: 'My Model',
+      units: units
+    });
+    const modelAPI = shapeup.addReshape({
+      autoPlaceUnits: autoPlaceUnits,
+      createMachine: createMachine,
+      destroyMachines: sinon.stub(),
+      placeUnit: placeUnit,
+      providerType: 'azure',
+      removeUnits: removeUnits,
+      updateMachineConstraints: sinon.stub(),
+      updateMachineSeries: sinon.stub()
+    });
     const renderer = jsTestUtils.shallowRender(
       // The component is wrapped to handle drag and drop, but we just want to
       // test the internal component so we access it via DecoratedComponent.
       <juju.components.MachineView.DecoratedComponent
         acl={acl}
-        addGhostAndEcsUnits={sinon.stub()}
-        autoPlaceUnits={autoPlaceUnits}
         changeState={sinon.stub()}
-        createMachine={createMachine}
-        destroyMachines={sinon.stub()}
-        environmentName="My Env"
+        dbAPI={dbAPI}
         generateMachineDetails={generateMachineDetails}
-        machines={machines}
+        modelAPI={modelAPI}
         parseConstraints={parseConstraints}
-        placeUnit={placeUnit}
-        providerType={'azure'}
-        removeUnits={removeUnits}
         series={['trusty', 'xenial']}
-        services={services}
-        units={units}
-        updateMachineConstraints={sinon.stub()}
-        updateMachineSeries={sinon.stub()} />, true);
+      />, true);
     const instance = renderer.getMountedInstance();
     const output = renderer.getRenderOutput();
+    const propTypes = (
+      juju.components.MachineViewUnplacedUnit.DecoratedComponent.propTypes);
     const expected = (
       <ul className="machine-view__list">
         {[<juju.components.MachineViewUnplacedUnit
-          acl={acl}
-          createMachine={createMachine}
-          icon="django.svg"
+          acl={acl.reshape(propTypes.acl)}
+          dbAPI={dbAPI.reshape(propTypes.dbAPI)}
           key="django/0"
-          machines={machines}
-          providerType={'azure'}
-          removeUnit={instance._removeUnit}
-          placeUnit={placeUnit}
-          selectMachine={instance.selectMachine}
+          modelAPI={modelAPI.reshape(propTypes.modelAPI)}
           series={['trusty', 'xenial']}
-          unit={unitList[0]} />]}
+          unitAPI={{
+            icon: 'django.svg',
+            removeUnit: instance._removeUnit,
+            selectMachine: instance.selectMachine,
+            unit: unitList[0]
+          }}
+        />]}
       </ul>);
     expect(
       output.props.children.props.children[0].props.children[1]
@@ -529,7 +578,7 @@ describe('MachineView', function() {
     const getStub = sinon.stub();
     getStub.withArgs('icon').returns('django.svg');
     getStub.withArgs('subordinate').returns(true);
-    const services = {
+    const applications = {
       size: sinon.stub().returns(1),
       getById: sinon.stub().returns({
         get: getStub
@@ -540,21 +589,26 @@ describe('MachineView', function() {
       // test the internal component so we access it via DecoratedComponent.
       <juju.components.MachineView.DecoratedComponent
         acl={acl}
-        addGhostAndEcsUnits={sinon.stub()}
-        autoPlaceUnits={sinon.stub()}
         changeState={sinon.stub()}
-        createMachine={sinon.stub()}
-        destroyMachines={sinon.stub()}
-        environmentName="My Env"
+        dbAPI={shapeup.addReshape({
+          addGhostAndEcsUnits: sinon.stub(),
+          applications: applications,
+          machines: machines,
+          modelName: 'My Model',
+          units: units
+        })}
         generateMachineDetails={generateMachineDetails}
-        machines={machines}
+        modelAPI={shapeup.addReshape({
+          autoPlaceUnits: sinon.stub(),
+          createMachine: sinon.stub(),
+          destroyMachines: sinon.stub(),
+          placeUnit: sinon.stub(),
+          removeUnits: sinon.stub(),
+          updateMachineConstraints: sinon.stub(),
+          updateMachineSeries: sinon.stub()
+        })}
         parseConstraints={parseConstraints}
-        placeUnit={sinon.stub()}
-        removeUnits={sinon.stub()}
-        services={services}
-        units={units}
-        updateMachineConstraints={sinon.stub()}
-        updateMachineSeries={sinon.stub()} />);
+      />);
     const expected = (
       <div className="machine-view__column-onboarding">
         <juju.components.SvgIcon name="task-done_16"
@@ -581,7 +635,7 @@ describe('MachineView', function() {
     const getStub = sinon.stub();
     getStub.withArgs('icon').returns('django.svg');
     getStub.withArgs('subordinate').returns(false);
-    const services = {
+    const applications = {
       size: sinon.stub().returns(1),
       getById: sinon.stub().returns({
         get: getStub
@@ -590,21 +644,26 @@ describe('MachineView', function() {
     const component = renderIntoDocument(
       <juju.components.MachineView
         acl={acl}
-        addGhostAndEcsUnits={sinon.stub()}
-        autoPlaceUnits={autoPlaceUnits}
         changeState={sinon.stub()}
-        createMachine={sinon.stub()}
-        destroyMachines={sinon.stub()}
-        environmentName="My Env"
+        dbAPI={shapeup.addReshape({
+          addGhostAndEcsUnits: sinon.stub(),
+          applications: applications,
+          machines: machines,
+          modelName: 'My Model',
+          units: units
+        })}
         generateMachineDetails={generateMachineDetails}
-        machines={machines}
+        modelAPI={shapeup.addReshape({
+          autoPlaceUnits: autoPlaceUnits,
+          createMachine: sinon.stub(),
+          destroyMachines: sinon.stub(),
+          placeUnit: sinon.stub(),
+          removeUnits: sinon.stub(),
+          updateMachineConstraints: sinon.stub(),
+          updateMachineSeries: sinon.stub()
+        })}
         parseConstraints={parseConstraints}
-        placeUnit={sinon.stub()}
-        removeUnits={sinon.stub()}
-        services={services}
-        units={units}
-        updateMachineConstraints={sinon.stub()}
-        updateMachineSeries={sinon.stub()} />);
+      />);
     const node = queryComponentSelector(component,
       '.machine-view__auto-place .button--inline-neutral');
     testUtils.Simulate.click(node);
@@ -612,7 +671,7 @@ describe('MachineView', function() {
   });
 
   it('can disable auto place when read only', function() {
-    acl.isReadOnly = sinon.stub().returns(true);
+    acl = shapeup.deepFreeze(shapeup.addReshape({isReadOnly: () => true}));
     const autoPlaceUnits = sinon.stub();
     const unitList = [{
       id: 'django/0',
@@ -627,7 +686,7 @@ describe('MachineView', function() {
     const getStub = sinon.stub();
     getStub.withArgs('icon').returns('django.svg');
     getStub.withArgs('subordinate').returns(false);
-    const services = {
+    const applications = {
       size: sinon.stub().returns(1),
       getById: sinon.stub().returns({
         get: getStub
@@ -636,21 +695,26 @@ describe('MachineView', function() {
     const output = jsTestUtils.shallowRender(
       <juju.components.MachineView.DecoratedComponent
         acl={acl}
-        addGhostAndEcsUnits={sinon.stub()}
-        autoPlaceUnits={autoPlaceUnits}
         changeState={sinon.stub()}
-        createMachine={sinon.stub()}
-        destroyMachines={sinon.stub()}
-        environmentName="My Env"
+        dbAPI={shapeup.addReshape({
+          addGhostAndEcsUnits: sinon.stub(),
+          applications: applications,
+          machines: machines,
+          modelName: 'My Model',
+          units: units
+        })}
         generateMachineDetails={generateMachineDetails}
-        machines={machines}
+        modelAPI={shapeup.addReshape({
+          autoPlaceUnits: autoPlaceUnits,
+          createMachine: sinon.stub(),
+          destroyMachines: sinon.stub(),
+          placeUnit: sinon.stub(),
+          removeUnits: sinon.stub(),
+          updateMachineConstraints: sinon.stub(),
+          updateMachineSeries: sinon.stub()
+        })}
         parseConstraints={parseConstraints}
-        placeUnit={sinon.stub()}
-        removeUnits={sinon.stub()}
-        services={services}
-        units={units}
-        updateMachineConstraints={sinon.stub()}
-        updateMachineSeries={sinon.stub()} />);
+      />);
     const expected = (
       <juju.components.GenericButton
         action={autoPlaceUnits}
@@ -671,7 +735,7 @@ describe('MachineView', function() {
     const units = {
       filterByMachine: sinon.stub().returns([])
     };
-    const services = {
+    const applications = {
       size: sinon.stub().returns(0)
     };
     const renderer = jsTestUtils.shallowRender(
@@ -679,21 +743,26 @@ describe('MachineView', function() {
       // test the internal component so we access it via DecoratedComponent.
       <juju.components.MachineView.DecoratedComponent
         acl={acl}
-        addGhostAndEcsUnits={sinon.stub()}
-        autoPlaceUnits={sinon.stub()}
         changeState={sinon.stub()}
-        createMachine={sinon.stub()}
-        destroyMachines={sinon.stub()}
-        environmentName="My Env"
+        dbAPI={shapeup.addReshape({
+          addGhostAndEcsUnits: sinon.stub(),
+          applications: applications,
+          machines: machines,
+          modelName: 'My Model',
+          units: units
+        })}
         generateMachineDetails={generateMachineDetails}
-        machines={machines}
+        modelAPI={shapeup.addReshape({
+          autoPlaceUnits: sinon.stub(),
+          createMachine: sinon.stub(),
+          destroyMachines: sinon.stub(),
+          placeUnit: sinon.stub(),
+          removeUnits: sinon.stub(),
+          updateMachineConstraints: sinon.stub(),
+          updateMachineSeries: sinon.stub()
+        })}
         parseConstraints={parseConstraints}
-        placeUnit={sinon.stub()}
-        removeUnits={sinon.stub()}
-        services={services}
-        units={units}
-        updateMachineConstraints={sinon.stub()}
-        updateMachineSeries={sinon.stub()} />, true);
+      />, true);
     const instance = renderer.getMountedInstance();
     const output = renderer.getRenderOutput();
     const expected = (
@@ -735,7 +804,7 @@ describe('MachineView', function() {
     const units = {
       filterByMachine: sinon.stub().returns([])
     };
-    const services = {
+    const applications = {
       size: sinon.stub().returns(0)
     };
     const destroyMachines = sinon.stub();
@@ -744,21 +813,26 @@ describe('MachineView', function() {
       // test the internal component so we access it via DecoratedComponent.
       <juju.components.MachineView.DecoratedComponent
         acl={acl}
-        addGhostAndEcsUnits={sinon.stub()}
-        autoPlaceUnits={sinon.stub()}
         changeState={sinon.stub()}
-        createMachine={sinon.stub()}
-        destroyMachines={destroyMachines}
-        environmentName="My Env"
+        dbAPI={shapeup.addReshape({
+          addGhostAndEcsUnits: sinon.stub(),
+          applications: applications,
+          machines: machines,
+          modelName: 'My Model',
+          units: units
+        })}
         generateMachineDetails={generateMachineDetails}
-        machines={machines}
+        modelAPI={shapeup.addReshape({
+          autoPlaceUnits: sinon.stub(),
+          createMachine: sinon.stub(),
+          destroyMachines: destroyMachines,
+          placeUnit: sinon.stub(),
+          removeUnits: sinon.stub(),
+          updateMachineConstraints: sinon.stub(),
+          updateMachineSeries: sinon.stub()
+        })}
         parseConstraints={parseConstraints}
-        placeUnit={sinon.stub()}
-        removeUnits={sinon.stub()}
-        services={services}
-        units={units}
-        updateMachineConstraints={sinon.stub()}
-        updateMachineSeries={sinon.stub()} />, true);
+      />, true);
     const output = renderer.getRenderOutput();
     const expected = (
       <div className="machine-view__column-onboarding">
@@ -789,76 +863,79 @@ describe('MachineView', function() {
     const units = {
       filterByMachine: sinon.stub().returns([])
     };
-    const services = {
+    const applications = {
       size: sinon.stub().returns(0)
     };
     const destroyMachines = sinon.stub();
-    const updateMachineConstraints = sinon.stub();
-    const updateMachineSeries = sinon.stub();
+    const dbAPI = shapeup.addReshape({
+      addGhostAndEcsUnits: sinon.stub(),
+      applications: applications,
+      machines: machines,
+      modelName: 'My Model',
+      units: units
+    });
+    const modelAPI = shapeup.addReshape({
+      autoPlaceUnits: sinon.stub(),
+      createMachine: sinon.stub(),
+      destroyMachines: destroyMachines,
+      placeUnit: sinon.stub(),
+      providerType: 'aws',
+      removeUnits: sinon.stub(),
+      updateMachineConstraints: sinon.stub(),
+      updateMachineSeries: sinon.stub()
+    });
     const renderer = jsTestUtils.shallowRender(
       // The component is wrapped to handle drag and drop, but we just want to
       // test the internal component so we access it via DecoratedComponent.
       <juju.components.MachineView.DecoratedComponent
         acl={acl}
-        addGhostAndEcsUnits={sinon.stub()}
-        autoPlaceUnits={sinon.stub()}
         changeState={sinon.stub()}
-        createMachine={sinon.stub()}
-        destroyMachines={destroyMachines}
-        environmentName="My Env"
+        dbAPI={dbAPI}
         generateMachineDetails={generateMachineDetails}
-        machines={machines}
+        modelAPI={modelAPI}
         parseConstraints={parseConstraints}
-        placeUnit={sinon.stub()}
-        providerType="aws"
-        removeUnits={sinon.stub()}
         series={['wily']}
-        services={services}
-        units={units}
-        updateMachineConstraints={updateMachineConstraints}
-        updateMachineSeries={updateMachineSeries} />, true);
+      />, true);
     const instance = renderer.getMountedInstance();
     const output = renderer.getRenderOutput();
+    const propTypes = (
+      juju.components.MachineViewMachine.DecoratedComponent.propTypes);
     const expected = (
       <ul className="machine-view__list">
         <juju.components.MachineViewMachine
-          acl={acl}
-          destroyMachines={destroyMachines}
+          acl={acl.reshape(propTypes.acl)}
+          dbAPI={dbAPI.reshape(propTypes.dbAPI)}
           dropUnit={instance._dropUnit}
-          generateMachineDetails={generateMachineDetails}
           key="new0"
-          machine={machineList[0]}
-          machineModel={{get: sinon.stub()}}
+          machineAPI={{
+            generateMachineDetails: generateMachineDetails,
+            machine: machineList[0],
+            selected: true,
+            selectMachine: instance.selectMachine,
+            series: ['wily']
+          }}
+          modelAPI={modelAPI.reshape(propTypes.modelAPI)}
           parseConstraints={parseConstraints}
-          providerType="aws"
-          selected={true}
-          selectMachine={instance.selectMachine}
-          series={['wily']}
-          services={services}
           showConstraints={true}
           type="machine"
-          units={units}
-          updateMachineConstraints={updateMachineConstraints}
-          updateMachineSeries={updateMachineSeries} />
+        />
         <juju.components.MachineViewMachine
-          acl={acl}
-          destroyMachines={destroyMachines}
+          acl={acl.reshape(propTypes.acl)}
+          dbAPI={dbAPI.reshape(propTypes.dbAPI)}
           dropUnit={instance._dropUnit}
-          generateMachineDetails={generateMachineDetails}
           key="new1"
-          machine={machineList[1]}
-          machineModel={{get: sinon.stub()}}
+          machineAPI={{
+            generateMachineDetails: generateMachineDetails,
+            machine: machineList[1],
+            selected: false,
+            selectMachine: instance.selectMachine,
+            series: ['wily']
+          }}
+          modelAPI={modelAPI.reshape(propTypes.modelAPI)}
           parseConstraints={parseConstraints}
-          providerType="aws"
-          selected={false}
-          selectMachine={instance.selectMachine}
-          series={['wily']}
-          services={services}
           showConstraints={true}
           type="machine"
-          units={units}
-          updateMachineConstraints={updateMachineConstraints}
-          updateMachineSeries={updateMachineSeries} />
+        />
       </ul>);
     expect(
       output.props.children.props.children[1].props.children[1]
@@ -884,80 +961,85 @@ describe('MachineView', function() {
     const units = {
       filterByMachine: sinon.stub().returns([])
     };
-    const services = {
+    const applications = {
       size: sinon.stub().returns(0)
     };
     const destroyMachines = sinon.stub();
     const updateMachineConstraints = sinon.stub();
     const updateMachineSeries = sinon.stub();
+    const dbAPI = shapeup.addReshape({
+      addGhostAndEcsUnits: sinon.stub(),
+      applications: applications,
+      machines: machines,
+      modelName: 'My Model',
+      units: units
+    });
+    const modelAPI = shapeup.addReshape({
+      autoPlaceUnits: sinon.stub(),
+      createMachine: sinon.stub(),
+      destroyMachines: destroyMachines,
+      placeUnit: sinon.stub(),
+      providerType: 'aws',
+      removeUnits: sinon.stub(),
+      updateMachineConstraints: updateMachineConstraints,
+      updateMachineSeries: updateMachineSeries
+    });
     const renderer = jsTestUtils.shallowRender(
       <juju.components.MachineView.DecoratedComponent
         acl={acl}
-        addGhostAndEcsUnits={sinon.stub()}
-        autoPlaceUnits={sinon.stub()}
         changeState={sinon.stub()}
-        createMachine={sinon.stub()}
-        destroyMachines={destroyMachines}
-        environmentName="My Env"
+        dbAPI={dbAPI}
         generateMachineDetails={generateMachineDetails}
-        machines={machines}
+        modelAPI={modelAPI}
         parseConstraints={parseConstraints}
-        placeUnit={sinon.stub()}
-        providerType="aws"
-        removeUnits={sinon.stub()}
         series={['wily']}
-        services={services}
-        units={units}
-        updateMachineConstraints={updateMachineConstraints}
-        updateMachineSeries={updateMachineSeries} />, true);
+      />, true);
     const instance = renderer.getMountedInstance();
     const output = renderer.getRenderOutput();
+    const propTypes = (
+      juju.components.MachineViewMachine.DecoratedComponent.propTypes);
     const expected = (
       <ul className="machine-view__list">
         <juju.components.MachineViewMachine
-          acl={acl}
-          destroyMachines={destroyMachines}
+          acl={acl.reshape(propTypes.acl)}
+          dbAPI={dbAPI.reshape(propTypes.dbAPI)}
           dropUnit={instance._dropUnit}
-          generateMachineDetails={generateMachineDetails}
           key="new0"
-          machine={{
-            displayName: 'new0',
-            id: 'new0'
+          machineAPI={{
+            generateMachineDetails: generateMachineDetails,
+            machine: {
+              displayName: 'new0',
+              id: 'new0'
+            },
+            selected: false,
+            selectMachine: instance.selectMachine,
+            series: ['wily']
           }}
-          machineModel={{get: sinon.stub()}}
+          modelAPI={modelAPI.reshape(propTypes.modelAPI)}
           parseConstraints={parseConstraints}
-          providerType="aws"
-          selected={false}
-          selectMachine={instance.selectMachine}
-          series={['wily']}
-          services={services}
           showConstraints={true}
           type="machine"
-          units={units}
-          updateMachineConstraints={updateMachineConstraints}
-          updateMachineSeries={updateMachineSeries} />
+        />
         <juju.components.MachineViewMachine
-          acl={acl}
-          destroyMachines={destroyMachines}
+          acl={acl.reshape(propTypes.acl)}
+          dbAPI={dbAPI.reshape(propTypes.dbAPI)}
           dropUnit={instance._dropUnit}
-          generateMachineDetails={generateMachineDetails}
           key="new5"
-          machine={{
-            displayName: 'new5',
-            id: 'new5'
+          machineAPI={{
+            generateMachineDetails: generateMachineDetails,
+            machine: {
+              displayName: 'new5',
+              id: 'new5'
+            },
+            selected: true,
+            selectMachine: instance.selectMachine,
+            series: ['wily']
           }}
-          machineModel={{get: sinon.stub()}}
+          modelAPI={modelAPI.reshape(propTypes.modelAPI)}
           parseConstraints={parseConstraints}
-          providerType="aws"
-          selected={true}
-          selectMachine={instance.selectMachine}
-          series={['wily']}
-          services={services}
           showConstraints={true}
           type="machine"
-          units={units}
-          updateMachineConstraints={updateMachineConstraints}
-          updateMachineSeries={updateMachineSeries} />
+        />
       </ul>);
     expect(
       output.props.children.props.children[1].props.children[1]
@@ -983,77 +1065,82 @@ describe('MachineView', function() {
     const units = {
       filterByMachine: sinon.stub().returns([])
     };
-    const services = {
+    const applications = {
       size: sinon.stub().returns(0)
     };
     const destroyMachines = sinon.stub();
     const updateMachineConstraints = sinon.stub();
     const updateMachineSeries = sinon.stub();
+    const dbAPI = shapeup.addReshape({
+      addGhostAndEcsUnits: sinon.stub(),
+      applications: applications,
+      machines: machines,
+      modelName: 'My Model',
+      units: units
+    });
+    const modelAPI = shapeup.addReshape({
+      autoPlaceUnits: sinon.stub(),
+      createMachine: sinon.stub(),
+      destroyMachines: destroyMachines,
+      placeUnit: sinon.stub(),
+      providerType: 'aws',
+      removeUnits: sinon.stub(),
+      updateMachineConstraints: updateMachineConstraints,
+      updateMachineSeries: updateMachineSeries
+    });
     const renderer = jsTestUtils.shallowRender(
       // The component is wrapped to handle drag and drop, but we just want to
       // test the internal component so we access it via DecoratedComponent.
       <juju.components.MachineView.DecoratedComponent
         acl={acl}
-        addGhostAndEcsUnits={sinon.stub()}
-        autoPlaceUnits={sinon.stub()}
         changeState={sinon.stub()}
-        createMachine={sinon.stub()}
-        destroyMachines={destroyMachines}
-        environmentName="My Env"
+        dbAPI={dbAPI}
         generateMachineDetails={generateMachineDetails}
-        machines={machines}
+        modelAPI={modelAPI}
         parseConstraints={parseConstraints}
-        placeUnit={sinon.stub()}
-        providerType="aws"
-        removeUnits={sinon.stub()}
         series={['wily']}
-        services={services}
-        units={units}
-        updateMachineConstraints={updateMachineConstraints}
-        updateMachineSeries={updateMachineSeries} />, true);
+      />, true);
     const instance = renderer.getMountedInstance();
     instance._toggleConstraints();
     const output = renderer.getRenderOutput();
+    const propTypes = (
+      juju.components.MachineViewMachine.DecoratedComponent.propTypes);
     const expected = (
       <ul className="machine-view__list">
         <juju.components.MachineViewMachine
-          acl={acl}
-          destroyMachines={destroyMachines}
+          acl={acl.reshape(propTypes.acl)}
+          dbAPI={dbAPI.reshape(propTypes.dbAPI)}
           dropUnit={instance._dropUnit}
-          generateMachineDetails={generateMachineDetails}
           key="new0"
-          machine={machineList[0]}
-          machineModel={{get: sinon.stub()}}
+          machineAPI={{
+            generateMachineDetails: generateMachineDetails,
+            machine: machineList[0],
+            selected: true,
+            selectMachine: instance.selectMachine,
+            series: ['wily']
+          }}
+          modelAPI={modelAPI.reshape(propTypes.modelAPI)}
           parseConstraints={parseConstraints}
-          providerType="aws"
-          selected={true}
-          selectMachine={instance.selectMachine}
-          services={services}
-          series={['wily']}
           showConstraints={true}
           type="machine"
-          units={units}
-          updateMachineConstraints={updateMachineConstraints}
-          updateMachineSeries={updateMachineSeries} />
+        />
         <juju.components.MachineViewMachine
-          acl={acl}
-          destroyMachines={destroyMachines}
+          acl={acl.reshape(propTypes.acl)}
+          dbAPI={dbAPI.reshape(propTypes.dbAPI)}
           dropUnit={instance._dropUnit}
-          generateMachineDetails={generateMachineDetails}
           key="new1"
-          machine={machineList[1]}
-          machineModel={{get: sinon.stub()}}
+          machineAPI={{
+            generateMachineDetails: generateMachineDetails,
+            machine: machineList[1],
+            selected: false,
+            selectMachine: instance.selectMachine,
+            series: ['wily']
+          }}
+          modelAPI={modelAPI.reshape(propTypes.modelAPI)}
           parseConstraints={parseConstraints}
-          providerType="aws"
-          selected={false}
-          selectMachine={instance.selectMachine}
-          series={['wily']}
-          services={services}
           showConstraints={false}
           type="machine"
-          units={units}
-          updateMachineConstraints={updateMachineConstraints}
-          updateMachineSeries={updateMachineSeries} />
+        />
       </ul>);
     expect(
       output.props.children.props.children[1].props.children[1]
@@ -1068,43 +1155,48 @@ describe('MachineView', function() {
     const units = {
       filterByMachine: sinon.stub().returns([])
     };
-    const services = {
+    const applications = {
       size: sinon.stub().returns(0)
     };
     const createMachine = sinon.stub();
     const placeUnit = sinon.stub();
+    const modelAPI = shapeup.addReshape({
+      autoPlaceUnits: sinon.stub(),
+      createMachine: createMachine,
+      destroyMachines: sinon.stub(),
+      placeUnit: placeUnit,
+      providerType: 'azure',
+      removeUnits: sinon.stub(),
+      updateMachineConstraints: sinon.stub(),
+      updateMachineSeries: sinon.stub()
+    });
     const renderer = jsTestUtils.shallowRender(
       // The component is wrapped to handle drag and drop, but we just want to
       // test the internal component so we access it via DecoratedComponent.
       <juju.components.MachineView.DecoratedComponent
         acl={acl}
-        addGhostAndEcsUnits={sinon.stub()}
-        autoPlaceUnits={sinon.stub()}
         changeState={sinon.stub()}
-        createMachine={createMachine}
-        destroyMachines={sinon.stub()}
-        environmentName="My Env"
+        dbAPI={shapeup.addReshape({
+          addGhostAndEcsUnits: sinon.stub(),
+          applications: applications,
+          machines: machines,
+          modelName: 'My Model',
+          units: units
+        })}
         generateMachineDetails={generateMachineDetails}
-        machines={machines}
+        modelAPI={modelAPI}
         parseConstraints={parseConstraints}
-        placeUnit={placeUnit}
-        providerType={'azure'}
-        removeUnits={sinon.stub()}
         series={['trusty', 'xenial']}
-        services={services}
-        units={units}
-        updateMachineConstraints={sinon.stub()}
-        updateMachineSeries={sinon.stub()} />, true);
+      />, true);
     const instance = renderer.getMountedInstance();
     instance._addMachine();
     const output = renderer.getRenderOutput();
+    const propTypes = juju.components.MachineViewAddMachine.propTypes;
     const expected = (
       <juju.components.MachineViewAddMachine
-        acl={acl}
+        acl={acl.reshape(propTypes.acl)}
         close={instance._closeAddMachine}
-        createMachine={createMachine}
-        placeUnit={placeUnit}
-        providerType={'azure'}
+        modelAPI={modelAPI.reshape(propTypes.modelAPI)}
         selectMachine={instance.selectMachine}
         series={['trusty', 'xenial']}
         unit={null} />);
@@ -1129,7 +1221,7 @@ describe('MachineView', function() {
     const units = {
       filterByMachine: sinon.stub().returns([])
     };
-    const services = {
+    const applications = {
       size: sinon.stub().returns(0)
     };
     const renderer = jsTestUtils.shallowRender(
@@ -1137,21 +1229,26 @@ describe('MachineView', function() {
       // test the internal component so we access it via DecoratedComponent.
       <juju.components.MachineView.DecoratedComponent
         acl={acl}
-        addGhostAndEcsUnits={sinon.stub()}
-        autoPlaceUnits={sinon.stub()}
         changeState={sinon.stub()}
-        createMachine={sinon.stub()}
-        destroyMachines={sinon.stub()}
-        environmentName="My Env"
+        dbAPI={shapeup.addReshape({
+          addGhostAndEcsUnits: sinon.stub(),
+          applications: applications,
+          machines: machines,
+          modelName: 'My Model',
+          units: units
+        })}
         generateMachineDetails={generateMachineDetails}
-        machines={machines}
+        modelAPI={shapeup.addReshape({
+          autoPlaceUnits: sinon.stub(),
+          createMachine: sinon.stub(),
+          destroyMachines: sinon.stub(),
+          placeUnit: sinon.stub(),
+          removeUnits: sinon.stub(),
+          updateMachineConstraints: sinon.stub(),
+          updateMachineSeries: sinon.stub()
+        })}
         parseConstraints={parseConstraints}
-        placeUnit={sinon.stub()}
-        removeUnits={sinon.stub()}
-        services={services}
-        units={units}
-        updateMachineConstraints={sinon.stub()}
-        updateMachineSeries={sinon.stub()} />, true);
+      />, true);
     const instance = renderer.getMountedInstance();
     assert.equal(instance.state.selectedMachine, 'new0');
     instance.selectMachine('new1');
@@ -1182,61 +1279,79 @@ describe('MachineView', function() {
     const units = {
       filterByMachine: sinon.stub().returns([])
     };
-    const services = {
+    const applications = {
       size: sinon.stub().returns(0)
     };
     const destroyMachines = sinon.stub();
     const removeUnits = sinon.stub();
+    const dbAPI = shapeup.addReshape({
+      addGhostAndEcsUnits: sinon.stub(),
+      applications: applications,
+      machines: machines,
+      modelName: 'My Model',
+      units: units
+    });
+    const modelAPI = shapeup.addReshape({
+      autoPlaceUnits: sinon.stub(),
+      createMachine: sinon.stub(),
+      destroyMachines: destroyMachines,
+      placeUnit: sinon.stub(),
+      removeUnits: removeUnits,
+      updateMachineConstraints: sinon.stub(),
+      updateMachineSeries: sinon.stub()
+    });
+
     const renderer = jsTestUtils.shallowRender(
       // The component is wrapped to handle drag and drop, but we just want to
       // test the internal component so we access it via DecoratedComponent.
       <juju.components.MachineView.DecoratedComponent
         acl={acl}
-        addGhostAndEcsUnits={sinon.stub()}
-        autoPlaceUnits={sinon.stub()}
         changeState={sinon.stub()}
-        createMachine={sinon.stub()}
-        destroyMachines={destroyMachines}
-        environmentName="My Env"
+        dbAPI={dbAPI}
         generateMachineDetails={generateMachineDetails}
-        machines={machines}
+        modelAPI={modelAPI}
         parseConstraints={parseConstraints}
-        placeUnit={sinon.stub()}
-        removeUnits={removeUnits}
-        services={services}
-        units={units}
-        updateMachineConstraints={sinon.stub()}
-        updateMachineSeries={sinon.stub()} />, true);
+      />, true);
     const instance = renderer.getMountedInstance();
     const output = renderer.getRenderOutput();
+    const propTypes = (
+      juju.components.MachineViewMachine.DecoratedComponent.propTypes);
     const expected = (
       <ul className="machine-view__list">
         <juju.components.MachineViewMachine
-          acl={acl}
-          destroyMachines={destroyMachines}
+          acl={acl.reshape(propTypes.acl)}
+          dbAPI={dbAPI.reshape(propTypes.dbAPI)}
           dropUnit={instance._dropUnit}
           key="new0"
-          machine={{
-            commitStatus: 'committed',
-            deleted: undefined,
-            displayName: 'Root container',
-            id: 'new0',
-            root: true
+          machineAPI={{
+            machine: {
+              commitStatus: 'committed',
+              deleted: undefined,
+              displayName: 'Root container',
+              id: 'new0',
+              root: true
+            },
+            removeUnit: instance._removeUnit
           }}
-          removeUnit={instance._removeUnit}
-          services={services}
+          modelAPI={modelAPI.reshape(propTypes.modelAPI)}
+          parseConstraints={parseConstraints}
           type="container"
-          units={units} />
+        />
         <juju.components.MachineViewMachine
-          acl={acl}
-          destroyMachines={destroyMachines}
+          acl={acl.reshape(propTypes.acl)}
+          dbAPI={dbAPI.reshape(propTypes.dbAPI)}
           dropUnit={instance._dropUnit}
           key="new0/lxc/0"
-          machine={{id: 'new0/lxc/0'}}
-          removeUnit={instance._removeUnit}
-          services={services}
+          machineAPI={{
+            machine: {
+              id: 'new0/lxc/0'
+            },
+            removeUnit: instance._removeUnit
+          }}
+          modelAPI={modelAPI.reshape(propTypes.modelAPI)}
+          parseConstraints={parseConstraints}
           type="container"
-          units={units} />
+        />
       </ul>);
     expect(
       output.props.children.props.children[2].props.children[1]).toEqualJSX(
@@ -1271,75 +1386,96 @@ describe('MachineView', function() {
     const units = {
       filterByMachine: sinon.stub().returns([])
     };
-    const services = {
+    const applications = {
       size: sinon.stub().returns(0)
     };
     const destroyMachines = sinon.stub();
     const removeUnits = sinon.stub();
+    const dbAPI = shapeup.addReshape({
+      addGhostAndEcsUnits: sinon.stub(),
+      applications: applications,
+      machines: machines,
+      modelName: 'My Model',
+      units: units
+    });
+    const modelAPI = shapeup.addReshape({
+      autoPlaceUnits: sinon.stub(),
+      createMachine: sinon.stub(),
+      destroyMachines: destroyMachines,
+      placeUnit: sinon.stub(),
+      removeUnits: removeUnits,
+      updateMachineConstraints: sinon.stub(),
+      updateMachineSeries: sinon.stub()
+    });
     const renderer = jsTestUtils.shallowRender(
       <juju.components.MachineView.DecoratedComponent
         acl={acl}
-        addGhostAndEcsUnits={sinon.stub()}
-        autoPlaceUnits={sinon.stub()}
         changeState={sinon.stub()}
-        createMachine={sinon.stub()}
-        destroyMachines={destroyMachines}
-        environmentName="My Env"
+        dbAPI={dbAPI}
         generateMachineDetails={generateMachineDetails}
-        machines={machines}
+        modelAPI={modelAPI}
         parseConstraints={parseConstraints}
-        placeUnit={sinon.stub()}
-        removeUnits={removeUnits}
-        services={services}
-        units={units}
-        updateMachineConstraints={sinon.stub()}
-        updateMachineSeries={sinon.stub()} />, true);
+      />, true);
     const instance = renderer.getMountedInstance();
     const output = renderer.getRenderOutput();
+    const propTypes = (
+      juju.components.MachineViewMachine.DecoratedComponent.propTypes);
+    const reshapedACL = acl.reshape(propTypes.acl);
+    const reshapedDBAPI = dbAPI.reshape(propTypes.dbAPI);
+    const reshapedModelAPI = modelAPI.reshape(propTypes.modelAPI);
     const expected = (
       <ul className="machine-view__list">
         <juju.components.MachineViewMachine
-          acl={acl}
-          destroyMachines={destroyMachines}
+          acl={reshapedACL}
+          dbAPI={reshapedDBAPI}
           dropUnit={instance._dropUnit}
           key="new0"
-          machine={{
-            commitStatus: 'committed',
-            deleted: undefined,
-            displayName: 'Root container',
-            id: 'new0',
-            root: true
+          machineAPI={{
+            machine: {
+              commitStatus: 'committed',
+              deleted: undefined,
+              displayName: 'Root container',
+              id: 'new0',
+              root: true
+            },
+            removeUnit: instance._removeUnit
           }}
-          removeUnit={instance._removeUnit}
-          services={services}
+          modelAPI={reshapedModelAPI}
+          parseConstraints={parseConstraints}
           type="container"
-          units={units} />
+        />
         <juju.components.MachineViewMachine
-          acl={acl}
-          destroyMachines={destroyMachines}
+          acl={reshapedACL}
+          dbAPI={reshapedDBAPI}
           dropUnit={instance._dropUnit}
           key="new0/lxc/0"
-          machine={{
-            displayName: 'new0/lxc/0',
-            id: 'new0/lxc/0'
+          machineAPI={{
+            machine: {
+              displayName: 'new0/lxc/0',
+              id: 'new0/lxc/0'
+            },
+            removeUnit: instance._removeUnit
           }}
-          removeUnit={instance._removeUnit}
-          services={services}
+          modelAPI={reshapedModelAPI}
+          parseConstraints={parseConstraints}
           type="container"
-          units={units} />
+        />
         <juju.components.MachineViewMachine
-          acl={acl}
-          destroyMachines={destroyMachines}
+          acl={reshapedACL}
+          dbAPI={reshapedDBAPI}
           dropUnit={instance._dropUnit}
           key="new0/lxc/5"
-          machine={{
-            displayName: 'new0/lxc/5',
-            id: 'new0/lxc/5'
+          machineAPI={{
+            machine: {
+              displayName: 'new0/lxc/5',
+              id: 'new0/lxc/5'
+            },
+            removeUnit: instance._removeUnit
           }}
-          removeUnit={instance._removeUnit}
-          services={services}
+          modelAPI={reshapedModelAPI}
+          parseConstraints={parseConstraints}
           type="container"
-          units={units} />
+        />
       </ul>);
     expect(
       output.props.children.props.children[2].props.children[1]).toEqualJSX(
@@ -1363,48 +1499,54 @@ describe('MachineView', function() {
     const units = {
       filterByMachine: sinon.stub().returns([])
     };
-    const services = {
+    const applications = {
       size: sinon.stub().returns(0)
     };
     const createMachine = sinon.stub();
     const destroyMachines = sinon.stub();
     const placeUnit = sinon.stub();
     const removeUnits = sinon.stub();
+    const modelAPI = shapeup.addReshape({
+      autoPlaceUnits: sinon.stub(),
+      createMachine: createMachine,
+      destroyMachines: destroyMachines,
+      placeUnit: placeUnit,
+      providerType: 'gce',
+      removeUnits: removeUnits,
+      updateMachineConstraints: sinon.stub(),
+      updateMachineSeries: sinon.stub()
+    });
     const renderer = jsTestUtils.shallowRender(
       // The component is wrapped to handle drag and drop, but we just want to
       // test the internal component so we access it via DecoratedComponent.
       <juju.components.MachineView.DecoratedComponent
         acl={acl}
-        addGhostAndEcsUnits={sinon.stub()}
-        autoPlaceUnits={sinon.stub()}
         changeState={sinon.stub()}
-        createMachine={createMachine}
-        destroyMachines={destroyMachines}
-        environmentName="My Env"
+        dbAPI={shapeup.addReshape({
+          addGhostAndEcsUnits: sinon.stub(),
+          applications: applications,
+          machines: machines,
+          modelName: 'My Model',
+          units: units
+        })}
         generateMachineDetails={generateMachineDetails}
-        machines={machines}
+        modelAPI={modelAPI}
         parseConstraints={parseConstraints}
-        placeUnit={placeUnit}
-        providerType={'gce'}
-        removeUnits={removeUnits}
         series={['trusty', 'xenial']}
-        services={services}
-        units={units}
-        updateMachineConstraints={sinon.stub()}
-        updateMachineSeries={sinon.stub()} />, true);
+      />, true);
     const instance = renderer.getMountedInstance();
     instance._addContainer();
     const output = renderer.getRenderOutput();
+    const propTypes = juju.components.MachineViewAddMachine.propTypes;
     const expected = (
       <juju.components.MachineViewAddMachine
-        acl={acl}
+        acl={acl.reshape(propTypes.acl)}
         close={instance._closeAddContainer}
-        createMachine={createMachine}
+        modelAPI={modelAPI.reshape(propTypes.modelAPI)}
         parentId="new0"
-        placeUnit={placeUnit}
-        providerType={'gce'}
         series={['trusty', 'xenial']}
-        unit={null} />);
+        unit={null}
+      />);
     expect(
       output.props.children.props.children[2].props.children[0]).toEqualJSX(
       expected);
@@ -1428,63 +1570,78 @@ describe('MachineView', function() {
     const units = {
       filterByMachine: sinon.stub().returns([])
     };
-    const services = {
+    const applications = {
       size: sinon.stub().returns(0)
     };
     const createMachine = sinon.stub();
     const destroyMachines = sinon.stub();
     const removeUnits = sinon.stub();
+    const dbAPI = shapeup.addReshape({
+      addGhostAndEcsUnits: sinon.stub(),
+      applications: applications,
+      machines: machines,
+      modelName: 'My Model',
+      units: units
+    });
+    const modelAPI = shapeup.addReshape({
+      autoPlaceUnits: sinon.stub(),
+      createMachine: createMachine,
+      destroyMachines: destroyMachines,
+      placeUnit: sinon.stub(),
+      removeUnits: removeUnits,
+      updateMachineConstraints: sinon.stub(),
+      updateMachineSeries: sinon.stub()
+    });
     const renderer = jsTestUtils.shallowRender(
       // The component is wrapped to handle drag and drop, but we just want to
       // test the internal component so we access it via DecoratedComponent.
       <juju.components.MachineView.DecoratedComponent
         acl={acl}
-        addGhostAndEcsUnits={sinon.stub()}
-        autoPlaceUnits={sinon.stub()}
         changeState={sinon.stub()}
-        createMachine={createMachine}
-        destroyMachines={destroyMachines}
-        environmentName="My Env"
+        dbAPI={dbAPI}
         generateMachineDetails={generateMachineDetails}
-        units={units}
+        modelAPI={modelAPI}
         parseConstraints={parseConstraints}
-        placeUnit={sinon.stub()}
-        removeUnits={removeUnits}
-        services={services}
-        machines={machines}
-        updateMachineConstraints={sinon.stub()}
-        updateMachineSeries={sinon.stub()} />, true);
+      />, true);
     const instance = renderer.getMountedInstance();
     instance._addContainer();
     const output = renderer.getRenderOutput();
+    const propTypes = (
+      juju.components.MachineViewMachine.DecoratedComponent.propTypes);
     const expected = (
       <ul className="machine-view__list">
         <juju.components.MachineViewMachine
-          acl={acl}
-          destroyMachines={destroyMachines}
+          acl={acl.reshape(propTypes.acl)}
+          dbAPI={dbAPI.reshape(propTypes.dbAPI)}
           dropUnit={instance._dropUnit}
           key="new0"
-          machine={{
-            commitStatus: 'committed',
-            deleted: true,
-            displayName: 'Root container',
-            id: 'new0',
-            root: true
+          machineAPI={{
+            machine: {
+              commitStatus: 'committed',
+              deleted: true,
+              displayName: 'Root container',
+              id: 'new0',
+              root: true
+            },
+            removeUnit: instance._removeUnit
           }}
-          removeUnit={instance._removeUnit}
-          services={services}
+          modelAPI={modelAPI.reshape(propTypes.modelAPI)}
+          parseConstraints={parseConstraints}
           type="container"
-          units={units} />
+        />
         <juju.components.MachineViewMachine
-          acl={acl}
-          destroyMachines={destroyMachines}
+          acl={acl.reshape(propTypes.acl)}
+          dbAPI={dbAPI.reshape(propTypes.dbAPI)}
           dropUnit={instance._dropUnit}
           key="new0/lxc/0"
-          machine={{id: 'new0/lxc/0'}}
-          removeUnit={instance._removeUnit}
-          services={services}
+          machineAPI={{
+            machine: {id: 'new0/lxc/0'},
+            removeUnit: instance._removeUnit
+          }}
+          modelAPI={modelAPI.reshape(propTypes.modelAPI)}
+          parseConstraints={parseConstraints}
           type="container"
-          units={units} />
+        />
       </ul>);
     expect(
       output.props.children.props.children[2].props.children[1]).toEqualJSX(
@@ -1505,7 +1662,7 @@ describe('MachineView', function() {
     const units = {
       filterByMachine: sinon.stub().returns([])
     };
-    const services = {
+    const applications = {
       size: sinon.stub().returns(0)
     };
     const createMachine = sinon.stub();
@@ -1516,21 +1673,26 @@ describe('MachineView', function() {
       // test the internal component so we access it via DecoratedComponent.
       <juju.components.MachineView.DecoratedComponent
         acl={acl}
-        addGhostAndEcsUnits={sinon.stub()}
-        autoPlaceUnits={sinon.stub()}
         changeState={sinon.stub()}
-        createMachine={createMachine}
-        destroyMachines={destroyMachines}
-        environmentName="My Env"
+        dbAPI={shapeup.addReshape({
+          addGhostAndEcsUnits: sinon.stub(),
+          applications: applications,
+          machines: machines,
+          modelName: 'My Model',
+          units: units
+        })}
         generateMachineDetails={generateMachineDetails}
-        machines={machines}
+        modelAPI={shapeup.addReshape({
+          autoPlaceUnits: sinon.stub(),
+          createMachine: createMachine,
+          destroyMachines: destroyMachines,
+          placeUnit: sinon.stub(),
+          removeUnits: removeUnits,
+          updateMachineConstraints: sinon.stub(),
+          updateMachineSeries: sinon.stub()
+        })}
         parseConstraints={parseConstraints}
-        placeUnit={sinon.stub()}
-        removeUnits={removeUnits}
-        services={services}
-        units={units}
-        updateMachineConstraints={sinon.stub()}
-        updateMachineSeries={sinon.stub()} />, true);
+      />, true);
     const instance = renderer.getMountedInstance();
     instance._removeUnit('wordpress/8');
     assert.equal(removeUnits.callCount, 1);
@@ -1551,7 +1713,7 @@ describe('MachineView', function() {
     const units = {
       filterByMachine: sinon.stub().returns([])
     };
-    const services = {
+    const applications = {
       size: sinon.stub().returns(0)
     };
     const createMachine = sinon.stub();
@@ -1563,21 +1725,26 @@ describe('MachineView', function() {
       // test the internal component so we access it via DecoratedComponent.
       <juju.components.MachineView.DecoratedComponent
         acl={acl}
-        addGhostAndEcsUnits={sinon.stub()}
-        autoPlaceUnits={sinon.stub()}
         changeState={sinon.stub()}
-        createMachine={createMachine}
-        destroyMachines={destroyMachines}
-        environmentName="My Env"
+        dbAPI={shapeup.addReshape({
+          addGhostAndEcsUnits: sinon.stub(),
+          applications: applications,
+          machines: machines,
+          modelName: 'My Model',
+          units: units
+        })}
         generateMachineDetails={generateMachineDetails}
-        machines={machines}
+        modelAPI={shapeup.addReshape({
+          autoPlaceUnits: sinon.stub(),
+          createMachine: createMachine,
+          destroyMachines: destroyMachines,
+          placeUnit: placeUnit,
+          removeUnits: removeUnits,
+          updateMachineConstraints: sinon.stub(),
+          updateMachineSeries: sinon.stub()
+        })}
         parseConstraints={parseConstraints}
-        placeUnit={placeUnit}
-        removeUnits={removeUnits}
-        services={services}
-        units={units}
-        updateMachineConstraints={sinon.stub()}
-        updateMachineSeries={sinon.stub()} />, true);
+      />, true);
     const instance = renderer.getMountedInstance();
     instance._dropUnit('wordpress/8', 'new0');
     assert.equal(placeUnit.callCount, 1);
@@ -1586,7 +1753,7 @@ describe('MachineView', function() {
   });
 
   it('can disable menu actions when read only', function() {
-    acl.isReadOnly = sinon.stub().returns(true);
+    acl = shapeup.deepFreeze(shapeup.addReshape({isReadOnly: () => true}));
     const machines = {
       filterByParent: sinon.stub().returns([]),
       revive: sinon.stub()
@@ -1594,7 +1761,7 @@ describe('MachineView', function() {
     const units = {
       filterByMachine: sinon.stub().returns([])
     };
-    const services = {
+    const applications = {
       size: sinon.stub().returns(0)
     };
     const placeUnit = sinon.stub();
@@ -1603,21 +1770,26 @@ describe('MachineView', function() {
       // test the internal component so we access it via DecoratedComponent.
       <juju.components.MachineView.DecoratedComponent
         acl={acl}
-        addGhostAndEcsUnits={sinon.stub()}
-        autoPlaceUnits={sinon.stub()}
         changeState={sinon.stub()}
-        createMachine={sinon.stub()}
-        destroyMachines={sinon.stub()}
-        environmentName="My Env"
+        dbAPI={shapeup.addReshape({
+          addGhostAndEcsUnits: sinon.stub(),
+          applications: applications,
+          machines: machines,
+          modelName: 'My Model',
+          units: units
+        })}
         generateMachineDetails={generateMachineDetails}
-        machines={machines}
+        modelAPI={shapeup.addReshape({
+          autoPlaceUnits: sinon.stub(),
+          createMachine: sinon.stub(),
+          destroyMachines: sinon.stub(),
+          placeUnit: placeUnit,
+          removeUnits: sinon.stub(),
+          updateMachineConstraints: sinon.stub(),
+          updateMachineSeries: sinon.stub()
+        })}
         parseConstraints={parseConstraints}
-        placeUnit={placeUnit}
-        removeUnits={sinon.stub()}
-        services={services}
-        units={units}
-        updateMachineConstraints={sinon.stub()}
-        updateMachineSeries={sinon.stub()} />, true);
+      />, true);
     const output = renderer.getRenderOutput();
     const machineMenuItems = output.props.children.props.children[1]
       .props.menuItems;

--- a/jujugui/static/gui/src/app/components/machine-view/unplaced-unit/test-unplaced-unit.js
+++ b/jujugui/static/gui/src/app/components/machine-view/unplaced-unit/test-unplaced-unit.js
@@ -21,7 +21,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 var juju = {components: {}}; // eslint-disable-line no-unused-vars
 
 describe('MachineViewUnplacedUnit', function() {
-  var acl;
+  let acl;
 
   beforeAll(function(done) {
     // By loading this file it adds the component to the juju components.
@@ -29,29 +29,36 @@ describe('MachineViewUnplacedUnit', function() {
   });
 
   beforeEach(() => {
-    acl = {isReadOnly: sinon.stub().returns(false)};
+    acl = shapeup.deepFreeze(shapeup.addReshape({isReadOnly: () => false}));
   });
 
   it('can render', function() {
-    var removeUnit = sinon.stub();
-    var unit = {displayName: 'django/7'};
-    var renderer = jsTestUtils.shallowRender(
+    const removeUnit = sinon.stub();
+    const unit = {displayName: 'django/7'};
+    const renderer = jsTestUtils.shallowRender(
       // The component is wrapped to handle drag and drop, but we just want to
       // test the internal component so we access it via DecoratedComponent.
       <juju.components.MachineViewUnplacedUnit.DecoratedComponent
         acl={acl}
         connectDragSource={jsTestUtils.connectDragSource}
-        createMachine={sinon.stub()}
-        icon="icon.svg"
+        dbAPI={{
+          machines: {}
+        }}
         isDragging={false}
-        machines={{}}
-        placeUnit={sinon.stub()}
-        removeUnit={removeUnit}
-        selectMachine={sinon.stub()}
-        unit={unit} />, true);
-    var instance = renderer.getMountedInstance();
-    var output = renderer.getRenderOutput();
-    var expected = (
+        modelAPI={{
+          createMachine: sinon.stub(),
+          placeUnit: sinon.stub()
+        }}
+        unitAPI={{
+          icon: 'icon.svg',
+          removeUnit: removeUnit,
+          selectMachine: sinon.stub(),
+          unit: unit
+        }}
+      />, true);
+    const instance = renderer.getMountedInstance();
+    const output = renderer.getRenderOutput();
+    const expected = (
       <li className="machine-view__unplaced-unit">
         <img src="icon.svg" alt="django/7"
           className="machine-view__unplaced-unit-icon" />
@@ -71,23 +78,30 @@ describe('MachineViewUnplacedUnit', function() {
   });
 
   it('can display in dragged mode', function() {
-    var removeUnit = sinon.stub();
-    var unit = {displayName: 'django/7'};
-    var output = jsTestUtils.shallowRender(
+    const removeUnit = sinon.stub();
+    const unit = {displayName: 'django/7'};
+    const output = jsTestUtils.shallowRender(
       // The component is wrapped to handle drag and drop, but we just want to
       // test the internal component so we access it via DecoratedComponent.
       <juju.components.MachineViewUnplacedUnit.DecoratedComponent
         acl={acl}
         connectDragSource={jsTestUtils.connectDragSource}
-        createMachine={sinon.stub()}
-        icon="icon.svg"
+        dbAPI={{
+          machines: {}
+        }}
         isDragging={true}
-        machines={{}}
-        placeUnit={sinon.stub()}
-        removeUnit={removeUnit}
-        selectMachine={sinon.stub()}
-        unit={unit} />);
-    var expected = (
+        modelAPI={{
+          createMachine: sinon.stub(),
+          placeUnit: sinon.stub()
+        }}
+        unitAPI={{
+          icon: 'icon.svg',
+          removeUnit: removeUnit,
+          selectMachine: sinon.stub(),
+          unit: unit
+        }}
+      />);
+    const expected = (
       <li className={'machine-view__unplaced-unit ' +
         'machine-view__unplaced-unit--dragged'}>
         {output.props.children}
@@ -96,47 +110,61 @@ describe('MachineViewUnplacedUnit', function() {
   });
 
   it('can remove a unit', function() {
-    var removeUnit = sinon.stub();
-    var unit = {displayName: 'django/7', id: 'django/7'};
-    var output = jsTestUtils.shallowRender(
+    const removeUnit = sinon.stub();
+    const unit = {displayName: 'django/7', id: 'django/7'};
+    const output = jsTestUtils.shallowRender(
       // The component is wrapped to handle drag and drop, but we just want to
       // test the internal component so we access it via DecoratedComponent.
       <juju.components.MachineViewUnplacedUnit.DecoratedComponent
         acl={acl}
         connectDragSource={jsTestUtils.connectDragSource}
-        createMachine={sinon.stub()}
-        icon="icon.svg"
+        dbAPI={{
+          machines: {}
+        }}
         isDragging={false}
-        machines={{}}
-        placeUnit={sinon.stub()}
-        removeUnit={removeUnit}
-        selectMachine={sinon.stub()}
-        unit={unit} />);
+        modelAPI={{
+          createMachine: sinon.stub(),
+          placeUnit: sinon.stub()
+        }}
+        unitAPI={{
+          icon: 'icon.svg',
+          removeUnit: removeUnit,
+          selectMachine: sinon.stub(),
+          unit: unit
+        }}
+      />);
     output.props.children[2].props.items[1].action();
     assert.equal(removeUnit.callCount, 1);
     assert.equal(removeUnit.args[0][0], 'django/7');
   });
 
   it('disables the menu items when read only', function() {
-    acl.isReadOnly = sinon.stub().returns(true);
-    var removeUnit = sinon.stub();
-    var unit = {displayName: 'django/7'};
-    var renderer = jsTestUtils.shallowRender(
+    acl = shapeup.deepFreeze(shapeup.addReshape({isReadOnly: () => true}));
+    const removeUnit = sinon.stub();
+    const unit = {displayName: 'django/7'};
+    const renderer = jsTestUtils.shallowRender(
       // The component is wrapped to handle drag and drop, but we just want to
       // test the internal component so we access it via DecoratedComponent.
       <juju.components.MachineViewUnplacedUnit.DecoratedComponent
         acl={acl}
         connectDragSource={jsTestUtils.connectDragSource}
-        createMachine={sinon.stub()}
-        icon="icon.svg"
+        dbAPI={{
+          machines: {}
+        }}
         isDragging={false}
-        machines={{}}
-        placeUnit={sinon.stub()}
-        removeUnit={removeUnit}
-        selectMachine={sinon.stub()}
-        unit={unit} />, true);
-    var output = renderer.getRenderOutput();
-    var expected = (
+        modelAPI={{
+          createMachine: sinon.stub(),
+          placeUnit: sinon.stub()
+        }}
+        unitAPI={{
+          icon: 'icon.svg',
+          removeUnit: removeUnit,
+          selectMachine: sinon.stub(),
+          unit: unit
+        }}
+      />, true);
+    const output = renderer.getRenderOutput();
+    const expected = (
       <juju.components.MoreMenu
         items={[{
           label: 'Deploy to...',

--- a/jujugui/static/gui/src/app/components/machine-view/unplaced-unit/unplaced-unit.js
+++ b/jujugui/static/gui/src/app/components/machine-view/unplaced-unit/unplaced-unit.js
@@ -29,7 +29,7 @@ MachineViewUnplacedUnitGlobals.dragSource = {
     @param {Object} props The component props.
   */
   beginDrag: function(props) {
-    return {unit: props.unit};
+    return {unit: props.unitAPI.unit};
   },
 
   /**
@@ -83,17 +83,16 @@ class MachineViewUnplacedUnit extends React.Component {
       return;
     }
     const props = this.props;
+    const propTypes = juju.components.MachineViewAddMachine.propTypes;
     return (
       <juju.components.MachineViewAddMachine
-        acl={props.acl}
+        acl={props.acl.reshape(propTypes.acl)}
         close={this._togglePlaceUnit.bind(this)}
-        createMachine={props.createMachine}
-        machines={props.machines}
-        placeUnit={props.placeUnit}
-        providerType={props.providerType}
-        selectMachine={props.selectMachine}
+        dbAPI={props.dbAPI.reshape(propTypes.dbAPI)}
+        modelAPI={props.modelAPI.reshape(propTypes.modelAPI)}
+        selectMachine={props.unitAPI.selectMachine}
         series={props.series}
-        unit={props.unit}
+        unit={props.unitAPI.unit}
       />
     );
   }
@@ -112,19 +111,21 @@ class MachineViewUnplacedUnit extends React.Component {
   }
 
   render() {
-    var isReadOnly = this.props.acl.isReadOnly();
-    var unit = this.props.unit;
-    var menuItems = [{
+    const props = this.props;
+    const isReadOnly = props.acl.isReadOnly();
+    const unitAPI = props.unitAPI;
+    const unit = unitAPI.unit;
+    const menuItems = [{
       label: 'Deploy to...',
       action: !isReadOnly && this._togglePlaceUnit.bind(this)
     }, {
       label: 'Destroy',
-      action: !isReadOnly && this.props.removeUnit.bind(null, unit.id)
+      action: !isReadOnly && unitAPI.removeUnit.bind(null, unit.id)
     }];
     // Wrap the returned components in the drag source method.
-    return this.props.connectDragSource(
+    return props.connectDragSource(
       <li className={this._generateClasses()}>
-        <img src={this.props.icon} alt={unit.displayName}
+        <img src={unitAPI.icon} alt={unit.displayName}
           className="machine-view__unplaced-unit-icon" />
         {unit.displayName}
         <juju.components.MoreMenu
@@ -137,18 +138,27 @@ class MachineViewUnplacedUnit extends React.Component {
 };
 
 MachineViewUnplacedUnit.propTypes = {
-  acl: PropTypes.object.isRequired,
+  acl: shapeup.shape({
+    isReadOnly: PropTypes.func.isRequired,
+    reshape: shapeup.reshapeFunc
+  }).frozen.isRequired,
   connectDragSource: PropTypes.func.isRequired,
-  createMachine: PropTypes.func.isRequired,
-  icon: PropTypes.string.isRequired,
+  dbAPI: shapeup.shape({
+    machines: PropTypes.object.isRequired
+  }),
   isDragging: PropTypes.bool.isRequired,
-  machines: PropTypes.object.isRequired,
-  placeUnit: PropTypes.func.isRequired,
-  providerType: PropTypes.string,
-  removeUnit: PropTypes.func.isRequired,
-  selectMachine: PropTypes.func.isRequired,
+  modelAPI: shapeup.shape({
+    createMachine: PropTypes.func.isRequired,
+    placeUnit: PropTypes.func.isRequired,
+    providerType: PropTypes.string
+  }).isRequired,
   series: PropTypes.array,
-  unit: PropTypes.object.isRequired
+  unitAPI: shapeup.shape({
+    icon: PropTypes.string.isRequired,
+    removeUnit: PropTypes.func.isRequired,
+    selectMachine: PropTypes.func.isRequired,
+    unit: PropTypes.object.isRequired
+  }).isRequired
 };
 
 YUI.add('machine-view-unplaced-unit', function() {

--- a/jujugui/static/gui/src/app/views/utils.js
+++ b/jujugui/static/gui/src/app/views/utils.js
@@ -2074,7 +2074,7 @@ YUI.add('juju-view-utils', function(Y) {
   };
 
   /**
-    Generate the series/hardward/constraints details for a machine
+    Generate the series/hardware/constraints details for a machine
 
     @param genericConstraints {Array} The constraints types.
     @param machine {Object} A machine.

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4823,9 +4823,9 @@
       }
     },
     "shapeup": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/shapeup/-/shapeup-0.2.1.tgz",
-      "integrity": "sha512-+Sb1CM1nBO13/m+H+KoY7Hwg94Lj1hQolhbQ3G6I7FvPb93j+6I+5MQ07mBEAT1imbg1/1x0PqQLx9tl2ZKosA==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/shapeup/-/shapeup-0.2.3.tgz",
+      "integrity": "sha512-nwOQVKmRBE3/H1h56lI1P9qbqiTVIzsMubznsnwdbLvXfnKnTnV/R+pl+7n+4RNbAH8cQ/vsDyeVU87uiwhKmA==",
       "requires": {
         "prop-types": "15.5.10"
       }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "react-dnd": "2.4.0",
     "react-dnd-html5-backend": "2.4.1",
     "react-dom": "15.6.1",
-    "shapeup": "0.2.1",
+    "shapeup": "0.2.3",
     "yui": "3.11.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This is an experiment about using shapeup in the machine view.
I am pretty happy about how testing can be made easier by introducing the library.
Of course the diff is huge due to all the changes in the properties of a quite complex component tree (and its tests).