### PR TITLE
Remove the usso login link hover notification

### DIFF
--- a/jujugui/static/gui/src/app/components/usso-login-link/_usso-login-link.scss
+++ b/jujugui/static/gui/src/app/components/usso-login-link/_usso-login-link.scss
@@ -1,23 +1,6 @@
 .usso-login {
   position: relative;
 
-  &__notification {
-    background: $white;
-    box-shadow: $box-shadow;
-    box-sizing: border-box;
-    color: $dark-warm-grey;
-    font-size: .875rem;
-    line-height: normal;
-    margin: 10px auto 0;
-    padding: 12px 25px;
-    position: absolute;
-    z-index: index($z-indexed-elements, environment-help);
-    top: 150%;
-    right: 0px;
-    width: 280px;
-    display: none;
-  }
-
   &__action {
     cursor: pointer;
     padding: 0;
@@ -31,19 +14,6 @@
       color: $white !important;
       // scss-lint:enable ImportantRule
       padding: 12px 24px;
-    }
-  }
-
-  &__action:hover + &__notification {
-    display: block;
-    // scss-lint:disable ImportantRule
-    color: $dark-warm-grey !important;
-    // scss-lint:enable ImportantRule
-
-    &.button--positive {
-      // scss-lint:disable ImportantRule
-      color: $white !important;
-      // scss-lint:enable ImportantRule
     }
   }
 }

--- a/jujugui/static/gui/src/app/components/usso-login-link/test-usso-login-link.js
+++ b/jujugui/static/gui/src/app/components/usso-login-link/test-usso-login-link.js
@@ -10,11 +10,6 @@ const jsTestUtils = require('../../utils/component-test-utils');
 const testUtils = require('react-dom/test-utils');
 
 describe('USSOLoginLink', () => {
-
-  const notification = `If requested,
-        in the address bar above, please allow popups
-        from ${window.location.origin}.`;
-
   it('can render a text link', () => {
     const output = jsTestUtils.shallowRender(
       <USSOLoginLink
@@ -24,13 +19,10 @@ describe('USSOLoginLink', () => {
     const expected = (
       <div className="usso-login">
         <a className="usso-login__action"
-          onClick={output.props.children[0].props.onClick}
+          onClick={output.props.children.props.onClick}
           target="_blank">
             Login
         </a>
-        <div className="usso-login__notification">
-          {notification}
-        </div>
       </div>);
     expect(output).toEqualJSX(expected);
   });
@@ -82,9 +74,6 @@ describe('USSOLoginLink', () => {
           type="positive" >
           Sign up/Log in with USSO
         </GenericButton>
-        <div className="usso-login__notification">
-          {notification}
-        </div>
       </div>);
     expect(output).toEqualJSX(expected);
   });
@@ -100,7 +89,7 @@ describe('USSOLoginLink', () => {
           Scooby Doo
       </USSOLoginLink>, true);
     const output = component.getRenderOutput();
-    assert.equal(output.props.children[0].props.children, 'Scooby Doo');
+    assert.equal(output.props.children.props.children, 'Scooby Doo');
   });
 
   it('can render a text link with custom content', () => {
@@ -114,7 +103,7 @@ describe('USSOLoginLink', () => {
           Scooby Doo
       </USSOLoginLink>, true);
     const output = component.getRenderOutput();
-    assert.equal(output.props.children[0].props.children, 'Scooby Doo');
+    assert.equal(output.props.children.props.children, 'Scooby Doo');
   });
 
   it('calls loginToController on click for button link', () => {

--- a/jujugui/static/gui/src/app/components/usso-login-link/usso-login-link.js
+++ b/jujugui/static/gui/src/app/components/usso-login-link/usso-login-link.js
@@ -76,9 +76,6 @@ class USSOLoginLink extends React.Component {
   }
 
   render() {
-    const notification = `If requested,
-      in the address bar above, please allow popups
-      from ${window.location.origin}.`;
     let ele;
     if (this.props.displayType === 'button') {
       ele = this._renderButtonLink();
@@ -88,9 +85,6 @@ class USSOLoginLink extends React.Component {
     return(
       <div className="usso-login">
         {ele}
-        <div className="usso-login__notification">
-          {notification}
-        </div>
       </div>);
   }
 };


### PR DESCRIPTION
The GUI already displays a notification informing the user on how to open the popup after button has been clicked so this was duplicate functionality.

Fixes: #3285.