### PR TITLE
Fix direct deploy icon race condition

### DIFF
--- a/jujugui/static/gui/src/app/components/deployment-flow/change-item/change-item.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/change-item/change-item.js
@@ -48,10 +48,6 @@ class DeploymentChangeItem extends React.Component {
 
   render() {
     var change = this.props.change;
-    if (!change.icon) {
-      console.log('change', change);
-
-    }
     return (
       <div className="deployment-change-item">
         <span className="deployment-change-item__change">

--- a/jujugui/static/gui/src/app/components/deployment-flow/change-item/change-item.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/change-item/change-item.js
@@ -17,7 +17,9 @@ class DeploymentChangeItem extends React.Component {
   _generateIcon(icon) {
     var node;
     var className = 'deployment-change-item__icon';
-    if (icon.indexOf('.svg') > -1) {
+    if (!icon) {
+      return null;
+    } else if (icon.indexOf('.svg') > -1) {
       node = <img alt="" className={className} src={icon} />;
     } else {
       node = (
@@ -46,6 +48,10 @@ class DeploymentChangeItem extends React.Component {
 
   render() {
     var change = this.props.change;
+    if (!change.icon) {
+      console.log('change', change);
+
+    }
     return (
       <div className="deployment-change-item">
         <span className="deployment-change-item__change">

--- a/jujugui/static/gui/src/app/components/deployment-flow/change-item/test-change-item.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/change-item/test-change-item.js
@@ -54,6 +54,12 @@ describe('DeploymentChangeItem', function() {
     assert.compareJSX(wrapper.find('.deployment-change-item__icon'), expected);
   });
 
+  it('can render without an icon', function() {
+    delete change.icon;
+    const wrapper = renderComponent();
+    assert.equal(wrapper.find('.deployment-change-item__icon').length, 0);
+  });
+
   it('can display without the time', function() {
     const wrapper = renderComponent({ showTime: false });
     assert.equal(wrapper.find('.deployment-change-item__time').length, 0);


### PR DESCRIPTION
There is an issue sometimes when the service is added it does not have an icon and then later gets updated with an icon. This would cause the direct deploy to crash as it loads when the service is being added.

There doesn't seem to be a good way to delay the direct deploy load until after the services are completely ready so this just fixes the error.