### PR TITLE
Add logo redirect

### DIFF
--- a/permanent-redirects.yaml
+++ b/permanent-redirects.yaml
@@ -1,0 +1,1 @@
+static/img/logos/juju-logo.svg: https://assets.ubuntu.com/v1/7e21b535-logo-juju.svg

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ Flask==1.0.2
 python-dateutil==2.8.0
 raven[flask]==6.5.0
 flake8==3.7.7
+canonicalwebteam.yaml-responses==1.1.1

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -8,6 +8,7 @@ import talisker.logs
 from werkzeug.contrib.fixers import ProxyFix
 from werkzeug.debug import DebuggedApplication
 from werkzeug.routing import BaseConverter
+from canonicalwebteam.yaml_responses.flask_helpers import prepare_redirects
 
 from webapp.blueprint import gui
 
@@ -34,6 +35,10 @@ if app.debug:
 talisker.flask.register(app)
 
 app.register_blueprint(gui)
+
+app.before_request(
+    prepare_redirects(path="permanent-redirects.yaml", permanent=True)
+)
 
 if __name__ == "__main__":
     app.run(host="0.0.0.0")


### PR DESCRIPTION
## Done

Redirect old logo path to the assets server to fix broken logo endpoint.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8032/static/img/logos/juju-logo.svg it should redirect to the assets server.

## Notes

This is the GUI side of the jaas.ai PR https://github.com/canonical-web-and-design/jaas.ai/pull/421
