### PR TITLE
 Don't re-assign object variables when adding machines.

### DIFF
--- a/jujugui/static/gui/src/app/init/autodeploy.js
+++ b/jujugui/static/gui/src/app/init/autodeploy.js
@@ -81,13 +81,12 @@ function _onMachineCreated(db, machine, response) {
     });
     shouldDestroy = true;
   }
-  var createdMachineName = createdMachine.name;
+  const createdMachineName = createdMachine.name;
   if (createdMachineName) {
-    machine = db.machines.updateModelId(
-      machine, createdMachineName, true);
+    const updatedMachine = db.machines.updateModelId(machine, createdMachineName, true);
     // We need to revive the model so that the change event triggers
     // the token UI to re-render.
-    var machineModel = db.machines.revive(machine);
+    const machineModel = db.machines.revive(updatedMachine);
     var parentId;
     // The createdMachineName may be a container so it will be in the format
     // machine/type/number. If it is then we just need the parent machine


### PR DESCRIPTION
Do not re-assign the object variable when updating the machine model Id. This allows it to be modified outside of scope as the reference is kept further up the stack.

Fixes #3556 