### PR TITLE
Add Invoice component to Profile

### DIFF
--- a/jujugui/static/gui/src/app/assets/css/_components.scss
+++ b/jujugui/static/gui/src/app/assets/css/_components.scss
@@ -89,6 +89,7 @@
 @import '../../components/inspector/service-overview/service-overview';
 @import '../../components/inspector/unit-details/unit-details';
 @import '../../components/inspector/unit-list/unit-list';
+@import '../../components/invoice/invoice';
 @import '../../components/isv-profile/isv-profile';
 @import '../../components/isv-profile/plans-usage/plans-usage';
 @import '../../components/lightbox/lightbox';

--- a/jujugui/static/gui/src/app/assets/css/base.scss
+++ b/jujugui/static/gui/src/app/assets/css/base.scss
@@ -77,7 +77,8 @@ $z-indexed-elements: search-results-list-block__tags,
   centered-column,
   notification,
   lightbox,
-  back-to-help;
+  back-to-help,
+  invoice;
 // sass-lint:enable indentation
 
 // Asset path used by Vanilla to load fonts instead of asset server

--- a/jujugui/static/gui/src/app/components/invoice/_invoice.scss
+++ b/jujugui/static/gui/src/app/components/invoice/_invoice.scss
@@ -1,0 +1,245 @@
+$invoice-bp: 600px;
+
+.invoice {
+  @extend %floating-panel;
+  min-height: 500vh;
+  width: 100vw;
+  z-index: index($z-indexed-elements, invoice);
+  overflow-x: hidden;
+  overflow-y: auto;
+  position: absolute;
+  top: 0;
+  right: 0;
+
+  &__inner {
+    padding: 1.5rem;
+    overflow-y: auto;
+    height: calc(100vh - 4rem);
+
+    @media (min-width: $invoice-bp) {
+      margin: 2rem auto;
+      max-width: 1200px;
+      padding: 2rem;
+    }
+  }
+
+  &__label {
+    color: $dark-warm-grey;
+  }
+
+  &__header {
+    position: relative;
+
+    @media (min-width: $invoice-bp) {
+
+      .invoice__meta {
+        position: relative;
+        top: 3rem;
+        min-height: 3rem;
+      }
+
+      .u-emphasis-value {
+        position: relative;
+        top: -1rem;
+      }
+    }
+  }
+
+  &__heading {
+    border-top: 1px solid $light-mid-grey;
+    font-size: 2.8rem;
+    margin-top: 1rem;
+
+    @media (min-width: $invoice-bp) {
+      position: absolute;
+      top: 2.25rem;
+      left: 0;
+      width: 100%;
+
+      .invoice__meta {
+        position: relative;
+        top: 3rem;
+      }
+    }
+  }
+
+  &__logo {
+    width: 80px;
+  }
+
+  &__info {
+    border-top: 1px solid $light-mid-grey;
+    margin-top: 1.5rem;
+
+    @media (min-width: $invoice-bp) {
+      position: relative;
+      margin-top: 3.5rem;
+      padding-top: 2rem;
+    }
+
+  }
+
+  &__address {
+    width: 100%;
+    margin: 1rem 0;
+
+    & > * {
+      display: block;
+      width: 100%;
+      margin-bottom: .25rem;
+    }
+
+    @media (min-width: $invoice-bp) {
+      position: absolute;
+      top: 1rem;
+      left: 0;
+    }
+  }
+
+  &__meta {
+    display: flex;
+
+    &__col {
+      flex: 1;
+
+      span {
+        display: block;
+        margin-bottom: .5rem;
+        text-align: right;
+      }
+
+      @media (min-width: $invoice-bp) {
+
+        &:first-child {
+          flex: 7.5;
+        }
+
+        &:last-child {
+          flex: 2.5;
+        }
+      }
+    }
+  }
+
+  &__summary {
+    margin-top: 1rem;
+    padding: 1rem 0;
+
+    * {
+      display: block;
+    }
+
+    & + .invoice__meta .u-emphasis-value {
+
+      @media (min-width: $invoice-bp) {
+        margin-top: -.75rem;
+      }
+    }
+
+    @media (max-width: $invoice-bp) {
+
+      .invoice__label {
+        margin-bottom: .5rem;
+      }
+    }
+
+
+    @media (min-width: $invoice-bp) {
+      margin-top: 0;
+      padding-top: 0;
+      position: absolute;
+      top: 0;
+      left: 0;
+
+      .invoice__label {
+        margin-bottom: .5rem;
+      }
+
+      & + .invoice__meta {
+        padding-bottom: 2rem;
+      }
+    }
+  }
+
+  &__billing-package {
+    border: 1px solid $light-mid-grey;
+    margin-bottom: 1rem;
+    padding: 1rem;
+
+    .invoice__meta {
+      min-height: 0;
+    }
+
+    p {
+      font-size: 1rem;
+    }
+
+    &__model-name {
+      margin-bottom: .25rem;
+    }
+  }
+
+  &__rel-wrap {
+    position: relative;
+
+    @media (min-width: $invoice-bp) {
+      padding-top: .5rem;
+    }
+  }
+
+  .u-btn-mar {
+    margin-bottom: 1rem;
+  }
+
+  .u-block-children * {
+    display: block;
+    margin-bottom: .25rem;
+  }
+
+  .u-emphasis-value {
+    font-size: 2rem;
+  }
+
+  .u-text-align--left {
+    text-align: left;
+  }
+
+  hr {
+    border: 0;
+    border-top: 1px solid $light-mid-grey;
+    margin: 2rem 0 1rem;
+  }
+}
+
+
+.invoice-details-lrg-screen {
+  display: none;
+}
+
+.invoice-details__title {
+  font-size: 20px;
+
+  @media (min-width: $invoice-bp) {
+    font-size: 23px;
+  }
+}
+
+@media (min-width: 768px) {
+
+  .invoice-details-sm-screen {
+    display: none;
+  }
+
+  .invoice-details-lrg-screen {
+    display: block;
+  }
+
+  .invoice__footer {
+    display: flex;
+    width: 100%;
+
+    &__col {
+      flex: 1;
+    }
+  }
+}

--- a/jujugui/static/gui/src/app/components/invoice/invoice.js
+++ b/jujugui/static/gui/src/app/components/invoice/invoice.js
@@ -211,9 +211,6 @@ class Invoice extends React.Component {
                 rows={rows} />
             </div>
             <hr />
-
-
-
             <div className="u-btn-mar">
               <img
                 alt="Canonical logo"

--- a/jujugui/static/gui/src/app/components/invoice/invoice.js
+++ b/jujugui/static/gui/src/app/components/invoice/invoice.js
@@ -1,0 +1,256 @@
+/* Copyright (C) 2018 Canonical Ltd. */
+'use strict';
+
+const React = require('react');
+
+const Spinner = require('../spinner/spinner');
+const BasicTable = require('../basic-table/basic-table');
+
+/**
+  React component used to display a list of the users invoices in their profile.
+*/
+class Invoice extends React.Component {
+  constructor() {
+    super();
+    this.xhrs = [];
+    this.state = {
+      data: [{
+        id: 1
+      }, {
+        id: 2
+      }],
+      loading: false
+    };
+  }
+
+  render() {
+    let content;
+    if (this.state.loading) {
+      content = (<Spinner />);
+    } else {
+      const rows = (this.state.data).map(invoice => {
+        return {
+          columns: [{
+            content: 'Ubuntu Advantage Essential',
+            columnSize: 3
+          }, {
+            content: '$0.09 per machine-hour',
+            columnSize: 3
+          }, {
+            content: '28,499 hours',
+            columnSize: 3
+          }, {
+            content: '$32,888',
+            columnSize: 3
+          }]
+        };
+      });
+      content = (
+        <div className="invoice__inner">
+          <header className="invoice__header">
+            <img
+              alt="Juju logo"
+              className="invoice__logo"
+              src="https://assets.ubuntu.com/v1/dc0fe093-juju-logo.svg" />
+
+            <h1 className="invoice__heading">Invoice</h1>
+
+            <div className="invoice__meta">
+              <div className="invoice__meta__col">
+                <span className="invoice__label">Invoice number:</span>
+              </div>
+              <div className="invoice__meta__col">
+                <span className="invoice__number u-emphasis-value">1003528</span>
+              </div>
+            </div>
+          </header>
+
+          <div className="invoice__info">
+
+            <div className="invoice__address">
+              <span>Paolo Roleto</span>
+              <span>Currency Analytics Ltd</span>
+              <span>110 Southwark St</span>
+              <span>London</span>
+              <span>SE1 0SU</span>
+              <span>UK</span>
+            </div>
+
+            <div className="invoice__meta">
+              <div className="invoice__meta__col">
+                <span className="invoice__label u-btn-mar">Invoice date:</span>
+
+                <span className="invoice__label">Our reference:</span>
+                <span className="invoice__label u-btn-mar">Your reference:</span>
+
+                <span className="invoice__label">Currency:</span>
+                <span className="invoice__label u-btn-mar">Net total:</span>
+
+                <span className="invoice__label">VAT number:</span>
+                <span className="invoice__label">VAT @ 20%:</span>
+                <span className="invoice__label">GDP</span>
+              </div>
+              <div className="invoice__meta__col">
+                <span className="invoice__value u-btn-mar">01 Feb 2018</span>
+
+                <span className="invoice__value">CGL_CN00601</span>
+                <span className="invoice__value u-btn-mar">280000000</span>
+
+                <span className="invoice__value">USD</span>
+                <span className="invoice__value u-btn-mar"><strong>$2,564.94</strong></span>
+
+                <span className="invoice__value">GB 123456789</span>
+                <span className="invoice__value"><strong>$512.75</strong></span>
+                <span className="invoice__value">£394.90</span>
+              </div>
+            </div>
+            <hr />
+            <div className="invoice__rel-wrap clearfix">
+              <div className="invoice__summary">
+                <div className="u-btn-mar">
+                  <span className="invoice__label">
+                    Services during the period
+                  </span>
+                  <span className="invoice__value">
+                    1st December 2017 - 31st January 2018
+                  </span>
+                </div>
+                <div className="u-btn-mar">
+                  <span className="invoice__label">
+                    Questions?
+                  </span>
+                  <span className="invoice__value">
+                    <a href="mailto:accountsrecievable@canonical.com">
+                      accountsrecievable@canonical.com
+                    </a>
+                  </span>
+                </div>
+              </div>
+              <div className="invoice__meta">
+                <div className="invoice__meta__col">
+                  <span className="invoice__label u-btn-mar">Total:</span>
+                  <span className="invoice__label u-btn-mar">Paid by card:</span>
+                </div>
+                <div className="invoice__meta__col">
+                  <span className="invoice__value u-emphasis-value">
+                    <strong>$3,077.93</strong>
+                  </span>
+                  <span className="invoice__value">xxxx xxxx xxxx 1234</span>
+                </div>
+              </div>
+            </div>
+            <hr />
+            <h3 className="u-btn-mar invoice-details__title">Details</h3>
+            <div className="invoice-details-sm-screen">
+              <div className="invoice__billing-package">
+                <p><strong>Ubuntu Advantage Essential</strong></p>
+                <p>$0.09 per machine hour</p>
+                <p className="invoice__billing-package__model-name">Model: fx-staging-ldn</p>
+                <div className="invoice__meta">
+                  <div className="invoice__meta__col">
+                    <span className="invoice__label u-text-align--left">28.999 hours</span>
+                  </div>
+                  <div className="invoice__meta__col">
+                    <span className="invoice__value">$2,567.94</span>
+                  </div>
+                </div>
+                <p className="invoice__billing-package__model-name">Model: version neo</p>
+                <div className="invoice__meta">
+                  <div className="invoice__meta__col">
+                    <span className="invoice__label u-text-align--left">28.999 hours</span>
+                  </div>
+                  <div className="invoice__meta__col">
+                    <span className="invoice__value">$2,567.94</span>
+                  </div>
+                </div>
+              </div>
+              <div className="invoice__billing-package">
+                <p><strong>Ubuntu Advantage Advanced</strong></p>
+                <p>$0.09 per machine hour</p>
+                <p>Model: fx-staging-ldn</p>
+                <div className="invoice__meta">
+                  <div className="invoice__meta__col">
+                    <span className="invoice__label u-text-align--left">28.999 hours</span>
+                  </div>
+                  <div className="invoice__meta__col">
+                    <span className="invoice__value">$2,567.94</span>
+                  </div>
+                </div>
+
+                <p>Model: version neo</p>
+                <div className="invoice__meta">
+                  <div className="invoice__meta__col">
+                    <span className="invoice__label u-text-align--left">28.999 hours</span>
+                  </div>
+                  <div className="invoice__meta__col">
+                    <span className="invoice__value">$2,567.94</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div className="invoice-details-lrg-screen clearfix">
+              <BasicTable
+                headerClasses={['profile__entity-table-header-row']}
+                headerColumnClasses={['profile__entity-table-header-column']}
+                headers={[{
+                  content: 'Item',
+                  columnSize: 3
+                }, {
+                  content: 'Unit price',
+                  columnSize: 3
+                }, {
+                  content: 'Quantity',
+                  columnSize: 3
+                }, {
+                  content: 'Amount',
+                  columnSize: 3
+                }]}
+                rowClasses={['profile__entity-table-row']}
+                rowColumnClasses={['profile__entity-table-column']}
+                rows={rows} />
+            </div>
+            <hr />
+
+
+
+            <div className="u-btn-mar">
+              <img
+                alt="Canonical logo"
+                src="https://assets.ubuntu.com/v1/5d6da5c4-logo-canonical-aubergine.svg"
+                width="120" />
+            </div>
+
+            <div className="invoice__footer">
+              <div className="u-btn-mar u-block-children invoice__footer__col">
+                <span className="invoice__label">UK Company Number</span>
+                <span className="invoice__value">06870835</span>
+              </div>
+
+              <div className="u-btn-mar u-block-children invoice__footer__col">
+                <span className="invoice__label">VAT Number</span>
+                <span className="invoice__value">GB 003232247</span>
+              </div>
+
+              <div className="u-btn-mar u-block-children invoice__footer__col">
+                <span className="invoice__label">Registered office</span>
+                <span className="invoice__value">5th Floor</span>
+                <span className="invoice__value">Bluefin Building</span>
+                <span className="invoice__value">110 Southwark Street</span>
+                <span className="invoice__value">London</span>
+                <span className="invoice__value">SE1 0SU</span>
+                <span className="invoice__value">UK</span>
+              </div>
+            </div>
+
+          </div>
+        </div>);
+    }
+    return (
+      <div>
+        {content}
+      </div>);
+  }
+};
+
+module.exports = Invoice;

--- a/jujugui/static/gui/src/app/components/invoice/invoice.js
+++ b/jujugui/static/gui/src/app/components/invoice/invoice.js
@@ -28,8 +28,9 @@ class Invoice extends React.Component {
     if (this.state.loading) {
       content = (<Spinner />);
     } else {
-      const rows = (this.state.data).map(invoice => {
+      const rows = (this.state.data).map((invoice, index) => {
         return {
+          key: `${index}`,
           columns: [{
             content: 'Ubuntu Advantage Essential',
             columnSize: 3

--- a/jujugui/static/gui/src/app/components/invoice/invoice.js
+++ b/jujugui/static/gui/src/app/components/invoice/invoice.js
@@ -240,14 +240,14 @@ class Invoice extends React.Component {
                 <span className="invoice__value">UK</span>
               </div>
             </div>
-
           </div>
         </div>);
     }
     return (
-      <div>
+      <React.Fragment>
         {content}
-      </div>);
+      </React.Fragment>
+    );
   }
 };
 

--- a/jujugui/static/gui/src/app/components/invoice/invoice.test.js
+++ b/jujugui/static/gui/src/app/components/invoice/invoice.test.js
@@ -1,0 +1,19 @@
+/* Copyright (C) 2018 Canonical Ltd. */
+
+'use strict';
+const React = require('react');
+const Invoice = require('./invoice');
+
+const jsTestUtils = require('../../utils/component-test-utils');
+
+describe('Invoice', function() {
+
+  function renderComponent(options={}) {
+    return jsTestUtils.shallowRender(
+      <Invoice />, true);
+  }
+
+  it('can render', () => {
+    renderComponent();
+  });
+});

--- a/jujugui/static/gui/src/app/components/invoice/invoice.test.js
+++ b/jujugui/static/gui/src/app/components/invoice/invoice.test.js
@@ -1,19 +1,21 @@
-/* Copyright (C) 2018 Canonical Ltd. */
-
+/* Copyright (C) 2017 Canonical Ltd. */
 'use strict';
-const React = require('react');
-const Invoice = require('./invoice');
 
-const jsTestUtils = require('../../utils/component-test-utils');
+const React = require('react');
+const enzyme = require('enzyme');
+
+const Invoice = require('./revenue-statement');
 
 describe('Invoice', function() {
 
-  function renderComponent(options={}) {
-    return jsTestUtils.shallowRender(
-      <Invoice />, true);
-  }
+  const renderComponent = (options = {}) => enzyme.shallow(
+    <Invoice />
+  );
 
   it('can render', () => {
-    renderComponent();
+    const wrapper = renderComponent();
+    assert.equal(wrapper.find('.revenue-statement__inner').length,
+      1, 
+      'Revenue statement inner wrapper');
   });
 });

--- a/jujugui/static/gui/src/app/components/profile/invoice-list/invoice-list.js
+++ b/jujugui/static/gui/src/app/components/profile/invoice-list/invoice-list.js
@@ -89,7 +89,6 @@ class ProfileInvoiceList extends React.Component {
     if (this.state.loading) {
       content = (<Spinner />);
     } else {
-      const path = 'invoice/id';
       const rows = (this.props.data || this.state.data).map(invoice => {
         return {
           columns: [{
@@ -98,7 +97,7 @@ class ProfileInvoiceList extends React.Component {
           }, {
             content: (
               <a
-                href={`${this.props.baseURL}${path}`}>
+                href='#invoices/42'>
                 {invoice.number}
               </a>),
             columnSize: 3

--- a/jujugui/static/gui/src/app/components/profile/profile.js
+++ b/jujugui/static/gui/src/app/components/profile/profile.js
@@ -13,6 +13,7 @@ const ProfileCharmList = require('./charm-list/charm-list');
 const ProfileBundleList = require('./bundle-list/bundle-list');
 const ProfileCredentialList = require('./credential-list/credential-list');
 const ProfileInvoiceList = require('./invoice-list/invoice-list');
+const Invoice = require('../invoice/invoice');
 const Panel = require('../panel/panel');
 
 /** Profile React component used to display user details. */
@@ -29,17 +30,17 @@ class Profile extends React.Component {
   }
 
   /**
-    Get the base URL for the active section e.g. "credentials/aws_prod" would
+    Get the base path for the active section e.g. "credentials/aws_prod" would
     return "credentials".
-    @returns {String} The active base section of the URL.
+    @returns {String} The active base section of the path.
   */
-  _getProfileURL() {
-    const URL = this.props.activeSection || '';
-    const parts = URL.split('/');
+  _getSectionInfo() {
+    const path = this.props.activeSection || '';
+    const parts = path.split('/');
     return {
-      full: URL,
-      activeSection: parts[0],
-      subSection: parts.length > 1 ? parts.slice(1, parts.length).join('/') : null
+      full: path,
+      active: parts[0],
+      sub: parts.length > 1 ? parts.slice(1, parts.length).join('/') : null
     };
   }
 
@@ -47,6 +48,15 @@ class Profile extends React.Component {
     const props = this.props;
     const isActiveUsersProfile = props.controllerUser.split('@')[0] === props.userInfo.profile;
     const sectionsMap = new Map();
+    const sectionInfo = this._getSectionInfo();
+    if (sectionInfo.active === 'invoices' && sectionInfo.sub !== null) {
+      return (
+        <Panel instanceName="invoice" visible={true}>
+          <Invoice />
+        </Panel>
+      );
+    }
+
     if (isActiveUsersProfile) {
       sectionsMap.set('models', {
         label: 'Models',
@@ -117,7 +127,7 @@ class Profile extends React.Component {
               controllerAPI={
                 shapeup.fromShape(props.controllerAPI, propTypes.controllerAPI)}
               controllerIsReady={props.controllerIsReady}
-              credential={this._getProfileURL().subSection}
+              credential={this._getSectionInfo().sub}
               initUtils={props.initUtils}
               sendAnalytics={this._sendAnalytics.bind(this)}
               username={props.controllerUser} />);
@@ -148,7 +158,7 @@ class Profile extends React.Component {
         }
       });
     }
-    let section = sectionsMap.get(this._getProfileURL().activeSection);
+    let section = sectionsMap.get(this._getSectionInfo().active);
     let mapEntry;
     if (section === undefined) {
       // Grab the first element in the sectionsMap if the provided
@@ -173,7 +183,7 @@ class Profile extends React.Component {
             <div className="profile__content inner-wrapper">
               <ProfileNavigation
                 // Use supplied activeSection or the key from the first map entry.
-                activeSection={this._getProfileURL().activeSection || mapEntry[0]}
+                activeSection={this._getSectionInfo().active || mapEntry[0]}
                 changeState={props.changeState}
                 sectionsMap={sectionsMap} />
               {section.getComponent()}

--- a/jujugui/static/gui/src/app/components/profile/test-profile.js
+++ b/jujugui/static/gui/src/app/components/profile/test-profile.js
@@ -138,10 +138,10 @@ describe('Profile', function() {
   it('correctly parses the URL', () => {
     const wrapper = renderComponent({activeSection: 'credentials/aws_test'});
     const instance = wrapper.instance();
-    assert.deepEqual(instance._getProfileURL(), {
+    assert.deepEqual(instance._getSectionInfo(), {
       full: 'credentials/aws_test',
-      activeSection: 'credentials',
-      subSection: 'aws_test'
+      active: 'credentials',
+      sub: 'aws_test'
     });
   });
 
@@ -150,10 +150,10 @@ describe('Profile', function() {
       activeSection: 'credentials'
     });
     const instance = wrapper.instance();
-    assert.deepEqual(instance._getProfileURL(), {
+    assert.deepEqual(instance._getSectionInfo(), {
       full: 'credentials',
-      activeSection: 'credentials',
-      subSection: null
+      active: 'credentials',
+      sub: null
     });
   });
 


### PR DESCRIPTION
This PR is the same changeset as previously approved #3491 but it has now been manually rebased on top of latest `develop` and proposed again here.

As the "Invoices" profile navigation menu item is under the `pay` feature flag, this can land - right @hatched?

