### PR TITLE
Terminal to handle unexpected disconnect

### DIFF
--- a/jujugui/static/gui/src/app/components/terminal/terminal.js
+++ b/jujugui/static/gui/src/app/components/terminal/terminal.js
@@ -113,7 +113,7 @@ class Terminal extends React.Component {
       }
     };
     ws.onclose = evt => {
-      if (evt.code > 1000) {
+      if (evt && evt.code > 1000) {
         // It is not a normal closure so we should issue an error.
         console.log(evt);
         props.addNotification({

--- a/jujugui/static/gui/src/app/components/terminal/terminal.js
+++ b/jujugui/static/gui/src/app/components/terminal/terminal.js
@@ -112,6 +112,17 @@ class Terminal extends React.Component {
         term.writeln('connected to temporary workspace.\n');
       }
     };
+    ws.onclose = evt => {
+      if (evt.code > 1000) {
+        // It is not a normal closure so we should issue an error.
+        console.log(evt);
+        props.addNotification({
+          title: 'Terminal connection unexpectedly closed.',
+          message: 'Terminal connection unexpectedly closed.',
+          level: 'error'
+        });
+      }
+    };
 
     this.attachResizeListener();
   }

--- a/jujugui/static/gui/src/app/components/terminal/terminal.js
+++ b/jujugui/static/gui/src/app/components/terminal/terminal.js
@@ -116,7 +116,7 @@ class Terminal extends React.Component {
       // 1000 is the code for a normal closure, anything above that is abnormal.
       if (evt && evt.code > 1000) {
         // It is not a normal closure so we should issue an error.
-        console.error(evt);
+        console.log(evt);
         props.addNotification({
           title: 'Terminal connection unexpectedly closed.',
           message: 'Terminal connection unexpectedly closed.',

--- a/jujugui/static/gui/src/app/components/terminal/terminal.js
+++ b/jujugui/static/gui/src/app/components/terminal/terminal.js
@@ -113,9 +113,10 @@ class Terminal extends React.Component {
       }
     };
     ws.onclose = evt => {
+      // 1000 is the code for a normal closure, anything above that is abnormal.
       if (evt && evt.code > 1000) {
         // It is not a normal closure so we should issue an error.
-        console.log(evt);
+        console.error(evt);
         props.addNotification({
           title: 'Terminal connection unexpectedly closed.',
           message: 'Terminal connection unexpectedly closed.',

--- a/jujugui/static/gui/src/app/components/terminal/test-terminal.js
+++ b/jujugui/static/gui/src/app/components/terminal/test-terminal.js
@@ -146,7 +146,7 @@ describe('Terminal', () => {
     }]);
   });
 
-  it('handles unexpected websocket closures', () => {
+  it('handles unexpected WebSocket closures', () => {
     setupWebsocket();
     const component = ReactTestUtils.renderIntoDocument(
       <Terminal

--- a/jujugui/static/gui/src/app/components/terminal/test-terminal.js
+++ b/jujugui/static/gui/src/app/components/terminal/test-terminal.js
@@ -146,6 +146,34 @@ describe('Terminal', () => {
     }]);
   });
 
+  it('handles unexpected websocket closures', () => {
+    setupWebsocket();
+    const component = ReactTestUtils.renderIntoDocument(
+      <Terminal
+        addNotification={sinon.stub()}
+        address="1.2.3.4:123"
+        changeState={sinon.stub()}
+        commands={['juju status', 'juju switch']}
+        creds={{
+          user: 'user',
+          password: 'password',
+          macaroons: {}
+        }}
+        WebSocket={websocket} />
+    );
+    component.ws.onclose({
+      // Should only throw the notification on code over 1000 which is an
+      // expected closure.
+      code: 1001
+    });
+    assert.deepEqual(component.props.addNotification.args[0], [{
+      title: 'Terminal connection unexpectedly closed.',
+      message: 'Terminal connection unexpectedly closed.',
+      level: 'error'
+    }]);
+    ReactDOM.unmountComponentAtNode(ReactDOM.findDOMNode(component).parentNode);
+  });
+
   it('can be resized by clicking the two resize buttons', () => {
     const renderer = renderComponent();
     const output = renderer.getRenderOutput();


### PR DESCRIPTION
Fixes #3343 

When the terminals websocket connection is unexpectedly disconnected then show an error notification.