### PR TITLE
terminal: include the model owner when sending the juju switch command.

### DIFF
--- a/jujugui/static/gui/src/app/init/component-renderers-mixin.js
+++ b/jujugui/static/gui/src/app/init/component-renderers-mixin.js
@@ -188,7 +188,13 @@ const ComponentRenderersMixin = (superclass) => class extends superclass {
     const config = this.applicationConfig;
     const user = this.user;
     const identityURL = user.identityURL();
-    const modelName = this.db.environment.get('name');
+    const modelAPI = this.modelAPI;
+    const commands = [];
+    const modelName = modelAPI.get('environmentName');
+    if (modelName) {
+      const modelOwner = modelAPI.get('modelOwner');
+      commands.push(`juju switch ${modelOwner}/${modelName}`);
+    }
     const creds = {};
     if (identityURL && config.gisf) {
       const serialized = user.getMacaroon('identity');
@@ -209,7 +215,7 @@ const ComponentRenderersMixin = (superclass) => class extends superclass {
         // provided by the environment.
         address={address}
         changeState={this._bound.changeState}
-        commands={[`juju switch ${modelName}`]}
+        commands={commands}
         creds={creds}
         WebSocket={WebSocket}/>,
       document.getElementById('terminal-container'));


### PR DESCRIPTION
Also, only send the juju switch command when actually connected to a model.
Fixes https://github.com/juju/juju-gui/issues/3345