### PR TITLE
Machine view: do not reset gui state when there is no machine

### DIFF
--- a/jujugui/static/gui/src/app/components/machine-view/machine-view.js
+++ b/jujugui/static/gui/src/app/components/machine-view/machine-view.js
@@ -19,8 +19,8 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 'use strict';
 
 class MachineView extends React.Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
     this.state = {
       containerSort: 'name',
       machineSort: 'name',
@@ -64,12 +64,13 @@ class MachineView extends React.Component {
 
     @method _getFirstMachine
     @param {Object} machines The list of machines.
-    @returns {String} The id of the first machine
+    @returns {String} The id of the first machine, or null if no machines are
+      present.
   */
   _getFirstMachineId(machines) {
-    var machineList = machines.filterByParent();
+    const machineList = machines.filterByParent();
     if (machineList.length === 0) {
-      return;
+      return null;
     }
     return machineList[0].id;
   }
@@ -232,9 +233,13 @@ class MachineView extends React.Component {
     Handle selecting a machine.
 
     @method selectMachine
-    @param {String} id The machine id to select.
+    @param {String} id The machine id to select. If the id is null, no machine
+      is selected.
   */
   selectMachine(id) {
+    if (id === null) {
+      return;
+    }
     this.props.changeState({gui: {machines: id}});
   }
 

--- a/jujugui/static/gui/src/app/components/machine-view/test-machine-view.js
+++ b/jujugui/static/gui/src/app/components/machine-view/test-machine-view.js
@@ -1340,6 +1340,51 @@ describe('MachineView', function() {
     assert.deepEqual(changeState.args[0][0], {gui: {machines: 'new1'}});
   });
 
+  it('does not select any machines on mount if there are not', function() {
+    const machineList = [];
+    const machines = {filterByParent: sinon.stub().returns(machineList)};
+    const units = {
+      filterByMachine: sinon.stub().returns([])
+    };
+    const applications = {
+      size: sinon.stub().returns(0)
+    };
+    const changeState = sinon.stub();
+    const renderer = jsTestUtils.shallowRender(
+      // The component is wrapped to handle drag and drop, but we just want to
+      // test the internal component so we access it via DecoratedComponent.
+      <juju.components.MachineView.DecoratedComponent
+        acl={acl}
+        changeState={changeState}
+        dbAPI={shapeup.addReshape({
+          addGhostAndEcsUnits: sinon.stub(),
+          applications: applications,
+          machines: machines,
+          modelName: 'My Model',
+          units: units
+        })}
+        generateMachineDetails={generateMachineDetails}
+        machine=""
+        modelAPI={shapeup.addReshape({
+          autoPlaceUnits: sinon.stub(),
+          createMachine: sinon.stub(),
+          destroyMachines: sinon.stub(),
+          placeUnit: sinon.stub(),
+          removeUnits: sinon.stub(),
+          updateMachineConstraints: sinon.stub(),
+          updateMachineSeries: sinon.stub()
+        })}
+        parseConstraints={parseConstraints}
+        parseMachineName={parseMachineName.returns({
+          parentId: null,
+          containerType: null,
+          number: 'new1'
+        })} />, true);
+    const instance = renderer.getMountedInstance();
+    instance.componentDidMount();
+    assert.equal(changeState.callCount, 0);
+  });
+
   it('can display a list of containers', function() {
     const machineList = [{
       displayName: 'new0',

--- a/jujugui/static/gui/src/app/utils/environment-change-set.js
+++ b/jujugui/static/gui/src/app/utils/environment-change-set.js
@@ -613,7 +613,7 @@ YUI.add('environment-change-set', function(Y) {
       });
       return this._createNewRecord('addPendingResources', command, parents);
     },
-    
+
     /**
       Creates a new entry in the queue for adding SSH keys to the model.
 
@@ -632,7 +632,7 @@ YUI.add('environment-change-set', function(Y) {
       };
       return this._createNewRecord('addSSHKeys', command, []);
     },
-  
+
     /**
       Creates a new entry in the queue for importing SSH keys to the model.
 


### PR DESCRIPTION
When there is no machine to select, the machine view, on mount, called selectMachine with an undefined id, causing the gui.machine state to be removed, and therefore an inconsistency between the state and the actual rendered page. This, in turn, prevented reconciliation in the machine view when the unplaced unit is revived. So, no re-rendering, no joy.
Fixes https://github.com/juju/juju-gui/issues/3163