### PR TITLE
Set focus back to terminal after resizing.

### DIFF
--- a/jujugui/static/gui/src/app/components/terminal/terminal.js
+++ b/jujugui/static/gui/src/app/components/terminal/terminal.js
@@ -162,8 +162,17 @@ class Terminal extends React.Component {
     }, () => {
       if (this.term) {
         this.term.fit();
+        this.focus();
       }
     });
+  }
+
+  /**
+    Set the focus back to the terminal so that users can keep typing.
+  */
+  focus() {
+    const textarea = this.refs.terminal.querySelector('textarea');
+    textarea.focus();
   }
 
   /**
@@ -201,7 +210,7 @@ class Terminal extends React.Component {
             </span>
           </div>
         </div>
-        <div className={terminalClassNames} style={styles}></div>
+        <div ref="terminal" className={terminalClassNames} style={styles}></div>
       </div>
     );
   }

--- a/jujugui/static/gui/src/app/components/terminal/test-terminal.js
+++ b/jujugui/static/gui/src/app/components/terminal/test-terminal.js
@@ -54,7 +54,11 @@ describe('Terminal', () => {
             </span>
           </div>
         </div>
-        <div className={'juju-shell__terminal juju-shell__terminal--min'} style={{}}></div>
+        <div
+          ref="terminal"
+          className={'juju-shell__terminal juju-shell__terminal--min'}
+          style={{}}>
+        </div>
       </div>);
     expect(renderComponent().getRenderOutput()).toEqualJSX(expected);
   });
@@ -146,9 +150,16 @@ describe('Terminal', () => {
     const renderer = renderComponent();
     const output = renderer.getRenderOutput();
     const instance = renderer.getMountedInstance();
+    const textarea = {focus: sinon.stub().withArgs()};
+    instance.refs = {terminal: {
+      querySelector: sinon.stub().withArgs('textarea').returns(textarea)
+    }};
+    instance.term = {fit: sinon.stub()}; // eslint-disable-line
     // Call the onClick for the maximize
     output.props.children[0].props.children[1].props.children[1].props.onClick();
     assert.equal(instance.state.size, 'max');
+    // The focus has been moved back to the terminal.
+    assert.strictEqual(textarea.focus.called, true, 'focus not called');
     const output2 = renderer.getRenderOutput();
     // Check that the styles have been updated for max height.
     // Because the browser dimensions can vary across machines this just checks


### PR DESCRIPTION
So that users can keep typing after clicking to resize.