### PR TITLE
Force Cloud facade to v2 to support UpdateCredentials method

### DIFF
--- a/gui/src/app/store/env/controller-api.js
+++ b/gui/src/app/store/env/controller-api.js
@@ -142,6 +142,12 @@ window.yui.add('juju-controller-api', function(Y) {
       if (!op.params) {
         op.params = {};
       }
+      // The Cloud facade api in the GUI requires the user of the
+      // "UpdateCredentials" method which is only available on facade version 2
+      // This will lock the facade version of the Cloud facade requests to 2.
+      if (op.type === 'Cloud') {
+        op.version = 2;
+      }
       var msg = JSON.stringify(op);
       this.ws.send(msg);
     },

--- a/gui/src/test/test_controller_api.js
+++ b/gui/src/test/test_controller_api.js
@@ -56,7 +56,7 @@ describe('Controller API', function() {
     controllerAPI.set('facades', {
       AllModelWatcher: [2],
       Bundle: [1],
-      Cloud: [1],
+      Cloud: [1, 2, 3, 4, 5],
       Controller: [3],
       MigrationTarget: [1],
       ModelManager: [4],
@@ -2085,7 +2085,7 @@ describe('Controller API', function() {
           'request-id': 1,
           type: 'Cloud',
           request: 'UpdateCredentials',
-          version: 1,
+          version: 2,
           params: {credentials: [{
             tag: 'cloudcred-' + name,
             credential: {'auth-type': authType, attrs: attrs}


### PR DESCRIPTION
When JAAS updated the version of Juju it also bumped the supported facades of the API. The GUI would automatically use the latest facade versions. This locks the `Cloud` facade requests to the latest supported by the GUI api, v2.

Fixes #4000

#### To QA
- Connect to a JAAS controller
- View your credentials in your profile.
- Add a credential on GCE/AWS and it should work as expected.