### PR TITLE
Always show the beta label

### DIFF
--- a/jujugui/static/gui/src/app/assets/css/_beta.scss
+++ b/jujugui/static/gui/src/app/assets/css/_beta.scss
@@ -9,7 +9,7 @@ body.u-is-beta:before {
   font-size: 23px;
   font-weight: 300;
   opacity: 0.6;
-  z-index: 10;
+  z-index: 11;
 }
 
 body.u-is-beta.display-cookie-notice:before {


### PR DESCRIPTION
The Beta label is now shown over top of the machine view and status view as well as the canvas.

Fixes: #3149 