### PR TITLE
Block deploying k8s charms via the GUI

### DIFF
--- a/gui/src/app/components/entity-details/header/header.js
+++ b/gui/src/app/components/entity-details/header/header.js
@@ -114,6 +114,39 @@ class EntityHeader extends React.Component {
   }
 
   /**
+    Returns a boolean whether an entity is kubernetes.
+    @param {Object} entity The entity object.
+    @returns {Boolean}
+  */
+  _isKubernetes(entity) {
+    if (!Array.isArray(entity.series)) {
+      return entity.series === 'kubernetes';
+    }
+    return !!entity.series.find(series => series === 'kubernetes');
+  }
+
+  /**
+    Returns a boolean whether the Add To Canvas button should be disabled.
+    @param {Object} entity The entity object.
+    @returns {Boolean}
+  */
+  _shouldDisableAddToCanvas(entity) {
+    return this.props.acl.isReadOnly() || this._isKubernetes(entity);
+  }
+
+  /**
+    Returns the deploy tooltip depending on the entities series.
+    @param {Object} entity The entity object.
+    @param {String} modelName The name of the model.
+  */
+  _getDeployTooltip(entity, modelName) {
+    if (this._isKubernetes(entity)) {
+      return 'Unable to deploy kubernetes charms via the GUI. Please use the CLI';
+    }
+    return `Add this ${entity.type} to ${modelName ? 'your current' : 'a new'} model`;
+  }
+
+  /**
     Generate the deploy action or a notice if deployment is not supported.
     XXX kadams54, 2016-01-04: the deployAction var will need to be removed
     once we fully support multi-series charms.
@@ -132,12 +165,11 @@ class EntityHeader extends React.Component {
         <span className="v1">
           <Button
             action={this._handleDeployClick.bind(this)}
-            disabled={this.props.acl.isReadOnly()}
+            disabled={this._shouldDisableAddToCanvas(entity)}
             modifier="positive"
             ref="deployAction"
             tooltip={{
-              msg: `Add this ${entity.type} to ` +
-                  `${modelName ? 'your current' : 'a new'} model`,
+              msg: this._getDeployTooltip(entity, modelName),
               position: 'btm-lft'
             }}>
             {title}

--- a/gui/src/app/components/entity-details/header/test-header.js
+++ b/gui/src/app/components/entity-details/header/test-header.js
@@ -288,4 +288,10 @@ describe('EntityHeader', function() {
     const wrapper = renderComponent();
     assert.equal(wrapper.find('Button').prop('disabled'), true);
   });
+
+  it('can disable the deploy button when series is kubernetes', function() {
+    mockEntity.set('series', 'kubernetes');
+    const wrapper = renderComponent();
+    assert.equal(wrapper.find('Button').prop('disabled'), true);
+  });
 });

--- a/gui/src/app/components/search-results/item/item.js
+++ b/gui/src/app/components/search-results/item/item.js
@@ -210,6 +210,17 @@ class SearchResultsItem extends React.Component {
     );
   }
 
+  /**
+    Returns a boolean whether the Add To Canvas button should be disabled.
+    @param {Object} entity The entity object.
+  */
+  _shouldDisableAddToCanvas(entity) {
+    const isReadOnly = this.props.acl.isReadOnly();
+    const isK8s = entity.series.filter(series => series.name === 'kubernetes').length > 0;
+    console.log(isReadOnly || isK8s);
+    return isReadOnly || isK8s;
+  }
+
   render() {
     var item = this.props.item;
     return (
@@ -252,7 +263,7 @@ class SearchResultsItem extends React.Component {
         <div className="one-col last-col list-block__list--item-deploy v1">
           <Button
             action={this._handleDeploy.bind(this, item.id)}
-            disabled={this.props.acl.isReadOnly()}
+            disabled={this._shouldDisableAddToCanvas(item)}
             extraClasses="is-inline list-block__list--item-deploy-link"
             modifier="neutral">
             <SvgIcon

--- a/gui/src/app/components/search-results/item/item.js
+++ b/gui/src/app/components/search-results/item/item.js
@@ -211,14 +211,21 @@ class SearchResultsItem extends React.Component {
   }
 
   /**
+    Returns a boolean whether an entity is kubernetes.
+    @param {Object} entity The entity object.
+    @returns {Boolean}
+  */
+  _isKubernetes(entity) {
+    return entity.series.filter(series => series.name === 'kubernetes').length > 0;
+  }
+
+  /**
     Returns a boolean whether the Add To Canvas button should be disabled.
     @param {Object} entity The entity object.
+    @returns {Boolean}
   */
   _shouldDisableAddToCanvas(entity) {
-    const isReadOnly = this.props.acl.isReadOnly();
-    const isK8s = entity.series.filter(series => series.name === 'kubernetes').length > 0;
-    console.log(isReadOnly || isK8s);
-    return isReadOnly || isK8s;
+    return this.props.acl.isReadOnly() || this._isKubernetes(entity);
   }
 
   render() {

--- a/gui/src/app/components/search-results/item/test-item.js
+++ b/gui/src/app/components/search-results/item/test-item.js
@@ -156,4 +156,18 @@ describe('SearchResultsItem', function() {
     assert.equal(addToModel.callCount, 1);
     assert.deepEqual(addToModel.args[0][0], 'mysql');
   });
+
+  it('disables deploying an entity if entity is k8s series', function() {
+    const changeState = sinon.stub();
+    const addToModel = sinon.stub();
+    item.series = [
+      {name: 'kubernetes', storeId: '~test-owner/kubernetes/mysql'}
+    ];
+    const wrapper = renderComponent({
+      addToModel,
+      changeState,
+      item
+    });
+    assert.equal(wrapper.find('Button').props().disabled, true);
+  });
 });


### PR DESCRIPTION
The GUI does not support deploying Kubernetes charms. This branch disables the add-to-canvas buttons when it has a `kubernetes` series.

Fixes #3995 
Fixes #3994 

# To QA
- search for `coredns` You should see that the `+` is disabled. 
- search for `kubernetes` You'll see that the `+` is active for entities in the result that don't have a `kubernetes` series.
- view the `coredns` charm. It should have the 'add-to-canvas' button disabled and a tooltip explaining why.
- view another charm and bundle. The add-to-canvas button should work as usual.
