### PR TITLE
Remove unused YUI modules from being required

### DIFF
--- a/jujugui/static/gui/src/app/init/test-changes-utils.js
+++ b/jujugui/static/gui/src/app/init/test-changes-utils.js
@@ -10,8 +10,7 @@ describe('ChangesUtils', () => {
     let requirements = [
       'changes-utils',
       'environment-change-set',
-      'juju-models',
-      'node'
+      'juju-models'
     ];
     Y = YUI(GlobalConfig).use(requirements, function(Y) {
       models = Y.namespace('juju.models');

--- a/jujugui/static/gui/src/app/models/handlers.js
+++ b/jujugui/static/gui/src/app/models/handlers.js
@@ -488,8 +488,5 @@ YUI.add('juju-delta-handlers', function(Y) {
   };
 
 }, '0.1.0', {
-  requires: [
-    'base',
-    'array-extras'
-  ]
+  requires: ['base']
 });

--- a/jujugui/static/gui/src/app/models/models.js
+++ b/jujugui/static/gui/src/app/models/models.js
@@ -2981,7 +2981,6 @@ YUI.add('juju-models', function(Y) {
     'datasource-io',
     'datasource-jsonschema',
     'io-base',
-    'json-parse',
     'juju-delta-handlers',
     'juju-view-utils',
     'juju-charm-models',

--- a/jujugui/static/gui/src/app/store/env/base.js
+++ b/jujugui/static/gui/src/app/store/env/base.js
@@ -423,9 +423,5 @@ YUI.add('juju-env-base', function(Y) {
   module.BaseEnvironment = BaseEnvironment;
 
 }, '0.1.0', {
-  requires: [
-    'base',
-    'json-parse',
-    'json-stringify'
-  ]
+  requires: ['base']
 });

--- a/jujugui/static/gui/src/test/globalconfig.js
+++ b/jujugui/static/gui/src/test/globalconfig.js
@@ -32,18 +32,9 @@ window.MODULES = [
   // juju-views group
   'juju-landscape',
   // end juju-views group
-  'io',
-  'json-parse',
-  'app-base',
-  'app-transitions',
   'base',
   'bundle-import-notifications',
-  'node',
   'model',
-  'cookie',
-  'querystring',
-  'event-key',
-  'event-touch',
   'model-controller',
   'ghost-deployer-extension',
   'environment-change-set',

--- a/jujugui/static/gui/src/test/test_landscape.js
+++ b/jujugui/static/gui/src/test/test_landscape.js
@@ -23,7 +23,7 @@ describe('Landscape integration', function() {
   var views, models, db, landscape;
 
   before(function(done) {
-    YUI(GlobalConfig).use(['node',
+    YUI(GlobalConfig).use([
       'juju-landscape',
       'juju-models'], function(Y) {
       var envAnno;

--- a/jujugui/static/gui/src/test/test_login.js
+++ b/jujugui/static/gui/src/test/test_login.js
@@ -22,7 +22,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
   describe('environment login support', function() {
     const requires = [
-      'node', 'juju-tests-utils', 'juju-env-api'];
+      'juju-tests-utils', 'juju-env-api'];
     let conn, env, utils, juju;
 
     before(function(done) {

--- a/jujugui/static/gui/src/test/test_model.js
+++ b/jujugui/static/gui/src/test/test_model.js
@@ -1726,7 +1726,6 @@ describe('test_model.js', function() {
 
     before(function(done) {
       Y = YUI(GlobalConfig).use([
-        'io',
         'juju-charm-models',
         'juju-tests-utils'
       ], function(Y) {

--- a/jujugui/static/gui/src/test/test_model.js
+++ b/jujugui/static/gui/src/test/test_model.js
@@ -1574,7 +1574,7 @@ describe('test_model.js', function() {
 
     before(function(done) {
       Y = YUI(GlobalConfig).use(['juju-models', 'juju-gui', 'datasource-local',
-        'juju-tests-utils', 'json-stringify'], function(Y) {
+        'juju-tests-utils'], function(Y) {
         models = Y.namespace('juju.models');
         juju = Y.namespace('juju');
         testUtils = Y.namespace('juju-tests.utils');

--- a/jujugui/static/gui/src/test/test_model_bundle.js
+++ b/jujugui/static/gui/src/test/test_model_bundle.js
@@ -43,7 +43,6 @@ describe('The bundle model', function() {
 
   before(function(done) {
     Y = YUI(GlobalConfig).use([
-      'io',
       'juju-bundle-models',
       'juju-tests-utils'
     ], function(Y) {

--- a/jujugui/templates/index.html.go
+++ b/jujugui/templates/index.html.go
@@ -294,14 +294,14 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     {{if .debug}}
     <script src="{{.comboURL}}?app/assets/javascripts/version.js"></script>
     <script src="{{.comboURL}}?app/init-pkg.js"></script>
-    <script src="{{.comboURL}}?app/assets/javascripts/yui/yui/yui.js&app/assets/javascripts/yui/loader/loader.js"></script>
+    <script src="{{.comboURL}}?app/assets/javascripts/yui/yui/yui.js"></script>
     <script src="{{.comboURL}}?modules.js"></script>
     <script src="{{.comboURL}}?app/assets/javascripts/js-macaroon.js"></script>
     <script src="{{.comboURL}}?app/state/state.js&app/user/user.js&app/utils/github-ssh-keys.js&app/utils/statsd.js&app/jujulib/index.js&app/jujulib/charmstore.js&app/jujulib/bundleservice.js&app/jujulib/plans.js&app/jujulib/payment.js&app/jujulib/stripe.js&app/jujulib/terms.js&app/jujulib/reconnecting-websocket.js&app/jujulib/urls.js&app/jujulib/bakery.js"></script>
     {{else}}
     <script src="{{.comboURL}}?app/init-pkg-min.js"></script>
     <script src="{{.comboURL}}?app/assets/javascripts/version-min.js"></script>
-    <script src="{{.comboURL}}?app/assets/javascripts/yui/yui/yui-min.js&app/assets/javascripts/yui/loader/loader-min.js"></script>
+    <script src="{{.comboURL}}?app/assets/javascripts/yui/yui/yui-min.js"></script>
     <script src="{{.comboURL}}?modules-min.js"></script>
     <script src="{{.comboURL}}?app/assets/javascripts/js-macaroon-min.js"></script>
     <script src="{{.comboURL}}?app/state/state-min.js&app/user/user-min.js&app/utils/github-ssh-keys-min.js&app/utils/statsd-min.js&app/jujulib/index-min.js&app/jujulib/charmstore-min.js&app/jujulib/bundleservice-min.js&app/jujulib/plans-min.js&app/jujulib/payment-min.js&app/jujulib/stripe-min.js&app/jujulib/terms-min.js&app/jujulib/reconnecting-websocket-min.js&app/jujulib/urls-min.js&app/jujulib/bakery-min.js"></script>
@@ -342,22 +342,12 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
             'juju-env-base',
             'juju-env-api',
             'juju-models',
-            'bakery-utils',
             // juju-views group
             'juju-landscape',
             // end juju-views group
-            'io',
-            'json-parse',
-            'app-base',
-            'app-transitions',
             'base',
             'bundle-import-notifications',
-            'node',
             'model',
-            'cookie',
-            'querystring',
-            'event-key',
-            'event-touch',
             'model-controller',
             'ghost-deployer-extension',
             'environment-change-set',

--- a/jujugui/templates/index.html.mako
+++ b/jujugui/templates/index.html.mako
@@ -294,14 +294,14 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     % if raw:
     <script src="${convoy_url}?app/assets/javascripts/version.js"></script>
     <script src="${convoy_url}?app/init-pkg.js"></script>
-    <script src="${convoy_url}?app/assets/javascripts/yui/yui/yui.js&app/assets/javascripts/yui/loader/loader.js"></script>
+    <script src="${convoy_url}?app/assets/javascripts/yui/yui/yui.js"></script>
     <script src="${convoy_url}?modules.js"></script>
     <script src="${convoy_url}?app/assets/javascripts/js-macaroon.js"></script>
     <script src="${convoy_url}?app/state/state.js&app/user/user.js&app/utils/github-ssh-keys.js&app/utils/statsd.js&app/jujulib/index.js&app/jujulib/charmstore.js&app/jujulib/bundleservice.js&app/jujulib/plans.js&app/jujulib/payment.js&app/jujulib/stripe.js&app/jujulib/terms.js&app/jujulib/reconnecting-websocket.js&app/jujulib/urls.js&app/jujulib/bakery.js"></script>
     % else:
     <script src="${convoy_url}?app/init-pkg-min.js"></script>
     <script src="${convoy_url}?app/assets/javascripts/version-min.js"></script>
-    <script src="${convoy_url}?app/assets/javascripts/yui/yui/yui-min.js&app/assets/javascripts/yui/loader/loader-min.js"></script>
+    <script src="${convoy_url}?app/assets/javascripts/yui/yui/yui-min.js"></script>
     <script src="${convoy_url}?modules-min.js"></script>
     <script src="${convoy_url}?app/assets/javascripts/js-macaroon-min.js"></script>
     <script src="${convoy_url}?app/state/state-min.js&app/user/user-min.js&app/utils/github-ssh-keys-min.js&app/utils/statsd-min.js&app/jujulib/index-min.js&app/jujulib/charmstore-min.js&app/jujulib/bundleservice-min.js&app/jujulib/plans-min.js&app/jujulib/payment-min.js&app/jujulib/stripe-min.js&app/jujulib/terms-min.js&app/jujulib/reconnecting-websocket-min.js&app/jujulib/urls-min.js&app/jujulib/bakery-min.js"></script>
@@ -347,18 +347,9 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
             // juju-views group
             'juju-landscape',
             // end juju-views group
-            'io',
-            'json-parse',
-            'app-base',
-            'app-transitions',
             'base',
             'bundle-import-notifications',
-            'node',
             'model',
-            'cookie',
-            'querystring',
-            'event-key',
-            'event-touch',
             'model-controller',
             'ghost-deployer-extension',
             'environment-change-set',


### PR DESCRIPTION
We were still requiring a lot of YUI code that was no longer being used. This removes those modules.