### PR TITLE
Only call the cleanup methods for existing state keys.

### DIFF
--- a/jujugui/static/gui/src/app/init.js
+++ b/jujugui/static/gui/src/app/init.js
@@ -650,7 +650,6 @@ class GUIApp {
     @param {Function} next - Run the next route handler, if any.
   */
   _clearRoot(state, next) {
-    this._clearCharmbrowser(state, next);
     this._clearLogin(state, next);
     next();
   }

--- a/jujugui/static/gui/src/app/state/test-state.js
+++ b/jujugui/static/gui/src/app/state/test-state.js
@@ -1359,9 +1359,16 @@ describe('State', () => {
         location: {href: '/u/hatch/staging/i/applications/inspector/ghost'}
       });
       const pushStub = sinon.stub(state, '_pushState');
-      state.dispatch();
+      state.bootstrap();
       const dispatchStub = sinon.stub(state, 'dispatch').returns({error: null});
+      // The location value will create a state which looks like
+      // {user: 'hatch/staging', gui: {applications: '', inspector: {id: 'ghost'}}
+      // In the changeState however we are calling null on `gui.inspector` by
+      // doing this we exersize the nullkey filtering for only calling dispatchers
+      // for state values that exist. The root cleanup dispatcher should
+      // not be called.
       state.changeState({
+        root: null,
         gui: {
           inspector: null,
           applications: null
@@ -1380,7 +1387,7 @@ describe('State', () => {
         location: {href: '/i/machines'}
       });
       const pushStub = sinon.stub(state, '_pushState');
-      state.dispatch();
+      state.bootstrap();
       const dispatchStub = sinon.stub(state, 'dispatch').returns({error: null});
       state.changeState({
         root: 'store',


### PR DESCRIPTION
Fixes #3481

Prior to this change, calls to changeState where you've set a key to null would always execute the cleanup method for that key. This meant that the cleanup methods had to be idempotent and was a minor performance issue. State will now only call cleanup methods if the state key previously existed. 