### PR TITLE
Work around the destroy storage error

### DIFF
--- a/jujugui/static/gui/src/app/components/profile/model-list/model-list.js
+++ b/jujugui/static/gui/src/app/components/profile/model-list/model-list.js
@@ -109,7 +109,7 @@ class ProfileModelList extends React.Component {
       type: 'destructive'
     }];
     const message = `Are you sure you want to destroy ${model.name}?`
-      + ' All the applications and units included in the model will be'
+      + ' All the applications, units and storage used by the model will be'
       + ' destroyed. This action cannot be undone.';
     this.setState({
       notification: (

--- a/jujugui/static/gui/src/app/store/env/controller-api.js
+++ b/jujugui/static/gui/src/app/store/env/controller-api.js
@@ -883,7 +883,12 @@ window.yui.add('juju-controller-api', function(Y) {
         tagKey = 'tag';
       }
       const entities = ids.map(function(id) {
-        return {[tagKey]: tags.build(tags.MODEL, id)};
+        return {
+          [tagKey]: tags.build(tags.MODEL, id),
+          // TODO(frankban): allow for selecting not to destroy storage.
+          // This will be available when switching to jujulib.
+          'destroy-storage': true
+        };
       });
       // Send the API request.
       this._send_rpc({

--- a/jujugui/static/gui/src/test/test_controller_api.js
+++ b/jujugui/static/gui/src/test/test_controller_api.js
@@ -636,7 +636,7 @@ describe('Controller API', function() {
           version: 4,
           request: 'DestroyModels',
           params: {models: [
-            {'model-tag': 'model-default'}
+            {'model-tag': 'model-default', 'destroy-storage': true}
           ]},
           'request-id': 1
         });
@@ -662,7 +662,7 @@ describe('Controller API', function() {
           version: 3,
           request: 'DestroyModels',
           params: {entities: [
-            {tag: 'model-default'}
+            {tag: 'model-default', 'destroy-storage': true}
           ]},
           'request-id': 1
         });
@@ -687,8 +687,8 @@ describe('Controller API', function() {
           version: 4,
           request: 'DestroyModels',
           params: {models: [
-            {'model-tag': 'model-test-1'},
-            {'model-tag': 'model-test-2'}
+            {'model-tag': 'model-test-1', 'destroy-storage': true},
+            {'model-tag': 'model-test-2', 'destroy-storage': true}
           ]},
           'request-id': 1
         });


### PR DESCRIPTION
When using a new client (jimm) with an old server (like staging) the client returned that error when the deploy-storage key is missing or false in the API request.
See https://github.com/juju/juju/blob/develop/api/modelmanager/modelmanager.go#L390
Fixes https://github.com/juju/juju-gui/issues/3659 (for now)
We will improve this later, when using the new jujulib.
