### PR TITLE
Send supplied commands on terminal connection

### DIFF
--- a/jujugui/static/gui/src/app/components/terminal/_terminal.scss
+++ b/jujugui/static/gui/src/app/components/terminal/_terminal.scss
@@ -48,10 +48,14 @@
       background-color: #111;
     }
 
+    .xterm-viewport {
+      background-color: #111;
+    }
+
     .xterm-rows,
     .xterm-selection {
       font-family: "ubuntu mono";
-      top: 10px;
+      background-color: #111;
       left: 10px;
     }
   }

--- a/jujugui/static/gui/src/app/components/terminal/terminal.js
+++ b/jujugui/static/gui/src/app/components/terminal/terminal.js
@@ -23,6 +23,9 @@ class Terminal extends React.Component {
     super(props);
     this.state = {
       size: 'min',
+      // The terminalSize will be set to the window height subtract some
+      // value, that will be set here and used to determine the height
+      // of the terminal.
       terminalSize: null
     };
     this.term = null;
@@ -81,13 +84,16 @@ class Terminal extends React.Component {
         });
         return;
       }
-      // Terminado sends a "disconnect" message when the process it's running
-      // exits. When we receive that, we close the terminal.
       switch(resp[0]) {
         case 'disconnect':
+          // Terminado sends a "disconnect" message when the process it's
+          // running exits. When we receive that, we close the terminal.
           this.close();
           break;
         case 'setup':
+          // Terminado sends a "setup" message after it's fully done setting
+          // up on the server side and will be sending the first PS1 to the
+          // client.
           this.terminalSetup = true;
           break;
         case 'stdout':
@@ -98,7 +104,8 @@ class Terminal extends React.Component {
               this.initialCommandsSent = true;
               const commands = props.commands;
               if (commands) {
-                commands.forEach(c => ws.send(JSON.stringify(['stdin', `${c}\n`])));
+                commands.forEach(
+                  cmd => ws.send(JSON.stringify(['stdin', `${cmd}\n`])));
               }
             }
           }
@@ -150,7 +157,7 @@ class Terminal extends React.Component {
   setSize(size) {
     let terminalSize = null;
     if (size === 'max') {
-      terminalSize= window.innerHeight - 250 + 'px';
+      terminalSize = window.innerHeight - 250 + 'px';
     }
     this.setState({
       size,

--- a/jujugui/static/gui/src/app/components/terminal/terminal.js
+++ b/jujugui/static/gui/src/app/components/terminal/terminal.js
@@ -92,6 +92,8 @@ class Terminal extends React.Component {
           break;
         case 'stdout':
           if (this.terminalSetup && !this.initialCommandsSent) {
+            // If the first PS1 presented to the user changes then this will
+            // need to be updated.
             if (resp[1].indexOf('\u001b[01;32') === 0) {
               this.initialCommandsSent = true;
               const commands = props.commands;

--- a/jujugui/static/gui/src/app/components/terminal/test-terminal.js
+++ b/jujugui/static/gui/src/app/components/terminal/test-terminal.js
@@ -100,6 +100,32 @@ describe('Terminal', () => {
     component.ws.onmessage({data: '["stdout", "\\u001b[01;32"]'});
     ReactDOM.unmountComponentAtNode(ReactDOM.findDOMNode(component).parentNode);
     assert.equal(websocket.prototype.send.callCount, 1);
+    assert.deepEqual(websocket.prototype.send.args[0], ['["stdin","juju status\\n"]']);
+  });
+
+  it('sends multiple commands when it is set up', () => {
+    setupWebsocket();
+    const component = ReactTestUtils.renderIntoDocument(
+      <Terminal
+        addNotification={sinon.stub()}
+        address="1.2.3.4:123"
+        changeState={sinon.stub()}
+        commands={['juju status', 'juju switch']}
+        creds={{
+          user: 'user',
+          password: 'password',
+          macaroons: {}
+        }}
+        WebSocket={websocket} />
+    );
+    // Send the setup from the term.
+    component.ws.onmessage({data: '["setup", {}]'});
+    // Send the initial PS1
+    component.ws.onmessage({data: '["stdout", "\\u001b[01;32"]'});
+    ReactDOM.unmountComponentAtNode(ReactDOM.findDOMNode(component).parentNode);
+    assert.equal(websocket.prototype.send.callCount, 2);
+    assert.deepEqual(websocket.prototype.send.args[0], ['["stdin","juju status\\n"]']);
+    assert.deepEqual(websocket.prototype.send.args[1], ['["stdin","juju switch\\n"]']);
   });
 
   it('can be closed by clicking the X', () => {

--- a/jujugui/static/gui/src/app/init/component-renderers-mixin.js
+++ b/jujugui/static/gui/src/app/init/component-renderers-mixin.js
@@ -188,6 +188,7 @@ const ComponentRenderersMixin = (superclass) => class extends superclass {
     const config = this.applicationConfig;
     const user = this.user;
     const identityURL = user.identityURL();
+    const modelName = this.db.environment.get('name');
     const creds = {};
     if (identityURL && config.gisf) {
       const serialized = user.getMacaroon('identity');
@@ -208,6 +209,7 @@ const ComponentRenderersMixin = (superclass) => class extends superclass {
         // provided by the environment.
         address={address}
         changeState={this._bound.changeState}
+        commands={[`juju switch ${modelName}`]}
         creds={creds}
         WebSocket={WebSocket}/>,
       document.getElementById('terminal-container'));


### PR DESCRIPTION
The terminal component can now take a `commands` array and they will be executed when the terminal connects.

When resizing the browser window the terminal component will resize if it is in the 'max' mode so that the canvas header is always visible. 