### PR TITLE
Add min-height to initial row item in bundles table

### DIFF
--- a/jujugui/static/gui/src/app/components/profile/bundle-list/_bundle-list.scss
+++ b/jujugui/static/gui/src/app/components/profile/bundle-list/_bundle-list.scss
@@ -18,6 +18,14 @@
 
   .expanding-row {
     padding-bottom: 0;
+
+    &__initial {
+      min-height: 35px;
+    }
+  }
+
+  .expanding-row--expanded .expanding-row__initial {
+    min-height: 0;
   }
 
   .profile-expanded-content {


### PR DESCRIPTION
This change will remove an unsightly jump in row height when the charm icons are loaded into the bundles row on the Profile page.

Fixes #3420