### PR TITLE
Add browserify-incremental to speed up development iterations.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ bin/
 build-debug
 build-prod
 build-shared
+browserify-cache.json
 classnames.js
 collected-requirements
 dist

--- a/Makefile
+++ b/Makefile
@@ -216,7 +216,7 @@ svg-sprite: $(SVG_SPRITE_MODULE)
 .PHONY: gui
 gui: $(JUJUGUI) $(MODULESMIN) $(BUILT_JS_ASSETS) $(BUILT_YUI) $(CSS_FILE) $(STATIC_CSS_FILES) $(STATIC_IMAGES) $(FAVICON) $(REACT_ASSETS) $(STATIC_FONT_FILES)
 	# Hack for the new init to be built.
-	$(NODE_MODULES)/.bin/browserify -r ./$(GUISRC)/app/init.js:init -o ./$(GUIBUILD)/app/init-pkg.js -t [ babelify --plugins [ transform-react-jsx ] ]
+	$(NODE_MODULES)/.bin/browserifyinc -r ./$(GUISRC)/app/init.js:init -o ./$(GUIBUILD)/app/init-pkg.js -t [ babelify --plugins [ transform-react-jsx ] ]
 
 .PHONY: watch
 watch:

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "babel-preset-babili": "0.1.4",
     "babelify": "https://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
     "browserify": "14.4.0",
+    "browserify-incremental": "^3.1.1",
     "chai": "4.1.1",
     "diff": "3.3.0",
     "eslint": "4.4.1",


### PR DESCRIPTION
When running `make run` this reduces the browserify build times dramatically. Tests however are still slow to boot.