### PR TITLE
Remove pendingResources from the ECS when charm parent record is removed.

### DIFF
--- a/jujugui/static/gui/src/app/utils/environment-change-set.js
+++ b/jujugui/static/gui/src/app/utils/environment-change-set.js
@@ -825,6 +825,13 @@ YUI.add('environment-change-set', function(Y) {
           // If the addCharm call is not used anywhere else then it can be
           // safely removed.
           if (!used) {
+            // It is possible that some resources were added with the charm
+            // which also needs to be removed.
+            record.parents.forEach(key => {
+              if (key.indexOf('addPendingResources-') === 0) {
+                this._removeExistingRecord(key);
+              }
+            });
             this._removeExistingRecord(key);
           }
         }

--- a/jujugui/static/gui/src/test/test_env_change_set.js
+++ b/jujugui/static/gui/src/test/test_env_change_set.js
@@ -1002,13 +1002,14 @@ describe('Environment Change Set', function() {
         db.relations.remove = sinon.stub();
         ecs.lazyAddCharm(
           ['cs:wordpress', 'cookies', null], {applicationId: 'foo'});
+        ecs.lazyAddPendingResources([{charmURL: 'cs:wordpress'}]);
         ecs.lazyDeploy(
           [{charmURL: 'cs:wordpress'}, function() {}], {modelId: 'baz'});
         ecs.lazyDeploy(
           [{charmURL: 'cs:wordpress'}, function() {}], {modelId: 'baz2'});
-        assert.equal(Object.keys(ecs.changeSet).length, 3);
+        assert.equal(Object.keys(ecs.changeSet).length, 4);
         ecs.lazyDestroyApplication(['baz']);
-        assert.equal(Object.keys(ecs.changeSet).length, 2);
+        assert.equal(Object.keys(ecs.changeSet).length, 3);
         ecs.lazyDestroyApplication(['baz2']);
         assert.equal(Object.keys(ecs.changeSet).length, 0);
       });


### PR DESCRIPTION
Fixes #3304 