### PR TITLE
Add identity API to jujulib

### DIFF
--- a/jujugui/options.py
+++ b/jujugui/options.py
@@ -10,6 +10,7 @@ from pyramid.settings import asbool
 DEFAULT_BUNDLESERVICE_URL = 'https://api.jujucharms.com/bundleservice/'
 DEFAULT_CHARMSTORE_URL = 'https://api.jujucharms.com/charmstore/'
 DEFAULT_PLANS_URL = 'https://api.jujucharms.com/omnibus/'
+DEFAULT_IDENTITY_URL = 'https://api.jujucharms.com/identity/'
 DEFAULT_PAYMENT_URL = 'https://api.jujucharms.com/payment/'
 DEFAULT_TERMS_URL = 'https://api.jujucharms.com/terms/'
 
@@ -37,6 +38,7 @@ def update(settings):
                 default=DEFAULT_BUNDLESERVICE_URL)
     _update_url(settings, 'jujugui.charmstore_url',
                 default=DEFAULT_CHARMSTORE_URL)
+    _update_url(settings, 'jujugui.identity_url', default=DEFAULT_IDENTITY_URL)
     _update_url(settings, 'jujugui.payment_url', default=DEFAULT_PAYMENT_URL)
     _update_url(settings, 'jujugui.plans_url', default=DEFAULT_PLANS_URL)
     _update_url(settings, 'jujugui.terms_url', default=DEFAULT_TERMS_URL)

--- a/jujugui/static/gui/src/app/init.js
+++ b/jujugui/static/gui/src/app/init.js
@@ -118,6 +118,12 @@ class GUIApp {
     this.bakery = newBakery(
       config, this.user, stateGetter, cookieSetter, webHandler);
     /**
+      An identity instance.
+      Used to retrieve information about the currently logged in user.
+      @type {Object}
+    */
+    this.identity = this._setupIdentity(config, window.jujulib.identity);
+    /**
       A charm store API client instance.
       Used to retrieve information about charms and bundles via the charm store.
       @type {Object}
@@ -333,6 +339,19 @@ class GUIApp {
     // addNotifications.
     this._bound.switchModel = utils.switchModel.bind(
       this, this.modelAPI, this._bound.addNotification);
+  }
+
+  /**
+    Creates a new instance of the Identity API. This method is idempotent.
+    @param {object} config The app instantiation configuration.
+    @param {Object} Identity The Identity class.
+    @return {Object} The existing or new instance of identity.
+  */
+  _setupIdentity(config, Identity) {
+    if (this.identity === undefined) {
+      this.identity = new Identity(config.identityURL, this.bakery);
+    }
+    return this.identity;
   }
 
   /**

--- a/jujugui/static/gui/src/app/init/test-endpoint-utils.js
+++ b/jujugui/static/gui/src/app/init/test-endpoint-utils.js
@@ -16,7 +16,8 @@ const createApp = (JujuGUI, config = {}) => {
     flags: {},
     gisf: false,
     plansURL: 'http://plans.example.com/',
-    termsURL: 'http://terms.example.com/'
+    termsURL: 'http://terms.example.com/',
+    identityURL: 'http://identity.example.com/'
   };
   // Overwrite any default values with those provided.
   const initConfig = Object.assign(defaults, config);

--- a/jujugui/static/gui/src/app/jujulib/identity.js
+++ b/jujugui/static/gui/src/app/jujulib/identity.js
@@ -1,0 +1,60 @@
+/* Copyright (C) 2018 Canonical Ltd. */
+'use strict';
+
+var module = module;
+
+(function(exports) {
+
+  const jujulib = exports.jujulib;
+
+  /**
+    Identity service client.
+
+    Provides access to the Identity API.
+  */
+
+  const identityAPIVersion = 'v1';
+
+  /**
+    Initializer.
+
+    @function identity
+    @param url {String} The URL of the identity instance, including
+      scheme and port, and excluding the API version.
+    @param bakery {Object} A bakery object for communicating with the identity
+      instance.
+    @returns {Object} A client object for making identity API calls.
+  */
+  function identity(url, bakery) {
+    // Store the API URL (including version) handling missing trailing slash.
+    this.url = url.replace(/\/?$/, '/') + identityAPIVersion;
+    this.bakery = bakery;
+  };
+
+  identity.prototype = {
+
+    /**
+      Fetch the user data from the identity service
+      @param {String} userName The user name to fetch the data for.
+      @param {Function} callback
+        Called with the call signature (error <Object>, userData <Object>).
+    */
+    getUser: function(userName, callback) {
+      return this.bakery.get(`${this.url}/u/${userName}`, null, (err, resp) => {
+        if (err) {
+          callback(err, null);
+          return;
+        }
+        try {
+          const data = JSON.parse(resp.target.responseText);
+          callback(null, data);
+        } catch (e) {
+          callback(e, null);
+        }
+      });
+    }
+  };
+
+  jujulib.identity = identity;
+
+}((module && module.exports) ? module.exports : this));

--- a/jujugui/static/gui/src/app/jujulib/identity.js
+++ b/jujugui/static/gui/src/app/jujulib/identity.js
@@ -49,7 +49,7 @@ var module = module;
           const data = JSON.parse(resp.target.responseText);
           callback(null, data);
         } catch (e) {
-          callback(e, null);
+          callback(e.toString(), null);
         }
       });
     }

--- a/jujugui/static/gui/src/app/jujulib/test-identity.js
+++ b/jujugui/static/gui/src/app/jujulib/test-identity.js
@@ -1,0 +1,58 @@
+/* Copyright (C) 2018 Canonical Ltd. */
+
+'use strict';
+
+describe('jujulib identity service', () => {
+
+  describe('getUser', () => {
+
+    const baseURL = 'http://1.2.3.4';
+
+    function setupBakery(returnVal) {
+      return {
+        get: function(url, headers, callback) {
+          assert.equal(url, `${baseURL}/v1/u/hatch`);
+          assert.equal(headers, null);
+          callback.apply(null, returnVal);
+        }
+      };
+    }
+
+    it('calls back with the parsed data', done => {
+      const userData = {user: 'data'};
+      const returnVal = [null, {
+        target: {
+          responseText: JSON.stringify(userData)
+        }
+      }];
+      const bakery = setupBakery(returnVal);
+      const identity = new window.jujulib.identity(baseURL, bakery);
+      identity.getUser('hatch', (err, data) => {
+        assert.deepEqual(data, userData);
+        done();
+      });
+    });
+
+    it('calls back with an error if the bakery request fails', done => {
+      const returnVal = [{error: 'foo'}, null];
+      const bakery = setupBakery(returnVal);
+      const identity = new window.jujulib.identity(baseURL, bakery);
+      identity.getUser('hatch', (err, data) => {
+        assert.deepEqual(err, returnVal[0]);
+        done();
+      });
+    });
+
+    it('calls back with an error if the json parsing fails', done => {
+      const returnVal = [null, 'invalid'];
+      const bakery = setupBakery(returnVal);
+      const identity = new window.jujulib.identity(baseURL, bakery);
+      identity.getUser('hatch', (err, data) => {
+        assert.deepEqual(
+          err, 'TypeError: Cannot read property \'responseText\' of undefined');
+        done();
+      });
+    });
+
+  });
+});

--- a/jujugui/static/gui/src/app/test-init.js
+++ b/jujugui/static/gui/src/app/test-init.js
@@ -17,7 +17,8 @@ describe('init', () => {
       flags: {},
       gisf: false,
       plansURL: 'http://plans.example.com/',
-      termsURL: 'http://terms.example.com/'
+      termsURL: 'http://terms.example.com/',
+      identityURL: 'http://identity.example.com/'
     };
     // Overwrite any default values with those provided.
     const initConfig = Object.assign(defaults, config);
@@ -140,6 +141,24 @@ describe('init', () => {
           app.charmstore.url,
           'http://1.2.3.4/v5',
           'It should only ever create a single instance of the charmstore');
+      });
+    });
+
+    describe('_setupIdentity', () => {
+      it('is called on application instantiation', () => {
+        assert.isNotNull(app.identity);
+      });
+
+      it('is idempotent', () => {
+        // The identity attribute is undefined by default
+        assert.equal(typeof app.identity, 'object');
+        assert.equal(app.identity.url, 'http://identity.example.com/v1');
+        app._setupIdentity(
+          {identityURL: 'it broke'}, window.jujulib.identity);
+        assert.equal(
+          app.identity.url,
+          'http://identity.example.com/v1',
+          'It should only ever create a single instance of the identity service');
       });
     });
 

--- a/jujugui/templates/config.js.go
+++ b/jujugui/templates/config.js.go
@@ -10,6 +10,7 @@ var juju_config = {
     "charmstoreAPIPath": "v4",
     "charmstoreURL": "https://api.jujucharms.com/charmstore/",
     "bundleServiceURL": "https://api.jujucharms.com/bundleservice/",
+    "identityURL": "https://api.jujucharms.com/identity",
     "plansURL": "https://api.jujucharms.com/omnibus/",
     "paymentURL": "https://api.jujucharms.com/payment/",
     "termsURL": "https://api.jujucharms.com/terms/",

--- a/jujugui/templates/index.html.go
+++ b/jujugui/templates/index.html.go
@@ -299,14 +299,14 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     <script src="{{.comboURL}}?app/assets/javascripts/yui/yui/yui.js"></script>
     <script src="{{.comboURL}}?modules.js"></script>
     <script src="{{.comboURL}}?app/assets/javascripts/js-macaroon.js"></script>
-    <script src="{{.comboURL}}?app/state/state.js&app/user/user.js&app/utils/github-ssh-keys.js&app/utils/statsd.js&app/jujulib/index.js&app/jujulib/charmstore.js&app/jujulib/bundleservice.js&app/jujulib/plans.js&app/jujulib/payment.js&app/jujulib/stripe.js&app/jujulib/terms.js&app/jujulib/reconnecting-websocket.js&app/jujulib/urls.js&app/jujulib/bakery.js"></script>
+    <script src="{{.comboURL}}?app/state/state.js&app/user/user.js&app/utils/github-ssh-keys.js&app/utils/statsd.js&app/jujulib/index.js&app/jujulib/charmstore.js&app/jujulib/identity.js&app/jujulib/bundleservice.js&app/jujulib/plans.js&app/jujulib/payment.js&app/jujulib/stripe.js&app/jujulib/terms.js&app/jujulib/reconnecting-websocket.js&app/jujulib/urls.js&app/jujulib/bakery.js"></script>
     {{else}}
     <script src="{{.comboURL}}?app/init-pkg-min.js"></script>
     <script src="{{.comboURL}}?app/assets/javascripts/version-min.js"></script>
     <script src="{{.comboURL}}?app/assets/javascripts/yui/yui/yui-min.js"></script>
     <script src="{{.comboURL}}?modules-min.js"></script>
     <script src="{{.comboURL}}?app/assets/javascripts/js-macaroon-min.js"></script>
-    <script src="{{.comboURL}}?app/state/state-min.js&app/user/user-min.js&app/utils/github-ssh-keys-min.js&app/utils/statsd-min.js&app/jujulib/index-min.js&app/jujulib/charmstore-min.js&app/jujulib/bundleservice-min.js&app/jujulib/plans-min.js&app/jujulib/payment-min.js&app/jujulib/stripe-min.js&app/jujulib/terms-min.js&app/jujulib/reconnecting-websocket-min.js&app/jujulib/urls-min.js&app/jujulib/bakery-min.js"></script>
+    <script src="{{.comboURL}}?app/state/state-min.js&app/user/user-min.js&app/utils/github-ssh-keys-min.js&app/utils/statsd-min.js&app/jujulib/index-min.js&app/jujulib/charmstore-min.js&app/jujulib/identity-min.js&app/jujulib/bundleservice-min.js&app/jujulib/plans-min.js&app/jujulib/payment-min.js&app/jujulib/stripe-min.js&app/jujulib/terms-min.js&app/jujulib/reconnecting-websocket-min.js&app/jujulib/urls-min.js&app/jujulib/bakery-min.js"></script>
     {{end}}
 
     <script>

--- a/jujugui/templates/index.html.mako
+++ b/jujugui/templates/index.html.mako
@@ -299,14 +299,14 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     <script src="${convoy_url}?app/assets/javascripts/yui/yui/yui.js"></script>
     <script src="${convoy_url}?modules.js"></script>
     <script src="${convoy_url}?app/assets/javascripts/js-macaroon.js"></script>
-    <script src="${convoy_url}?app/state/state.js&app/user/user.js&app/utils/github-ssh-keys.js&app/utils/statsd.js&app/jujulib/index.js&app/jujulib/charmstore.js&app/jujulib/bundleservice.js&app/jujulib/plans.js&app/jujulib/payment.js&app/jujulib/stripe.js&app/jujulib/terms.js&app/jujulib/reconnecting-websocket.js&app/jujulib/urls.js&app/jujulib/bakery.js"></script>
+    <script src="${convoy_url}?app/state/state.js&app/user/user.js&app/utils/github-ssh-keys.js&app/utils/statsd.js&app/jujulib/index.js&app/jujulib/charmstore.js&app/jujulib/identity.js&app/jujulib/bundleservice.js&app/jujulib/plans.js&app/jujulib/payment.js&app/jujulib/stripe.js&app/jujulib/terms.js&app/jujulib/reconnecting-websocket.js&app/jujulib/urls.js&app/jujulib/bakery.js"></script>
     % else:
     <script src="${convoy_url}?app/init-pkg-min.js"></script>
     <script src="${convoy_url}?app/assets/javascripts/version-min.js"></script>
     <script src="${convoy_url}?app/assets/javascripts/yui/yui/yui-min.js"></script>
     <script src="${convoy_url}?modules-min.js"></script>
     <script src="${convoy_url}?app/assets/javascripts/js-macaroon-min.js"></script>
-    <script src="${convoy_url}?app/state/state-min.js&app/user/user-min.js&app/utils/github-ssh-keys-min.js&app/utils/statsd-min.js&app/jujulib/index-min.js&app/jujulib/charmstore-min.js&app/jujulib/bundleservice-min.js&app/jujulib/plans-min.js&app/jujulib/payment-min.js&app/jujulib/stripe-min.js&app/jujulib/terms-min.js&app/jujulib/reconnecting-websocket-min.js&app/jujulib/urls-min.js&app/jujulib/bakery-min.js"></script>
+    <script src="${convoy_url}?app/state/state-min.js&app/user/user-min.js&app/utils/github-ssh-keys-min.js&app/utils/statsd-min.js&app/jujulib/index-min.js&app/jujulib/charmstore-min.js&app/jujulib/identity-min.js&app/jujulib/bundleservice-min.js&app/jujulib/plans-min.js&app/jujulib/payment-min.js&app/jujulib/stripe-min.js&app/jujulib/terms-min.js&app/jujulib/reconnecting-websocket-min.js&app/jujulib/urls-min.js&app/jujulib/bakery-min.js"></script>
     % endif
 
     <script>

--- a/jujugui/tests/test_options.py
+++ b/jujugui/tests/test_options.py
@@ -32,6 +32,7 @@ class TestUpdate(unittest.TestCase):
         'jujugui.stripe_key': '',
         'jujugui.terms_url': options.DEFAULT_TERMS_URL,
         'jujugui.payment_url': options.DEFAULT_PAYMENT_URL,
+        'jujugui.identity_url': options.DEFAULT_IDENTITY_URL,
         'jujugui.user': None,
         'jujugui.flags': {},
     }
@@ -66,6 +67,7 @@ class TestUpdate(unittest.TestCase):
             'jujugui.stripe_key': '123',
             'jujugui.payment_url': 'https://1.2.3.4/payment-api/',
             'jujugui.terms_url': 'https://1.2.3.4/terms-api/',
+            'jujugui.identity_url': 'https://1.2.3.4/identity-api/',
             'jujugui.user': 'who',
             'jujugui.flags': {'foo': True}
         }
@@ -92,6 +94,7 @@ class TestUpdate(unittest.TestCase):
             'jujugui.stripe_key': '123',
             'jujugui.payment_url': 'https://1.2.3.4/payment-api/',
             'jujugui.terms_url': 'https://1.2.3.4/terms-api/',
+            'jujugui.identity_url': 'https://1.2.3.4/identity-api/',
             'jujugui.user': 'who',
             'jujugui.flags': {'foo': True}
         }

--- a/jujugui/tests/test_views.py
+++ b/jujugui/tests/test_views.py
@@ -136,6 +136,7 @@ class ConfigTests(ViewTestCase):
         self.assertEqual(options.DEFAULT_PLANS_URL, config['plansURL'])
         self.assertEqual('', config['statsURL'])
         self.assertEqual(options.DEFAULT_TERMS_URL, config['termsURL'])
+        self.assertEqual(options.DEFAULT_IDENTITY_URL, config['identityURL'])
         self.assertFalse(config['GTM_enabled'])
         # Note that here we are testing that the value is actually True or
         # False, not that it just evaluates to True/False(like in assertTrue).

--- a/jujugui/views.py
+++ b/jujugui/views.py
@@ -101,6 +101,7 @@ def config(request):
         # The external services' URLs.
         'bundleServiceURL': settings['jujugui.bundleservice_url'],
         'charmstoreURL': settings['jujugui.charmstore_url'],
+        'identityURL': settings['jujugui.identity_url'],
         'plansURL': settings['jujugui.plans_url'],
         'paymentURL': settings['jujugui.payment_url'],
         'statsURL': settings['jujugui.stats_url'],

--- a/karma.conf.js.tmpl
+++ b/karma.conf.js.tmpl
@@ -26,6 +26,7 @@ module.exports = function(config) {
 
       'jujugui/static/gui/src/app/jujulib/index.js',
       'jujugui/static/gui/src/app/jujulib/charmstore.js',
+      'jujugui/static/gui/src/app/jujulib/identity.js',
       'jujugui/static/gui/src/app/jujulib/plans.js',
       'jujugui/static/gui/src/app/jujulib/payment.js',
       'jujugui/static/gui/src/app/jujulib/stripe.js',


### PR DESCRIPTION
To support some of the features in the new profile view we need to be able to query for the logged in users information. This supplies the necessary API instance for that.