### PR TITLE
Add bundle URL annotations to each application when deploying a bundle

### DIFF
--- a/jujugui/static/gui/src/app/components/entity-details/header/header.js
+++ b/jujugui/static/gui/src/app/components/entity-details/header/header.js
@@ -26,13 +26,14 @@ class EntityHeader extends React.Component {
     @param {Object} e The click event
   */
   _handleDeployClick(e) {
-    var entityModel = this.props.entityModel;
-    var entity = entityModel.toEntity();
+    const props = this.props;
+    const entityModel = props.entityModel;
+    const entity = entityModel.toEntity();
     if (entity.type === 'charm') {
-      var refs = this.refs;
-      var plans = this.props.plans;
-      var plan = refs.plan && refs.plan.value;
-      var activePlan;
+      const refs = this.refs;
+      const plans = props.plans;
+      const plan = refs.plan && refs.plan.value;
+      let activePlan;
       if (plan && Array.isArray(plans)) {
         // It is possible that plan is a string "loading plans..."
         plans.some(item => {
@@ -44,10 +45,10 @@ class EntityHeader extends React.Component {
       }
       // The second param needs to be set as undefined not null as this is the
       // format the method expects.
-      this.props.deployService(entityModel, undefined, plans, activePlan);
+      props.deployService(entityModel, undefined, plans, activePlan);
     } else {
-      const bundleURL = window.jujulib.URL.fromLegacyString(entity.id);
-      this.props.getBundleYAML(
+      const bundleURL = props.urllib.fromLegacyString(entity.id);
+      props.getBundleYAML(
         bundleURL.legacyPath(),
         this._getBundleYAMLCallback.bind(this, bundleURL.path()));
     }

--- a/jujugui/static/gui/src/app/components/entity-details/header/header.js
+++ b/jujugui/static/gui/src/app/components/entity-details/header/header.js
@@ -46,8 +46,10 @@ class EntityHeader extends React.Component {
       // format the method expects.
       this.props.deployService(entityModel, undefined, plans, activePlan);
     } else {
-      var id = entity.id.replace('cs:', '');
-      this.props.getBundleYAML(id, this._getBundleYAMLCallback.bind(this));
+      const bundleURL = window.jujulib.URL.fromLegacyString(entity.id);
+      this.props.getBundleYAML(
+        bundleURL.legacyPath(),
+        this._getBundleYAMLCallback.bind(this, bundleURL.path()));
     }
     this._closeEntityDetails();
   }
@@ -71,10 +73,11 @@ class EntityHeader extends React.Component {
     Callback for getting the bundle YAML.
 
     @method _getBundleYAMLSuccess
+    @param {String} bundleURL The url of the bundle that is being deployed.
     @param {String} error The error, if any. Null if no error.
     @param {String} yaml The yaml for the bundle
   */
-  _getBundleYAMLCallback(error, yaml) {
+  _getBundleYAMLCallback(bundleURL, error, yaml) {
     if (error) {
       console.error(error);
       this.props.addNotification({
@@ -85,7 +88,7 @@ class EntityHeader extends React.Component {
       });
       return;
     }
-    this.props.importBundleYAML(yaml);
+    this.props.importBundleYAML(yaml, bundleURL);
     this._closeEntityDetails();
   }
 

--- a/jujugui/static/gui/src/app/components/entity-details/header/test-header.js
+++ b/jujugui/static/gui/src/app/components/entity-details/header/test-header.js
@@ -20,7 +20,8 @@ describe('EntityHeader', function() {
     urllib = sinon.stub();
     urllib.fromLegacyString = sinon.stub().returns({
       revision: 42,
-      path: sinon.stub().returns('u/who/django/42')
+      path: sinon.stub().returns('u/who/django/42'),
+      legacyPath: sinon.stub().returns('django-cluster')
     });
   });
 

--- a/jujugui/static/gui/src/app/components/entity-details/header/test-header.js
+++ b/jujugui/static/gui/src/app/components/entity-details/header/test-header.js
@@ -491,12 +491,15 @@ describe('EntityHeader', function() {
         urllib={urllib}
       />);
     const deployAction = output.refs.deployAction;
+    sinon.spy(output, '_getBundleYAMLCallback');
     // Simulate a click.
     deployAction.props.action();
     assert.equal(getBundleYAML.callCount, 1);
     assert.equal(getBundleYAML.args[0][0], 'django-cluster');
+    assert.equal(output._getBundleYAMLCallback.args[0][0], 'u/who/django/42');
     assert.equal(importBundleYAML.callCount, 1);
     assert.deepEqual(importBundleYAML.args[0][0], 'mock yaml');
+    assert.equal(importBundleYAML.args[0][1], 'u/who/django/42');
   });
 
   it('displays a notification if there is a bundle deploy error', function() {

--- a/jujugui/static/gui/src/app/init.js
+++ b/jujugui/static/gui/src/app/init.js
@@ -1510,17 +1510,18 @@ class GUIApp {
     // The charmstore apiv4 format can have the bundle keyword either at the
     // start, for charmers bundles, or after the username, for namespaced
     // bundles. ex) bundle/swift & ~jorge/bundle/swift
-    if (entityId.indexOf('bundle/') > -1) {
+    const entityURL = window.jujulib.URL.fromLegacyString(entityId);
+    if (entityURL.isBundle()) {
       charmstore.getBundleYAML(entityId, (error, bundleYAML) => {
         if (error) {
           failureNotification(error);
         } else {
-          this.bundleImporter.importBundleYAML(bundleYAML);
+          this.bundleImporter.importBundleYAML(bundleYAML, entityURL.path());
         }
       });
     } else {
       // If it's not a bundle then it's a charm.
-      charmstore.getEntity(entityId.replace('cs:', ''), (error, charm) => {
+      charmstore.getEntity(entityURL.legacyPath(), (error, charm) => {
         if (error) {
           failureNotification(error);
         } else {

--- a/jujugui/static/gui/src/app/init/bundle-importer.js
+++ b/jujugui/static/gui/src/app/init/bundle-importer.js
@@ -117,11 +117,12 @@ class BundleImporter {
 
   /**
     Adds the bundle-url annotation to the changeset.
-    @param {String} bundleURL THe bundle url to save to the annotations.
+    @param {String} bundleURL The bundle URL to save to the annotations.
     @param {Array} changes The bundle changeset.
   */
   _addBundleURLAnnotation(bundleURL, changes) {
-    // For each different application records and add an annotation for each one.
+    // Find all of the deploy records and add an annotation containing the
+    // bundle URL for each one.
     changes.forEach(record => {
       if (record.method === 'deploy') {
         // Get the length of the changes array so we can properly index

--- a/jujugui/static/gui/src/app/init/bundle-importer.js
+++ b/jujugui/static/gui/src/app/init/bundle-importer.js
@@ -107,11 +107,16 @@ class BundleImporter {
       return;
     }
     // Add the bundle id annotation record.
-    changes = this._addBundleIdAnnotation('cs:mybundle', changes);
+    changes = this._addBundleURLAnnotation('cs:mybundle', changes);
     this.importBundleDryRun(changes);
   }
 
-  _addBundleIdAnnotation(bundleId, changes) {
+  /**
+    Adds the bundle-url annotation to the changeset.
+    @param {String} bundleURL THe bundle url to save to the annotations.
+    @param {Array} changes The bundle changeset.
+  */
+  _addBundleURLAnnotation(bundleURL, changes) {
     // For each different application records and add an annotation for each one.
     changes.forEach(record => {
       if (record.method === 'deploy') {
@@ -125,7 +130,7 @@ class BundleImporter {
             if (innerRecord.args[0] === `$${record.id}`) {
               // If this setAnnotations is for the outer record then add the
               // bundle-url key to it.
-              innerRecord.args[2]['bundle-url'] = bundleId;
+              innerRecord.args[2]['bundle-url'] = bundleURL;
               return true;
             }
           }
@@ -135,7 +140,7 @@ class BundleImporter {
           changes.push({
             id: `setAnnotations-${length}`,
             method: 'setAnnotations',
-            args: [`$${record.id}`, 'application', {'bundle-url': bundleId}],
+            args: [`$${record.id}`, 'application', {'bundle-url': bundleURL}],
             requires: [record.id]
           });
         }

--- a/jujugui/static/gui/src/app/init/topology/service.js
+++ b/jujugui/static/gui/src/app/init/topology/service.js
@@ -1052,15 +1052,16 @@ class ServiceModule {
           message: 'Changeset processing started.',
           level: 'important'
         });
-        var charmstore = topo.charmstore;
-        charmstore.getBundleYAML(
+        topo.charmstore.getBundleYAML(
           entityData.id.replace('cs:', ''),
           function(error, bundleYAML) {
             if (error) {
               console.error(error);
               return;
             }
-            topo.bundleImporter.importBundleYAML(bundleYAML);
+            topo.bundleImporter.importBundleYAML(
+              bundleYAML,
+              window.jujulib.URL.fromLegacyString(entityData.id).path());
           }.bind(this));
       }
     }


### PR DESCRIPTION
So that the UI can know which applications were deployed from bundles, this branch adds the `bundle-url` annotation to each application deployed that way. 