### PR TITLE
Fix a race generating weird app placement in the canvas

### DIFF
--- a/jujugui/static/gui/src/app/d3-components/test-d3-components.js
+++ b/jujugui/static/gui/src/app/d3-components/test-d3-components.js
@@ -145,20 +145,6 @@ describe('d3-components', function() {
       assert.strictEqual(state.dbldbl, true);
     });
 
-  it('should correctly handle synthetic event bindings', function(done) {
-    comp = new Component({container: container});
-    class modA extends TestModule {
-      windowResizeHandler(evt) {
-        resized = true;
-        done();
-      }
-    }
-    var resized = false;
-    comp.addModule(modA, {name: 'modA', container: container});
-    window.dispatchEvent(new Event('resize'));
-    assert.isTrue(resized);
-  });
-
   it('deep clones event objects to avoid shared bindings', function() {
     var compA = new Component({container: container});
     compA.addModule(TestModule);

--- a/jujugui/static/gui/src/app/init/test-bundle-importer.js
+++ b/jujugui/static/gui/src/app/init/test-bundle-importer.js
@@ -4,7 +4,7 @@
 const BundleImporter = require('./bundle-importer');
 const jujulibConversionUtils = require('./jujulib-conversion-utils');
 
-// XXX There are test failures in thsi branch when it's not run in the full
+// XXX There are test failures in this branch when it's not run in the full
 // suite of tests.
 describe('BundleImporter', () => {
   let bundleImporter, charmstore, db, getBundleChanges,
@@ -52,9 +52,12 @@ describe('BundleImporter', () => {
     });
   });
 
-  afterEach(() => {
+  afterEach(done => {
     db.destroy();
-    modelAPI.destroy();
+    modelAPI.close(() => {
+      modelAPI.destroy();
+      done();
+    });
   });
 
   it('can be instantiated', () => {

--- a/jujugui/static/gui/src/app/models/handlers.js
+++ b/jujugui/static/gui/src/app/models/handlers.js
@@ -327,6 +327,18 @@ YUI.add('juju-delta-handlers', function(Y) {
         subordinate: change.subordinate,
         workloadVersion: change['workload-version'] || ''
       };
+      // Check whether there is a ghost for this application, in which case
+      // we need to summon and resurrect it.
+      db.services.filter(model => {
+        return model.get('pending') && model.get('name') === change.name;
+      }).forEach(model => {
+        model.setAttrs({
+          id: change.name,
+          displayName: undefined,
+          pending: false,
+          loading: false
+        });
+      });
       // Process the stream.
       db.services.process_delta(action, data);
       if (action !== 'remove') {

--- a/jujugui/static/gui/src/test/test_model_handlers.js
+++ b/jujugui/static/gui/src/test/test_model_handlers.js
@@ -337,6 +337,30 @@ describe('Juju delta handlers', function() {
       assert.strictEqual(application.get('workloadVersion'), '2.0.1');
     });
 
+    it('promote a ghost application in the database', function() {
+      db.services.add({
+        id: '4247',
+        name: 'wordpress',
+        pending: true,
+        loading: true,
+        charm: 'cs:quantal/wordpress-11',
+        exposed: true
+      });
+      var change = {
+        name: 'wordpress',
+        'charm-url': 'cs:quantal/wordpress-11',
+        exposed: false
+      };
+      applicationInfo(db, 'change', change);
+      assert.strictEqual(db.services.size(), 1);
+      // Retrieve the application from the database.
+      var application = db.services.getById('wordpress');
+      assert.strictEqual(application.get('charm'), 'cs:quantal/wordpress-11');
+      assert.strictEqual(application.get('exposed'), false, 'exposed');
+      assert.strictEqual(application.get('pending'), false, 'pending');
+      assert.strictEqual(application.get('loading'), false, 'loading');
+    });
+
     it('handles missing constraints', function() {
       db.services.add({
         id: 'wordpress',


### PR DESCRIPTION
We lived in the assumption that the deploy callbacks are executed before the mega-watcher handlers, which is not always the case.
When the mega-watcher messages arrive before the corresponding ghost applications were resurrected, then a duplication occurred, in which app names clashed and also mega-watcher entities had no x/y annotations.