### PR TITLE
Add border-bottom to indicate state on inspector tabs

### DIFF
--- a/jujugui/static/gui/src/app/components/env-size-display/_env-size-display.scss
+++ b/jujugui/static/gui/src/app/components/env-size-display/_env-size-display.scss
@@ -30,11 +30,11 @@
     }
 
     &:hover {
-      background-color: $canvas-background;
+      border-bottom: 3px solid $light-mid-grey;
     }
 
-    &.is-active &__link &__icon {
-      color: $ubuntu-orange;
+    &.is-active {
+      border-bottom: 3px solid $ubuntu-orange;
     }
   }
 

--- a/jujugui/static/gui/src/app/components/env-size-display/env-size-display.js
+++ b/jujugui/static/gui/src/app/components/env-size-display/env-size-display.js
@@ -16,8 +16,8 @@ class EnvSizeDisplay extends React.Component {
     const view = e.currentTarget.dataset.view;
     this.props.appState.changeState({
       gui: {
-        machines: view === 'machine' ? '' : null,
-        status: view === 'status' ? '' : null
+        machines: view === 'machines' ? true : null,
+        status: view === 'status' ? true : null
       }
     });
   }
@@ -32,6 +32,20 @@ class EnvSizeDisplay extends React.Component {
   */
   _genClasses(section) {
     const guiState = this.props.appState.current.gui;
+    let isDefaultTab = false;
+
+    if (guiState) {
+      if (guiState.hasOwnProperty(section) === 'machine' ||
+          guiState.hasOwnProperty(section) === 'status') {
+        isDefaultTab = true;
+      }
+    } else {
+      isDefaultTab = true;
+    }
+
+    if (isDefaultTab && section === 'application') {
+      return 'env-size-display__list-item is-active';
+    }
     return classNames(
       'env-size-display__list-item',
       {
@@ -50,7 +64,8 @@ class EnvSizeDisplay extends React.Component {
       <li className={this._genClasses('status')}>
         <a data-view="status"
           onClick={this._changeEnvironmentView.bind(this)}
-          className="env-size-display__link">
+          className="env-size-display__link"
+          href="#_">
           status
         </a>
       </li>);
@@ -67,15 +82,17 @@ class EnvSizeDisplay extends React.Component {
           <li className={this._genClasses('application')}>
             <a data-view="application"
               onClick={this._changeEnvironmentView.bind(this)}
-              className="env-size-display__link">
+              className="env-size-display__link"
+              href="#_">
               {serviceCount}&nbsp;
               {pluralize('application', serviceCount)}
             </a>
           </li>
-          <li className={this._genClasses('machine')}>
-            <a data-view="machine"
+          <li className={this._genClasses('machines')}>
+            <a data-view="machines"
               onClick={this._changeEnvironmentView.bind(this)}
-              className="env-size-display__link">
+              className="env-size-display__link"
+              href="#_">
               {machineCount}&nbsp;
               {pluralize('machine', machineCount)}
             </a>

--- a/jujugui/static/gui/src/app/components/env-size-display/env-size-display.js
+++ b/jujugui/static/gui/src/app/components/env-size-display/env-size-display.js
@@ -16,8 +16,8 @@ class EnvSizeDisplay extends React.Component {
     const view = e.currentTarget.dataset.view;
     this.props.appState.changeState({
       gui: {
-        machines: view === 'machines' ? true : null,
-        status: view === 'status' ? true : null
+        machines: view === 'machines' ? '' : null,
+        status: view === 'status' ? '' : null
       }
     });
   }
@@ -32,24 +32,15 @@ class EnvSizeDisplay extends React.Component {
   */
   _genClasses(section) {
     const guiState = this.props.appState.current.gui;
-    let isDefaultTab = false;
 
-    if (guiState) {
-      if (guiState.hasOwnProperty(section) === 'machine' ||
-          guiState.hasOwnProperty(section) === 'status') {
-        isDefaultTab = true;
-      }
-    } else {
-      isDefaultTab = true;
-    }
-
-    if (isDefaultTab && section === 'application') {
+    if (!guiState && section === 'application') {
       return 'env-size-display__list-item is-active';
     }
+
     return classNames(
       'env-size-display__list-item',
       {
-        'is-active': guiState && guiState[section]
+        'is-active': guiState && guiState[section] !== undefined
       }
     );
   }
@@ -64,8 +55,7 @@ class EnvSizeDisplay extends React.Component {
       <li className={this._genClasses('status')}>
         <a data-view="status"
           onClick={this._changeEnvironmentView.bind(this)}
-          className="env-size-display__link"
-          href="#_">
+          className="env-size-display__link">
           status
         </a>
       </li>);
@@ -82,8 +72,7 @@ class EnvSizeDisplay extends React.Component {
           <li className={this._genClasses('application')}>
             <a data-view="application"
               onClick={this._changeEnvironmentView.bind(this)}
-              className="env-size-display__link"
-              href="#_">
+              className="env-size-display__link">
               {serviceCount}&nbsp;
               {pluralize('application', serviceCount)}
             </a>
@@ -91,8 +80,7 @@ class EnvSizeDisplay extends React.Component {
           <li className={this._genClasses('machines')}>
             <a data-view="machines"
               onClick={this._changeEnvironmentView.bind(this)}
-              className="env-size-display__link"
-              href="#_">
+              className="env-size-display__link">
               {machineCount}&nbsp;
               {pluralize('machine', machineCount)}
             </a>

--- a/jujugui/static/gui/src/app/components/env-size-display/test-env-size-display.js
+++ b/jujugui/static/gui/src/app/components/env-size-display/test-env-size-display.js
@@ -22,7 +22,7 @@ describe('EnvSizeDisplay', function() {
     appState = {
       current: {
         gui: {
-          machines: true
+          machines: ''
         }
       },
       changeState: sinon.stub()
@@ -81,7 +81,7 @@ describe('EnvSizeDisplay', function() {
     assert.equal(appState.changeState.callCount, 2);
     assert.deepEqual(appState.changeState.getCall(0).args[0], {
       gui: {
-        machines: true,
+        machines: '',
         status: null
       }
     });
@@ -115,7 +115,7 @@ describe('EnvSizeDisplay', function() {
     assert.equal(appState.changeState.callCount, 1);
     assert.deepEqual(appState.changeState.args[0][0], {
       gui: {
-        machines: true,
+        machines: '',
         status: null
       }
     });
@@ -139,7 +139,7 @@ describe('EnvSizeDisplay', function() {
     assert.equal(appState.changeState.callCount, 2);
     assert.deepEqual(appState.changeState.args[0][0], {
       gui: {
-        machines: true,
+        machines: '',
         status: null
       }
     });

--- a/jujugui/static/gui/src/app/components/env-size-display/test-env-size-display.js
+++ b/jujugui/static/gui/src/app/components/env-size-display/test-env-size-display.js
@@ -22,7 +22,7 @@ describe('EnvSizeDisplay', function() {
     appState = {
       current: {
         gui: {
-          machine: true
+          machines: true
         }
       },
       changeState: sinon.stub()
@@ -45,7 +45,7 @@ describe('EnvSizeDisplay', function() {
         component, 'a[data-view=application]').innerText, '3 applications');
     assert.equal(
       queryComponentSelector(
-        component, 'a[data-view=machine]').innerText, '4 machines');
+        component, 'a[data-view=machines]').innerText, '4 machines');
   });
 
   it('highlights active tab on initial render', function() {
@@ -59,7 +59,7 @@ describe('EnvSizeDisplay', function() {
     assert.notEqual(
       queryComponentSelector(
         component,
-        '.env-size-display__list-item.is-active a[data-view=machine]'),
+        '.env-size-display__list-item.is-active a[data-view=machines]'),
       null);
   });
 
@@ -74,14 +74,14 @@ describe('EnvSizeDisplay', function() {
     var serviceLink = queryComponentSelector(component,
       'a[data-view=application]');
     var machineLink = queryComponentSelector(component,
-      'a[data-view=machine]');
+      'a[data-view=machines]');
     testUtils.Simulate.click(machineLink);
     testUtils.Simulate.click(serviceLink);
 
     assert.equal(appState.changeState.callCount, 2);
     assert.deepEqual(appState.changeState.getCall(0).args[0], {
       gui: {
-        machines: '',
+        machines: true,
         status: null
       }
     });
@@ -104,18 +104,18 @@ describe('EnvSizeDisplay', function() {
     var serviceLink = queryComponentSelector(component,
       'a[data-view=application]');
     var machineLink = queryComponentSelector(component,
-      'a[data-view=machine]');
+      'a[data-view=machines]');
 
     testUtils.Simulate.click(machineLink);
     assert.notEqual(
       queryComponentSelector(
         component,
-        '.env-size-display__list-item.is-active a[data-view=machine]'),
+        '.env-size-display__list-item.is-active a[data-view=machines]'),
       null);
     assert.equal(appState.changeState.callCount, 1);
     assert.deepEqual(appState.changeState.args[0][0], {
       gui: {
-        machines: '',
+        machines: true,
         status: null
       }
     });
@@ -139,7 +139,7 @@ describe('EnvSizeDisplay', function() {
     assert.equal(appState.changeState.callCount, 2);
     assert.deepEqual(appState.changeState.args[0][0], {
       gui: {
-        machines: '',
+        machines: true,
         status: null
       }
     });


### PR DESCRIPTION
Added visual state to Inspector tabs in form of a bottom border

Fixes https://app.zenhub.com/workspace/o/canonicalltd/juju-design/issues/308
Fixes #3322