### PR TITLE
Change in the SHA version used in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -731,7 +731,7 @@
     },
     "babelify": {
       "version": "https://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
-      "integrity": "sha1-qlau3nBn/XvVSWZu4W3ChQh+iOU=",
+      "integrity": "sha512-vID8Fz6pPN5pJMdlUnNFSfrlcx5MUule4k9aKs/zbZPyXxMTcRrB0M4Tarw22L8afr8eYSWxDPYCob3TdrqtlA==",
       "dev": true,
       "requires": {
         "babel-core": "6.26.0",
@@ -4392,7 +4392,7 @@
     },
     "js-yaml": {
       "version": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.1.tgz",
-      "integrity": "sha1-CHdc69/dNZIJ8NKs04PI+GppBKA=",
+      "integrity": "sha512-CbcG379L1e+mWBnLvHWWeLs8GyV/EMw862uLI3c+GxVyDHWZcjZinwuBd3iW2pgxgIlksW/1vNJa4to+RvDOww==",
       "requires": {
         "argparse": "1.0.9",
         "esprima": "4.0.0"


### PR DESCRIPTION
Installing the latest version of npm (5.8.0) addressed the fsevent optional package problem (see `https://github.com/npm/npm/issues/17722`) but introduces this change.