### PR TITLE
Don't set an empty htmlFor property in Firefox so there aren't errors.

### DIFF
--- a/jujugui/static/gui/src/app/components/check-list-item/check-list-item.js
+++ b/jujugui/static/gui/src/app/components/check-list-item/check-list-item.js
@@ -36,7 +36,9 @@ class CheckListItem extends React.Component {
     @returns {String} The id of the element or a blank string.
   */
   _generateId(id) {
-    return this.props.action ? '' : id;
+    // Firefox does not link empty htmlFor properties so set it to undefined so
+    // the property does not get set.
+    return this.props.action ? undefined : id;
   }
 
   /**

--- a/jujugui/static/gui/src/app/components/check-list-item/test-check-list-item.js
+++ b/jujugui/static/gui/src/app/components/check-list-item/test-check-list-item.js
@@ -101,7 +101,7 @@ describe('CheckListItem', () => {
         action={sinon.stub()}
         id="apache/2"
         whenChanged={sinon.stub()} />);
-    assert.equal(output.props.children.props.htmlFor, '');
+    assert.equal(output.props.children.props.htmlFor, undefined);
   });
 
   it('has a nav class if it is a nav element', () => {


### PR DESCRIPTION
Fixes: #3483.