### PR TITLE
Require YUI modules

### DIFF
--- a/jujugui/static/gui/src/app/extensions/yui-patches.js
+++ b/jujugui/static/gui/src/app/extensions/yui-patches.js
@@ -22,7 +22,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 /**
  * Provides a consistant place to put any monkey patches to YUI modules.
  */
-YUI.add('yui-patches', function(Y) {
+window.yui.add('yui-patches', function(Y) {
 
   /**
     Lazy Model List maintains a _idMap property with id's of all of the models

--- a/jujugui/static/gui/src/app/init.js
+++ b/jujugui/static/gui/src/app/init.js
@@ -29,6 +29,8 @@ window.models = yui.namespace('juju.models');
 
 window.jujulib = require('./jujulib');
 
+require('./yui-modules');
+
 class GUIApp {
   constructor(config) {
     /**

--- a/jujugui/static/gui/src/app/init/test-endpoint-utils.js
+++ b/jujugui/static/gui/src/app/init/test-endpoint-utils.js
@@ -31,16 +31,19 @@ describe('Relation endpoints logic', () => {
       sample_env, JujuGUI;
 
   beforeAll(done => {
-    YUI(GlobalConfig).use(MODULES, Y => {
+    YUI(GlobalConfig).use([], Y => {
       sample_env = utils.loadFixture('data/large_stream.json', true);
       sample_endpoints = utils.loadFixture('data/large_endpoints.json', true);
       // init.js requires the window to contain the YUI object.
       window.yui = Y;
       // The gui version is required to be set by component-renderers-mixin.js.
       window.GUI_VERSION = {version: '1.2.3'};
-      // The require needs to be after the yui modules have been loaded.
-      JujuGUI = require('../init');
-      done();
+      require('../yui-modules');
+      window.yui.use(window.MODULES, function() {
+        // The require needs to be after the yui modules have been loaded.
+        JujuGUI = require('../init');
+        done();
+      });
     });
   });
 
@@ -369,18 +372,21 @@ describe('Endpoints map handlers', function() {
   let app, container, controller, destroyMe, factory, JujuGUI;
 
   beforeAll(done => {
-    YUI(GlobalConfig).use(MODULES.concat([
+    YUI(GlobalConfig).use([
       'juju-tests-factory',
-      'datasource-local']),
+      'datasource-local'],
     Y => {
       factory = Y.namespace('juju-tests.factory');
       // init.js requires the window to contain the YUI object.
       window.yui = Y;
       // The gui version is required to be set by component-renderers-mixin.js.
       window.GUI_VERSION = {version: '1.2.3'};
-      // The require needs to be after the yui modules have been loaded.
-      JujuGUI = require('../init');
-      done();
+      require('../yui-modules');
+      window.yui.use(window.MODULES, function() {
+        // The require needs to be after the yui modules have been loaded.
+        JujuGUI = require('../init');
+        done();
+      });
     });
   });
 
@@ -514,14 +520,17 @@ describe('Application config handlers', () => {
   let JujuGUI, app, conn, container, destroyMe;
 
   beforeAll(done => {
-    YUI(GlobalConfig).use(MODULES.concat(['environment-change-set']), Y => {
+    YUI(GlobalConfig).use([], Y => {
       // init.js requires the window to contain the YUI object.
       window.yui = Y;
       // The gui version is required to be set by component-renderers-mixin.js.
       window.GUI_VERSION = {version: '1.2.3'};
-      // The require needs to be after the yui modules have been loaded.
-      JujuGUI = require('../init');
-      done();
+      require('../yui-modules');
+      window.yui.use(window.MODULES, function() {
+        // The require needs to be after the yui modules have been loaded.
+        JujuGUI = require('../init');
+        done();
+      });
     });
   });
 

--- a/jujugui/static/gui/src/app/models/bundle.js
+++ b/jujugui/static/gui/src/app/models/bundle.js
@@ -31,7 +31,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
  * @submodule models.bundle
  */
 
-YUI.add('juju-bundle-models', function(Y) {
+window.yui.add('juju-bundle-models', function(Y) {
 
   var models = Y.namespace('juju.models'),
       utils = Y.namespace('juju.views.utils');

--- a/jujugui/static/gui/src/app/models/charm.js
+++ b/jujugui/static/gui/src/app/models/charm.js
@@ -25,7 +25,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
  * @submodule models.charm
  */
 
-YUI.add('juju-charm-models', function(Y) {
+window.yui.add('juju-charm-models', function(Y) {
 
   var models = Y.namespace('juju.models');
   var utils = Y.namespace('juju.views.utils');

--- a/jujugui/static/gui/src/app/models/charm.js
+++ b/jujugui/static/gui/src/app/models/charm.js
@@ -18,6 +18,8 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 'use strict';
 
+const utils = require('../views/utils');
+
 /**
  * Provide the Charm and CharmList classes.
  *
@@ -28,7 +30,6 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 window.yui.add('juju-charm-models', function(Y) {
 
   var models = Y.namespace('juju.models');
-  var utils = Y.namespace('juju.views.utils');
 
   /**
    * Helper to use a setter so that we can set null when the api returns an
@@ -846,7 +847,6 @@ window.yui.add('juju-charm-models', function(Y) {
 
 }, '0.1.0', {
   requires: [
-    'juju-view-utils',
     'model',
     'model-list',
     'entity-extension'

--- a/jujugui/static/gui/src/app/models/entity-extension.js
+++ b/jujugui/static/gui/src/app/models/entity-extension.js
@@ -18,7 +18,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 'use strict';
 
-YUI.add('entity-extension', function(Y) {
+window.yui.add('entity-extension', function(Y) {
   var ns = Y.namespace('juju.models'),
       utils = Y.namespace('juju.views.utils');
 

--- a/jujugui/static/gui/src/app/models/entity-extension.js
+++ b/jujugui/static/gui/src/app/models/entity-extension.js
@@ -18,9 +18,10 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 'use strict';
 
+const utils = require('../views/utils');
+
 window.yui.add('entity-extension', function(Y) {
-  var ns = Y.namespace('juju.models'),
-      utils = Y.namespace('juju.views.utils');
+  var ns = Y.namespace('juju.models');
 
   /**
    * Class extension containing functionality common to both charms and
@@ -86,5 +87,5 @@ window.yui.add('entity-extension', function(Y) {
   ns.EntityExtension = EntityExtension;
 
 }, '', {
-  requires: ['juju-view-utils']
+  requires: []
 });

--- a/jujugui/static/gui/src/app/models/handlers.js
+++ b/jujugui/static/gui/src/app/models/handlers.js
@@ -27,7 +27,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
    @module handlers
  */
 
-YUI.add('juju-delta-handlers', function(Y) {
+window.yui.add('juju-delta-handlers', function(Y) {
 
   var models = Y.namespace('juju.models');
 

--- a/jujugui/static/gui/src/app/models/model-controller.js
+++ b/jujugui/static/gui/src/app/models/model-controller.js
@@ -18,7 +18,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 'use strict';
 
-YUI.add('model-controller', function(Y) {
+window.yui.add('model-controller', function(Y) {
   /**
     Provides a collection of utility methods to interact
     with the db and it's models.

--- a/jujugui/static/gui/src/app/models/models.js
+++ b/jujugui/static/gui/src/app/models/models.js
@@ -24,7 +24,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
  * @module models
  */
 
-YUI.add('juju-models', function(Y) {
+window.yui.add('juju-models', function(Y) {
 
   var models = Y.namespace('juju.models'),
       utils = Y.namespace('juju.views.utils'),

--- a/jujugui/static/gui/src/app/models/models.js
+++ b/jujugui/static/gui/src/app/models/models.js
@@ -18,6 +18,8 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 'use strict';
 
+const utils = require('../views/utils');
+
 /**
  * The database models.
  *
@@ -27,7 +29,6 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 window.yui.add('juju-models', function(Y) {
 
   var models = Y.namespace('juju.models'),
-      utils = Y.namespace('juju.views.utils'),
       environments = Y.namespace('juju.environments'),
       handlers = models.handlers;
 
@@ -2951,7 +2952,6 @@ window.yui.add('juju-models', function(Y) {
     'datasource-jsonschema',
     'io-base',
     'juju-delta-handlers',
-    'juju-view-utils',
     'juju-charm-models',
     'juju-env-api'
   ]

--- a/jujugui/static/gui/src/app/store/env/api.js
+++ b/jujugui/static/gui/src/app/store/env/api.js
@@ -25,7 +25,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
  * @submodule api.go
  */
 
-YUI.add('juju-env-api', function(Y) {
+window.yui.add('juju-env-api', function(Y) {
   const module = Y.juju.environments;
   const tags = module.tags;
   const utils = Y.namespace('juju.views.utils');

--- a/jujugui/static/gui/src/app/store/env/api.js
+++ b/jujugui/static/gui/src/app/store/env/api.js
@@ -18,6 +18,8 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 'use strict';
 
+const utils = require('../../views/utils');
+
 /**
  * The Go model API connection.
  *
@@ -28,7 +30,6 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 window.yui.add('juju-env-api', function(Y) {
   const module = Y.juju.environments;
   const tags = module.tags;
-  const utils = Y.namespace('juju.views.utils');
 
   // Define the error returned by Juju when the mega-watcher is stopped and
   // clients make a "Next" request.
@@ -3598,7 +3599,6 @@ window.yui.add('juju-env-api', function(Y) {
 }, '0.1.0', {
   requires: [
     'base',
-    'juju-env-base',
-    'juju-view-utils'
+    'juju-env-base'
   ]
 });

--- a/jujugui/static/gui/src/app/store/env/base.js
+++ b/jujugui/static/gui/src/app/store/env/base.js
@@ -25,7 +25,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
  * @submodule env.base
  */
 
-YUI.add('juju-env-base', function(Y) {
+window.yui.add('juju-env-base', function(Y) {
 
   const module = Y.namespace('juju.environments');
   // Define a Juju tags management object.

--- a/jujugui/static/gui/src/app/store/env/controller-api.js
+++ b/jujugui/static/gui/src/app/store/env/controller-api.js
@@ -18,7 +18,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 'use strict';
 
-YUI.add('juju-controller-api', function(Y) {
+window.yui.add('juju-controller-api', function(Y) {
   const module = Y.juju.environments;
   const tags = module.tags;
 

--- a/jujugui/static/gui/src/app/test-init.js
+++ b/jujugui/static/gui/src/app/test-init.js
@@ -28,14 +28,17 @@ describe('init', () => {
   beforeAll(done => {
     // The module list is copied from index.html.mako and is required by
     // init.js.
-    YUI(GlobalConfig).use(MODULES, Y => {
+    YUI(GlobalConfig).use([], Y => {
       // init.js requires the window to contain the YUI object.
       window.yui = Y;
       // The gui version is required to be set by component-renderers-mixin.js.
       window.GUI_VERSION = {version: '1.2.3'};
-      // The require needs to be after the yui modules have been loaded.
-      JujuGUI = require('../app/init');
-      done();
+      require('./yui-modules');
+      window.yui.use(window.MODULES, function() {
+        // The require needs to be after the yui modules have been loaded.
+        JujuGUI = require('../app/init');
+        done();
+      });
     });
   });
 

--- a/jujugui/static/gui/src/app/utils/environment-change-set.js
+++ b/jujugui/static/gui/src/app/utils/environment-change-set.js
@@ -18,7 +18,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 'use strict';
 
-YUI.add('environment-change-set', function(Y) {
+window.yui.add('environment-change-set', function(Y) {
   var ns = Y.namespace('juju'),
       utils = Y.namespace('juju.views.utils');
 

--- a/jujugui/static/gui/src/app/utils/environment-change-set.js
+++ b/jujugui/static/gui/src/app/utils/environment-change-set.js
@@ -18,9 +18,10 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 'use strict';
 
+const utils = require('../views/utils');
+
 window.yui.add('environment-change-set', function(Y) {
-  var ns = Y.namespace('juju'),
-      utils = Y.namespace('juju.views.utils');
+  var ns = Y.namespace('juju');
 
   var name = 'environment-change-set';
 
@@ -1653,7 +1654,6 @@ window.yui.add('environment-change-set', function(Y) {
 }, '', {
   requires: [
     'base',
-    'base-build',
-    'juju-view-utils'
+    'base-build'
   ]
 });

--- a/jujugui/static/gui/src/app/views/bundle-import-notifications.js
+++ b/jujugui/static/gui/src/app/views/bundle-import-notifications.js
@@ -15,7 +15,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 'use strict';
 
-YUI.add('bundle-import-notifications', function(Y) {
+window.yui.add('bundle-import-notifications', function(Y) {
   var ns = Y.namespace('juju');
 
   // Maps bundle deployment statuses to notification messages.

--- a/jujugui/static/gui/src/app/views/ghost-deployer-extension.js
+++ b/jujugui/static/gui/src/app/views/ghost-deployer-extension.js
@@ -26,7 +26,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
   @submodule views.ghostInspector
  */
 
-YUI.add('ghost-deployer-extension', function(Y) {
+window.yui.add('ghost-deployer-extension', function(Y) {
 
   /**
     JujuGUI app extension to add the ghost deployer method.

--- a/jujugui/static/gui/src/app/views/utils.js
+++ b/jujugui/static/gui/src/app/views/utils.js
@@ -169,8 +169,7 @@ viewsUtils.formatConstraints = constraints => {
 try {
   module.exports = viewsUtils;
 } catch (e) {}
-
-if (YUI) {
+if (window.yui) {
   window.yui.add('juju-view-utils', function(Y) {
     Y.namespace('juju.views').utils = viewsUtils;
   }, '0.1.0', {

--- a/jujugui/static/gui/src/app/views/utils.js
+++ b/jujugui/static/gui/src/app/views/utils.js
@@ -171,7 +171,7 @@ try {
 } catch (e) {}
 
 if (YUI) {
-  YUI.add('juju-view-utils', function(Y) {
+  window.yui.add('juju-view-utils', function(Y) {
     Y.namespace('juju.views').utils = viewsUtils;
   }, '0.1.0', {
     requires: [

--- a/jujugui/static/gui/src/app/yui-modules.js
+++ b/jujugui/static/gui/src/app/yui-modules.js
@@ -1,0 +1,17 @@
+/* Copyright (C) 2018 Canonical Ltd. */
+'use strict';
+
+require('./extensions/yui-patches');
+require('./models/bundle');
+require('./models/charm');
+require('./models/entity-extension');
+require('./models/handlers');
+require('./models/model-controller');
+require('./models/models');
+require('./store/env/api');
+require('./store/env/base');
+require('./store/env/controller-api');
+require('./utils/environment-change-set');
+require('./views/bundle-import-notifications');
+require('./views/ghost-deployer-extension');
+require('./views/utils');

--- a/jujugui/static/gui/src/test/test_bundle_import_notifications.js
+++ b/jujugui/static/gui/src/test/test_bundle_import_notifications.js
@@ -24,11 +24,14 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     var db, env, ns;
 
     before(function(done) {
-      YUI(GlobalConfig).use(
-        'bundle-import-notifications',
+      YUI(GlobalConfig).use([],
         function(Y) {
-          ns = Y.namespace('juju');
-          done();
+          window.yui = Y;
+          require('../app/yui-modules');
+          window.yui.use(window.MODULES, function() {
+            ns = window.yui.namespace('juju');
+            done();
+          });
         });
     });
 

--- a/jujugui/static/gui/src/test/test_controller_api.js
+++ b/jujugui/static/gui/src/test/test_controller_api.js
@@ -22,13 +22,14 @@ describe('Controller API', function() {
   var cleanups, conn, controllerAPI, juju, utils, Y;
 
   before(function(done) {
-    Y = YUI(GlobalConfig).use([
-      'juju-controller-api',
-      'juju-tests-utils'
-    ], function(Y) {
-      juju = Y.namespace('juju');
-      utils = Y.namespace('juju-tests.utils');
-      done();
+    Y = YUI(GlobalConfig).use([], function(Y) {
+      window.yui = Y;
+      require('../app/yui-modules');
+      window.yui.use(window.MODULES.concat(['juju-tests-utils']), function() {
+        juju = window.yui.namespace('juju');
+        utils = window.yui.namespace('juju-tests.utils');
+        done();
+      });
     });
   });
 

--- a/jujugui/static/gui/src/test/test_entity_extension.js
+++ b/jujugui/static/gui/src/test/test_entity_extension.js
@@ -24,13 +24,14 @@ describe('Entity Extension', function() {
   var Y, EntityModel, entityModel, jujuConfig, models, utils, windowJujulib;
 
   before(function(done) {
-    Y = YUI(GlobalConfig).use([
-      'juju-models',
-      'juju-tests-utils'
-    ], function(Y) {
-      models = Y.namespace('juju.models');
-      utils = Y.namespace('juju-tests.utils');
-      done();
+    Y = YUI(GlobalConfig).use([], function(Y) {
+      window.yui = Y;
+      require('../app/yui-modules');
+      window.yui.use(window.MODULES.concat(['juju-tests-utils']), function() {
+        models = window.yui.namespace('juju.models');
+        utils = window.yui.namespace('juju-tests.utils');
+        done();
+      });
     });
   });
 

--- a/jujugui/static/gui/src/test/test_env.js
+++ b/jujugui/static/gui/src/test/test_env.js
@@ -26,10 +26,14 @@ const ReconnectingWebSocket = require('../app/jujulib/reconnecting-websocket');
     let environments, juju, windowJujulib;
 
     before(function(done) {
-      YUI(GlobalConfig).use('juju-env-base', function(Y) {
-        juju = Y.namespace('juju');
-        environments = juju.environments;
-        done();
+      YUI(GlobalConfig).use([], function(Y) {
+        window.yui = Y;
+        require('../app/yui-modules');
+        window.yui.use(window.MODULES.concat(['base-build']), function() {
+          juju = window.yui.namespace('juju');
+          environments = juju.environments;
+          done();
+        });
       });
     });
 
@@ -177,14 +181,17 @@ const ReconnectingWebSocket = require('../app/jujulib/reconnecting-websocket');
   });
 
   describe('tags management', function() {
-    const requires = ['juju-env-base'];
     let tags;
 
     before(done => {
-      YUI(GlobalConfig).use(requires, function(Y) {
-        const module = Y.namespace('juju').environments;
-        tags = module.tags;
-        done();
+      YUI(GlobalConfig).use([], function(Y) {
+        window.yui = Y;
+        require('../app/yui-modules');
+        window.yui.use(window.MODULES.concat(['base-build']), function() {
+          const module = window.yui.namespace('juju').environments;
+          tags = module.tags;
+          done();
+        });
       });
     });
 

--- a/jujugui/static/gui/src/test/test_env_api.js
+++ b/jujugui/static/gui/src/test/test_env_api.js
@@ -27,8 +27,12 @@ const urls = require('../app/jujulib/urls');
 
     before(function(done) {
       YUI(GlobalConfig).use(['juju-env-api'], function(Y) {
-        environments = Y.namespace('juju.environments');
-        done();
+        window.yui = Y;
+        require('../app/yui-modules');
+        window.yui.use(window.MODULES, function() {
+          environments = window.yui.namespace('juju.environments');
+          done();
+        });
       });
     });
 
@@ -101,15 +105,15 @@ const urls = require('../app/jujulib/urls');
         utils, Y;
 
     before(function(done) {
-      Y = YUI(GlobalConfig).use([
-        'environment-change-set',
-        'juju-tests-utils',
-        'juju-env-api'
-      ], function(Y) {
-        juju = Y.namespace('juju');
-        utils = Y.namespace('juju-tests.utils');
-        machineJobs = Y.namespace('juju.environments').machineJobs;
-        done();
+      Y = YUI(GlobalConfig).use([], function(Y) {
+        window.yui = Y;
+        require('../app/yui-modules');
+        window.yui.use(window.MODULES.concat(['juju-tests-utils']), function() {
+          juju = window.yui.namespace('juju');
+          utils = window.yui.namespace('juju-tests.utils');
+          machineJobs = window.yui.namespace('juju.environments').machineJobs;
+          done();
+        });
       });
     });
 

--- a/jujugui/static/gui/src/test/test_env_change_set.js
+++ b/jujugui/static/gui/src/test/test_env_change_set.js
@@ -18,22 +18,21 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 'use strict';
 
+const viewUtils = require('../app/views/utils');
+
 describe('Environment Change Set', function() {
-  var Y, ECS, ecs, envObj, dbObj, models, testUtils, viewUtils;
+  var Y, ECS, ecs, envObj, dbObj, models, testUtils;
 
   before(function(done) {
-    var modules = [
-      'environment-change-set',
-      'juju-models',
-      'juju-tests-utils',
-      'juju-view-utils'
-    ];
-    Y = YUI(GlobalConfig).use(modules, function(Y) {
-      ECS = Y.namespace('juju').EnvironmentChangeSet;
-      testUtils = Y.namespace('juju-tests').utils;
-      viewUtils = Y.namespace('juju.views.utils');
-      models = Y.namespace('juju.models');
-      done();
+    Y = YUI(GlobalConfig).use([], function(Y) {
+      window.yui = Y;
+      require('../app/yui-modules');
+      window.yui.use(window.MODULES.concat(['juju-tests-utils']), function() {
+        ECS = window.yui.namespace('juju').EnvironmentChangeSet;
+        testUtils = window.yui.namespace('juju-tests').utils;
+        models = window.yui.namespace('juju.models');
+        done();
+      });
     });
   });
 

--- a/jujugui/static/gui/src/test/test_ghost_deployer_extension.js
+++ b/jujugui/static/gui/src/test/test_ghost_deployer_extension.js
@@ -23,13 +23,15 @@ describe('Ghost Deployer Extension', function() {
   var Y, juju, ghostDeployer, GhostDeployer, models;
 
   before(function(done) {
-    var requires = ['base', 'base-build', 'model', 'ghost-deployer-extension',
-      'juju-models'];
-    Y = YUI(GlobalConfig).use(requires, function(Y) {
-      juju = Y.namespace('juju');
-      models = Y.namespace('juju.models');
-      models._getECS = sinon.stub().returns({changeSet: {}});
-      done();
+    Y = YUI(GlobalConfig).use([], function(Y) {
+      window.yui = Y;
+      require('../app/yui-modules');
+      window.yui.use(window.MODULES.concat(['base-build']), function() {
+        juju = window.yui.namespace('juju');
+        models = window.yui.namespace('juju.models');
+        models._getECS = sinon.stub().returns({changeSet: {}});
+        done();
+      });
     });
   });
 

--- a/jujugui/static/gui/src/test/test_login.js
+++ b/jujugui/static/gui/src/test/test_login.js
@@ -21,15 +21,17 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 (function() {
 
   describe('environment login support', function() {
-    const requires = [
-      'juju-tests-utils', 'juju-env-api'];
     let conn, env, utils, juju;
 
     before(function(done) {
-      YUI(GlobalConfig).use(requires, function(Y) {
-        utils = Y.namespace('juju-tests').utils;
-        juju = Y.namespace('juju');
-        done();
+      YUI(GlobalConfig).use([], function(Y) {
+        window.yui = Y;
+        require('../app/yui-modules');
+        window.yui.use(window.MODULES.concat(['juju-tests-utils']), function() {
+          utils = window.yui.namespace('juju-tests').utils;
+          juju = window.yui.namespace('juju');
+          done();
+        });
       });
     });
 

--- a/jujugui/static/gui/src/test/test_model.js
+++ b/jujugui/static/gui/src/test/test_model.js
@@ -38,10 +38,14 @@ describe('test_model.js', function() {
     let models;
 
     before(function(done) {
-      YUI(GlobalConfig).use('juju-models', 'juju-charm-models', function(Y) {
-        models = Y.namespace('juju.models');
-        models._getECS = sinon.stub().returns({changeSet: {}});
-        done();
+      YUI(GlobalConfig).use([], function(Y) {
+        window.yui = Y;
+        require('../app/yui-modules');
+        window.yui.use(window.MODULES, function() {
+          models = window.yui.namespace('juju.models');
+          models._getECS = sinon.stub().returns({changeSet: {}});
+          done();
+        });
       });
     });
 

--- a/jujugui/static/gui/src/test/test_model_bundle.js
+++ b/jujugui/static/gui/src/test/test_model_bundle.js
@@ -24,9 +24,13 @@ describe('Bundle initialization', function() {
   var models;
 
   before(function(done) {
-    YUI(GlobalConfig).use('juju-models', 'juju-bundle-models', function(Y) {
-      models = Y.namespace('juju.models');
-      done();
+    YUI(GlobalConfig).use([], function(Y) {
+      window.yui = Y;
+      require('../app/yui-modules');
+      window.yui.use(window.MODULES.concat(['juju-delta-handlers']), function() {
+        models = window.yui.namespace('juju.models');
+        done();
+      });
     });
   });
 

--- a/jujugui/static/gui/src/test/test_model_controller.js
+++ b/jujugui/static/gui/src/test/test_model_controller.js
@@ -27,17 +27,21 @@ describe('Model Controller Promises', function() {
       windowJujulib, yui;
 
   before(function(done) {
-    YUI(GlobalConfig).use(
-      'juju-charm-models', 'juju-models', 'juju-tests-factory',
-      'juju-tests-utils', 'model-controller',
+    YUI(GlobalConfig).use([],
       function(Y) {
-        var goenv = Y.juju.environments.GoEnvironment;
         yui = Y;
-        load = Y.juju.models.Charm.prototype.load;
-        getApplicationConfig = goenv.prototype.getApplicationConfig;
-        utils = Y.namespace('juju-tests.utils');
-        factory = Y.namespace('juju-tests.factory');
-        done();
+        window.yui = Y;
+        require('../app/yui-modules');
+        window.yui.use(
+          window.MODULES.concat(['juju-tests-factory', 'juju-tests-utils']),
+          function() {
+            var goenv = window.yui.juju.environments.GoEnvironment;
+            load = window.yui.juju.models.Charm.prototype.load;
+            getApplicationConfig = goenv.prototype.getApplicationConfig;
+            utils = window.yui.namespace('juju-tests.utils');
+            factory = window.yui.namespace('juju-tests.factory');
+            done();
+          });
       });
   });
 

--- a/jujugui/static/gui/src/test/test_model_handlers.js
+++ b/jujugui/static/gui/src/test/test_model_handlers.js
@@ -22,14 +22,16 @@ const urls = require('../app/jujulib/urls');
 
 describe('Juju delta handlers', function() {
   var db, models, handlers;
-  var requirements = [
-    'juju-models', 'juju-delta-handlers'];
 
   before(function(done) {
-    YUI(GlobalConfig).use(requirements, function(Y) {
-      models = Y.namespace('juju.models');
-      handlers = models.handlers;
-      done();
+    YUI(GlobalConfig).use([], function(Y) {
+      window.yui = Y;
+      require('../app/yui-modules');
+      window.yui.use(window.MODULES.concat(['juju-delta-handlers']), function() {
+        models = window.yui.namespace('juju.models');
+        handlers = models.handlers;
+        done();
+      });
     });
   });
 

--- a/jujugui/templates/index.html.go
+++ b/jujugui/templates/index.html.go
@@ -312,46 +312,26 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       // function which will be picked up by the setTimeout, and the app will
       // start.
       startTheApp = function() {
-        var GlobalConfig = {
-          combine: true,
-          base: '{{.comboURL}}?/app/assets/javascripts/yui/',
-          comboBase: '{{.comboURL}}?',
-          maxURLLenght: 1300,
-          root: 'app/assets/javascripts/yui/',
-          groups: {
-            app: {
-                {{if .Debug}}
-                filter: 'raw',
-                combine: false,
-                {{else}}
-                combine: true,
-                {{end}}
-                base: "{{.comboURL}}?app/",
-                comboBase: "{{.comboURL}}?",
-                root: 'app/',
-                // From modules.js
-                modules: YUI_MODULES
-            }
-          }
-        };
-
-        YUI(GlobalConfig).use([
-            'juju-charm-models',
-            'juju-bundle-models',
-            'juju-controller-api',
-            'juju-env-base',
-            'juju-env-api',
-            'juju-models',
-            'base',
-            'bundle-import-notifications',
-            'model',
-            'model-controller',
-            'ghost-deployer-extension',
-            'environment-change-set',
-            'yui-patches'], function(Y) {
+        YUI().use([], function(Y) {
           window.yui = Y;
           const JujuGUI = require('init');
-          window.JujuGUI = new JujuGUI(juju_config);
+          window.yui.use([
+              'juju-charm-models',
+              'juju-bundle-models',
+              'juju-controller-api',
+              'juju-env-base',
+              'juju-env-api',
+              'juju-models',
+              'base',
+              'bundle-import-notifications',
+              'model',
+              'model-controller',
+              'ghost-deployer-extension',
+              'environment-change-set',
+              'yui-patches'
+          ], function () {
+            window.JujuGUI = new JujuGUI(juju_config);
+          });
 
           const stopHandler = () => {
             document.removeEventListener('login', stopHandler);

--- a/jujugui/templates/index.html.mako
+++ b/jujugui/templates/index.html.mako
@@ -312,48 +312,26 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       // function which will be picked up by the setTimeout, and the app will
       // start.
       startTheApp = function() {
-        var GlobalConfig = {
-          combine: true,
-          base: '${convoy_url}?/app/assets/javascripts/yui/',
-          comboBase: '${convoy_url}?',
-          maxURLLenght: 1300,
-          root: 'app/assets/javascripts/yui/',
-          groups: {
-            app: {
-                % if raw:
-                filter: 'raw',
-                % endif
-                % if combine:
-                combine: true,
-                % else:
-                combine: false,
-                % endif
-                base: "${convoy_url}?app/",
-                comboBase: "${convoy_url}?",
-                root: 'app/',
-                // From modules.js
-                modules: YUI_MODULES
-            }
-          }
-        };
-
-        YUI(GlobalConfig).use([
-            'juju-charm-models',
-            'juju-bundle-models',
-            'juju-controller-api',
-            'juju-env-base',
-            'juju-env-api',
-            'juju-models',
-            'base',
-            'bundle-import-notifications',
-            'model',
-            'model-controller',
-            'ghost-deployer-extension',
-            'environment-change-set',
-            'yui-patches'], function(Y) {
+        YUI().use([], function(Y) {
           window.yui = Y;
           const JujuGUI = require('init');
-          window.JujuGUI = new JujuGUI(juju_config);
+          window.yui.use([
+              'juju-charm-models',
+              'juju-bundle-models',
+              'juju-controller-api',
+              'juju-env-base',
+              'juju-env-api',
+              'juju-models',
+              'base',
+              'bundle-import-notifications',
+              'model',
+              'model-controller',
+              'ghost-deployer-extension',
+              'environment-change-set',
+              'yui-patches'
+          ], function () {
+            window.JujuGUI = new JujuGUI(juju_config);
+          });
 
           const stopHandler = () => {
             document.removeEventListener('login', stopHandler);


### PR DESCRIPTION
Require YUI modules instead of combo loading them so that we can require() utils etc. inside the YUI modules.