### PR TITLE
Disable mangle to to prevent babili memory leak

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,13 @@
 {
-  "presets": [],
-  "plugins": [
-    "transform-react-jsx",
-    "rewire"
-  ]
+  "env": {
+    "production": {
+      "presets": [
+        ["babili", {"mangle": false}]
+      ],
+      "plugins": [
+        "transform-react-jsx",
+        "rewire"
+      ]
+    }
+  }
 }

--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,9 @@
 {
+  "presets": [],
+  "plugins": [
+    "transform-react-jsx",
+    "rewire"
+  ],
   "env": {
     "production": {
       "presets": [

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ $(JUJUGUI): $(PYRAMID)
 
 $(MODULESMIN): $(NODE_MODULES) $(PYRAMID) $(BUILT_RAWJSFILES) $(MIN_JS_FILES) $(BUILT_YUI) $(BUILT_JS_ASSETS)
 	$(PY) scripts/generate_modules.py -n YUI_MODULES -s $(GUIBUILD)/app -o $(MODULES) -x "(-min.js)|(\/yui\/)"
-	$(NODE_MODULES)/.bin/babel --presets babel-preset-babili --minified --no-comments $(MODULES) -o $(MODULESMIN)
+	BABEL_ENV=production $(NODE_MODULES)/.bin/babel --minified --no-comments $(MODULES) -o $(MODULESMIN)
 
 $(GUIBUILD)/app/%.js $(GUIBUILD)/app/%-min.js: $(GUISRC)/app/%.js
 	./scripts/transpile.js
@@ -134,7 +134,7 @@ $(BUILT_JS_ASSETS): $(NODE_MODULES)
 	echo 'window.GUI_VERSION = {"version": "$(CURRENT_VERSION)", "commit": "$(CURRENT_COMMIT)"};' > $(GUIBUILD)/app/assets/javascripts/version.js
 	find $(BUILT_JS_ASSETS) -type f -name "*.js" \
 		sed s/\.js$$//g | \
-		xargs -I {} $(NODE_MODULES)/.bin/babel --presets babel-preset-babili --minified --no-comments {}.js -o {}-min.js
+		xargs -I {} BABEL_ENV=production $(NODE_MODULES)/.bin/babel --minified --no-comments {}.js -o {}-min.js
 
 $(YUI): $(NODE_MODULES)
 
@@ -332,13 +332,13 @@ version:
 .PHONY: dist
 dist: clean-all deps prod-gui test-deps collect-requirements version
 	# We are only minifying the init bundle here because it takes considerable time.
-	$(NODE_MODULES)/.bin/babel --presets babel-preset-babili --minified --no-comments ./$(GUIBUILD)/app/init-pkg.js -o ./$(GUIBUILD)/app/init-pkg-min.js
+	BABEL_ENV=production $(NODE_MODULES)/.bin/babel --minified --no-comments ./$(GUIBUILD)/app/init-pkg.js -o ./$(GUIBUILD)/app/init-pkg-min.js
 	$(PY) setup.py sdist --formats=bztar\
 
 .PHONY: fast-dist
 fast-dist: deps gui test-deps collect-requirements version
 	# We are only minifying the init bundle here because it takes considerable time.
-	$(NODE_MODULES)/.bin/babel --presets babel-preset-babili --minified --no-comments ./$(GUIBUILD)/app/init-pkg.js -o ./$(GUIBUILD)/app/init-pkg-min.js
+	BABEL_ENV=production $(NODE_MODULES)/.bin/babel --minified --no-comments ./$(GUIBUILD)/app/init-pkg.js -o ./$(GUIBUILD)/app/init-pkg-min.js
 	$(PY) setup.py sdist --formats=bztar\
 
 #######


### PR DESCRIPTION
Fixes #3707 

By disabling the 'mangle' option in babili we no longer get the memory leak causing `make dist` to crash. 

Re: https://github.com/babel/minify/issues/332