### PR TITLE
Remove unused dist files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -14,9 +14,9 @@ recursive-exclude jujugui/static/gui/src *
 recursive-exclude jujugui/tests *
 recursive-exclude test *
 
-# To get only the *min.js files we first remove all js files and then add the
-# min.js files back in
+# First remove all js files before adding back in the files we need.
 recursive-exclude jujugui/static/gui/build *.js
-recursive-include jujugui/static/gui/build *min.js
-# Remove the minified test files.
-recursive-exclude jujugui/static/gui/build/app/components test-*.js
+# Add back in the YUI files.
+recursive-include jujugui/static/gui/build/app/assets/javascripts/yui *min.js
+# Add the main file that all components, utils etc. have been combined into.
+include jujugui/static/gui/build/app/init-pkg-min.js

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,6 @@ PYRAMID := lib/python2.7/site-packages/pyramid
 PYTESTPKG := lib/python2.7/site-packages/pytest.py
 NODE_MODULES := node_modules
 SVG_SPRITE_MODULE := $(NODE_MODULES)/svg-sprite/
-MODULES := $(GUIBUILD)/modules.js
-MODULESMIN := $(GUIBUILD)/modules-min.js
 YUI := $(NODE_MODULES)/yui
 BUILT_YUI := $(BUILT_JS_ASSETS)/yui
 SELENIUM := lib/python2.7/site-packages/selenium-2.47.3-py2.7.egg/selenium/selenium.py
@@ -120,10 +118,6 @@ venv: $(PY)
 $(JUJUGUI): $(PYRAMID)
 	$(PY) setup.py develop
 
-$(MODULESMIN): $(NODE_MODULES) $(PYRAMID) $(BUILT_RAWJSFILES) $(MIN_JS_FILES) $(BUILT_YUI) $(BUILT_JS_ASSETS)
-	$(PY) scripts/generate_modules.py -n YUI_MODULES -s $(GUIBUILD)/app -o $(MODULES) -x "(-min.js)|(\/yui\/)"
-	BABEL_ENV=production $(NODE_MODULES)/.bin/babel --minified --no-comments $(MODULES) -o $(MODULESMIN)
-
 $(GUIBUILD)/app/%.js $(GUIBUILD)/app/%-min.js: $(GUISRC)/app/%.js
 	./scripts/transpile.js
 
@@ -176,7 +170,7 @@ svg-sprite: $(SVG_SPRITE_MODULE)
 	cp $(GUISRC)/app/assets/stack/svg/sprite.css.svg $(GUIBUILD)/app/assets/stack/svg/sprite.css.svg
 
 .PHONY: gui-deps
-gui-deps: $(JUJUGUI) $(MODULESMIN) $(BUILT_JS_ASSETS) $(BUILT_YUI) $(CSS_FILE) $(STATIC_IMAGES) $(FAVICON) $(STATIC_FONT_FILES)
+gui-deps: $(JUJUGUI) $(BUILT_JS_ASSETS) $(BUILT_YUI) $(CSS_FILE) $(STATIC_IMAGES) $(FAVICON) $(STATIC_FONT_FILES)
 
 .PHONY: gui
 gui: gui-deps

--- a/jujugui/static/gui/src/app/components/deployment-flow/deployment-flow.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/deployment-flow.js
@@ -643,7 +643,6 @@ class DeploymentFlow extends React.Component {
         <DeploymentSSHKey
           addNotification={this.props.addNotification}
           cloud={cloud}
-          getGithubSSHKeys={this.props.getGithubSSHKeys}
           setLaunchpadUsernames={this._setLaunchpadUsernames.bind(this)}
           setSSHKeys={this._setSSHKeys.bind(this)}
           username={this.props.username}
@@ -1281,7 +1280,6 @@ DeploymentFlow.propTypes = {
   generateMachineDetails: PropTypes.func.isRequired,
   generatePath: PropTypes.func.isRequired,
   getCurrentChangeSet: PropTypes.func.isRequired,
-  getGithubSSHKeys: PropTypes.func.isRequired,
   getSLAMachineRates: PropTypes.func,
   getServiceByName: PropTypes.func.isRequired,
   getUserName: PropTypes.func.isRequired,

--- a/jujugui/static/gui/src/app/components/deployment-flow/sshkey/sshkey.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/sshkey/sshkey.js
@@ -8,6 +8,7 @@ const InsetSelect = require('../../inset-select/inset-select');
 const SvgIcon = require('../../svg-icon/svg-icon');
 const GenericButton = require('../../generic-button/generic-button');
 const GenericInput = require('../../generic-input/generic-input');
+const githubSSHKeys = require('../../../utils/github-ssh-keys');
 const Notification = require('../../notification/notification');
 
 /**
@@ -144,7 +145,7 @@ class DeploymentSSHKey extends React.Component {
     this.setState({error: null});
     if (source === 'github') {
       const githubUsername = this.refs.githubUsername.getValue();
-      this.props.getGithubSSHKeys(
+      githubSSHKeys(
         new this.props.WebHandler,
         githubUsername,
         this._addGithubKeysCallback.bind(this)
@@ -471,7 +472,6 @@ DeploymentSSHKey.propTypes = {
   WebHandler: PropTypes.func.isRequired,
   addNotification: PropTypes.func.isRequired,
   cloud: PropTypes.object,
-  getGithubSSHKeys: PropTypes.func.isRequired,
   setLaunchpadUsernames: PropTypes.func.isRequired,
   setSSHKeys: PropTypes.func.isRequired,
   username: PropTypes.string

--- a/jujugui/static/gui/src/app/components/deployment-flow/sshkey/test-sshkey.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/sshkey/test-sshkey.js
@@ -15,13 +15,11 @@ describe('DeploymentSSHKey', function() {
   let addNotification;
   let setSSHKeys;
   let setLaunchpadUsernames;
-  let getGithubSSHKeys;
 
   const renderComponent = (options = {}) => enzyme.shallow(
     <DeploymentSSHKey
       addNotification={options.addNotification || addNotification}
       cloud={options.cloud === undefined ? {cloudType: 'aws'} : options.cloud}
-      getGithubSSHKeys={options.getGithubSSHKeys || getGithubSSHKeys}
       setLaunchpadUsernames={options.setLaunchpadUsernames || setLaunchpadUsernames}
       setSSHKeys={options.setSSHKeys || setSSHKeys}
       username={options.username}
@@ -32,7 +30,6 @@ describe('DeploymentSSHKey', function() {
     addNotification = sinon.stub();
     setSSHKeys = sinon.stub();
     setLaunchpadUsernames = sinon.stub();
-    getGithubSSHKeys = sinon.stub();
   });
 
   it('does not render without a cloud', function() {

--- a/jujugui/static/gui/src/app/components/deployment-flow/test-deployment-flow.js
+++ b/jujugui/static/gui/src/app/components/deployment-flow/test-deployment-flow.js
@@ -74,7 +74,6 @@ describe('DeploymentFlow', function() {
       getSLAMachineRates: sinon.stub(),
       getServiceByName: sinon.stub(),
       getUserName: sinon.stub().returns('dalek'),
-      getGithubSSHKeys: sinon.stub(),
       hash: null,
       isLoggedIn: sinon.stub().returns(true),
       loginToController: sinon.stub(),
@@ -227,7 +226,6 @@ describe('DeploymentFlow', function() {
               <DeploymentSSHKey
                 addNotification={sinon.stub()}
                 cloud={null}
-                getGithubSSHKeys={sinon.stub()}
                 setLaunchpadUsernames={
                   wrapper.find('DeploymentSSHKey').prop('setLaunchpadUsernames')}
                 setSSHKeys={wrapper.find('DeploymentSSHKey').prop('setSSHKeys')}

--- a/jujugui/static/gui/src/app/init.js
+++ b/jujugui/static/gui/src/app/init.js
@@ -15,6 +15,7 @@ const BundleImporter = require('./init/bundle-importer');
 const EndpointsController = require('./init/endpoints-controller');
 const ModelController = require('./models/model-controller');
 const State = require('./state/state');
+const User = require('./user/user');
 const WebHandler = require('./store/env/web-handler');
 
 const newBakery = require('./init/utils/bakery-utils');
@@ -107,7 +108,7 @@ class GUIApp {
       Application instance of the user class.
       @type {Object}
     */
-    this.user = config.user || new window.jujugui.User({
+    this.user = config.user || new User({
       externalAuth: config.auth,
       expiration: window.sessionStorage.getItem('expirationDatetime')
     });

--- a/jujugui/static/gui/src/app/init.js
+++ b/jujugui/static/gui/src/app/init.js
@@ -15,6 +15,7 @@ const BundleImporter = require('./init/bundle-importer');
 const EndpointsController = require('./init/endpoints-controller');
 const ModelController = require('./models/model-controller');
 const State = require('./state/state');
+const StatsClient = require('./utils/statsd');
 const User = require('./user/user');
 const WebHandler = require('./store/env/web-handler');
 
@@ -244,7 +245,7 @@ class GUIApp {
     */
     this.stats = null;
     if (config.statsURL) {
-      this.stats = new window.jujugui.StatsClient(config.statsURL, 'gui');
+      this.stats = new StatsClient(config.statsURL, 'gui');
     }
 
     /**

--- a/jujugui/static/gui/src/app/init.js
+++ b/jujugui/static/gui/src/app/init.js
@@ -14,6 +14,7 @@ const cookieUtil = require('./init/cookie-util');
 const BundleImporter = require('./init/bundle-importer');
 const EndpointsController = require('./init/endpoints-controller');
 const ModelController = require('./models/model-controller');
+const State = require('./state/state');
 const WebHandler = require('./store/env/web-handler');
 
 const newBakery = require('./init/utils/bakery-utils');
@@ -516,7 +517,7 @@ class GUIApp {
     if (this.state) {
       return this.state;
     }
-    const state = new window.jujugui.State({
+    const state = new State({
       baseURL: baseURL,
       seriesList: urls.SERIES,
       sendAnalytics: this.sendAnalytics

--- a/jujugui/static/gui/src/app/init/component-renderers-mixin.js
+++ b/jujugui/static/gui/src/app/init/component-renderers-mixin.js
@@ -967,7 +967,6 @@ Browser: ${navigator.userAgent}`
             initUtils, modelAPI.genericConstraints, db.units)}
         generatePath={this.state.generatePath.bind(this.state)}
         getCurrentChangeSet={ecs.getCurrentChangeSet.bind(ecs)}
-        getGithubSSHKeys={window.jujugui.sshKeys.githubSSHKeys}
         getServiceByName={services.getServiceByName.bind(services)}
         getSLAMachineRates={this.rates.getSLAMachineRates.bind(this.rates)}
         getUserName={getUserName}

--- a/jujugui/static/gui/src/app/init/test-bundle-importer.js
+++ b/jujugui/static/gui/src/app/init/test-bundle-importer.js
@@ -4,6 +4,7 @@
 const BundleImporter = require('./bundle-importer');
 const EnvironmentChangeSet = require('./environment-change-set');
 const factory = require('./testing-factory');
+const User = require('../user/user');
 const utils = require('./testing-utils');
 
 describe('BundleImporter', () => {
@@ -33,7 +34,7 @@ describe('BundleImporter', () => {
         };
       };
     };
-    const userClass = new window.jujugui.User({sessionStorage: getMockStorage()});
+    const userClass = new User({sessionStorage: getMockStorage()});
     userClass.controller = {user: 'user', password: 'password'};
     db = new models.Database({getECS: sinon.stub().returns({changeSet: {}})});
     modelAPI = new yui.juju.environments.GoEnvironment({

--- a/jujugui/static/gui/src/app/init/test-endpoint-utils.js
+++ b/jujugui/static/gui/src/app/init/test-endpoint-utils.js
@@ -558,12 +558,7 @@ describe('Application config handlers', () => {
         id: 'wordpress',
         pending: true,
         charm: charmUrl});
-      assert.equal(conn.messages.length, 1);
-      // This is irrelevant, just confirming that it didn't try and make
-      // the request for the application info.
-      const msg = conn.last_message();
-      assert.equal(msg.type, 'Admin');
-      assert.equal(msg.request, 'Login');
+      assert.equal(conn.messages.length, 0);
     });
 
   it('should call Application.Get when non-pending services are added',
@@ -577,7 +572,7 @@ describe('Application config handlers', () => {
         id: applicationName,
         pending: false,
         charm: charmUrl});
-      assert.equal(conn.messages.length, 2);
+      assert.equal(conn.messages.length, 1);
       var msg = conn.last_message();
       assert.strictEqual(msg.type, 'Application');
       assert.strictEqual(msg.request, 'Get');
@@ -593,7 +588,7 @@ describe('Application config handlers', () => {
       id: applicationName,
       pending: false,
       charm: charmUrl});
-    assert.equal(conn.messages.length, 2);
+    assert.equal(conn.messages.length, 1);
     var msg = conn.last_message();
     assert.strictEqual(msg.type, 'Application');
     assert.strictEqual(msg.request, 'Get');
@@ -602,7 +597,7 @@ describe('Application config handlers', () => {
     var charm2 = app.db.charms.add({id: charmUrl, loaded: true});
     destroyMe.push(charm2);
     svc.set('charm', charmUrl);
-    assert.equal(conn.messages.length, 2);
+    assert.equal(conn.messages.length, 1);
     var msg = conn.last_message();
     assert.strictEqual(msg.type, 'Application');
     assert.strictEqual(msg.request, 'Get');

--- a/jujugui/static/gui/src/app/init/test-endpoint-utils.js
+++ b/jujugui/static/gui/src/app/init/test-endpoint-utils.js
@@ -3,6 +3,7 @@
 
 const endpointUtils = require('./endpoint-utils');
 const factory = require('./testing-factory');
+const User = require('../user/user');
 const utils = require('./testing-utils');
 
 const EndpointsController = require('./endpoints-controller');
@@ -59,8 +60,7 @@ describe('Relation endpoints logic', () => {
         };
       };
     };
-    const userClass = new window.jujugui.User(
-      {sessionStorage: getMockStorage()});
+    const userClass = new User({sessionStorage: getMockStorage()});
     userClass.controller = {user: 'user', password: 'password'};
     container = utils.makeAppContainer();
     app = createApp(JujuGUI);

--- a/jujugui/static/gui/src/app/init/test-environment-change-set.js
+++ b/jujugui/static/gui/src/app/init/test-environment-change-set.js
@@ -20,6 +20,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 const ECS = require('./environment-change-set');
 const testUtils = require('./testing-utils');
+const User = require('../user/user');
 const utils = require('./utils');
 
 describe('Environment Change Set', function() {
@@ -47,8 +48,7 @@ describe('Environment Change Set', function() {
         };
       };
     };
-    const userClass = new window.jujugui.User(
-      {sessionStorage: getMockStorage()});
+    const userClass = new User({sessionStorage: getMockStorage()});
     userClass.controller = {user: 'user', password: 'password'};
     dbObj = new models.Database({getECS: sinon.stub().returns({changeSet: {}})});
     dbObj.fireEvent = sinon.stub();

--- a/jujugui/static/gui/src/app/init/test-utils.js
+++ b/jujugui/static/gui/src/app/init/test-utils.js
@@ -1,6 +1,7 @@
 /* Copyright (C) 2017 Canonical Ltd. */
 'use strict';
 
+const User = require('../user/user');
 const utils = require('./utils');
 const testUtils = require('./testing-utils');
 
@@ -567,8 +568,7 @@ describe('init utils', () => {
           };
         };
       };
-      const userClass = new window.jujugui.User(
-        {sessionStorage: getMockStorage()});
+      const userClass = new User({sessionStorage: getMockStorage()});
       userClass.controller = {user: 'user', password: 'password'};
       callback = sinon.stub();
       commit = sinon.stub();

--- a/jujugui/static/gui/src/app/init/topology/test-environment.js
+++ b/jujugui/static/gui/src/app/init/topology/test-environment.js
@@ -9,6 +9,7 @@ const EnvironmentChangeSet = require('../environment-change-set');
 const environmentUtils = require('./environment-utils');
 const relationUtils = require('../relation-utils');
 const testUtils = require('../testing-utils');
+const User = require('../../user/user');
 
 const getEndpoints = sinon.stub();
 
@@ -230,8 +231,7 @@ describe('EnvironmentView', function() {
               };
             };
           };
-          const userClass = new window.jujugui.User(
-            {sessionStorage: getMockStorage()});
+          const userClass = new User({sessionStorage: getMockStorage()});
           userClass.controller = {user: 'user', password: 'password'};
           models = window.yui.namespace('juju.models');
           juju = window.yui.namespace('juju');
@@ -250,7 +250,7 @@ describe('EnvironmentView', function() {
           };
         };
       };
-      const userClass = new window.jujugui.User({storage: getMockStorage()});
+      const userClass = new User({storage: getMockStorage()});
       userClass.controller = {user: 'user', password: 'password'};
       conn = new testUtils.SocketStub();
       db = new models.Database({getECS: sinon.stub().returns({changeSet: {}})});

--- a/jujugui/static/gui/src/app/models/test-model-controller.js
+++ b/jujugui/static/gui/src/app/models/test-model-controller.js
@@ -19,8 +19,9 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 'use strict';
 
 const factory = require('../init/testing-factory');
-const utils = require('../init/testing-utils');
 const ModelController = require('./model-controller');
+const User = require('../user/user');
+const utils = require('../init/testing-utils');
 
 describe('Model Controller Promises', function() {
   var cleanups, conn, db, env, environment,
@@ -53,8 +54,7 @@ describe('Model Controller Promises', function() {
         };
       };
     };
-    const userClass = new window.jujugui.User(
-      {sessionStorage: getMockStorage()});
+    const userClass = new User({sessionStorage: getMockStorage()});
     userClass.controller = {user: 'user', password: 'password'};
     conn = new utils.SocketStub();
     environment = env = new yui.juju.environments.GoEnvironment({

--- a/jujugui/static/gui/src/app/models/test-models.js
+++ b/jujugui/static/gui/src/app/models/test-models.js
@@ -19,6 +19,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 'use strict';
 
 const relationUtils = require('../init/relation-utils');
+const User = require('../user/user');
 const utils = require('../init/testing-utils');
 
 describe('test_model.js', function() {
@@ -1627,8 +1628,7 @@ describe('test_model.js', function() {
           };
         };
       };
-      const userClass = new window.jujugui.User(
-        {sessionStorage: getMockStorage()});
+      const userClass = new User({sessionStorage: getMockStorage()});
       userClass.controller = {user: 'user', password: 'password'};
       conn = new utils.SocketStub();
       env = new juju.environments.GoEnvironment({

--- a/jujugui/static/gui/src/app/state/state.js
+++ b/jujugui/static/gui/src/app/state/state.js
@@ -18,10 +18,6 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 'use strict';
 
-if (typeof this.jujugui === 'undefined') {
-  this.jujugui = {};
-}
-
 const ROOT_RESERVED = [
   'about', 'bigdata', 'docs', 'juju', 'login', 'logout', 'new', 'account'];
 const PROFILE_RESERVED = ['charms', 'issues', 'revenue', 'settings'];
@@ -31,7 +27,7 @@ const GUI_PATH_DELIMETERS = [
   'status'];
 
 /** Class representing the State of the Juju GUI */
-const State = class State {
+class State {
   /**
     Create a new instance of the GUI state.
     @param {Object} cfg - The configuration options for a new State instance.
@@ -982,4 +978,4 @@ const State = class State {
   }
 };
 
-this.jujugui.State = State;
+module.exports = State;

--- a/jujugui/static/gui/src/app/state/test-state.js
+++ b/jujugui/static/gui/src/app/state/test-state.js
@@ -18,7 +18,9 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 'use strict';
 
-describe('State', () => {
+const State = require('./state');
+
+fdescribe('State', () => {
 
   const specialStateTests = [{
     path: 'http://abc.com:123/?deploy-target=cs:ghost-4',
@@ -468,21 +470,21 @@ describe('State', () => {
   }];
 
   it('can be instantiated', () => {
-    const state = new window.jujugui.State({
+    const state = new State({
       baseURL: 'http://abc.com:123',
       seriesList: ['precise', 'trusty', 'xenial']
     });
-    assert.equal(state instanceof window.jujugui.State, true);
+    assert.equal(state instanceof State, true);
   });
 
   it('throws if no baseURL is provided', () => {
     assert.throws(function() {
-      new window.jujugui.State({});
+      new State({});
     });
   });
 
   it('can receive a location value for testing', () => {
-    const state = new window.jujugui.State({
+    const state = new State({
       baseURL: 'http://abc.com:123',
       seriesList: ['trusty']
     });
@@ -491,7 +493,7 @@ describe('State', () => {
   });
 
   it('can be instantiated with a location value', () => {
-    const state = new window.jujugui.State({
+    const state = new State({
       baseURL: 'http://abc.com:123',
       seriesList: ['trusty'],
       location: {origin: 'foo'}
@@ -500,7 +502,7 @@ describe('State', () => {
   });
 
   it('uses the window.location if none is provided', () => {
-    const state = new window.jujugui.State({
+    const state = new State({
       baseURL: 'http://abc.com:123',
       seriesList: ['trusty']
     });
@@ -509,7 +511,7 @@ describe('State', () => {
 
   describe('steriesList', () => {
     it('adds \'bundle\' to the series list', () => {
-      const state = new window.jujugui.State({
+      const state = new State({
         baseURL: 'http://abc.com:123',
         seriesList: ['trusty']
       });
@@ -518,7 +520,7 @@ describe('State', () => {
 
     it('throws if the seriesList value is not an array', () => {
       assert.throws(function() {
-        new window.jujugui.State({
+        new State({
           baseURL: 'http://abc.com:123',
           seriesList: 'notanarray'
         });
@@ -527,7 +529,7 @@ describe('State', () => {
 
     it('throws no seriesList is provided', () => {
       assert.throws(function() {
-        new window.jujugui.State({
+        new State({
           baseURL: 'http://abc.com:123'
         });
       });
@@ -536,7 +538,7 @@ describe('State', () => {
 
   describe('_appStateHistory', () => {
     it('is instantiated with an empty array', () => {
-      const state = new window.jujugui.State({
+      const state = new State({
         baseURL: 'http://abc.com:123',
         seriesList: ['trusty']
       });
@@ -544,7 +546,7 @@ describe('State', () => {
     });
 
     it('returns the last record in the history', () => {
-      const state = new window.jujugui.State({
+      const state = new State({
         baseURL: 'http://abc.com:123',
         seriesList: ['trusty']
       });
@@ -556,7 +558,7 @@ describe('State', () => {
     });
 
     it('returns the previous record in the history', () => {
-      const state = new window.jujugui.State({
+      const state = new State({
         baseURL: 'http://abc.com:123',
         seriesList: ['trusty']
       });
@@ -568,7 +570,7 @@ describe('State', () => {
     });
 
     it('has a public accessor', () => {
-      const state = new window.jujugui.State({
+      const state = new State({
         baseURL: 'http://abc.com:123',
         seriesList: ['trusty']
       });
@@ -580,7 +582,7 @@ describe('State', () => {
 
   describe('State._processURL()', () => {
     it('correctly processes urls', () => {
-      const state = new window.jujugui.State({
+      const state = new State({
         baseURL: 'http://abc.com:123',
         seriesList: ['precise', 'trusty', 'xenial']
       });
@@ -622,7 +624,7 @@ describe('State', () => {
 
   describe('State._parseSpecial()', () => {
     it('extracts the deploy-target from the query string', () => {
-      const state = new window.jujugui.State({
+      const state = new State({
         baseURL: 'http://abc.com:123',
         seriesList: ['precise', 'trusty', 'xenial']
       });
@@ -633,7 +635,7 @@ describe('State', () => {
     });
 
     it('does not pushState if allowStateModifications is false', () => {
-      const state = new window.jujugui.State({
+      const state = new State({
         baseURL: 'http://abc.com:123',
         seriesList: ['precise', 'trusty', 'xenial']
       });
@@ -647,7 +649,7 @@ describe('State', () => {
 
   describe('State._parseRoot()', () => {
     it('populates the root portion of the state object', () => {
-      const state = new window.jujugui.State({
+      const state = new State({
         baseURL: 'http://abc.com:123',
         seriesList: ['precise', 'trusty', 'xenial']
       });
@@ -660,7 +662,7 @@ describe('State', () => {
 
   describe('State._parseSearch()', () => {
     it('populates the search portion of the state object', () => {
-      const state = new window.jujugui.State({
+      const state = new State({
         baseURL: 'http://abc.com:123',
         seriesList: ['precise', 'trusty', 'xenial']
       });
@@ -674,7 +676,7 @@ describe('State', () => {
     });
 
     it('handles query parameters', () => {
-      const state = new window.jujugui.State({
+      const state = new State({
         baseURL: 'http://abc.com:123',
         seriesList: ['precise', 'trusty', 'xenial']
       });
@@ -693,7 +695,7 @@ describe('State', () => {
 
   describe('State._parseGUI', () => {
     it('populates the gui portion of the state object', () => {
-      const state = new window.jujugui.State({
+      const state = new State({
         baseURL: 'http://abc.com:123',
         seriesList: ['precise', 'trusty', 'xenial']
       });
@@ -750,7 +752,7 @@ describe('State', () => {
 
   describe('State._parseUser()', () => {
     it('populates the user and store portions of the state object', () => {
-      const state = new window.jujugui.State({
+      const state = new State({
         baseURL: 'http://abc.com:123',
         seriesList: ['precise', 'trusty', 'xenial']
       });
@@ -926,7 +928,7 @@ describe('State', () => {
     }].forEach(test => {
       it(test.title, () => {
         const baseURL = 'http://abc.com:123';
-        const state = new window.jujugui.State({
+        const state = new State({
           baseURL: baseURL,
           seriesList: ['precise', 'trusty', 'xenial']
         });
@@ -948,7 +950,7 @@ describe('State', () => {
     });
 
     it('correctly returns with an error for invalid urls', () => {
-      const state = new window.jujugui.State({
+      const state = new State({
         baseURL: 'http://abc.com:123',
         seriesList: ['precise', 'trusty', 'xenial']
       });
@@ -1005,7 +1007,7 @@ describe('State', () => {
     });
 
     it('can disable state modifications for parse special', () => {
-      const state = new window.jujugui.State({
+      const state = new State({
         baseURL: 'http://abc.com:123',
         seriesList: ['precise', 'trusty', 'xenial']
       });
@@ -1020,7 +1022,7 @@ describe('State', () => {
 
   describe('State.register()', () => {
     it('stores the supplied dispatchers', () => {
-      const state = new window.jujugui.State({
+      const state = new State({
         baseURL: 'http://abc.com:123',
         seriesList: ['precise', 'trusty', 'xenial']
       });
@@ -1046,7 +1048,7 @@ describe('State', () => {
 
   describe('State.bootstrap()', () => {
     it('calls dispatch with the proper values', () => {
-      const state = new window.jujugui.State({
+      const state = new State({
         baseURL: 'http://abc.com:123',
         seriesList: ['precise', 'trusty', 'xenial'],
         location: {href: '/hatch/ghost'}
@@ -1060,7 +1062,7 @@ describe('State', () => {
 
   describe('State.dispatch()', () => {
     it('dispatches from the current state not the url by default', () => {
-      const state = new window.jujugui.State({
+      const state = new State({
         baseURL: 'http://abc.com:123',
         seriesList: ['precise', 'trusty', 'xenial'],
         location: {href: '/hatch/ghost'}
@@ -1081,7 +1083,7 @@ describe('State', () => {
     });
 
     it('passes the current location to generateState', () => {
-      const state = new window.jujugui.State({
+      const state = new State({
         baseURL: 'http://abc.com:123',
         seriesList: ['precise', 'trusty', 'xenial'],
         location: {href: '/hatch/ghost'}
@@ -1095,7 +1097,7 @@ describe('State', () => {
     });
 
     it('updates the _appStateHistory with the new state', () => {
-      const state = new window.jujugui.State({
+      const state = new State({
         baseURL: 'http://abc.com:123',
         seriesList: ['precise', 'trusty', 'xenial'],
         location: {href: 'hatch/ghost'}
@@ -1108,7 +1110,7 @@ describe('State', () => {
     });
 
     it('properly extracts complex states', () => {
-      const state = new window.jujugui.State({
+      const state = new State({
         baseURL: 'http://abc.com:123',
         seriesList: ['precise', 'trusty', 'xenial'],
         location: {href: 'hatch/ghost'}
@@ -1128,7 +1130,7 @@ describe('State', () => {
     });
 
     it('dispatches registered dispatchers in proper order', () => {
-      const state = new window.jujugui.State({
+      const state = new State({
         baseURL: 'http://abc.com:123',
         seriesList: ['precise', 'trusty', 'xenial'],
         location: {href: 'ghost/trusty/i/machines'}
@@ -1163,7 +1165,7 @@ describe('State', () => {
     });
 
     it('dispatches registered cleanup dispatchers in proper order', () => {
-      const state = new window.jujugui.State({
+      const state = new State({
         baseURL: 'http://abc.com:123',
         seriesList: ['precise', 'trusty', 'xenial'],
         location: {href: 'ghost/trusty/i/machines'}
@@ -1207,7 +1209,7 @@ describe('State', () => {
     });
 
     it('finds and executes parent dispatchers', () => {
-      const state = new window.jujugui.State({
+      const state = new State({
         baseURL: 'http://abc.com:123',
         seriesList: ['precise', 'trusty', 'xenial'],
         location: {href: '/i/inspector/apache/unit/0'}
@@ -1222,7 +1224,7 @@ describe('State', () => {
     });
 
     it('can handle dispatching when back is called', () => {
-      const state = new window.jujugui.State({
+      const state = new State({
         baseURL: 'http://abc.com:123',
         seriesList: ['precise', 'trusty', 'xenial'],
         location: {href: '/i/machines'}
@@ -1255,7 +1257,7 @@ describe('State', () => {
   describe('State.changeState()', () => {
     it('can update state', () => {
       const sendAnalytics = sinon.stub();
-      const state = new window.jujugui.State({
+      const state = new State({
         baseURL: 'http://abc.com:123',
         seriesList: ['precise', 'trusty', 'xenial'],
         location: {href: '/u/hatch/staging/i/applications/inspector/ghost'},
@@ -1293,7 +1295,7 @@ describe('State', () => {
     });
 
     it('prunes null values when removing states', () => {
-      const state = new window.jujugui.State({
+      const state = new State({
         baseURL: 'http://abc.com:123',
         seriesList: ['precise', 'trusty', 'xenial'],
         location: {href: '/u/hatch/staging/i/applications/inspector/ghost'}
@@ -1324,7 +1326,7 @@ describe('State', () => {
     });
 
     it('calls dispatch with the key paths that were pruned', () => {
-      const state = new window.jujugui.State({
+      const state = new State({
         baseURL: 'http://abc.com:123',
         seriesList: ['precise', 'trusty', 'xenial'],
         location: {href: '/u/hatch/staging/i/applications/inspector/ghost'}
@@ -1352,7 +1354,7 @@ describe('State', () => {
     });
 
     it('calls dispatch with the key paths that were pruned #2', () => {
-      const state = new window.jujugui.State({
+      const state = new State({
         baseURL: 'http://abc.com:123',
         seriesList: ['precise', 'trusty', 'xenial'],
         location: {href: '/i/machines'}
@@ -1372,7 +1374,7 @@ describe('State', () => {
     });
 
     it('updates state sub objects', () => {
-      const state = new window.jujugui.State({
+      const state = new State({
         baseURL: 'http://abc.com:123',
         seriesList: ['precise', 'trusty', 'xenial'],
         location: {href: 'i/machines'}
@@ -1420,7 +1422,7 @@ describe('State', () => {
       const historyStub = {
         pushState: sinon.stub()
       };
-      const state = new window.jujugui.State({
+      const state = new State({
         baseURL: 'http://abc.com:123',
         seriesList: ['precise', 'trusty', 'xenial'],
         location: {href: '/u/hatch/staging'},
@@ -1435,7 +1437,7 @@ describe('State', () => {
 
   describe('State.reset()', () => {
     it('generates a new null state and calls changeState', () => {
-      const state = new window.jujugui.State({
+      const state = new State({
         baseURL: 'http://abc.com:123',
         seriesList: ['precise', 'trusty', 'xenial'],
         location: {href: '/u/hatch/staging'}
@@ -1489,7 +1491,7 @@ describe('State', () => {
     }].forEach(test => {
       it(test.title, () => {
         const baseURL = 'http://abc.com:123';
-        const state = new window.jujugui.State({
+        const state = new State({
           baseURL: baseURL,
           seriesList: ['precise', 'trusty', 'xenial']
         });
@@ -1501,7 +1503,7 @@ describe('State', () => {
     });
 
     it('can be passed a custom state object', () => {
-      const state = new window.jujugui.State({
+      const state = new State({
         baseURL: 'http://abc.com:123',
         seriesList: ['precise', 'trusty', 'xenial']
       });

--- a/jujugui/static/gui/src/app/state/test-state.js
+++ b/jujugui/static/gui/src/app/state/test-state.js
@@ -20,7 +20,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 const State = require('./state');
 
-fdescribe('State', () => {
+describe('State', () => {
 
   const specialStateTests = [{
     path: 'http://abc.com:123/?deploy-target=cs:ghost-4',

--- a/jujugui/static/gui/src/app/test-init.js
+++ b/jujugui/static/gui/src/app/test-init.js
@@ -1,8 +1,10 @@
 /* Copyright (C) 2017 Canonical Ltd. */
 'use strict';
 
-const utils = require('./init/testing-utils');
 const ReactDOM = require('react-dom');
+
+const User = require('./user/user');
+const utils = require('./init/testing-utils');
 
 const {
   charmstore,
@@ -348,8 +350,7 @@ describe('init', () => {
     beforeEach(() => {
       conn = new utils.SocketStub();
       app.destructor();
-      const userClass = new window.jujugui.User(
-        {sessionStorage: getMockStorage()});
+      const userClass = new User({sessionStorage: getMockStorage()});
       userClass.controller = {user: 'user', password: 'password'};
       app = createApp({
         conn: conn,
@@ -447,8 +448,7 @@ describe('init', () => {
   describe('Application Connection State', () => {
     it('should be able to handle env connection status changes', () => {
       const conn = new utils.SocketStub();
-      const userClass = new window.jujugui.User(
-        {sessionStorage: getMockStorage()});
+      const userClass = new User({sessionStorage: getMockStorage()});
       userClass.controller = {user: 'user', password: 'password'};
       app.destructor();
       app = createApp({
@@ -1123,8 +1123,7 @@ describe('init', () => {
     };
 
     beforeEach(() => {
-      userClass = new window.jujugui.User(
-        {sessionStorage: getMockStorage()});
+      userClass = new User({sessionStorage: getMockStorage()});
       userClass.controller = {};
       setupApp();
     });

--- a/jujugui/static/gui/src/app/user/test-user.js
+++ b/jujugui/static/gui/src/app/user/test-user.js
@@ -18,13 +18,11 @@
 
 'use strict';
 
-chai.config.includeStack = true;
-chai.config.truncateThreshold = 0;
-
+const User = require('./user');
 
 describe('user auth class', () => {
   it('exists', () => {
-    const user = new window.jujugui.User();
+    const user = new User();
     assert.isObject(user);
   });
 
@@ -57,12 +55,12 @@ describe('user auth class', () => {
 
     beforeEach(() => {
       storage = getMockStorage();
-      user = new window.jujugui.User({sessionStorage: storage});
+      user = new User({sessionStorage: storage});
     });
 
     beforeEach(() => {
       storage = getMockStorage();
-      user = new window.jujugui.User({sessionStorage: storage});
+      user = new User({sessionStorage: storage});
     });
 
     it('can be set', () => {
@@ -110,7 +108,7 @@ describe('user auth class', () => {
 
     beforeEach(() => {
       storage = getMockStorage();
-      user = new window.jujugui.User({sessionStorage: storage});
+      user = new User({sessionStorage: storage});
     });
 
     it('can be set', () => {
@@ -158,7 +156,7 @@ describe('user auth class', () => {
 
     beforeEach(() => {
       storage = getMockStorage();
-      user = new window.jujugui.User({localStorage: storage});
+      user = new User({localStorage: storage});
     });
 
     it('can set a macaroon', () => {
@@ -183,7 +181,7 @@ describe('user auth class', () => {
 
     beforeEach(() => {
       storage = getMockStorage();
-      user = new window.jujugui.User({localStorage: storage});
+      user = new User({localStorage: storage});
       storage.setItem('charmstore', '<charmstore macaroon>');
       storage.setItem('identity', '<identity token>');
       storage.setItem('terms', '<terms macaroon>');
@@ -212,7 +210,7 @@ describe('user auth class', () => {
 
     beforeEach(() => {
       storage = getMockStorage();
-      user = new window.jujugui.User({localStorage: storage});
+      user = new User({localStorage: storage});
       user.controller = {user: 'dalek'};
     });
 
@@ -236,7 +234,7 @@ describe('user auth class', () => {
 
     beforeEach(() => {
       storage = getMockStorage();
-      user = new window.jujugui.User({sessionStorage: storage});
+      user = new User({sessionStorage: storage});
     });
 
     it('can set an expiration time', () => {
@@ -245,7 +243,7 @@ describe('user auth class', () => {
         sessionStorage: storage,
         expirationDatetime: expiration
       };
-      user = new window.jujugui.User(cfg);
+      user = new User(cfg);
       assert.deepEqual(
         new Date(user.expirationDatetime).getTime(),
         expiration.getTime());
@@ -268,7 +266,7 @@ describe('user auth class', () => {
         sessionStorage: storage,
         expirationDatetime: expiration
       };
-      user = new window.jujugui.User(cfg);
+      user = new User(cfg);
       storage.setItem('foo', 'bar');
       user._purgeIfExpired();
       assert.isNull(storage.getItem('foo'));

--- a/jujugui/static/gui/src/app/user/user.js
+++ b/jujugui/static/gui/src/app/user/user.js
@@ -18,10 +18,6 @@
 
 'use strict';
 
-if (typeof this.jujugui === 'undefined') {
-  this.jujugui = {};
-}
-
 // XXX j.c.sackett 2016-05-26 Session expiration should be set via config, but
 // as that also requires an update from blues browser we'll do that in a follow
 // up. For now it's set to the same timeout as in blues browser.
@@ -38,7 +34,7 @@ function getExpirationDate() {
 }
 
 /** Class representing a user's authorizations in the GUI **/
-const User = class User {
+class User {
 
   constructor(cfg = {}) {
     // We pass in these values to make test setup easier.
@@ -313,4 +309,4 @@ const User = class User {
   }
 };
 
-this.jujugui.User = User;
+module.exports = User;

--- a/jujugui/static/gui/src/app/utils/github-ssh-keys.js
+++ b/jujugui/static/gui/src/app/utils/github-ssh-keys.js
@@ -18,15 +18,6 @@
 
 'use strict';
 
-if (typeof this.jujugui === 'undefined') {
-  this.jujugui = {};
-}
-
-// Future-proof if we want to grab SSH keys from anywhere else
-// (gitlab, gogs, etc).
-if (typeof this.jujugui.sshKeys === 'undefined') {
-  this.jujugui.sshKeys = {};
-}
 
 /**
   Fetch SSH keys from a user's GitHub account.
@@ -47,7 +38,7 @@ const githubSSHKeys = (handler, username, callback) => {
     }
 
     // If there's an error, set it to the message from GitHub
-    const error = response.currentTarget.status !== 200 ? 
+    const error = response.currentTarget.status !== 200 ?
       `cannot retrieve SSH keys from GitHub: ${data.message}` : null;
 
     // If there's no error, pull the key into its respective parts for use by
@@ -77,4 +68,4 @@ const githubSSHKeys = (handler, username, callback) => {
 
 };
 
-this.jujugui.sshKeys.githubSSHKeys = githubSSHKeys;
+module.exports = githubSSHKeys;

--- a/jujugui/static/gui/src/app/utils/statsd.js
+++ b/jujugui/static/gui/src/app/utils/statsd.js
@@ -2,14 +2,10 @@
 
 'use strict';
 
-if (typeof this.jujugui === 'undefined') {
-  this.jujugui = {};
-}
-
 /**
   A statsd client used to send application metrics.
 */
-const StatsClient = class StatsClient {
+class StatsClient {
 
   /**
     Create the statsd client.
@@ -73,4 +69,4 @@ const StatsClient = class StatsClient {
 
 };
 
-this.jujugui.StatsClient = StatsClient;
+module.exports = StatsClient;

--- a/jujugui/static/gui/src/app/utils/test-github-ssh-keys.js
+++ b/jujugui/static/gui/src/app/utils/test-github-ssh-keys.js
@@ -2,8 +2,7 @@
 
 'use strict';
 
-chai.config.includeStack = true;
-chai.config.truncateThreshold = 0;
+const githubSSHKeys = require('./github-ssh-keys');
 
 describe('GitHub SSH key fetching', () => {
   let sendGetRequest, callback;
@@ -14,7 +13,7 @@ describe('GitHub SSH key fetching', () => {
   });
 
   it('fetches github SSH keys', () => {
-    window.jujugui.sshKeys.githubSSHKeys(
+    githubSSHKeys(
       {sendGetRequest: sendGetRequest},
       'rose',
       callback);
@@ -56,7 +55,7 @@ describe('GitHub SSH key fetching', () => {
   });
 
   it('surfaces errors', () => {
-    window.jujugui.sshKeys.githubSSHKeys(
+    githubSSHKeys(
       {sendGetRequest: sendGetRequest},
       'bad-wolf',
       callback);
@@ -81,7 +80,7 @@ describe('GitHub SSH key fetching', () => {
   });
 
   it('handles invalid responses', () => {
-    window.jujugui.sshKeys.githubSSHKeys(
+    githubSSHKeys(
       {sendGetRequest: sendGetRequest},
       'bad-wolf',
       callback);

--- a/jujugui/static/gui/src/app/utils/test-statsd.js
+++ b/jujugui/static/gui/src/app/utils/test-statsd.js
@@ -2,9 +2,7 @@
 
 'use strict';
 
-var juju = {components: {}}; // eslint-disable-line no-unused-vars
-chai.config.includeStack = true;
-chai.config.truncateThreshold = 0;
+const StatsClient = require('./statsd');
 
 describe('StatsClient', () => {
   let mockXHR;
@@ -46,27 +44,27 @@ describe('StatsClient', () => {
 
   it('increases a counter', () => {
     const url = 'https://example.com/stats/';
-    const client = new window.jujugui.StatsClient(url);
+    const client = new StatsClient(url);
     client.increase('foo');
     assertXHRSent(url, 'foo:1|c');
   });
 
   it('adds the trailing slash to the URL', () => {
-    const client = new window.jujugui.StatsClient('https://example.com');
+    const client = new StatsClient('https://example.com');
     client.increase('bar');
     assertXHRSent('https://example.com/', 'bar:1|c');
   });
 
   it('increases a counter by more than one', () => {
     const url = 'https://example.com/stats/';
-    const client = new window.jujugui.StatsClient(url);
+    const client = new StatsClient(url);
     client.increase('my-key', 42);
     assertXHRSent(url, 'my-key:42|c');
   });
 
   it('can include a prefix', () => {
     const url = 'https://example.com/stats/';
-    const client = new window.jujugui.StatsClient(url, 'gui');
+    const client = new StatsClient(url, 'gui');
     client.increase('awesome');
     assertXHRSent(url, 'gui.awesome:1|c');
   });
@@ -74,7 +72,7 @@ describe('StatsClient', () => {
   it('adds flags as statsd tags', () => {
     const url = 'https://example.com/stats/';
     const flags = {'test.bar': true, 'baz': true};
-    const client = new window.jujugui.StatsClient(url, 'gui', flags);
+    const client = new StatsClient(url, 'gui', flags);
     const name = client._addFlags('foo');
     assert.equal(name, 'foo,test.bar=true');
   });
@@ -87,7 +85,7 @@ describe('StatsClient', () => {
       'test.bad': false,
       'test.foo': true
     };
-    const client = new window.jujugui.StatsClient(url, 'gui', flags);
+    const client = new StatsClient(url, 'gui', flags);
     const name = client._addFlags('deploy');
     assert.equal(name, 'deploy,test.bar=true,test.foo=true');
   });

--- a/jujugui/static/gui/src/test/globalconfig.js
+++ b/jujugui/static/gui/src/test/globalconfig.js
@@ -15,8 +15,7 @@ window.GlobalConfig = {
         comboBase: "/dev/combo?",
         root: 'app/',
         filter: 'raw',
-        // From modules.js
-        modules: YUI_MODULES,
+        modules: {},
     },
   },
   test_url: window.location.protocol + '//' + window.location.host + "/base/jujugui/static/gui/src/test/"

--- a/jujugui/static/gui/src/test/test_controller_api.js
+++ b/jujugui/static/gui/src/test/test_controller_api.js
@@ -18,6 +18,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 'use strict';
 
+const User = require('../app/user/user');
 const utils = require('../app/init/testing-utils');
 
 describe('Controller API', function() {
@@ -45,8 +46,7 @@ describe('Controller API', function() {
   };
 
   beforeEach(function() {
-    const user = new window.jujugui.User(
-      {sessionStorage: getMockStorage()});
+    const user = new User({sessionStorage: getMockStorage()});
     user.controller = {user: 'user', password: 'password'};
     conn = new utils.SocketStub();
     controllerAPI = new juju.ControllerAPI({
@@ -152,8 +152,7 @@ describe('Controller API', function() {
     });
 
     it('stops the pinger when the controller is destroyed', function(done) {
-      const userClass = new window.jujugui.User(
-        {sessionStorage: getMockStorage()});
+      const userClass = new User({sessionStorage: getMockStorage()});
       userClass.controller = {user: 'user', password: 'password'};
       const api = new juju.ControllerAPI({conn: conn, user: userClass});
       api.after('destroy', evt => {

--- a/jujugui/static/gui/src/test/test_env.js
+++ b/jujugui/static/gui/src/test/test_env.js
@@ -18,6 +18,8 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 'use strict';
 
+const User = require('../app/user/user');
+
 (function() {
 
   describe('Base Environment', function() {
@@ -46,8 +48,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     };
 
     it('calls "open" on connection if available.', function() {
-      const userClass = new window.jujugui.User(
-        {sessionStorage: getMockStorage()});
+      const userClass = new User({sessionStorage: getMockStorage()});
       userClass.controller = {user: 'user', password: 'password'};
       const conn= {
         open: sinon.stub(),
@@ -61,8 +62,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     });
 
     it('calls "cleanup" when the connection is closed', function() {
-      const userClass = new window.jujugui.User(
-        {sessionStorage: getMockStorage()});
+      const userClass = new User({sessionStorage: getMockStorage()});
       userClass.controller = {user: 'who', password: 'tardis'};
       const conn = {
         open: sinon.stub(),
@@ -94,8 +94,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     });
 
     it('sets connecting when it is attempting a connection', function() {
-      const userClass = new window.jujugui.User(
-        {sessionStorage: getMockStorage()});
+      const userClass = new User({sessionStorage: getMockStorage()});
       userClass.controller = {user: 'user', password: 'password'};
       const env = new environments.BaseEnvironment({user: userClass});
       env.set('socket_url', 'ws://sandbox');
@@ -109,8 +108,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
       let baseModel;
 
       beforeEach(() => {
-        const userClass = new window.jujugui.User(
-          {sessionStorage: getMockStorage()});
+        const userClass = new User({sessionStorage: getMockStorage()});
         userClass.controller = {user: 'user', password: 'password'};
         const conn = {
           open: sinon.stub(),

--- a/jujugui/static/gui/src/test/test_env_api.js
+++ b/jujugui/static/gui/src/test/test_env_api.js
@@ -19,6 +19,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 'use strict';
 
 const EnvironmentChangeSet = require('../app/init/environment-change-set');
+const User = require('../app/user/user');
 const utils = require('../app/init/testing-utils');
 
 (function() {
@@ -126,8 +127,7 @@ const utils = require('../app/init/testing-utils');
           };
         };
       };
-      const userClass = new window.jujugui.User(
-        {sessionStorage: getMockStorage()});
+      const userClass = new User({sessionStorage: getMockStorage()});
       userClass.controller = {user: 'user', password: 'password'};
       conn = new utils.SocketStub();
       ecs = new EnvironmentChangeSet({});

--- a/jujugui/static/gui/src/test/test_login.js
+++ b/jujugui/static/gui/src/test/test_login.js
@@ -18,6 +18,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 'use strict';
 
+const User = require('../app/user/user');
 const utils = require('../app/init/testing-utils');
 
 (function() {
@@ -47,8 +48,7 @@ const utils = require('../app/init/testing-utils');
     };
 
     beforeEach(function() {
-      const userClass = new window.jujugui.User(
-        {sessionStorage: getMockStorage()});
+      const userClass = new User({sessionStorage: getMockStorage()});
       userClass.controller = {user: 'user', password: 'password'};
       conn = new utils.SocketStub();
       env = new juju.environments.GoEnvironment({conn: conn, user: userClass});

--- a/jujugui/templates/index.html.go
+++ b/jujugui/templates/index.html.go
@@ -297,12 +297,12 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     <script src="{{.comboURL}}?app/assets/javascripts/version.js"></script>
     <script src="{{.comboURL}}?app/init-pkg.js"></script>
     <script src="{{.comboURL}}?app/assets/javascripts/yui/yui/yui.js"></script>
-    <script src="{{.comboURL}}?app/state/state.js&app/user/user.js&app/utils/github-ssh-keys.js&app/utils/statsd.js"></script>
+    <script src="{{.comboURL}}?app/user/user.js&app/utils/github-ssh-keys.js&app/utils/statsd.js"></script>
     {{else}}
     <script src="{{.comboURL}}?app/init-pkg-min.js"></script>
     <script src="{{.comboURL}}?app/assets/javascripts/version-min.js"></script>
     <script src="{{.comboURL}}?app/assets/javascripts/yui/yui/yui-min.js"></script>
-    <script src="{{.comboURL}}?app/state/state-min.js&app/user/user-min.js&app/utils/github-ssh-keys-min.js&app/utils/statsd-min.js"></script>
+    <script src="{{.comboURL}}?app/user/user-min.js&app/utils/github-ssh-keys-min.js&app/utils/statsd-min.js"></script>
     {{end}}
 
     <script>

--- a/jujugui/templates/index.html.go
+++ b/jujugui/templates/index.html.go
@@ -297,12 +297,12 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     <script src="{{.comboURL}}?app/assets/javascripts/version.js"></script>
     <script src="{{.comboURL}}?app/init-pkg.js"></script>
     <script src="{{.comboURL}}?app/assets/javascripts/yui/yui/yui.js"></script>
-    <script src="{{.comboURL}}?app/user/user.js&app/utils/github-ssh-keys.js&app/utils/statsd.js"></script>
+    <script src="{{.comboURL}}?app/utils/github-ssh-keys.js&app/utils/statsd.js"></script>
     {{else}}
     <script src="{{.comboURL}}?app/init-pkg-min.js"></script>
     <script src="{{.comboURL}}?app/assets/javascripts/version-min.js"></script>
     <script src="{{.comboURL}}?app/assets/javascripts/yui/yui/yui-min.js"></script>
-    <script src="{{.comboURL}}?app/user/user-min.js&app/utils/github-ssh-keys-min.js&app/utils/statsd-min.js"></script>
+    <script src="{{.comboURL}}?app/utils/github-ssh-keys-min.js&app/utils/statsd-min.js"></script>
     {{end}}
 
     <script>

--- a/jujugui/templates/index.html.go
+++ b/jujugui/templates/index.html.go
@@ -297,13 +297,11 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     <script src="{{.comboURL}}?app/assets/javascripts/version.js"></script>
     <script src="{{.comboURL}}?app/init-pkg.js"></script>
     <script src="{{.comboURL}}?app/assets/javascripts/yui/yui/yui.js"></script>
-    <script src="{{.comboURL}}?modules.js"></script>
     <script src="{{.comboURL}}?app/state/state.js&app/user/user.js&app/utils/github-ssh-keys.js&app/utils/statsd.js"></script>
     {{else}}
     <script src="{{.comboURL}}?app/init-pkg-min.js"></script>
     <script src="{{.comboURL}}?app/assets/javascripts/version-min.js"></script>
     <script src="{{.comboURL}}?app/assets/javascripts/yui/yui/yui-min.js"></script>
-    <script src="{{.comboURL}}?modules-min.js"></script>
     <script src="{{.comboURL}}?app/state/state-min.js&app/user/user-min.js&app/utils/github-ssh-keys-min.js&app/utils/statsd-min.js"></script>
     {{end}}
 

--- a/jujugui/templates/index.html.go
+++ b/jujugui/templates/index.html.go
@@ -297,12 +297,10 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     <script src="{{.comboURL}}?app/assets/javascripts/version.js"></script>
     <script src="{{.comboURL}}?app/init-pkg.js"></script>
     <script src="{{.comboURL}}?app/assets/javascripts/yui/yui/yui.js"></script>
-    <script src="{{.comboURL}}?app/utils/github-ssh-keys.js&app/utils/statsd.js"></script>
     {{else}}
     <script src="{{.comboURL}}?app/init-pkg-min.js"></script>
     <script src="{{.comboURL}}?app/assets/javascripts/version-min.js"></script>
     <script src="{{.comboURL}}?app/assets/javascripts/yui/yui/yui-min.js"></script>
-    <script src="{{.comboURL}}?app/utils/github-ssh-keys-min.js&app/utils/statsd-min.js"></script>
     {{end}}
 
     <script>

--- a/jujugui/templates/index.html.mako
+++ b/jujugui/templates/index.html.mako
@@ -297,12 +297,12 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     <script src="${convoy_url}?app/assets/javascripts/version.js"></script>
     <script src="${convoy_url}?app/init-pkg.js"></script>
     <script src="${convoy_url}?app/assets/javascripts/yui/yui/yui.js"></script>
-    <script src="${convoy_url}?app/user/user.js&app/utils/github-ssh-keys.js&app/utils/statsd.js"></script>
+    <script src="${convoy_url}?app/utils/github-ssh-keys.js&app/utils/statsd.js"></script>
     % else:
     <script src="${convoy_url}?app/init-pkg-min.js"></script>
     <script src="${convoy_url}?app/assets/javascripts/version-min.js"></script>
     <script src="${convoy_url}?app/assets/javascripts/yui/yui/yui-min.js"></script>
-    <script src="${convoy_url}?app/user/user-min.js&app/utils/github-ssh-keys-min.js&app/utils/statsd-min.js"></script>
+    <script src="${convoy_url}?app/utils/github-ssh-keys-min.js&app/utils/statsd-min.js"></script>
     % endif
 
     <script>

--- a/jujugui/templates/index.html.mako
+++ b/jujugui/templates/index.html.mako
@@ -297,12 +297,12 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     <script src="${convoy_url}?app/assets/javascripts/version.js"></script>
     <script src="${convoy_url}?app/init-pkg.js"></script>
     <script src="${convoy_url}?app/assets/javascripts/yui/yui/yui.js"></script>
-    <script src="${convoy_url}?app/state/state.js&app/user/user.js&app/utils/github-ssh-keys.js&app/utils/statsd.js"></script>
+    <script src="${convoy_url}?app/user/user.js&app/utils/github-ssh-keys.js&app/utils/statsd.js"></script>
     % else:
     <script src="${convoy_url}?app/init-pkg-min.js"></script>
     <script src="${convoy_url}?app/assets/javascripts/version-min.js"></script>
     <script src="${convoy_url}?app/assets/javascripts/yui/yui/yui-min.js"></script>
-    <script src="${convoy_url}?app/state/state-min.js&app/user/user-min.js&app/utils/github-ssh-keys-min.js&app/utils/statsd-min.js"></script>
+    <script src="${convoy_url}?app/user/user-min.js&app/utils/github-ssh-keys-min.js&app/utils/statsd-min.js"></script>
     % endif
 
     <script>

--- a/jujugui/templates/index.html.mako
+++ b/jujugui/templates/index.html.mako
@@ -297,12 +297,12 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     <script src="${convoy_url}?app/assets/javascripts/version.js"></script>
     <script src="${convoy_url}?app/init-pkg.js"></script>
     <script src="${convoy_url}?app/assets/javascripts/yui/yui/yui.js"></script>
-    <script src="${convoy_url}?app/utils/github-ssh-keys.js&app/utils/statsd.js"></script>
+    <script src="${convoy_url}?app/utils/statsd.js"></script>
     % else:
     <script src="${convoy_url}?app/init-pkg-min.js"></script>
     <script src="${convoy_url}?app/assets/javascripts/version-min.js"></script>
     <script src="${convoy_url}?app/assets/javascripts/yui/yui/yui-min.js"></script>
-    <script src="${convoy_url}?app/utils/github-ssh-keys-min.js&app/utils/statsd-min.js"></script>
+    <script src="${convoy_url}?app/utils/statsd-min.js"></script>
     % endif
 
     <script>

--- a/jujugui/templates/index.html.mako
+++ b/jujugui/templates/index.html.mako
@@ -297,12 +297,10 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     <script src="${convoy_url}?app/assets/javascripts/version.js"></script>
     <script src="${convoy_url}?app/init-pkg.js"></script>
     <script src="${convoy_url}?app/assets/javascripts/yui/yui/yui.js"></script>
-    <script src="${convoy_url}?app/utils/statsd.js"></script>
     % else:
     <script src="${convoy_url}?app/init-pkg-min.js"></script>
     <script src="${convoy_url}?app/assets/javascripts/version-min.js"></script>
     <script src="${convoy_url}?app/assets/javascripts/yui/yui/yui-min.js"></script>
-    <script src="${convoy_url}?app/utils/statsd-min.js"></script>
     % endif
 
     <script>

--- a/jujugui/templates/index.html.mako
+++ b/jujugui/templates/index.html.mako
@@ -297,13 +297,11 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
     <script src="${convoy_url}?app/assets/javascripts/version.js"></script>
     <script src="${convoy_url}?app/init-pkg.js"></script>
     <script src="${convoy_url}?app/assets/javascripts/yui/yui/yui.js"></script>
-    <script src="${convoy_url}?modules.js"></script>
     <script src="${convoy_url}?app/state/state.js&app/user/user.js&app/utils/github-ssh-keys.js&app/utils/statsd.js"></script>
     % else:
     <script src="${convoy_url}?app/init-pkg-min.js"></script>
     <script src="${convoy_url}?app/assets/javascripts/version-min.js"></script>
     <script src="${convoy_url}?app/assets/javascripts/yui/yui/yui-min.js"></script>
-    <script src="${convoy_url}?modules-min.js"></script>
     <script src="${convoy_url}?app/state/state-min.js&app/user/user-min.js&app/utils/github-ssh-keys-min.js&app/utils/statsd-min.js"></script>
     % endif
 

--- a/karma-mocha-old.conf.js.tmpl
+++ b/karma-mocha-old.conf.js.tmpl
@@ -28,7 +28,6 @@ module.exports = function(config) {
 
       'jujugui/static/gui/build/app/assets/javascripts/yui/yui/yui.js',
       'jujugui/static/gui/build/app/assets/javascripts/yui/loader/loader.js',
-      'jujugui/static/gui/src/app/user/user.js',
 
       'jujugui/static/gui/src/test/test_entity_extension.js',
       'jujugui/static/gui/src/test/test_env_api.js',

--- a/karma-mocha-old.conf.js.tmpl
+++ b/karma-mocha-old.conf.js.tmpl
@@ -23,8 +23,6 @@ module.exports = function(config) {
     // with the preprocessors, to watch the source files and serve the compiled
     // files.
     files: [
-      'jujugui/static/gui/build/modules.js',
-
       'jujugui/static/gui/src/test/test-setup.js',
       'jujugui/static/gui/src/test/globalconfig.js',
 

--- a/karma-mocha-old.conf.js.tmpl
+++ b/karma-mocha-old.conf.js.tmpl
@@ -28,7 +28,6 @@ module.exports = function(config) {
 
       'jujugui/static/gui/build/app/assets/javascripts/yui/yui/yui.js',
       'jujugui/static/gui/build/app/assets/javascripts/yui/loader/loader.js',
-      'jujugui/static/gui/src/app/state/state.js',
       'jujugui/static/gui/src/app/user/user.js',
 
       'jujugui/static/gui/src/test/test_entity_extension.js',

--- a/karma.conf.js.tmpl
+++ b/karma.conf.js.tmpl
@@ -32,11 +32,10 @@ module.exports = function(config) {
       'jujugui/static/gui/src/app/components/**/test-*.js',
 
       'jujugui/static/gui/src/app/user/test-*.js',
+      'jujugui/static/gui/src/app/utils/test-*.js',
 
       'jujugui/static/gui/build/app/utils/statsd.js',
       'jujugui/static/gui/build/app/utils/test-statsd.js',
-      'jujugui/static/gui/build/app/utils/github-ssh-keys.js',
-      'jujugui/static/gui/build/app/utils/test-github-ssh-keys.js',
 
       'jujugui/static/gui/src/test/globalconfig.js',
       'jujugui/static/gui/src/app/test-*.js',
@@ -60,7 +59,7 @@ module.exports = function(config) {
       'jujugui/static/gui/src/app/models/test-*.js': ['browserify'],
       'jujugui/static/gui/src/app/state/*.js': ['browserify'],
       'jujugui/static/gui/src/app/user/*.js': ['browserify'],
-      'jujugui/static/gui/src/app/utils/component-test-utils.js': ['browserify'],
+      'jujugui/static/gui/src/app/utils/*.js': ['browserify'],
       'jujugui/static/gui/src/app/store/env/test-*.js': ['browserify'],
       'jujugui/static/gui/src/test/globalconfig.js': ['browserify'],
       'jujugui/static/gui/src/test/enzyme-setup.js': ['browserify'],

--- a/karma.conf.js.tmpl
+++ b/karma.conf.js.tmpl
@@ -39,7 +39,6 @@ module.exports = function(config) {
       'jujugui/static/gui/build/app/utils/github-ssh-keys.js',
       'jujugui/static/gui/build/app/utils/test-github-ssh-keys.js',
 
-      'jujugui/static/gui/build/modules.js',
       'jujugui/static/gui/src/test/globalconfig.js',
       'jujugui/static/gui/src/app/test-*.js',
       'jujugui/static/gui/src/app/d3-components/test-*.js',

--- a/karma.conf.js.tmpl
+++ b/karma.conf.js.tmpl
@@ -21,7 +21,7 @@ module.exports = function(config) {
       'jujugui/static/gui/build/app/assets/javascripts/yui/yui/yui.js',
       'jujugui/static/gui/build/app/assets/javascripts/yui/loader/loader.js',
 
-      'jujugui/static/gui/src/app/state/*.js',
+      'jujugui/static/gui/src/app/state/test-*.js',
 
       'jujugui/static/gui/src/test/enzyme-setup.js',
       'jujugui/static/gui/src/test/chai-setup.js',
@@ -31,8 +31,7 @@ module.exports = function(config) {
       'jujugui/static/gui/src/test/required-props.js',
       'jujugui/static/gui/src/app/components/**/test-*.js',
 
-      'jujugui/static/gui/build/app/user/user.js',
-      'jujugui/static/gui/build/app/user/test-user.js',
+      'jujugui/static/gui/src/app/user/test-*.js',
 
       'jujugui/static/gui/build/app/utils/statsd.js',
       'jujugui/static/gui/build/app/utils/test-statsd.js',
@@ -60,6 +59,7 @@ module.exports = function(config) {
       'jujugui/static/gui/src/app/init/topology/environment-utils.js': ['browserify'],
       'jujugui/static/gui/src/app/models/test-*.js': ['browserify'],
       'jujugui/static/gui/src/app/state/*.js': ['browserify'],
+      'jujugui/static/gui/src/app/user/*.js': ['browserify'],
       'jujugui/static/gui/src/app/utils/component-test-utils.js': ['browserify'],
       'jujugui/static/gui/src/app/store/env/test-*.js': ['browserify'],
       'jujugui/static/gui/src/test/globalconfig.js': ['browserify'],

--- a/karma.conf.js.tmpl
+++ b/karma.conf.js.tmpl
@@ -21,14 +21,16 @@ module.exports = function(config) {
       'jujugui/static/gui/build/app/assets/javascripts/yui/yui/yui.js',
       'jujugui/static/gui/build/app/assets/javascripts/yui/loader/loader.js',
 
-      'jujugui/static/gui/src/app/state/test-*.js',
 
       'jujugui/static/gui/src/test/enzyme-setup.js',
       'jujugui/static/gui/src/test/chai-setup.js',
-      // This file needs to go before any tests as it adds a beforEach and
+      // This file needs to go before any tests as it adds a beforeEach and
       // afterEach for every test so that we can ensure there are no prop type
       // errors.
       'jujugui/static/gui/src/test/required-props.js',
+      'jujugui/static/gui/src/test/globalconfig.js',
+
+      'jujugui/static/gui/src/app/state/test-*.js',
       'jujugui/static/gui/src/app/components/**/test-*.js',
       'jujugui/static/gui/src/app/d3-components/test-*.js',
       'jujugui/static/gui/src/app/init/**/test-*.js',
@@ -36,8 +38,7 @@ module.exports = function(config) {
       'jujugui/static/gui/src/app/store/env/test-*.js',
       'jujugui/static/gui/src/app/test-*.js',
       'jujugui/static/gui/src/app/user/test-*.js',
-      'jujugui/static/gui/src/app/utils/test-*.js',
-      'jujugui/static/gui/src/test/globalconfig.js'
+      'jujugui/static/gui/src/app/utils/test-*.js'
     ],
 
     // list of files to exclude

--- a/karma.conf.js.tmpl
+++ b/karma.conf.js.tmpl
@@ -59,6 +59,7 @@ module.exports = function(config) {
       'jujugui/static/gui/src/app/init/**/test-*.js': ['browserify'],
       'jujugui/static/gui/src/app/init/topology/environment-utils.js': ['browserify'],
       'jujugui/static/gui/src/app/models/test-*.js': ['browserify'],
+      'jujugui/static/gui/src/app/state/*.js': ['browserify'],
       'jujugui/static/gui/src/app/utils/component-test-utils.js': ['browserify'],
       'jujugui/static/gui/src/app/store/env/test-*.js': ['browserify'],
       'jujugui/static/gui/src/test/globalconfig.js': ['browserify'],

--- a/karma.conf.js.tmpl
+++ b/karma.conf.js.tmpl
@@ -30,19 +30,14 @@ module.exports = function(config) {
       // errors.
       'jujugui/static/gui/src/test/required-props.js',
       'jujugui/static/gui/src/app/components/**/test-*.js',
-
-      'jujugui/static/gui/src/app/user/test-*.js',
-      'jujugui/static/gui/src/app/utils/test-*.js',
-
-      'jujugui/static/gui/build/app/utils/statsd.js',
-      'jujugui/static/gui/build/app/utils/test-statsd.js',
-
-      'jujugui/static/gui/src/test/globalconfig.js',
-      'jujugui/static/gui/src/app/test-*.js',
       'jujugui/static/gui/src/app/d3-components/test-*.js',
       'jujugui/static/gui/src/app/init/**/test-*.js',
       'jujugui/static/gui/src/app/models/test-*.js',
-      'jujugui/static/gui/src/app/store/env/test-*.js'
+      'jujugui/static/gui/src/app/store/env/test-*.js',
+      'jujugui/static/gui/src/app/test-*.js',
+      'jujugui/static/gui/src/app/user/test-*.js',
+      'jujugui/static/gui/src/app/utils/test-*.js',
+      'jujugui/static/gui/src/test/globalconfig.js'
     ],
 
     // list of files to exclude

--- a/scripts/generate_modules.py
+++ b/scripts/generate_modules.py
@@ -1,2 +1,0 @@
-from convoy.meta import main
-main()


### PR DESCRIPTION
In this branch:
- removed the modules.js definition (the YUI modules are now require()ed - this was empty in the last release, it generated `var YUI_MODULES=function(){return{}}();`)
- updated a bunch of modules to be require()ed rather than being loaded using the combo loader and were being attached window globals
- update the manifest to only require the files that need to be passed to the browser