### PR TITLE
Handle searches without query text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Broken GCP cloud logo in Firefox.
 - Repeating port values on Status pane.
 - Broken styles on the Status pane.
+- Searches without query text would reload forever.
 
 ## [2.14.1] - 2018-10-26
 ### Changed

--- a/jujugui/static/gui/src/app/components/search-results/search-results.js
+++ b/jujugui/static/gui/src/app/components/search-results/search-results.js
@@ -259,11 +259,12 @@ class SearchResults extends React.Component {
     @param {Object} nextProps The next set of properties.
   */
   _shouldSearch(nextProps) {
-    if (!this.state.data || !this.state.data.text) {
-      return true;
+    let currentText = '';
+    if (this.state.data && this.state.data.text) {
+      currentText = this.state.data.text;
     }
-    var nextQuery = JSON.stringify(nextProps.query),
-        currentQuery = JSON.stringify(this.state.data.text);
+    var nextQuery = JSON.stringify(nextProps.query || ''),
+        currentQuery = JSON.stringify(currentText || '');
     return nextQuery !== currentQuery ||
         nextProps.type !== this.props.type ||
         nextProps.tags !== this.props.tags ||

--- a/jujugui/static/gui/src/app/components/search-results/test-search-results.js
+++ b/jujugui/static/gui/src/app/components/search-results/test-search-results.js
@@ -619,6 +619,25 @@ describe('SearchResults', function() {
       assert.equal(spy.getCall(0).args[0], nextProps.query);
     });
 
+    it('triggers a search request when a search param changes', function() {
+      var nextProps = {type: 'bundle'};
+      searchResults.props = {query: 'spinach'};
+      searchResults._searchRequest = sinon.spy();
+      var spy = searchResults._searchRequest;
+      searchResults.componentWillReceiveProps(nextProps);
+      assert.equal(spy.getCall(0).args[2], nextProps.type);
+    });
+
+    it('handles search param changes without a query', function() {
+      var nextProps = {type: 'bundle'};
+      searchResults.props = {type: 'bundle'};
+      searchResults.state.data = {};
+      searchResults._searchRequest = sinon.spy();
+      var spy = searchResults._searchRequest;
+      searchResults.componentWillReceiveProps(nextProps);
+      assert.equal(spy.callCount, 0);
+    });
+
     it('re-renders only after a new search has finished', function() {
       searchResults._shouldSearch = sinon.stub().returns(true);
       searchResults.state = {waitingForSearch: false};


### PR DESCRIPTION
Fixes: #3904. Search URLs that did not include query text would infinitely reload e.g. listing by tag/entity type.