### PR TITLE
Upgrade jaaslib to remove the request for `revision-info` on Charmstore requests.

### DIFF
--- a/gui/src/app/components/added-services-list/label/label.js
+++ b/gui/src/app/components/added-services-list/label/label.js
@@ -4,7 +4,7 @@
 const PropTypes = require('prop-types');
 const React = require('react');
 
-const {urls} = require('jaaslib');
+const {urls} = require('@canonical/jaaslib');
 
 class AddedServicesLabel extends React.Component {
 

--- a/gui/src/app/components/deployment-flow/direct-deploy/direct-deploy.js
+++ b/gui/src/app/components/deployment-flow/direct-deploy/direct-deploy.js
@@ -2,7 +2,7 @@
 'use strict';
 
 const PropTypes = require('prop-types');
-const {urls} = require('jaaslib');
+const {urls} = require('@canonical/jaaslib');
 const React = require('react');
 
 const {Button} = require('@canonical/juju-react-components');

--- a/gui/src/app/components/entity-details/content/files/files.js
+++ b/gui/src/app/components/entity-details/content/files/files.js
@@ -3,7 +3,7 @@
 
 const PropTypes = require('prop-types');
 const React = require('react');
-const {urls} = require('jaaslib');
+const {urls} = require('@canonical/jaaslib');
 
 const initUtils = require('../../../../init/utils');
 

--- a/gui/src/app/components/entity-details/content/resources/resources.js
+++ b/gui/src/app/components/entity-details/content/resources/resources.js
@@ -3,7 +3,7 @@
 
 const PropTypes = require('prop-types');
 const React = require('react');
-const {urls} = require('jaaslib');
+const {urls} = require('@canonical/jaaslib');
 
 const initUtils = require('../../../../init/utils');
 

--- a/gui/src/app/components/entity-details/entity-details.js
+++ b/gui/src/app/components/entity-details/entity-details.js
@@ -5,7 +5,7 @@ const classNames = require('classnames');
 const PropTypes = require('prop-types');
 const React = require('react');
 const shapeup = require('shapeup');
-const {urls} = require('jaaslib');
+const {urls} = require('@canonical/jaaslib');
 
 const EntityContent = require('./content/content');
 const EntityHeader = require('./header/header');

--- a/gui/src/app/components/entity-details/header/header.js
+++ b/gui/src/app/components/entity-details/header/header.js
@@ -3,7 +3,7 @@
 
 const PropTypes = require('prop-types');
 const React = require('react');
-const {urls} = require('jaaslib');
+const {urls} = require('@canonical/jaaslib');
 
 const CopyToClipboard = require('../../copy-to-clipboard/copy-to-clipboard');
 const {Button} = require('@canonical/juju-react-components');

--- a/gui/src/app/components/icon-list/icon-list.js
+++ b/gui/src/app/components/icon-list/icon-list.js
@@ -4,7 +4,7 @@
 const PropTypes = require('prop-types');
 const React = require('react');
 
-const {urls} = require('jaaslib');
+const {urls} = require('@canonical/jaaslib');
 
 require('./_icon-list.scss');
 

--- a/gui/src/app/components/inspector/change-version/change-version.js
+++ b/gui/src/app/components/inspector/change-version/change-version.js
@@ -4,7 +4,7 @@
 const PropTypes = require('prop-types');
 const React = require('react');
 const shapeup = require('shapeup');
-const {urls} = require('jaaslib');
+const {urls} = require('@canonical/jaaslib');
 
 const Spinner = require('../../spinner/spinner');
 const InspectorChangeVersionItem = require('./item/item');

--- a/gui/src/app/components/inspector/change-version/item/test-item.js
+++ b/gui/src/app/components/inspector/change-version/item/test-item.js
@@ -3,7 +3,7 @@
 
 const React = require('react');
 const enzyme = require('enzyme');
-const {urls} = require('jaaslib');
+const {urls} = require('@canonical/jaaslib');
 
 const InspectorChangeVersionItem = require('./item');
 const {Button} = require('@canonical/juju-react-components');

--- a/gui/src/app/components/inspector/change-version/test-change-version.js
+++ b/gui/src/app/components/inspector/change-version/test-change-version.js
@@ -4,7 +4,7 @@
 const enzyme = require('enzyme');
 const React = require('react');
 const shapeup = require('shapeup');
-const {urls} = require('jaaslib');
+const {urls} = require('@canonical/jaaslib');
 
 const Analytics = require('test/fake-analytics');
 const InspectorChangeVersion = require('./change-version');

--- a/gui/src/app/components/inspector/config/config.js
+++ b/gui/src/app/components/inspector/config/config.js
@@ -4,7 +4,7 @@
 const classNames = require('classnames');
 const PropTypes = require('prop-types');
 const React = require('react');
-const {urls} = require('jaaslib');
+const {urls} = require('@canonical/jaaslib');
 
 const BooleanConfig = require('../../boolean-config/boolean-config');
 const initUtils = require('../../../init/utils');

--- a/gui/src/app/components/inspector/header/header.js
+++ b/gui/src/app/components/inspector/header/header.js
@@ -5,7 +5,7 @@ const classNames = require('classnames');
 const PropTypes = require('prop-types');
 const React = require('react');
 const ReactDOM = require('react-dom');
-const {urls} = require('jaaslib');
+const {urls} = require('@canonical/jaaslib');
 
 require('./_header.scss');
 

--- a/gui/src/app/components/inspector/service-overview/service-overview.js
+++ b/gui/src/app/components/inspector/service-overview/service-overview.js
@@ -3,7 +3,7 @@
 
 const PropTypes = require('prop-types');
 const React = require('react');
-const {urls} = require('jaaslib');
+const {urls} = require('@canonical/jaaslib');
 
 const {ButtonRow} = require('@canonical/juju-react-components');
 const initUtils = require('../../../init/utils');

--- a/gui/src/app/components/post-deployment/post-deployment.js
+++ b/gui/src/app/components/post-deployment/post-deployment.js
@@ -5,7 +5,7 @@ const marked = require('marked');
 const PropTypes = require('prop-types');
 const React = require('react');
 const shapeup = require('shapeup');
-const {urls} = require('jaaslib');
+const {urls} = require('@canonical/jaaslib');
 
 const {Button} = require('@canonical/juju-react-components');
 const {Panel} = require('@canonical/juju-react-components');

--- a/gui/src/app/components/profile/bundle-list/bundle-list.js
+++ b/gui/src/app/components/profile/bundle-list/bundle-list.js
@@ -4,7 +4,7 @@
 const PropTypes = require('prop-types');
 const React = require('react');
 const shapeup = require('shapeup');
-const {urls} = require('jaaslib');
+const {urls} = require('@canonical/jaaslib');
 
 const {BasicTable} = require('@canonical/juju-react-components');
 const IconList = require('../../icon-list/icon-list');

--- a/gui/src/app/components/profile/charm-list/charm-list.js
+++ b/gui/src/app/components/profile/charm-list/charm-list.js
@@ -4,7 +4,7 @@
 const PropTypes = require('prop-types');
 const React = require('react');
 const shapeup = require('shapeup');
-const {urls} = require('jaaslib');
+const {urls} = require('@canonical/jaaslib');
 
 const {BasicTable} = require('@canonical/juju-react-components');
 const ProfileCharmstoreLogin = require('../charmstore-login/charmstore-login');

--- a/gui/src/app/components/search-results/item/item.js
+++ b/gui/src/app/components/search-results/item/item.js
@@ -4,7 +4,7 @@
 const classNames = require('classnames');
 const PropTypes = require('prop-types');
 const React = require('react');
-const {urls} = require('jaaslib');
+const {urls} = require('@canonical/jaaslib');
 
 const {Button} = require('@canonical/juju-react-components');
 const IconList = require('../../icon-list/icon-list');

--- a/gui/src/app/components/store/store.js
+++ b/gui/src/app/components/store/store.js
@@ -4,7 +4,7 @@
 const PropTypes = require('prop-types');
 const React = require('react');
 const classNames = require('classnames');
-const {charmstore} = require('jaaslib');
+const {charmstore} = require('@canonical/jaaslib');
 
 const ExpertStoreCard = require('../expert-store-card/expert-store-card');
 

--- a/gui/src/app/init.js
+++ b/gui/src/app/init.js
@@ -40,7 +40,7 @@ const {
   stripe,
   terms,
   urls
-} = require('jaaslib');
+} = require('@canonical/jaaslib');
 
 require('./yui-modules');
 

--- a/gui/src/app/init/app.js
+++ b/gui/src/app/init/app.js
@@ -6,7 +6,7 @@ const PropTypes = require('prop-types');
 const queryString = require('query-string');
 const React = require('react');
 const shapeup = require('shapeup');
-const jaaslib = require('jaaslib');
+const jaaslib = require('@canonical/jaaslib');
 
 // This CSS needs to be imported before the components below so that the order
 // of CSS is correct.

--- a/gui/src/app/init/testing-factory.js
+++ b/gui/src/app/init/testing-factory.js
@@ -18,7 +18,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 'use strict';
 
-const {charmstore} = require('jaaslib');
+const {charmstore} = require('@canonical/jaaslib');
 
 const factory = {
 

--- a/gui/src/app/init/topology/service.js
+++ b/gui/src/app/init/topology/service.js
@@ -3,7 +3,7 @@
 
 const d3 = require('d3');
 const jsyaml = require('js-yaml');
-const {urls} = require('jaaslib');
+const {urls} = require('@canonical/jaaslib');
 
 const environmentUtils = require('./environment-utils');
 const relationUtils = require('../relation-utils');

--- a/gui/src/app/init/topology/test-environment.js
+++ b/gui/src/app/init/topology/test-environment.js
@@ -2,7 +2,7 @@
 'use strict';
 
 let d3 = require('d3');
-const {charmstore} = require('jaaslib');
+const {charmstore} = require('@canonical/jaaslib');
 
 const Analytics = require('test/fake-analytics');
 const EnvironmentChangeSet = require('../environment-change-set');

--- a/gui/src/app/init/topology/test-service.js
+++ b/gui/src/app/init/topology/test-service.js
@@ -2,7 +2,7 @@
 'use strict';
 
 let d3 = require('d3');
-const {charmstore} = require('jaaslib');
+const {charmstore} = require('@canonical/jaaslib');
 
 const utils = require('testing-utils');
 

--- a/gui/src/app/init/utils.js
+++ b/gui/src/app/init/utils.js
@@ -4,7 +4,7 @@
 const jsyaml = require('js-yaml');
 const React = require('react');
 const FileSaver = require('file-saver');
-const {charmstore} = require('jaaslib');
+const {charmstore} = require('@canonical/jaaslib');
 
 const BundleExporter = require('./bundle-exporter');
 const initUtils = require('./utils');

--- a/gui/src/app/models/charm.js
+++ b/gui/src/app/models/charm.js
@@ -18,7 +18,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 'use strict';
 
-const {urls} = require('jaaslib');
+const {urls} = require('@canonical/jaaslib');
 
 const utils = require('../init/utils');
 

--- a/gui/src/app/models/handlers.js
+++ b/gui/src/app/models/handlers.js
@@ -18,7 +18,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 'use strict';
 
-const {urls} = require('jaaslib');
+const {urls} = require('@canonical/jaaslib');
 
 /**
    Delta handlers.

--- a/gui/src/app/models/test-bundle.js
+++ b/gui/src/app/models/test-bundle.js
@@ -18,7 +18,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 'use strict';
 
-const jaaslib = require('jaaslib');
+const jaaslib = require('@canonical/jaaslib');
 const charmstoreUtils = jaaslib.charmstore;
 const utils = require('../init/testing-utils');
 

--- a/gui/src/app/store/env/api.js
+++ b/gui/src/app/store/env/api.js
@@ -18,7 +18,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 'use strict';
 
-const {urls} = require('jaaslib');
+const {urls} = require('@canonical/jaaslib');
 
 const utils = require('../../init/utils');
 

--- a/gui/src/app/test-init.js
+++ b/gui/src/app/test-init.js
@@ -11,7 +11,7 @@ const {
   plans,
   terms,
   urls
-} = require('jaaslib');
+} = require('@canonical/jaaslib');
 
 
 describe('init', () => {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "test": "yarn run lint-python && yarn run lint-js && yarn run test-js"
   },
   "dependencies": {
+    "@canonical/jaaslib": "^0.6.0",
     "classnames": "^2.2.6",
     "clipboard": "^1.7.1",
     "cryptojs": "2.5.3",
@@ -35,7 +36,6 @@
     "envify": "4.1.0",
     "file-saver": "1.3.8",
     "graceful-fs": "4.1.11",
-    "jaaslib": "0.5.0",
     "js-cookie": "^2.2.0",
     "js-yaml": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.1.tgz",
     "lodash.clonedeep": "^4.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -119,6 +119,11 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
+"@canonical/jaaslib@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@canonical/jaaslib/-/jaaslib-0.6.0.tgz#7b77ff0a6899a2e58adc1b2077d8971de019047b"
+  integrity sha512-3x0DmeFP1Fu/JPT9Sn/vJcNbCI5QSMmwF4rHIH7N/3T/KxwI1dK+gjv8djOFAe3UD8wVbFNwlhOpuhdg+2A+VQ==
+
 "@canonical/juju-react-components@0.5.0":
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/@canonical/juju-react-components/-/juju-react-components-0.5.0.tgz#65a65988666bc31d7dc128f349342cb615f23886"
@@ -5382,7 +5387,7 @@ istanbul-reports@^1.5.1:
   dependencies:
     handlebars "^4.0.3"
 
-jaaslib@0.5.0, jaaslib@^0.5.0:
+jaaslib@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/jaaslib/-/jaaslib-0.5.0.tgz#78cefa2acdc0894c0198509495b2e9deb5cc1acd"
   integrity sha512-zT0BVgJFgTfh8NZFwuLkbKfpyju99jwepnoDg3Q9DjZ/QmE4Cm+DV0DfGTGM+uqOxxFr3aa9OGFmFH1LGSLHaQ==


### PR DESCRIPTION
Fixes #4013 

#### To QA:
- Visit a charm details page and look at the request. It should not have `revision-info` in the url.
- The details page should work as expected. It should not have a link for 'latest version'