### PR TITLE
Add k8s configuration in deploy/site.yaml

### DIFF
--- a/deploy/site.yaml
+++ b/deploy/site.yaml
@@ -1,0 +1,21 @@
+domain: jujucharms.com
+
+image: prod-comms.docker-registry.canonical.com/jujucharms.com
+
+useProxy: false
+
+# Overrides for production
+production:
+  replicas: 5
+  nginxConfigurationSnippet: |
+    if ($host != 'jujucharms.com' ) {
+      rewrite ^ https://jujucharms.com$request_uri? permanent;
+    }
+    more_set_headers "Link: <https://assets.ubuntu.com>; rel=preconnect; crossorigin, <https://assets.ubuntu.com>; rel=preconnect";
+
+# Overrides for staging
+staging:
+  replicas: 3
+  nginxConfigurationSnippet: |
+    more_set_headers "X-Robots-Tag: noindex";
+    more_set_headers "Link: <https://assets.ubuntu.com>; rel=preconnect; crossorigin, <https://assets.ubuntu.com>; rel=preconnect";


### PR DESCRIPTION
This PR is needed because we are moving the Kubernetes configuration file from all our sites to deploy/site.yaml in each project.

This file comes from: https://github.com/canonical-web-and-design/deployment-configs/blob/master/sites/jujucharms.com.yaml