### PR TITLE
terminal: enable the feature when the user specifies a jujushell URL

### DIFF
--- a/jujugui/static/gui/src/app/components/modal-gui-settings/modal-gui-settings.js
+++ b/jujugui/static/gui/src/app/components/modal-gui-settings/modal-gui-settings.js
@@ -69,18 +69,6 @@ class ModalGUISettings extends React.Component {
     const props = this.props;
     const state = this.state;
     const handleChange = this._handleChange.bind(this);
-    let jujushellNode = null;
-    if (props.flags.terminal) {
-      jujushellNode = (<p>
-        <label htmlFor="jujushell-url">
-          <input type="text" name="jujushell-url"
-            id="jujushell-url"
-            onChange={handleChange}
-            value={state['jujushell-url']} />&nbsp;
-          DNS name for the Juju Shell.
-        </label>
-      </p>);
-    }
     return (
       <div className="modal modal--narrow">
         <div className="twelve-col no-margin-bottom">
@@ -118,7 +106,15 @@ class ModalGUISettings extends React.Component {
               Default to not automatically place units on commit.
             </label>
           </p>
-          {jujushellNode}
+          <p>
+            <label htmlFor="jujushell-url">
+              <input type="text" name="jujushell-url"
+                id="jujushell-url"
+                onChange={handleChange}
+                value={state['jujushell-url']} />&nbsp;
+              DNS name for the Juju Shell.
+            </label>
+          </p>
           <p>
             <small>
               NOTE: You will need to reload for changes to take effect.
@@ -135,7 +131,6 @@ class ModalGUISettings extends React.Component {
 
 ModalGUISettings.propTypes = {
   closeModal: PropTypes.func.isRequired,
-  flags: PropTypes.object.isRequired,
   localStorage: PropTypes.object.isRequired
 };
 

--- a/jujugui/static/gui/src/app/components/modal-gui-settings/test-modal-gui-settings.js
+++ b/jujugui/static/gui/src/app/components/modal-gui-settings/test-modal-gui-settings.js
@@ -30,20 +30,9 @@ describe('ModalGUISettings', function() {
   }
 
   // Return a node wit the component expected output.
-  function expectedOutput(instance, includeShell=false) {
+  function expectedOutput(instance) {
     const handleChange = instance._handleChange.bind(instance);
     const handleSave = instance._handleSave.bind(instance);
-    const shellNode = includeShell ? (
-      <p>
-        <label htmlFor="jujushell-url">
-          <input type="text" name="jujushell-url"
-            id="jujushell-url"
-            onChange={handleChange}
-            value="" />&nbsp;
-          DNS name for the Juju Shell.
-        </label>
-      </p>
-    ) : null;
     return (
       <div className="modal modal--narrow">
         <div className="twelve-col no-margin-bottom">
@@ -81,7 +70,15 @@ describe('ModalGUISettings', function() {
               Default to not automatically place units on commit.
             </label>
           </p>
-          {shellNode}
+          <p>
+            <label htmlFor="jujushell-url">
+              <input type="text" name="jujushell-url"
+                id="jujushell-url"
+                onChange={handleChange}
+                value="" />&nbsp;
+              DNS name for the Juju Shell.
+            </label>
+          </p>
           <p>
             <small>
               NOTE: You will need to reload for changes to take effect.
@@ -98,11 +95,6 @@ describe('ModalGUISettings', function() {
   it('renders', function() {
     const comp = render();
     expect(comp.output).toEqualJSX(expectedOutput(comp.instance));
-  });
-
-  it('renders including the jujushell URL input', function() {
-    const comp = render({flags: {terminal: true}});
-    expect(comp.output).toEqualJSX(expectedOutput(comp.instance, true));
   });
 
   it('saves state', function() {

--- a/jujugui/static/gui/src/app/init/component-renderers-mixin.js
+++ b/jujugui/static/gui/src/app/init/component-renderers-mixin.js
@@ -424,7 +424,6 @@ Browser: ${navigator.userAgent}`
     ReactDOM.render(
       <ModalGUISettings
         closeModal={this._clearSettingsModal.bind(this)}
-        flags={this.applicationConfig.flags}
         localStorage={localStorage} />,
       document.getElementById('modal-gui-settings'));
   }

--- a/jujugui/static/gui/src/app/init/component-renderers-mixin.js
+++ b/jujugui/static/gui/src/app/init/component-renderers-mixin.js
@@ -132,10 +132,17 @@ const ComponentRenderersMixin = superclass => class extends superclass {
   */
   _renderModelActions() {
     const modelAPI = this.modelAPI;
+    const displayTerminalButton = (
+      this.applicationConfig.flags.terminal ||
+      // Always allow for opening the terminal if the user specified a
+      // jujushell URL in the GUI settings.
+      localStorage.getItem('jujushell-url') ||
+      false
+    );
     ReactDOM.render(
       <ModelActions
         acl={this.acl}
-        displayTerminalButton={this.applicationConfig.flags.terminal || false}
+        displayTerminalButton={displayTerminalButton}
         appState={this.state}
         changeState={this._bound.changeState}
         exportEnvironmentFile={


### PR DESCRIPTION
Indicating a jujushell URL in the GUI settings makes the functionality available, even without the terminal flag.