### PR TITLE
Group applications by bundle in the inspector

### DIFF
--- a/jujugui/static/gui/src/app/components/added-services-list/__snapshots__/test-added-services-list.js.snap
+++ b/jujugui/static/gui/src/app/components/added-services-list/__snapshots__/test-added-services-list.js.snap
@@ -1,0 +1,131 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AddedServicesList adds a label to services with bundleURL annotations 1`] = `
+<div
+  className="inspector-view"
+>
+  <ul
+    className="added-services-list inspector-view__list"
+  >
+    <AddedServicesLabel
+      bundleURL="elasticsearch-cluster/bundle/17"
+      changeState={[Function]}
+      key="elasticsearch-cluster/bundle/17"
+    />
+    <AddedServicesListItem
+      changeState={[Function]}
+      hovered={false}
+      key="elasticsearch-cluser/bundle/17"
+      lastInList={true}
+      service={
+        Object {
+          "get": [Function],
+        }
+      }
+      serviceModule={
+        Object {
+          "hoverService": [Function],
+          "panToService": [Function],
+          "reshape": [Function],
+        }
+      }
+    />
+    <AddedServicesListItem
+      changeState={[Function]}
+      hovered={false}
+      key="1"
+      service={
+        Object {
+          "get": [Function],
+        }
+      }
+      serviceModule={
+        Object {
+          "hoverService": [Function],
+          "panToService": [Function],
+          "reshape": [Function],
+        }
+      }
+    />
+    <AddedServicesListItem
+      changeState={[Function]}
+      hovered={false}
+      key="3"
+      service={
+        Object {
+          "get": [Function],
+        }
+      }
+      serviceModule={
+        Object {
+          "hoverService": [Function],
+          "panToService": [Function],
+          "reshape": [Function],
+        }
+      }
+    />
+  </ul>
+</div>
+`;
+
+exports[`AddedServicesList generates a list of added services list items 1`] = `
+<div
+  className="inspector-view"
+>
+  <ul
+    className="added-services-list inspector-view__list"
+  >
+    <AddedServicesListItem
+      changeState={[Function]}
+      hovered={false}
+      key="1"
+      service={
+        Object {
+          "get": [Function],
+        }
+      }
+      serviceModule={
+        Object {
+          "hoverService": [Function],
+          "panToService": [Function],
+          "reshape": [Function],
+        }
+      }
+    />
+    <AddedServicesListItem
+      changeState={[Function]}
+      hovered={false}
+      key="2"
+      service={
+        Object {
+          "get": [Function],
+        }
+      }
+      serviceModule={
+        Object {
+          "hoverService": [Function],
+          "panToService": [Function],
+          "reshape": [Function],
+        }
+      }
+    />
+    <AddedServicesListItem
+      changeState={[Function]}
+      hovered={false}
+      key="3"
+      service={
+        Object {
+          "get": [Function],
+        }
+      }
+      serviceModule={
+        Object {
+          "hoverService": [Function],
+          "panToService": [Function],
+          "reshape": [Function],
+        }
+      }
+    />
+  </ul>
+</div>
+`;

--- a/jujugui/static/gui/src/app/components/added-services-list/_added-services-list.scss
+++ b/jujugui/static/gui/src/app/components/added-services-list/_added-services-list.scss
@@ -34,11 +34,27 @@
     }
   }
 
-  &__label-item {
-    font-size: 15px;
-    font-weight: bold;
-    padding: 10px 20px;
-    position: relative;
+  &__label {
+    &-item {
+      padding: 10px 20px;
+      position: relative;
+    }
+
+    &-name {
+      font-size: 15px;
+      font-weight: bold;
+    }
+
+    &-link-list li {
+      display: inline-block;
+      margin-right: 10px;
+      cursor: pointer;
+
+      &:hover {
+        color: $link-blue;
+      }
+    }
+
   }
 
   &__item-icon {

--- a/jujugui/static/gui/src/app/components/added-services-list/_added-services-list.scss
+++ b/jujugui/static/gui/src/app/components/added-services-list/_added-services-list.scss
@@ -28,6 +28,17 @@
     &:hover {
       background-color: $hover-background;
     }
+
+    &__last {
+      border-bottom: 1px solid $light-mid-grey;
+    }
+  }
+
+  &__label-item {
+    font-size: 15px;
+    font-weight: bold;
+    padding: 10px 20px;
+    position: relative;
   }
 
   &__item-icon {

--- a/jujugui/static/gui/src/app/components/added-services-list/added-services-list.js
+++ b/jujugui/static/gui/src/app/components/added-services-list/added-services-list.js
@@ -63,10 +63,8 @@ class AddedServicesList extends React.Component {
         // We will deal with the solo ones separately at the end.
         continue;
       }
-      // A bundleURL is in the format elasticsearch-cluster/bundle/17 so just
-      // create a label using the bundle name itself.
-      const name = key.split('/')[0].replace('-', ' ');
-      items.push(<AddedServicesLabel key={name} name={name} />);
+      items.push(
+        <AddedServicesLabel bundleURL={key} changeState={this.props.changeState} key={key} />);
       // Now that the label has been added, loop through the applications in that
       // bundle.
       const length = grouped[key].length - 1;

--- a/jujugui/static/gui/src/app/components/added-services-list/added-services-list.js
+++ b/jujugui/static/gui/src/app/components/added-services-list/added-services-list.js
@@ -23,16 +23,16 @@ class AddedServicesList extends React.Component {
     @param {Boolean} lastInList Indicator if it's the last item in a list.
     @returns {Function} The AddedServicesListItem.
   */
-  _newListItem(service, lastInList) {
+  _generateListItem(service, lastInList) {
     return (
       <AddedServicesListItem
+        changeState={this.props.changeState}
+        hovered={service.get('id') === this.props.hoveredId}
         // We use the 'name' instead of the 'id' here because when a
         // ghost service is added it uses the ghost id structure instead
         // of the final deployed service id structure and we want react
         // to treat them as the same record instead of re-rendering
         // when they key changes.
-        changeState={this.props.changeState}
-        hovered={service.get('id') === this.props.hoveredId}
         key={service.get('name')}
         lastInList={lastInList}
         ref={'AddedServicesListItem-' + service.get('id')}
@@ -46,6 +46,7 @@ class AddedServicesList extends React.Component {
     @returns {Array} A list of applications and label components to render.
   */
   generateItemList(services) {
+    const SOLO = Symbol('solo');
     const grouped = {};
     // Group all of the applications by the bundleURL if one exists.
     services.each(service => {
@@ -54,12 +55,12 @@ class AddedServicesList extends React.Component {
         addToObj(grouped, bundleURL, service);
         return;
       }
-      addToObj(grouped, 'solo', service);
+      addToObj(grouped, SOLO, service);
     });
     const items = [];
 
     for (let key in grouped) {
-      if (key === 'solo') {
+      if (key === SOLO) {
         // We will deal with the solo ones separately at the end.
         continue;
       }
@@ -69,12 +70,12 @@ class AddedServicesList extends React.Component {
       // bundle.
       const length = grouped[key].length - 1;
       grouped[key].forEach((app, idx) => {
-        items.push(this._newListItem(app, idx === length));
+        items.push(this._generateListItem(app, idx === length));
       });
     }
-    if (grouped.solo) {
-      grouped.solo.forEach(app => {
-        items.push(this._newListItem(app));
+    if (grouped[SOLO]) {
+      grouped[SOLO].forEach(app => {
+        items.push(this._generateListItem(app));
       });
     }
     return items;

--- a/jujugui/static/gui/src/app/components/added-services-list/added-services-list.js
+++ b/jujugui/static/gui/src/app/components/added-services-list/added-services-list.js
@@ -6,25 +6,72 @@ const React = require('react');
 const shapeup = require('shapeup');
 
 const AddedServicesListItem = require('./item/item');
+const AddedServicesLabel = require('./label/label');
+
+const addToObj = (obj, key, value) => {
+  if (!obj[key]) {
+    obj[key] = [];
+  }
+  obj[key].push(value);
+};
 
 class AddedServicesList extends React.Component {
+
+  /**
+    Generate a new AddedServicesListItem component and return it.
+    @param {Object} service The service instance to fetch data from.
+    @returns {Function} The AddedServicesListItem.
+  */
+  _newListItem(service) {
+    return (
+      <AddedServicesListItem
+        // We use the 'name' instead of the 'id' here because when a
+        // ghost service is added it uses the ghost id structure instead
+        // of the final deployed service id structure and we want react
+        // to treat them as the same record instead of re-rendering
+        // when they key changes.
+        changeState={this.props.changeState}
+        hovered={service.get('id') === this.props.hoveredId}
+        key={service.get('name')}
+        ref={'AddedServicesListItem-' + service.get('id')}
+        service={service}
+        serviceModule={this.props.serviceModule} />);
+  }
+
+  /**
+    Generate the list of the labels and applications.
+    @param {Object} services A YUI ModelList of applications.
+    @returns {Array} A list of applications and label components to render.
+  */
   generateItemList(services) {
-    var items = [];
+    const grouped = {};
+    // Group all of the applications by the bundleURL if one exists.
     services.each(service => {
-      items.push(
-        <AddedServicesListItem
-          // We use the 'name' instead of the 'id' here because when a
-          // ghost service is added it uses the ghost id structure instead
-          // of the final deployed service id structure and we want react
-          // to treat them as the same record instead of re-rendering
-          // when they key changes.
-          changeState={this.props.changeState}
-          hovered={service.get('id') === this.props.hoveredId}
-          key={service.get('name')}
-          ref={'AddedServicesListItem-' + service.get('id')}
-          service={service}
-          serviceModule={this.props.serviceModule} />);
+      const bundleURL = service.get('annotations').bundleURL;
+      if (bundleURL) {
+        addToObj(grouped, bundleURL, service);
+        return;
+      }
+      addToObj(grouped, 'solo', service);
     });
+    const items = [];
+    // We'll put the solo ones at the top for now, this can be moved later.
+    if (grouped.solo) {
+      grouped.solo.forEach(app => {
+        items.push(this._newListItem(app));
+      });
+      delete grouped.solo;
+    }
+    for (let key in grouped) {
+      // A bundleURL is in the format elasticsearch-cluster/bundle/17 so just
+      // create a label using the bundle name itself.
+      items.push(<AddedServicesLabel name={key.split('/')[0]} />);
+      // Now that the label has been added, loop through the applications in that
+      // bundle.
+      grouped[key].forEach(app => {
+        items.push(this._newListItem(app));
+      });
+    }
     return items;
   }
 

--- a/jujugui/static/gui/src/app/components/added-services-list/added-services-list.js
+++ b/jujugui/static/gui/src/app/components/added-services-list/added-services-list.js
@@ -76,7 +76,6 @@ class AddedServicesList extends React.Component {
       grouped.solo.forEach(app => {
         items.push(this._newListItem(app));
       });
-      delete grouped.solo;
     }
     return items;
   }

--- a/jujugui/static/gui/src/app/components/added-services-list/item/item.js
+++ b/jujugui/static/gui/src/app/components/added-services-list/item/item.js
@@ -73,7 +73,8 @@ class AddedServicesListItem extends React.Component {
       'inspector-view__list-item',
       {
         'visibility-toggled': service.get('highlight') || service.get('fade'),
-        hover: props.hovered
+        hover: props.hovered,
+        'inspector-view__list-item__last': this.props.lastInList
       }
     );
   }
@@ -128,6 +129,7 @@ AddedServicesListItem.propTypes = {
     PropTypes.string,
     PropTypes.bool
   ]),
+  lastInList: PropTypes.bool,
   service: PropTypes.object.isRequired,
   serviceModule: shapeup.shape({
     hoverService: PropTypes.func.isRequired,

--- a/jujugui/static/gui/src/app/components/added-services-list/label/__snapshots__/test-label.js.snap
+++ b/jujugui/static/gui/src/app/components/added-services-list/label/__snapshots__/test-label.js.snap
@@ -20,7 +20,7 @@ exports[`AddedServicesLabel renders 1`] = `
     <li
       onClick={[Function]}
     >
-      Get Started
+      Get started
     </li>
   </ul>
 </li>

--- a/jujugui/static/gui/src/app/components/added-services-list/label/__snapshots__/test-label.js.snap
+++ b/jujugui/static/gui/src/app/components/added-services-list/label/__snapshots__/test-label.js.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AddedServicesLabel renders 1`] = `
+<li
+  className="inspector-view__label-item"
+>
+  <div
+    className="inspector-view__label-name"
+  >
+    elasticsearch cluster
+  </div>
+  <ul
+    className="inspector-view__label-link-list"
+  >
+    <li
+      onClick={[Function]}
+    >
+      Readme
+    </li>
+    <li
+      onClick={[Function]}
+    >
+      Get Started
+    </li>
+  </ul>
+</li>
+`;

--- a/jujugui/static/gui/src/app/components/added-services-list/label/__snapshots__/test-label.js.snap
+++ b/jujugui/static/gui/src/app/components/added-services-list/label/__snapshots__/test-label.js.snap
@@ -15,7 +15,7 @@ exports[`AddedServicesLabel renders 1`] = `
     <li
       onClick={[Function]}
     >
-      Readme
+      Bundle details
     </li>
     <li
       onClick={[Function]}

--- a/jujugui/static/gui/src/app/components/added-services-list/label/label.js
+++ b/jujugui/static/gui/src/app/components/added-services-list/label/label.js
@@ -5,7 +5,7 @@ const PropTypes = require('prop-types');
 const React = require('react');
 
 const AddedServicesLabel = props =>
-  <li className="inspector-view__list-item" key={props.name}>{props.name}</li>;
+  <li className="inspector-view__label-item">{props.name}</li>;
 
 AddedServicesLabel.propTypes = {
   name: PropTypes.string.isRequired

--- a/jujugui/static/gui/src/app/components/added-services-list/label/label.js
+++ b/jujugui/static/gui/src/app/components/added-services-list/label/label.js
@@ -1,0 +1,14 @@
+/* Copyright (C) 2018 Canonical Ltd. */
+'use strict';
+
+const PropTypes = require('prop-types');
+const React = require('react');
+
+const AddedServicesLabel = props =>
+  <li className="inspector-view__list-item" key={props.name}>{props.name}</li>;
+
+AddedServicesLabel.propTypes = {
+  name: PropTypes.string.isRequired
+};
+
+module.exports = AddedServicesLabel;

--- a/jujugui/static/gui/src/app/components/added-services-list/label/label.js
+++ b/jujugui/static/gui/src/app/components/added-services-list/label/label.js
@@ -4,10 +4,12 @@
 const PropTypes = require('prop-types');
 const React = require('react');
 
+const {urls} = require('jaaslib');
+
 class AddedServicesLabel extends React.Component {
 
   /**
-    Calls changeState to show the readme
+    Calls changeState to show the readme.
   */
   _showReadme() {
     this.props.changeState({store: this.props.bundleURL});
@@ -22,13 +24,14 @@ class AddedServicesLabel extends React.Component {
 
   render() {
     // A bundleURL is in the format elasticsearch-cluster/bundle/17
-    const name = this.props.bundleURL.split('/')[0].replace('-', ' ');
+    const url = urls.URL.fromAnyString(this.props.bundleURL);
+    const name = url.name.replace('-', ' ');
     return (
       <li className="inspector-view__label-item">
         <div className="inspector-view__label-name">{name}</div>
         <ul className="inspector-view__label-link-list">
           <li onClick={this._showReadme.bind(this)}>Readme</li>
-          <li onClick={this._showGetStarted.bind(this)}>Get Started</li>
+          <li onClick={this._showGetStarted.bind(this)}>Get started</li>
         </ul>
       </li>);
   }

--- a/jujugui/static/gui/src/app/components/added-services-list/label/label.js
+++ b/jujugui/static/gui/src/app/components/added-services-list/label/label.js
@@ -4,11 +4,39 @@
 const PropTypes = require('prop-types');
 const React = require('react');
 
-const AddedServicesLabel = props =>
-  <li className="inspector-view__label-item">{props.name}</li>;
+class AddedServicesLabel extends React.Component {
+
+  /**
+    Calls changeState to show the readme
+  */
+  _showReadme() {
+    this.props.changeState({store: this.props.bundleURL});
+  }
+
+  /**
+    Calls changeState to show the post deployment panel.
+  */
+  _showGetStarted() {
+    this.props.changeState({postDeploymentPanel: this.props.bundleURL});
+  }
+
+  render() {
+    // A bundleURL is in the format elasticsearch-cluster/bundle/17
+    const name = this.props.bundleURL.split('/')[0].replace('-', ' ');
+    return (
+      <li className="inspector-view__label-item">
+        <div className="inspector-view__label-name">{name}</div>
+        <ul className="inspector-view__label-link-list">
+          <li onClick={this._showReadme.bind(this)}>Readme</li>
+          <li onClick={this._showGetStarted.bind(this)}>Get Started</li>
+        </ul>
+      </li>);
+  }
+}
 
 AddedServicesLabel.propTypes = {
-  name: PropTypes.string.isRequired
+  bundleURL: PropTypes.string.isRequired,
+  changeState: PropTypes.func.isRequired
 };
 
 module.exports = AddedServicesLabel;

--- a/jujugui/static/gui/src/app/components/added-services-list/label/label.js
+++ b/jujugui/static/gui/src/app/components/added-services-list/label/label.js
@@ -30,7 +30,7 @@ class AddedServicesLabel extends React.Component {
       <li className="inspector-view__label-item">
         <div className="inspector-view__label-name">{name}</div>
         <ul className="inspector-view__label-link-list">
-          <li onClick={this._showReadme.bind(this)}>Readme</li>
+          <li onClick={this._showReadme.bind(this)}>Bundle details</li>
           <li onClick={this._showGetStarted.bind(this)}>Get started</li>
         </ul>
       </li>);

--- a/jujugui/static/gui/src/app/components/added-services-list/label/test-label.js
+++ b/jujugui/static/gui/src/app/components/added-services-list/label/test-label.js
@@ -1,0 +1,40 @@
+/* Copyright (C) 2018 Canonical Ltd. */
+'use strict';
+
+const enzyme = require('enzyme');
+const React = require('react');
+
+const AddedServicesLabel = require('./label');
+
+describe('AddedServicesLabel', () => {
+
+  const bundleURL = 'elasticsearch-cluster/bundle/17';
+
+  const renderComponent = (options = {}) => enzyme.shallow(
+    <AddedServicesLabel
+      bundleURL={options.bundleURL || bundleURL}
+      changeState={options.changeState || sinon.stub()} />
+  );
+
+  it('renders', () => {
+    const component = renderComponent();
+    expect(component).toMatchSnapshot();
+  });
+
+  it('calls to show readme on click', () => {
+    const changeState = sinon.stub();
+    const component = renderComponent({changeState});
+    component.find('.inspector-view__label-link-list li').at(0).simulate('click');
+    assert.equal(changeState.callCount, 1);
+    assert.deepEqual(changeState.args[0][0], {store: bundleURL});
+  });
+
+  it('calls to show post deployment on click', () => {
+    const changeState = sinon.stub();
+    const component = renderComponent({changeState});
+    component.find('.inspector-view__label-link-list li').at(1).simulate('click');
+    assert.equal(changeState.callCount, 1);
+    assert.deepEqual(changeState.args[0][0], {postDeploymentPanel: bundleURL});
+  });
+
+});

--- a/jujugui/static/gui/src/app/components/added-services-list/test-added-services-list.js
+++ b/jujugui/static/gui/src/app/components/added-services-list/test-added-services-list.js
@@ -6,7 +6,6 @@ const React = require('react');
 const shapeup = require('shapeup');
 
 const AddedServicesList = require('./added-services-list');
-const AddedServicesListItem = require('./item/item');
 
 describe('AddedServicesList', () => {
   let serviceModule;
@@ -28,40 +27,23 @@ describe('AddedServicesList', () => {
   });
 
   it('generates a list of added services list items', () => {
-    var allServices = [{get: () => 1}, {get: () => 2}, {get: () => 3}];
-    var services = {
-      each: cb => {
-        allServices.forEach(cb);
+    const allServices = [{get: () => 1}, {get: () => 2}, {get: () => 3}];
+    const services = {each: cb => allServices.forEach(cb)};
+    const component = renderComponent({ services });
+    expect(component).toMatchSnapshot();
+  });
+
+  it('adds a label to services with bundleURL annotations', () => {
+    const allServices = [{get: () => 1}, {get: key => {
+      if (key === 'annotations') {
+        return {bundleURL: 'elasticsearch-cluster/bundle/17'};
       }
-    };
-    const wrapper = renderComponent({ services });
-    const instance = wrapper.instance();
-    const expected = (
-      <div className="inspector-view">
-        <ul className="added-services-list inspector-view__list">
-          <AddedServicesListItem
-            changeState={instance.props.changeState}
-            hovered={false}
-            key={allServices[0].get()}
-            ref={'AddedServicesListItem-' + allServices[0].get()}
-            service={allServices[0]}
-            serviceModule={serviceModule} />
-          <AddedServicesListItem
-            changeState={instance.props.changeState}
-            hovered={false}
-            key={allServices[1].get()}
-            ref={'AddedServicesListItem-' + allServices[1].get()}
-            service={allServices[1]}
-            serviceModule={serviceModule} />
-          <AddedServicesListItem
-            changeState={instance.props.changeState}
-            hovered={false}
-            key={allServices[2].get()}
-            ref={'AddedServicesListItem-' + allServices[2].get()}
-            service={allServices[2]}
-            serviceModule={serviceModule} />
-        </ul>
-      </div>);
-    assert.compareJSX(wrapper, expected);
+      if (key === 'name') {
+        return 'elasticsearch-cluser/bundle/17';
+      }
+    }}, {get: () => 3}];
+    const services = {each: cb => allServices.forEach(cb)};
+    const component = renderComponent({ services });
+    expect(component).toMatchSnapshot();
   });
 });

--- a/jujugui/static/gui/src/app/init/component-renderers-mixin.js
+++ b/jujugui/static/gui/src/app/init/component-renderers-mixin.js
@@ -467,16 +467,16 @@ Browser: ${navigator.userAgent}`
     if (typeof state.postDeploymentPanel === 'string') {
       // A specific URL was provided so pass that through
       entityURLs.push(state.postDeploymentPanel);
+    } else {
+      entityURLs = entityURLs.concat(this.db.services.toArray().reduce(
+        (accumulator, app) => {
+          const url = app.get('annotations').bundleURL;
+          if (url) {
+            accumulator.push(url);
+          }
+          return accumulator;
+        }, []));
     }
-    entityURLs = entityURLs.concat(this.db.services.toArray().reduce(
-      (accumulator, app) => {
-        const url = app.get('annotations').bundleURL;
-        if (url) {
-          accumulator.push(url);
-        }
-        return accumulator;
-      }, []));
-
     if (entityURLs.length > 0) {
       ReactDOM.render(
         <PostDeployment

--- a/package-lock.json
+++ b/package-lock.json
@@ -4737,7 +4737,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.4",
@@ -4942,6 +4943,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }


### PR DESCRIPTION
Applications with a `bundleURL` annotation will be grouped by the same `bundleURL` and displayed with links to show the bundles 'readme' and 'get started'.