### PR TITLE
Fix tooltip messaging format for add-to-model button.

### DIFF
--- a/gui/src/app/components/entity-details/header/__snapshots__/test-header.js.snap
+++ b/gui/src/app/components/entity-details/header/__snapshots__/test-header.js.snap
@@ -121,7 +121,12 @@ exports[`EntityHeader renders the latest entity properly 1`] = `
             action={[Function]}
             disabled={false}
             modifier="positive"
-            tooltip="Add this charm to a new model"
+            tooltip={
+              Object {
+                "msg": "Add this charm to a new model",
+                "position": "btm-lft",
+              }
+            }
           >
             Add to model
           </Button>

--- a/gui/src/app/components/entity-details/header/header.js
+++ b/gui/src/app/components/entity-details/header/header.js
@@ -126,9 +126,11 @@ class EntityHeader extends React.Component {
             disabled={this.props.acl.isReadOnly()}
             modifier="positive"
             ref="deployAction"
-            tooltip={
-              `Add this ${entity.type} to ` +
-              `${modelName ? 'your current' : 'a new'} model`}>
+            tooltip={{
+              msg: `Add this ${entity.type} to ` +
+                  `${modelName ? 'your current' : 'a new'} model`,
+              position: 'btm-lft'
+            }}>
             {title}
           </Button>
         </span>


### PR DESCRIPTION
Fixes #3928 

#### To QA
View an entity and then hover over the "add-to-model" button. It should have a message.