### PR TITLE
Call to fit the terminal after it received it's first PS1 and not on a timeout.

### DIFF
--- a/jujugui/static/gui/src/app/components/terminal/terminal.js
+++ b/jujugui/static/gui/src/app/components/terminal/terminal.js
@@ -45,11 +45,6 @@ class Terminal extends React.Component {
     const term = new XTerm();
     term.write('Connecting... ');
     this.term = term;
-    term.on('open', () => {
-      // To properly have the terminal area fit the full width we have to
-      // call fit a little bit after it's been opened.
-      setTimeout(() => term.fit(), 500);
-    });
     term.open(
       ReactDOM.findDOMNode(this).querySelector('.juju-shell__terminal'),
       true);
@@ -101,6 +96,8 @@ class Terminal extends React.Component {
             // If the first PS1 presented to the user changes then this will
             // need to be updated.
             if (resp[1].indexOf('\u001b[01;32') === 0) {
+              // Call to resize the terminal after getting the first PS1.
+              term.fit();
               this.initialCommandsSent = true;
               const commands = props.commands;
               if (commands) {

--- a/jujugui/static/gui/src/app/components/terminal/test-terminal.js
+++ b/jujugui/static/gui/src/app/components/terminal/test-terminal.js
@@ -94,10 +94,13 @@ describe('Terminal', () => {
         }}
         WebSocket={websocket} />
     );
+    // Check that fit is called after receiving the first PS1.
+    component.term.fit = sinon.stub(); // eslint-disable-line
     // Send the setup from the term.
     component.ws.onmessage({data: '["setup", {}]'});
     // Send the initial PS1
     component.ws.onmessage({data: '["stdout", "\\u001b[01;32"]'});
+    assert.equal(component.term.fit.callCount, 1); // eslint-disable-line
     ReactDOM.unmountComponentAtNode(ReactDOM.findDOMNode(component).parentNode);
     assert.equal(websocket.prototype.send.callCount, 1);
     assert.deepEqual(websocket.prototype.send.args[0], ['["stdin","juju status\\n"]']);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "juju-gui",
-  "version": "2.10.2",
+  "version": "2.11.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Depending on the time it takes the terminal to receive the data from the server the settimeout to refit the terminal was always incorrect. This branch changes the first call to resize the terminal until after it receives its first PS1.