### PR TITLE
Update dist generation to ship production React build

### DIFF
--- a/jujugui/templates/index.html.go
+++ b/jujugui/templates/index.html.go
@@ -342,7 +342,6 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
             'juju-env-base',
             'juju-env-api',
             'juju-models',
-            'bakery-utils',
             // juju-views group
             'juju-landscape',
             // end juju-views group

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "cloud-vanilla-theme": "0.1.2",
     "cryptojs": ">= 2.5.3",
     "d3": "3.5.16",
+    "envify": "^4.1.0",
     "file-saver": "1.3.3",
     "graceful-fs": "4.1.11",
     "js-yaml": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.1.tgz",


### PR DESCRIPTION
Now when running `make dist` it will generate a dist with the production build of React. If you still want the development version of React in the dist you can run the `fast-dist` target, or a fresh dist with the development version of React `clean-all fast-dist`