### PR TITLE
Post Deployment component now correctly updates and handles no-get-started gracefully

### DIFF
--- a/jujugui/static/gui/src/app/components/post-deployment/_post-deployment.scss
+++ b/jujugui/static/gui/src/app/components/post-deployment/_post-deployment.scss
@@ -2,6 +2,7 @@
   max-height: calc(100% - 140px - 100px);
   z-index: index($z-indexed-elements, post-deployment);
   width: auto;
+  min-width: 275px;
   max-width: 295px;
   left: auto;
   right: 20px;


### PR DESCRIPTION
- The post-deployment component now correctly updates when the state changes with a new bundle url to display. 
- It also gracefully handles the case where a bundle author has not provided a `getstarted.md` file.