### PR TITLE
Export bundles with series information for applications.

### DIFF
--- a/jujugui/static/gui/src/app/components/added-services-list/label/label.js
+++ b/jujugui/static/gui/src/app/components/added-services-list/label/label.js
@@ -23,9 +23,20 @@ class AddedServicesLabel extends React.Component {
   }
 
   render() {
-    // A bundleURL is in the format elasticsearch-cluster/bundle/17
-    const url = urls.URL.fromAnyString(this.props.bundleURL);
-    const name = url.name.replace('-', ' ');
+    // A bundleURL is in the format elasticsearch-cluster/bundle/17 unless it
+    // has been imported from a local file then it'll be the file name without
+    // the extension.
+    let name = '';
+    const bundleURL = this.props.bundleURL;
+
+    try {
+      const url = urls.URL.fromAnyString(bundleURL);
+      name = url.name.replace('-', ' ');
+    } catch (e) {
+      // The bundleURL is probably a local file import.
+      name = bundleURL;
+    }
+
     return (
       <li className="inspector-view__label-item">
         <div className="inspector-view__label-name">{name}</div>

--- a/jujugui/static/gui/src/app/components/added-services-list/label/test-label.js
+++ b/jujugui/static/gui/src/app/components/added-services-list/label/test-label.js
@@ -37,4 +37,10 @@ describe('AddedServicesLabel', () => {
     assert.deepEqual(changeState.args[0][0], {postDeploymentPanel: bundleURL});
   });
 
+  it('supports local bundle urls', () => {
+    const name = 'local-bundle (1)';
+    const component = renderComponent({bundleURL: name});
+    assert.equal(component.find('.inspector-view__label-name').text(), name);
+  });
+
 });

--- a/jujugui/static/gui/src/app/components/post-deployment/post-deployment.js
+++ b/jujugui/static/gui/src/app/components/post-deployment/post-deployment.js
@@ -51,9 +51,15 @@ class PostDeployment extends React.Component {
     const props = this.props;
     const getFile = props.charmstore.getFile;
     props.entityURLs.forEach(entityURL => {
-      const url = urls.URL.fromAnyString(entityURL).toLegacyString();
-      getFile(url, GET_STARTED, this._handleFileResponse.bind(this, GET_STARTED));
-      getFile(url, POST_DEPLOYMENT, this._handleFileResponse.bind(this, POST_DEPLOYMENT));
+      try {
+        const url = urls.URL.fromAnyString(entityURL).toLegacyString();
+        getFile(url, GET_STARTED, this._handleFileResponse.bind(this, GET_STARTED));
+        getFile(url, POST_DEPLOYMENT, this._handleFileResponse.bind(this, POST_DEPLOYMENT));
+      } catch(e) {
+        // If the bundleURL is a local file then the url parser could fail
+        // for a number of reasons. Just carry on if this doesn't parse
+        // properly.
+      }
     });
   }
 

--- a/jujugui/static/gui/src/app/components/post-deployment/test-post-deployment.js
+++ b/jujugui/static/gui/src/app/components/post-deployment/test-post-deployment.js
@@ -51,6 +51,12 @@ describe('PostDeployment', () => {
     assert.equal(content, 'The bundle author has not provided a getstarted.md file.');
   });
 
+  it('supports local bundle paths', () => {
+    // If the fix is not implemented in _fetchFiles this will fail by throwing
+    // on render so no assertions are necessary.
+    renderComponent({entityURLs: ['local-bundle (1)']});
+  });
+
   it('correctly updates when the entityURLs prop changes', () => {
     const getFileStub = sinon.stub();
     const wrapper = renderComponent({

--- a/jujugui/static/gui/src/app/init/bundle-exporter.js
+++ b/jujugui/static/gui/src/app/init/bundle-exporter.js
@@ -80,6 +80,11 @@ class BundleExporter {
         serviceData.expose = true;
       }
 
+      const series = service.get('series');
+      if (series) {
+        serviceData.series = series;
+      }
+
       // XXX: Only expose position. Currently these are position absolute
       // rather than relative.
       var anno = service.get('annotations');

--- a/jujugui/static/gui/src/app/init/test-bundle-exporter.js
+++ b/jujugui/static/gui/src/app/init/test-bundle-exporter.js
@@ -42,13 +42,14 @@ describe('bundle exporter', () => {
 
   it('can export the model as a bundle', () => {
     // Mock a topology that can return positions.
-    db.services.add({id: 'mysql', charm: 'precise/mysql-1'});
+    db.services.add({id: 'mysql', charm: 'precise/mysql-1', series: 'xenial'});
     db.services.add({
       id: 'wordpress',
       charm: 'precise/wordpress-1',
       config: {debug: 'no', username: 'admin'},
       constraints: 'cpu-power=2 cpu-cores=4',
-      annotations: {'gui-x': 100, 'gui-y': 200}
+      annotations: {'gui-x': 100, 'gui-y': 200},
+      series: 'bionic'
     });
     db.addUnits({
       id: 'wordpress/0'
@@ -82,6 +83,8 @@ describe('bundle exporter', () => {
     var relation = result.relations[0];
 
     assert.equal(result.series, 'precise');
+    assert.equal(result.applications.mysql.series, 'xenial');
+    assert.equal(result.applications.wordpress.series, 'bionic');
     assert.equal(result.applications.mysql.charm, 'precise/mysql-1');
     assert.equal(result.applications.wordpress.charm, 'precise/wordpress-1');
     // Services with no units are allowed.


### PR DESCRIPTION
When a model has a default series, say `bionic` and it contains a number of multi-series applications, on export those applications wouldn't report the series they were deployed as, so sometimes you'd end up with a machine and application being `xenial` but when re-importing that bundle it would try and deploy `bionic` application on a `xenial` machine. This branch makes it explicit what the series of the application is without inferring from the machine.