### PR TITLE
Update changelog headers

### DIFF
--- a/jujugui/static/gui/src/app/components/budget-table/budget-table.js
+++ b/jujugui/static/gui/src/app/components/budget-table/budget-table.js
@@ -66,11 +66,8 @@ class BudgetTable extends React.Component {
     return (
       <div className="budget-table twelve-col">
         <div className="budget-table__row-header twelve-col">
-          <div className="three-col">
+          <div className="five-col">
             Name
-          </div>
-          <div className="two-col">
-            New units
           </div>
           {this._generatePlanHeaders()}
         </div>

--- a/jujugui/static/gui/src/app/components/budget-table/row/row.js
+++ b/jujugui/static/gui/src/app/components/budget-table/row/row.js
@@ -218,13 +218,10 @@ class BudgetTableRow extends React.Component {
     var service = this.props.service;
     return (
       <div>
-        <div className="three-col no-margin-bottom">
+        <div className="five-col no-margin-bottom">
           <img className="budget-table__charm-icon"
             src={service.get('icon')} />
           {service.get('name')}
-        </div>
-        <div className="one-col no-margin-bottom">
-          {service.get('unit_count')}
         </div>
       </div>);
   }

--- a/jujugui/static/gui/src/app/components/budget-table/row/test-row.js
+++ b/jujugui/static/gui/src/app/components/budget-table/row/test-row.js
@@ -93,13 +93,10 @@ describe('BudgetTableRow', function() {
           expanded={false}>
           <div>
             <div>
-              <div className="three-col no-margin-bottom">
+              <div className="five-col no-margin-bottom">
                 <img className="budget-table__charm-icon"
                   src="landscape.svg" />
                 Landscape
-              </div>
-              <div className="one-col no-margin-bottom">
-                {4}
               </div>
             </div>
             <div>
@@ -151,13 +148,10 @@ describe('BudgetTableRow', function() {
           expanded={false}>
           <div>
             <div>
-              <div className="three-col no-margin-bottom">
+              <div className="five-col no-margin-bottom">
                 <img className="budget-table__charm-icon"
                   src="landscape.svg" />
                 Landscape
-              </div>
-              <div className="one-col no-margin-bottom">
-                {4}
               </div>
             </div>
             <div className="twelve-col no-margin-bottom" />
@@ -197,13 +191,10 @@ describe('BudgetTableRow', function() {
           expanded={false}>
           <div>
             <div>
-              <div className="three-col no-margin-bottom">
+              <div className="five-col no-margin-bottom">
                 <img className="budget-table__charm-icon"
                   src="landscape.svg" />
                 Landscape
-              </div>
-              <div className="one-col no-margin-bottom">
-                {4}
               </div>
             </div>
             <div>
@@ -279,13 +270,10 @@ describe('BudgetTableRow', function() {
           expanded={false}>
           <div>
             <div>
-              <div className="three-col no-margin-bottom">
+              <div className="five-col no-margin-bottom">
                 <img className="budget-table__charm-icon"
                   src="landscape.svg" />
                 Landscape
-              </div>
-              <div className="one-col no-margin-bottom">
-                {4}
               </div>
             </div>
             <div>
@@ -338,13 +326,10 @@ describe('BudgetTableRow', function() {
           expanded={false}>
           <div>
             <div>
-              <div className="three-col no-margin-bottom">
+              <div className="five-col no-margin-bottom">
                 <img className="budget-table__charm-icon"
                   src="landscape.svg" />
                 Landscape
-              </div>
-              <div className="one-col no-margin-bottom">
-                {4}
               </div>
             </div>
             <div>
@@ -397,13 +382,10 @@ describe('BudgetTableRow', function() {
           expanded={false}>
           <div>
             <div>
-              <div className="three-col no-margin-bottom">
+              <div className="five-col no-margin-bottom">
                 <img className="budget-table__charm-icon"
                   src="landscape.svg" />
                 Landscape
-              </div>
-              <div className="one-col no-margin-bottom">
-                {4}
               </div>
             </div>
             <div>
@@ -438,13 +420,10 @@ describe('BudgetTableRow', function() {
               <div className={
                 'budget-table__current twelve-col no-margin-bottom'}>
                 <div>
-                  <div className="three-col no-margin-bottom">
+                  <div className="five-col no-margin-bottom">
                     <img className="budget-table__charm-icon"
                       src="landscape.svg" />
                     Landscape
-                  </div>
-                  <div className="one-col no-margin-bottom">
-                    {4}
                   </div>
                 </div>
               </div>
@@ -528,13 +507,10 @@ describe('BudgetTableRow', function() {
           expanded={false}>
           <div>
             <div>
-              <div className="three-col no-margin-bottom">
+              <div className="five-col no-margin-bottom">
                 <img className="budget-table__charm-icon"
                   src="landscape.svg" />
                 Landscape
-              </div>
-              <div className="one-col no-margin-bottom">
-                {4}
               </div>
             </div>
             <div>
@@ -569,13 +545,10 @@ describe('BudgetTableRow', function() {
               <div className={
                 'budget-table__current twelve-col no-margin-bottom'}>
                 <div>
-                  <div className="three-col no-margin-bottom">
+                  <div className="five-col no-margin-bottom">
                     <img className="budget-table__charm-icon"
                       src="landscape.svg" />
                     Landscape
-                  </div>
-                  <div className="one-col no-margin-bottom">
-                    {4}
                   </div>
                 </div>
               </div>
@@ -680,13 +653,10 @@ describe('BudgetTableRow', function() {
           expanded={false}>
           <div>
             <div>
-              <div className="three-col no-margin-bottom">
+              <div className="five-col no-margin-bottom">
                 <img className="budget-table__charm-icon"
                   src="landscape.svg" />
                 Landscape
-              </div>
-              <div className="one-col no-margin-bottom">
-                {4}
               </div>
             </div>
             <div>
@@ -747,13 +717,10 @@ describe('BudgetTableRow', function() {
           expanded={false}>
           <div>
             <div>
-              <div className="three-col no-margin-bottom">
+              <div className="five-col no-margin-bottom">
                 <img className="budget-table__charm-icon"
                   src="landscape.svg" />
                 Landscape
-              </div>
-              <div className="one-col no-margin-bottom">
-                {4}
               </div>
             </div>
             <div>

--- a/jujugui/static/gui/src/app/components/budget-table/test-budget-table.js
+++ b/jujugui/static/gui/src/app/components/budget-table/test-budget-table.js
@@ -33,11 +33,8 @@ describe('BudgetTable', function() {
     var expected = (
       <div className="budget-table twelve-col">
         <div className="budget-table__row-header twelve-col">
-          <div className="three-col">
+          <div className="five-col">
             Name
-          </div>
-          <div className="two-col">
-            New units
           </div>
           <div>
             <div className="three-col">
@@ -102,11 +99,8 @@ describe('BudgetTable', function() {
     var expected = (
       <div className="budget-table twelve-col">
         <div className="budget-table__row-header twelve-col">
-          <div className="three-col">
+          <div className="five-col">
             Name
-          </div>
-          <div className="two-col">
-            New units
           </div>
           {undefined}
         </div>
@@ -158,11 +152,8 @@ describe('BudgetTable', function() {
     var expected = (
       <div className="budget-table twelve-col">
         <div className="budget-table__row-header twelve-col">
-          <div className="three-col">
+          <div className="five-col">
             Name
-          </div>
-          <div className="two-col">
-            New units
           </div>
           <div>
             <div className="three-col">


### PR DESCRIPTION
Remove the new units header as it only makes sense when all the apps in the changelog are adding new units. Fixes: #3335.