### PR TITLE
Bakery: store the identity URL.

### DIFF
--- a/jujugui/static/gui/src/app/components/terminal/terminal.js
+++ b/jujugui/static/gui/src/app/components/terminal/terminal.js
@@ -41,18 +41,22 @@ class Terminal extends React.Component {
     this.setState({opened: opened});
   }
 
+  /**
+    Set up the terminal WebSocket connection, including handling of initial
+    handlshake and then attaching the xterm.js session.
+  */
   startTerm() {
     const props = this.props;
+    const creds = props.creds;
     // For now, the shell server is listening for ws (rather than wss)
     // connections. This will need to be changed when certs are passed in.
     const ws = new WebSocket(`ws://${props.address}/ws/`);
     ws.onopen = () => {
-      const macaroons = props.creds.macaroons && [props.creds.macaroons];
       ws.send(JSON.stringify({
         operation: 'login',
-        username: props.creds.user,
-        password: props.creds.password,
-        macaroons: macaroons
+        username: creds.user,
+        password: creds.password,
+        macaroons: creds.macaroons
       }));
       ws.send(JSON.stringify({operation: 'start'}));
     };
@@ -92,6 +96,10 @@ class Terminal extends React.Component {
     this.ws = ws;
   }
 
+  /**
+    Destroy the terminal window and close the WebSocket connection to the
+    Juju shell service.
+  */
   stopTerm() {
     this.term.destroy();
     this.term = null;
@@ -142,7 +150,7 @@ Terminal.propTypes = {
   creds: shapeup.shape({
     user: PropTypes.string,
     password: PropTypes.string,
-    macaroons: PropTypes.array
+    macaroons: PropTypes.object
   })
 };
 

--- a/jujugui/static/gui/src/app/init.js
+++ b/jujugui/static/gui/src/app/init.js
@@ -343,7 +343,7 @@ class GUIApp {
   */
   _setupCharmstore(config, Charmstore) {
     if (this.charmstore === undefined) {
-      return new Charmstore(config.charmstoreURL, this.bakery);
+      this.charmstore = new Charmstore(config.charmstoreURL, this.bakery);
       // Store away the charmstore auth info.
       if (this.bakery.storage.get(config.charmstoreURL)) {
         this.users['charmstore'] = {loading: true};

--- a/jujugui/static/gui/src/app/init/component-renderers-mixin.js
+++ b/jujugui/static/gui/src/app/init/component-renderers-mixin.js
@@ -138,6 +138,10 @@ const ComponentRenderersMixin = (superclass) => class extends superclass {
     const creds = {};
     if (identityURL) {
       const serialized = user.getMacaroon('identity');
+      // Note that the macaroons we provide to jujushell are not the same
+      // already stored in the user. For being able to log in to both the
+      // controller and models we provide the identity token here, and that's
+      // the reason why we cannot use fromShape.
       creds.macaroons = {};
       creds.macaroons[identityURL] = JSON.parse(atob(serialized));
     } else {

--- a/jujugui/static/gui/src/app/init/component-renderers-mixin.js
+++ b/jujugui/static/gui/src/app/init/component-renderers-mixin.js
@@ -50,7 +50,6 @@ const Profile = require('../components/profile/profile');
 const Sharing = require('../components/sharing/sharing');
 const Status = require('../components/status/status');
 const SvgIcon = require('../components/svg-icon/svg-icon');
-const Terminal = require('../components/terminal/terminal');
 const UserMenu = require('../components/user-menu/user-menu');
 const UserProfile = require('../components/user-profile/user-profile');
 const USSOLoginLink = require('../components/usso-login-link/usso-login-link');
@@ -134,6 +133,17 @@ const ComponentRenderersMixin = (superclass) => class extends superclass {
     const db = this.db;
     const modelAPI = this.modelAPI;
     const address = this.db.environment.get('jujushellAddress');
+    const user = this.user;
+    const identityURL = user.identityURL();
+    const creds = {};
+    if (identityURL) {
+      const serialized = user.getMacaroon('identity');
+      creds.macaroons = {};
+      creds.macaroons[identityURL] = JSON.parse(atob(serialized));
+    } else {
+      creds.user = user.controller.user;
+      creds.password = user.controller.password;
+    }
     ReactDOM.render(
       <ModelActions
         acl={this.acl}
@@ -141,7 +151,7 @@ const ComponentRenderersMixin = (superclass) => class extends superclass {
         address={address}
         appState={this.state}
         changeState={this._bound.changeState}
-        creds={shapeup.fromShape(this.user.model, Terminal.propTypes.creds)}
+        creds={creds}
         exportEnvironmentFile={
           initUtils.exportEnvironmentFile.bind(initUtils, db)}
         flags={window.juju_config.flags}

--- a/jujugui/static/gui/src/app/jujulib/test-bakery.js
+++ b/jujugui/static/gui/src/app/jujulib/test-bakery.js
@@ -434,21 +434,22 @@ describe('Bakery', () => {
     });
 
     describe('keys', () => {
-      it('special cases identity', () => {
-        // There's no identity url in services
-        Object.keys(storage._services).forEach(key => {
-          assert.notEqual('identity', key);
-        });
+      it('removes discharge suffix', () => {
         assert.equal(
-          'identity', storage._getKey('http://example.com/identity/'));
+          'http://example.com/identity',
+          storage._getKey('http://example.com/identity/discharge'));
       });
 
       it('gets keys from services', () => {
         assert.equal(
-          'charmstore', storage._getKey('http://example.com/charmstore'));
+          'charmstore',
+          storage._getKey('http://example.com/charmstore'));
+      });
+
+      it('does not modify other keys', () => {
+        assert.equal('a-key', storage._getKey('a-key'));
       });
     });
 
   });
 });
-

--- a/jujugui/static/gui/src/app/user/user.js
+++ b/jujugui/static/gui/src/app/user/user.js
@@ -48,31 +48,32 @@ const User = class User {
     this.expirationDatetime = cfg.expirationDatetime || getExpirationDate();
   }
 
-  /** Gets the expiration date out of session storage for the user.
+  /**
+    Gets the expiration date out of session storage for the user.
 
-   Since all data dumped into session storage is serialized, so this also
-   converts the value back into a Date.
-   */
+    Since all data dumped into session storage is serialized, so this also
+    converts the value back into a Date.
+  */
   get expirationDatetime() {
     return new Date(this.sessionStorage.getItem('expirationDatetime'));
   }
 
   /**
-   Sets the expiration date for the user's tokens.
+    Sets the expiration date for the user's tokens.
 
-   Since the date is stored in session storage it will be serialized.
+    Since the date is stored in session storage it will be serialized.
 
-   @param expirationDate Date The time to expire the session for the user.
-   */
+    @param expirationDate Date The time to expire the session for the user.
+  */
   set expirationDatetime(expirationDatetime) {
     this.sessionStorage.setItem('expirationDatetime', expirationDatetime);
   }
 
   /**
-   Checks the expiration date and if reached purges the data. We dump all tokens
-   (controller/models, charmstore, omni, &c) as this is a full session
-   expiration.
-   */
+    Checks the expiration date and if reached purges the data. We dump all
+    tokens (controller/models, charmstore, omni, etc.) as this is a full session
+    expiration.
+  */
   _purgeIfExpired() {
     const now = new Date();
     if (now > this.expirationDatetime) {
@@ -82,13 +83,13 @@ const User = class User {
   }
 
   /**
-   Get's the user's display name from the username in controller credentials.
+    Gets the user's display name from the username in controller credentials.
 
-   The user's display name is the first half of the full username. That is, in
-   "doctor@who", the display name is "doctor".
+    The user's display name is the first half of the full username. That is, in
+    "doctor@who", the display name is "doctor".
 
-   If external auth -- e.g. from HJC -- exists, that is used for name data.
-   */
+    If external auth -- e.g. from HJC -- exists, that is used for name data.
+  */
   get displayName() {
     this._purgeIfExpired();
     if (this.externalAuth) {
@@ -98,12 +99,12 @@ const User = class User {
   }
 
   /**
-   Get's the user's username from the username in controller credentials.
+    Gets the user's username from the username in controller credentials.
 
-   The full username includes location, e.g. @external.
+    The full username includes location, e.g. @external.
 
-   If external auth -- e.g. from HJC -- exists, that is used for name data.
-   */
+    If external auth -- e.g. from HJC -- exists, that is used for name data.
+  */
   get username() {
     this._purgeIfExpired();
     if (this.externalAuth) {
@@ -113,21 +114,21 @@ const User = class User {
   }
 
   /**
-   Setter for external auth information, i.e. from HJC.
+    Setter for external auth information, i.e. from HJC.
 
-   External auth information is used for determining username display and
-   controller credential status.
-   */
+    External auth information is used for determining username display and
+    controller credential status.
+  */
   set externalAuth(val) {
     this._external = val;
   }
 
   /**
-   Getter for external auth information, i.e. from HJC.
+    Getter for external auth information, i.e. from HJC.
 
-   Since external auth from HJC can be a nested object, this moves name data to
-   the top level of the object.
-   */
+    Since external auth from HJC can be a nested object, this moves name data to
+    the top level of the object.
+  */
   get externalAuth() {
     this._purgeIfExpired();
     const externalAuth = this._external;
@@ -141,12 +142,12 @@ const User = class User {
   }
 
   /**
-   Gets credentials out of sessionStorage.
+    Gets credentials out of sessionStorage.
 
-   @param {String} type The type of credential. Expected to be either
-   'controller' or 'model'.
-   @return {Object} A credentials object with both the stored data and
-   convenience attributes for handling login flow.
+    @param {String} type The type of credential. Expected to be either
+      'controller' or 'model'.
+    @return {Object} A credentials object with both the stored data and
+      convenience attributes for handling login flow.
   */
   _getCredentials(type) {
     this._purgeIfExpired();
@@ -178,12 +179,12 @@ const User = class User {
       },
       areAvailable: {
         /**
-          * Reports whether or not credentials are populated.
-          *
-          * @method get
-          * @return {Boolean} Whether or not either user and password or
-          *   macaroons are set.
-          */
+          Reports whether or not credentials are populated.
+
+          @method get
+          @return {Boolean} Whether or not either user and password or
+            macaroons are set.
+        */
         get: function() {
           const creds = !!((this.user && this.password) || this.macaroons);
           // In typical deploys this is sufficient however in HJC or when
@@ -196,26 +197,43 @@ const User = class User {
   }
 
   /**
-   Sets credentials in sessionStorage.
+    Sets credentials in sessionStorage.
 
-   @param {String} type The type of credential. Expected to be either
-   'controller' or 'model'.
-   @param {Object} credentials The credentials object to be stored.
-   */
+    @param {String} type The type of credential. Expected to be either
+      'controller' or 'model'.
+    @param {Object} credentials The credentials object to be stored.
+  */
   _setCredentials(type, credentials) {
     this.sessionStorage.setItem(
       type + 'Credentials', JSON.stringify(credentials));
   }
 
+  /**
+    Returns controller credentials.
+
+    @return {Object} A credentials object with both the stored data and
+      convenience attributes for handling login flow.
+  */
   get controller() {
     this._purgeIfExpired();
     return this._getCredentials('controller');
   }
 
+  /**
+    Sets controller credentials.
+
+    @param {Object} credentials The credentials object to be stored.
+  */
   set controller(credentials) {
     this._setCredentials('controller', credentials);
   }
 
+  /**
+    Returns model credentials.
+
+    @return {Object} A credentials object with both the stored data and
+      convenience attributes for handling login flow.
+  */
   get model() {
     this._purgeIfExpired();
     // There are situations where we have no model creds but can fall back to
@@ -228,23 +246,68 @@ const User = class User {
     return this._getCredentials('controller');
   }
 
+  /**
+    Sets model credentials.
+
+    @param {Object} credentials The credentials object to be stored.
+  */
   set model(credentials) {
     this._setCredentials('model', credentials);
   }
 
+  /**
+    Returns the inferred identity URL, which is only available after a
+    successful login, and can be assumed to be valid only for the duration of
+    the user session.
+
+    @return {String} The URL of the identity manager (or null if not present).
+  */
+  identityURL() {
+    const token = this.getMacaroon('identity');
+    if (!token) {
+      return null;
+    }
+    for (const key in this.localStorage) {
+      if (key !== 'identity' && this.getMacaroon(key) === token) {
+        return key;
+      }
+    }
+    return null;
+  }
+
+  /**
+    Sets the given serialized macaroons for the given service.
+
+    @param {String} service The service name, like "charmstore" or "terms".
+    @param {String} macaroon The serialized macaroons.
+  */
   setMacaroon(service, macaroon) {
     this.localStorage.setItem(service, macaroon);
   }
 
+  /**
+    Retrieves serialized macaroons for the given service.
+
+    @param {String} service The service name, like "charmstore" or "terms".
+    @return {String} The serialized macaroons.
+  */
   getMacaroon(service) {
     this._purgeIfExpired();
     return this.localStorage.getItem(service);
   }
 
+  /**
+    Removes macaroons for the given service.
+
+    @param {String} service The service name, like "charmstore" or "terms".
+  */
   clearMacaroon(service) {
     this.localStorage.removeItem(service);
   }
 
+  /**
+    Removes all stored macaroons (for all services).
+  */
   clearMacaroons() {
     this.localStorage.clear();
   }


### PR DESCRIPTION
This way we have a convenient way for generating the macaroons to be included in jujushell auth request.

Also fix a bug in the handling of charm store users: right now in production we force users to click to log into the charm store after refreshing.