### PR TITLE
Add static routes to redirect to jaas.ai

### DIFF
--- a/webapp/blueprint.py
+++ b/webapp/blueprint.py
@@ -45,6 +45,7 @@ def root():
 @gui.route("/jaas")
 @gui.route("/kubernetes")
 @gui.route("/openstack")
+@gui.route("/store")
 @gui.route("/support")
 def jaas():
     return flask.redirect(JAAS_URL)

--- a/webapp/blueprint.py
+++ b/webapp/blueprint.py
@@ -31,7 +31,21 @@ def root():
         return flask.redirect(JAAS_URL)
 
 
+@gui.route("/big-data")
+@gui.route("/community")
+@gui.route("/community/cards")
+@gui.route("/community/partners")
+@gui.route("/containers")
+@gui.route("/experts")
+@gui.route("/experts/spicule")
+@gui.route("/experts/tengu")
+@gui.route("/getting-started")
 @gui.route("/home")
+@gui.route("/how-it-works")
+@gui.route("/jaas")
+@gui.route("/kubernetes")
+@gui.route("/openstack")
+@gui.route("/support")
 def jaas():
     return flask.redirect(JAAS_URL)
 


### PR DESCRIPTION
Fixes #3949 

#### To QA
- Visit all of the routes that were added to make sure they are redirected to jaas.ai/*
- Cross reference the routes with the routes in jaas.ai to make sure none were missed. https://github.com/canonical-web-and-design/jaas.ai/blob/master/webapp/jaasai/views.py