### PR TITLE
Allow for setting the jujushell URL in the local storage.

### DIFF
--- a/jujugui/static/gui/src/app/components/modal-gui-settings/modal-gui-settings.js
+++ b/jujugui/static/gui/src/app/components/modal-gui-settings/modal-gui-settings.js
@@ -6,20 +6,25 @@ const React = require('react');
 
 const SvgIcon = require('../svg-icon/svg-icon');
 
+// Handle global GUI settings to be saved on a storage like the local storage.
 class ModalGUISettings extends React.Component {
+
   constructor(props) {
     super(props);
-    let state = {};
     const localStorage = this.props.localStorage;
-    // We have to check for the 'true' string. Because localStorage is all
-    // about the strings.
-    state['disable-cookie'] = localStorage.
-      getItem('disable-cookie') === 'true';
-    state['disable-auto-place'] = localStorage.
-      getItem('disable-auto-place') === 'true';
-    state['force-containers'] = localStorage.
-      getItem('force-containers') === 'true';
-    this.state = state;
+    const getString = key => {
+      return localStorage.getItem(key) || '';
+    };
+    const getBool = key => {
+      // As localStorage only handles strings, check for the 'true' string.
+      return getString(key) === 'true';
+    };
+    this.state = {
+      'disable-auto-place': getBool('disable-auto-place'),
+      'disable-cookie': getBool('disable-cookie'),
+      'force-containers': getBool('force-containers'),
+      'jujushell-url': getString('jujushell-url')
+    };
   }
 
   /**
@@ -29,39 +34,60 @@ class ModalGUISettings extends React.Component {
   */
   _handleChange(evt) {
     const target = evt.target;
-    const value = target.checked;
-    const name = target.name;
-    this.setState({
-      [name]: value
-    });
+    let value;
+    switch (target.type) {
+      case 'checkbox':
+        value = target.checked;
+        break;
+      case 'text':
+        value = target.value;
+        break;
+      default:
+        console.error('ModalGUISettings: invalid target type', target.type);
+        return;
+    }
+    this.setState({[target.name]: value});
   }
 
   /**
     When the save button is pressed, commit to localStorage.
   */
   _handleSave() {
+    const props = this.props;
     Object.keys(this.state).forEach(key => {
-      if (key !== 'visible') {
-        if (this.state[key] === true) {
-          this.props.localStorage.setItem(key, true);
-        } else {
-          this.props.localStorage.removeItem(key);
-        }
+      const value = this.state[key];
+      if (value) {
+        props.localStorage.setItem(key, value);
+      } else {
+        props.localStorage.removeItem(key);
       }
     });
-
-    this.props.closeModal();
+    props.closeModal();
   }
 
   render() {
+    const props = this.props;
+    const state = this.state;
+    const handleChange = this._handleChange.bind(this);
+    let jujushellNode = null;
+    if (props.flags.terminal) {
+      jujushellNode = (<p>
+        <label htmlFor="jujushell-url">
+          <input type="text" name="jujushell-url"
+            id="jujushell-url"
+            onChange={handleChange}
+            value={state['jujushell-url']} />&nbsp;
+          DNS name for the Juju Shell.
+        </label>
+      </p>);
+    }
     return (
       <div className="modal modal--narrow">
         <div className="twelve-col no-margin-bottom">
           <h2 className="bordered">Custom GUI Settings</h2>
           <span className="close" tabIndex="0" role="button"
-            onClick={this.props.closeModal}>
-            <SvgIcon name="close_16"
-              size="16" />
+            onClick={props.closeModal}>
+            <SvgIcon name="close_16" size="16" />
           </span>
         </div>
         <div className="content">
@@ -69,29 +95,30 @@ class ModalGUISettings extends React.Component {
             <label htmlFor="disable-cookie">
               <input type="checkbox" name="disable-cookie"
                 id="disable-cookie"
-                onChange={this._handleChange.bind(this)}
-                defaultChecked={this.state['disable-cookie']} />&nbsp;
-                Disable the EU cookie warning.
+                onChange={handleChange}
+                defaultChecked={state['disable-cookie']} />&nbsp;
+              Disable the EU cookie warning.
             </label>
           </p>
           <p>
             <label htmlFor="force-containers">
               <input type="checkbox" name="force-containers"
                 id="force-containers"
-                onChange={this._handleChange.bind(this)}
-                defaultChecked={this.state['force-containers']} />&nbsp;
-                Enable container control for this provider.
+                onChange={handleChange}
+                defaultChecked={state['force-containers']} />&nbsp;
+              Enable container control for this provider.
             </label>
           </p>
           <p>
             <label htmlFor="disable-auto-place">
               <input type="checkbox" name="disable-auto-place"
                 id="disable-auto-place"
-                onChange={this._handleChange.bind(this)}
-                defaultChecked={this.state['disable-auto-place']} />&nbsp;
-                Default to not automatically place units on commit.
+                onChange={handleChange}
+                defaultChecked={state['disable-auto-place']} />&nbsp;
+              Default to not automatically place units on commit.
             </label>
           </p>
+          {jujushellNode}
           <p>
             <small>
               NOTE: You will need to reload for changes to take effect.
@@ -108,6 +135,7 @@ class ModalGUISettings extends React.Component {
 
 ModalGUISettings.propTypes = {
   closeModal: PropTypes.func.isRequired,
+  flags: PropTypes.object.isRequired,
   localStorage: PropTypes.object.isRequired
 };
 

--- a/jujugui/static/gui/src/app/components/modal-gui-settings/modal-gui-settings.js
+++ b/jujugui/static/gui/src/app/components/modal-gui-settings/modal-gui-settings.js
@@ -11,9 +11,9 @@ class ModalGUISettings extends React.Component {
 
   constructor(props) {
     super(props);
-    const localStorage = this.props.localStorage;
+    const storage = this.props.localStorage;
     const getString = key => {
-      return localStorage.getItem(key) || '';
+      return storage.getItem(key) || '';
     };
     const getBool = key => {
       // As localStorage only handles strings, check for the 'true' string.

--- a/jujugui/static/gui/src/app/components/modal-gui-settings/test-modal-gui-settings.js
+++ b/jujugui/static/gui/src/app/components/modal-gui-settings/test-modal-gui-settings.js
@@ -9,95 +9,114 @@ const SvgIcon = require('../svg-icon/svg-icon');
 const jsTestUtils = require('../../utils/component-test-utils');
 
 describe('ModalGUISettings', function() {
-  const _localStorage = {
+  const storage = {
     setItem: sinon.stub(),
     removeItem: sinon.stub(),
     getItem: sinon.stub().returns(false)
   };
 
-  function visibleRender(
-    hide = sinon.stub(),
-    _handleChange = sinon.stub(),
-    state = {
-      'disable-cookie': false,
-      'force-containers': false,
-      'disable-auto-place': false
-    },
-    _handleSave = sinon.stub()) {
-    return (<div className="modal modal--narrow">
-      <div className="twelve-col no-margin-bottom">
-        <h2 className="bordered">Custom GUI Settings</h2>
-        <span className="close" tabIndex="0" role="button"
-          onClick={hide}>
-          <SvgIcon name="close_16"
-            size="16" />
-        </span>
-      </div>
-      <div className="content">
-        <p>
-          <label htmlFor="disable-cookie">
-            <input type="checkbox" name="disable-cookie"
-              id="disable-cookie"
-              onChange={_handleChange}
-              defaultChecked={state['disable-cookie']} />&nbsp;
+  // Shallow render the component with the given parameters, and return an
+  // object with the instance and the resulting output.
+  function render(params={}) {
+    const renderer = jsTestUtils.shallowRender(
+      <ModalGUISettings
+        closeModal={params.close || sinon.stub()}
+        flags={params.flags || {terminal: false}}
+        localStorage={params.storage || storage} />, true);
+    return {
+      instance: renderer.getMountedInstance(),
+      output: renderer.getRenderOutput()
+    };
+  }
+
+  // Return a node wit the component expected output.
+  function expectedOutput(instance, includeShell=false) {
+    const handleChange = instance._handleChange.bind(instance);
+    const handleSave = instance._handleSave.bind(instance);
+    const shellNode = includeShell ? (
+      <p>
+        <label htmlFor="jujushell-url">
+          <input type="text" name="jujushell-url"
+            id="jujushell-url"
+            onChange={handleChange}
+            value="" />&nbsp;
+          DNS name for the Juju Shell.
+        </label>
+      </p>
+    ) : null;
+    return (
+      <div className="modal modal--narrow">
+        <div className="twelve-col no-margin-bottom">
+          <h2 className="bordered">Custom GUI Settings</h2>
+          <span className="close" tabIndex="0" role="button"
+            onClick={instance.props.closeModal}>
+            <SvgIcon name="close_16" size="16" />
+          </span>
+        </div>
+        <div className="content">
+          <p>
+            <label htmlFor="disable-cookie">
+              <input type="checkbox" name="disable-cookie"
+                id="disable-cookie"
+                onChange={handleChange}
+                defaultChecked={false} />&nbsp;
               Disable the EU cookie warning.
-          </label>
-        </p>
-        <p>
-          <label htmlFor="force-containers">
-            <input type="checkbox" name="force-containers"
-              id="force-containers"
-              onChange={_handleChange}
-              defaultChecked={state['force-containers']} />&nbsp;
+            </label>
+          </p>
+          <p>
+            <label htmlFor="force-containers">
+              <input type="checkbox" name="force-containers"
+                id="force-containers"
+                onChange={handleChange}
+                defaultChecked={false} />&nbsp;
               Enable container control for this provider.
-          </label>
-        </p>
-        <p>
-          <label htmlFor="disable-auto-place">
-            <input type="checkbox" name="disable-auto-place"
-              id="disable-auto-place"
-              onChange={_handleChange}
-              defaultChecked={state['disable-auto-place']} />&nbsp;
+            </label>
+          </p>
+          <p>
+            <label htmlFor="disable-auto-place">
+              <input type="checkbox" name="disable-auto-place"
+                id="disable-auto-place"
+                onChange={handleChange}
+                defaultChecked={false} />&nbsp;
               Default to not automatically place units on commit.
-          </label>
-        </p>
-        <p>
-          <small>
-            NOTE: You will need to reload for changes to take effect.
-          </small>
-        </p>
-        <input type="button" className="button--positive"
-          name="save-settings" onClick={_handleSave}
-          id="save-settings" value="Save" />
+            </label>
+          </p>
+          {shellNode}
+          <p>
+            <small>
+              NOTE: You will need to reload for changes to take effect.
+            </small>
+          </p>
+          <input type="button" className="button--positive"
+            name="save-settings" onClick={handleSave}
+            id="save-settings" value="Save" />
+        </div>
       </div>
-    </div>);
+    );
   }
 
   it('renders', function() {
-    const close = sinon.stub();
-    const renderer = jsTestUtils.shallowRender(
-      <ModalGUISettings
-        closeModal={close}
-        localStorage={_localStorage} />, true);
-    let output = renderer.getRenderOutput();
-    let expected = visibleRender(close);
-    expect(output).toEqualJSX(expected);
+    const comp = render();
+    expect(comp.output).toEqualJSX(expectedOutput(comp.instance));
+  });
+
+  it('renders including the jujushell URL input', function() {
+    const comp = render({flags: {terminal: true}});
+    expect(comp.output).toEqualJSX(expectedOutput(comp.instance, true));
   });
 
   it('saves state', function() {
-    const close = sinon.stub();
-    const renderer = jsTestUtils.shallowRender(
-      <ModalGUISettings
-        closeModal={close}
-        localStorage={_localStorage} />, true);
-    const instance = renderer.getMountedInstance();
-    instance.setState({
+    const comp = render();
+    comp.instance.setState({
       'disable-cookie': true,
       'disable-auto-place': null
     });
-    instance._handleSave();
-
-    assert.equal(_localStorage.setItem.callCount, 1);
-    assert.equal(_localStorage.removeItem.callCount, 2);
+    comp.instance._handleSave();
+    assert.equal(storage.setItem.callCount, 1);
+    assert.deepEqual(storage.setItem.args[0], ['disable-cookie', true]);
+    assert.equal(storage.removeItem.callCount, 3);
+    assert.deepEqual(storage.removeItem.args[0], ['disable-auto-place']);
+    assert.deepEqual(storage.removeItem.args[1], ['force-containers']);
+    assert.deepEqual(storage.removeItem.args[2], ['jujushell-url']);
   });
 });

--- a/jujugui/static/gui/src/app/init/component-renderers-mixin.js
+++ b/jujugui/static/gui/src/app/init/component-renderers-mixin.js
@@ -234,7 +234,8 @@ Browser: ${navigator.userAgent}`
       `${githubIssueHref}?${queryString.stringify(githubIssueValues)}`;
     const address = initUtils.jujushellURL(localStorage, db, config);
     if (!address) {
-      let message = 'an unknown error has occurred please file an issue ';
+      // This should never happen.
+      let message = 'an unexpected error has occurred please file an issue ';
       let link = <a href={githubIssueLink} target="_blank" key="link">here</a>;
       const jujushell = db.services.getServicesFromCharmName('jujushell')[0];
       if (!jujushell || jujushell.get('pending')) {

--- a/jujugui/static/gui/src/app/init/component-renderers-mixin.js
+++ b/jujugui/static/gui/src/app/init/component-renderers-mixin.js
@@ -135,7 +135,7 @@ const ComponentRenderersMixin = superclass => class extends superclass {
     ReactDOM.render(
       <ModelActions
         acl={this.acl}
-        displayTerminalButton={this.applicationConfig.flags['terminal'] || false}
+        displayTerminalButton={this.applicationConfig.flags.terminal || false}
         appState={this.state}
         changeState={this._bound.changeState}
         exportEnvironmentFile={
@@ -430,6 +430,7 @@ Browser: ${navigator.userAgent}`
     ReactDOM.render(
       <ModalGUISettings
         closeModal={this._clearSettingsModal.bind(this)}
+        flags={this.applicationConfig.flags}
         localStorage={localStorage} />,
       document.getElementById('modal-gui-settings'));
   }

--- a/jujugui/static/gui/src/app/init/component-renderers-mixin.js
+++ b/jujugui/static/gui/src/app/init/component-renderers-mixin.js
@@ -232,14 +232,7 @@ Browser: ${navigator.userAgent}`
     };
     const githubIssueLink =
       `${githubIssueHref}?${queryString.stringify(githubIssueValues)}`;
-    const address = function() {
-      if (db.environment.get('jujushellURL')) {
-        return `ws://${db.environment.get('jujushellURL')}/ws/`;
-      }
-      if (config.jujushellURL) {
-        return config.jujushellURL;
-      }
-    }();
+    const address = initUtils.jujushellURL(localStorage, db, config);
     if (!address) {
       let message = 'an unknown error has occurred please file an issue ';
       let link = <a href={githubIssueLink} target="_blank" key="link">here</a>;

--- a/jujugui/static/gui/src/app/init/test-utils.js
+++ b/jujugui/static/gui/src/app/init/test-utils.js
@@ -99,6 +99,55 @@ describe('init utils', () => {
     });
   });
 
+  describe('jujushellURL', () => {
+    // Set up mock sources from which to retrieve the jujushell URL.
+    const setupSources = values => {
+      const config = {jujushellURL: values.config || ''};
+      const db = {
+        environment: {
+          get: sinon.stub().withArgs('jujushellURL').returns(values.db || '')
+        }
+      };
+      const storage = {
+        getItem: sinon.stub().withArgs('jujushell-url').returns(
+          values.storage || '')
+      };
+      return {
+        config: config,
+        db: db,
+        storage: storage
+      };
+    };
+
+    // Check that a call to jujushellURL in a scenario set up with the given
+    // values returns the expected URL.
+    const assertURL = (values, expectedURL) => {
+      const params = setupSources(values);
+      const url = utils.jujushellURL(params.storage, params.db, params.config);
+      assert.strictEqual(url, expectedURL);
+    };
+
+    it('returns the URL stored in the storage', () => {
+      assertURL({storage: 'wss://1.2.3.4/ws1/'}, 'wss://1.2.3.4/ws1/');
+      assertURL({storage: 'ws://1.2.3.4/ws2/'}, 'ws://1.2.3.4/ws2/');
+      assertURL({storage: '1.2.3.4/ws3/'}, 'wss://1.2.3.4/ws3/');
+      assertURL({storage: 'http://1.2.3.4/ws4/'}, 'ws://1.2.3.4/ws4/');
+      assertURL({storage: 'https://1.2.3.4/ws5/'}, 'wss://1.2.3.4/ws5/');
+    });
+
+    it('returns the URL stored in the db', () => {
+      assertURL({db: '1.2.3.4'}, 'ws://1.2.3.4/ws/');
+    });
+
+    it('returns the URL stored in the config', () => {
+      assertURL({config: 'wss://4.3.2.1/ws'}, 'wss://4.3.2.1/ws');
+    });
+
+    it('returns null if the URL cannot be found', () => {
+      assertURL({}, null);
+    });
+  });
+
   describe('destroyService', () => {
     it('responds to service removal failure by alerting the user', () => {
       let notificationAdded;

--- a/jujugui/static/gui/src/app/init/utils.js
+++ b/jujugui/static/gui/src/app/init/utils.js
@@ -262,6 +262,35 @@ utils.pluralize = (word, object, plural_word, options) => {
 };
 
 /**
+  Retrieve the jujushell URL from the provided sources.
+  Return null if jujushell is not available.
+
+  @param {Object} storage A storage object for persisting custom settings.
+  @param {Object} db The application database.
+  @param {Object} config The application config.
+*/
+utils.jujushellURL = (storage, db, config) => {
+  // First check if the user has put the jujushell URL in the GUI settings.
+  let url = storage.getItem('jujushell-url');
+  if (url) {
+    url = url.replace(/^(http:\/\/)/, 'ws://');
+    url = url.replace(/^(https:\/\/)/, 'wss://');
+    if (url.indexOf('ws://') !== 0 && url.indexOf('wss://') !== 0) {
+      url = 'wss://' + url;
+    }
+    return url;
+  }
+  // Then try and check whether there is a jujushell charm deployed and ready
+  // on the current model.
+  url = db.environment.get('jujushellURL');
+  if (url) {
+    return `ws://${url}/ws/`;
+  }
+  // Last option is the application settings (JAAS case).
+  return config.jujushellURL || null;
+};
+
+/**
   Remove a service. If it is uncommitted then remove it otherwise use the
   ecs.
   @param {Object} db Reference to the app db.


### PR DESCRIPTION
The GUI settings (shift+!) can be used to set a jujushell dns name, either as a remote http(s) or ws(s) address.